### PR TITLE
[Review only] GH-87 Add support for `ackOnError`

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
@@ -116,6 +116,7 @@ public abstract class AbstractMessageListenerContainer<K, V>
 
 	private ErrorHandler errorHandler = new LoggingErrorHandler();
 
+	private volatile boolean ackOnError = true;
 
 	@Override
 	public void setBeanName(String name) {
@@ -228,6 +229,30 @@ public abstract class AbstractMessageListenerContainer<K, V>
 	 */
 	public long getAckTime() {
 		return this.ackTime;
+	}
+
+	/**
+	 * Flag that controls whether the container should ack messages that throw exceptions.
+	 * This works in conjunction with {@link #getAckMode()} and is effective only when
+	 * auto ack is false. When this property is set to {@code true}, all messages handled
+	 * will be acked. When set to {@code false}, acks will be produced only for successful
+	 * messages, and allows a component that starts throwing exceptions consistently to
+	 * resume from the last successfully processed message.
+	 * @param ackOnError whether the container should acknowledge messages that throw
+	 * exceptions.
+	 */
+	public void setAckOnError(boolean ackOnError) {
+		this.ackOnError = ackOnError;
+	}
+
+	/**
+	 * Return whether messages are acknowledged when exceptions are thrown by the
+	 * listener.
+	 * @return whether messages are acknowledged when exceptions are thrown by the
+	 * listener.
+	 */
+	public boolean isAckOnError() {
+		return this.ackOnError;
 	}
 
 	@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
@@ -213,6 +213,7 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 				container.setRecentOffset(this.recentOffset);
 				container.setAutoStartup(false);
 				container.setMessageListener(getMessageListener());
+				container.setAckOnError(this.isAckOnError());
 				if (getTaskExecutor() != null) {
 					container.setTaskExecutor(getTaskExecutor());
 				}


### PR DESCRIPTION
This PR will need to be merged (and probably slightly adjusted) after #91 as it modifies the way in which commits are processed (and the algorithm would beed to be slightly adapted to match the asynchronous model introduced by #91, esp. wrt. how batches are committed).

But we can still validated the approach. 
