### PR TITLE
ErrorHandler method is not set

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
@@ -213,6 +213,7 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 				container.setRecentOffset(this.recentOffset);
 				container.setAutoStartup(false);
 				container.setMessageListener(getMessageListener());
+                container.setErrorHandler(getErrorHandler());
 				if (getTaskExecutor() != null) {
 					container.setTaskExecutor(getTaskExecutor());
 				}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
@@ -213,7 +213,7 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 				container.setRecentOffset(this.recentOffset);
 				container.setAutoStartup(false);
 				container.setMessageListener(getMessageListener());
-                container.setErrorHandler(getErrorHandler());
+				container.setErrorHandler(getErrorHandler());
 				if (getTaskExecutor() != null) {
 					container.setTaskExecutor(getTaskExecutor());
 				}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
@@ -43,7 +43,7 @@ import org.springframework.util.Assert;
  * @author Marius Bogoevici
  * @author Gary Russell
  * @author Murali Reddy
- * @author Jérôme Mirc
+ * @author Jerome Mirc
  */
 public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageListenerContainer<K, V> {
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
@@ -43,6 +43,7 @@ import org.springframework.util.Assert;
  * @author Marius Bogoevici
  * @author Gary Russell
  * @author Murali Reddy
+ * @author Jérôme Mirc
  */
 public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageListenerContainer<K, V> {
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
@@ -60,7 +60,7 @@ import org.springframework.kafka.test.utils.KafkaTestUtils;
 /**
  * @author Gary Russell
  * @author Artem Bilan
- * @author Jérôme Mirc
+ * @author Jerome Mirc
  *
  */
 public class ConcurrentMessageListenerContainerTests {

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
@@ -60,6 +60,7 @@ import org.springframework.kafka.test.utils.KafkaTestUtils;
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Jérôme Mirc
  *
  */
 public class ConcurrentMessageListenerContainerTests {

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.commons.logging.Log;
@@ -532,6 +533,7 @@ public class ConcurrentMessageListenerContainerTests {
 		ConcurrentMessageListenerContainer<Integer, String> container =
 				new ConcurrentMessageListenerContainer<>(cf, topic6);
 		final CountDownLatch latch = new CountDownLatch(4);
+		final AtomicBoolean catchError = new AtomicBoolean(false);
 		container.setMessageListener(new MessageListener<Integer, String>() {
 
 			@Override
@@ -543,6 +545,12 @@ public class ConcurrentMessageListenerContainerTests {
 		});
 		container.setConcurrency(2);
 		container.setBeanName("testException");
+		container.setErrorHandler(new ErrorHandler() {
+			@Override
+			public void handle(Exception thrownException, ConsumerRecord<?, ?> record) {
+				catchError.set(true);
+			}
+		});
 		container.start();
 		ContainerTestUtils.waitForAssignment(container, embeddedKafka.getPartitionsPerTopic());
 		Map<String, Object> senderProps = KafkaTestUtils.producerProps(embeddedKafka);
@@ -555,9 +563,9 @@ public class ConcurrentMessageListenerContainerTests {
 		template.sendDefault(2, "qux");
 		template.flush();
 		assertThat(latch.await(60, TimeUnit.SECONDS)).isTrue();
+		assertThat(catchError.get()).isTrue();
 		container.stop();
 		logger.info("Stop exception");
 
 	}
-
 }


### PR DESCRIPTION
When a KafkaMessageListenerContainer is created, the error handler method is not called. There is no way to set the error handler after it is created