### PR TITLE
GH-99 Idle Container Events

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
@@ -18,6 +18,8 @@ package org.springframework.kafka.config;
 
 
 import org.springframework.beans.BeanUtils;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.listener.AbstractMessageListenerContainer;
 import org.springframework.kafka.listener.adapter.DeDuplicationStrategy;
@@ -32,11 +34,12 @@ import org.springframework.kafka.support.converter.MessageConverter;
  * @param <V> the value type.
  *
  * @author Stephane Nicoll
+ * @author Gary Russell
  *
  * @see AbstractMessageListenerContainer
  */
 public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMessageListenerContainer<K, V>, K, V>
-		implements KafkaListenerContainerFactory<C> {
+		implements KafkaListenerContainerFactory<C>, ApplicationEventPublisherAware {
 
 	private final ContainerProperties containerProperties = new ContainerProperties("propertiesFactory");
 
@@ -49,6 +52,8 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 	private MessageConverter messageConverter;
 
 	private DeDuplicationStrategy<K, V> deDuplicationStrategy;
+
+	private ApplicationEventPublisher applicationEventPublisher;
 
 	/**
 	 * Specify a {@link ConsumerFactory} to use.
@@ -96,6 +101,11 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 		this.deDuplicationStrategy = deDuplicationStrategy;
 	}
 
+	@Override
+	public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
+		this.applicationEventPublisher = applicationEventPublisher;
+	}
+
 	/**
 	 * Obtain the properties template for this factory - set properties as needed
 	 * and they will be copied to a final properties instance for the endpoint.
@@ -115,6 +125,9 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 		}
 		if (this.phase != null) {
 			instance.setPhase(this.phase);
+		}
+		if (this.applicationEventPublisher != null) {
+			instance.setApplicationEventPublisher(this.applicationEventPublisher);
 		}
 		if (endpoint.getId() != null) {
 			instance.setBeanName(endpoint.getId());

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistry.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistry.java
@@ -249,7 +249,12 @@ public class KafkaListenerEndpointRegistry implements DisposableBean, SmartLifec
 		Collection<MessageListenerContainer> listenerContainers = getListenerContainers();
 		AggregatingCallback aggregatingCallback = new AggregatingCallback(listenerContainers.size(), callback);
 		for (MessageListenerContainer listenerContainer : listenerContainers) {
-			listenerContainer.stop(aggregatingCallback);
+			if (listenerContainer.isRunning()) {
+				listenerContainer.stop(aggregatingCallback);
+			}
+			else {
+				aggregatingCallback.run();
+			}
 		}
 	}
 
@@ -297,7 +302,7 @@ public class KafkaListenerEndpointRegistry implements DisposableBean, SmartLifec
 
 		@Override
 		public void run() {
-			if (this.count.decrementAndGet() == 0) {
+			if (this.count.decrementAndGet() <= 0) {
 				this.finishCallback.run();
 			}
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/event/KafkaEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/KafkaEvent.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2015-2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.event;
+
+import org.springframework.context.ApplicationEvent;
+
+
+/**
+ * Base class for events.
+ *
+ * @author Gary Russell
+ *
+ */
+@SuppressWarnings("serial")
+public abstract class KafkaEvent extends ApplicationEvent {
+
+	public KafkaEvent(Object source) {
+		super(source);
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/event/ListenerContainerIdleEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/ListenerContainerIdleEvent.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.event;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.kafka.common.TopicPartition;
+
+/**
+ * An event that is emitted when a container is idle if the container
+ * is configured to do so.
+ *
+ * @author Gary Russell
+ *
+ */
+@SuppressWarnings("serial")
+public class ListenerContainerIdleEvent extends KafkaEvent {
+
+	private final long idleTime;
+
+	private final String listenerId;
+
+	private final List<TopicPartition> topicPartitions;
+
+	public ListenerContainerIdleEvent(Object source, long idleTime, String id,
+			Collection<TopicPartition> topicPartitions) {
+		super(source);
+		this.idleTime = idleTime;
+		this.listenerId = id;
+		this.topicPartitions = new ArrayList<TopicPartition>(topicPartitions);
+	}
+
+	/**
+	 * How long the container has been idle.
+	 * @return the time in milliseconds.
+	 */
+	public long getIdleTime() {
+		return this.idleTime;
+	}
+
+	/**
+	 * The queues the container is listening to.
+	 * @return the queue names.
+	 */
+	public String[] getTopicPartitions() {
+		return this.topicPartitions.toArray(new String[this.topicPartitions.size()]);
+	}
+
+	/**
+	 * The id of the listener (if {@code @RabbitListener}) or the container bean name.
+	 * @return the id.
+	 */
+	public String getListenerId() {
+		return this.listenerId;
+	}
+
+	@Override
+	public String toString() {
+		return "ListenerContainerIdleEvent [idleTime="
+				+ ((float) this.idleTime / 1000) + "s, listenerId=" + this.listenerId
+				+ ", container=" + getSource()
+				+ ", topicPartitions=" + this.topicPartitions + "]";
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/event/package-info.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Application Events.
+ */
+package org.springframework.kafka.event;

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/config/ContainerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/config/ContainerProperties.java
@@ -51,17 +51,17 @@ public class ContainerProperties {
 	/**
 	 * Topic names.
 	 */
-	public final String[] topics;
+	private final String[] topics;
 
 	/**
 	 * Topic pattern.
 	 */
-	public final Pattern topicPattern;
+	private final Pattern topicPattern;
 
 	/**
 	 * Topics/partitions.
 	 */
-	public final TopicPartition[] topicPartitions;
+	private final TopicPartition[] topicPartitions;
 
 	/**
 	 * The ack mode to use when auto ack (in the configuration properties) is false.
@@ -76,102 +76,102 @@ public class ContainerProperties {
 	 * {@link AcknowledgingMessageListener}.
 	 * </ul>
 	 */
-	public AbstractMessageListenerContainer.AckMode ackMode = AckMode.BATCH;
+	private AbstractMessageListenerContainer.AckMode ackMode = AckMode.BATCH;
 
 	/**
 	 * The number of outstanding record count after which offsets should be
 	 * committed when {@link AckMode#COUNT} or {@link AckMode#COUNT_TIME} is being
 	 * used.
 	 */
-	public int ackCount;
+	private int ackCount;
 
 	/**
 	 * The time (ms) after which outstanding offsets should be committed when
 	 * {@link AckMode#TIME} or {@link AckMode#COUNT_TIME} is being used. Should be
 	 * larger than
 	 */
-	public long ackTime;
+	private long ackTime;
 
 	/**
 	 * The message listener; must be a {@link MessageListener} or
 	 * {@link AcknowledgingMessageListener}.
 	 */
-	public Object messageListener;
+	private Object messageListener;
 
 	/**
 	 * The max time to block in the consumer waiting for records.
 	 */
-	public volatile long pollTimeout = 1000;
+	private volatile long pollTimeout = 1000;
 
 	/**
 	 * The executor for threads that poll the consumer.
 	 */
-	public AsyncListenableTaskExecutor consumerTaskExecutor;
+	private AsyncListenableTaskExecutor consumerTaskExecutor;
 
 	/**
 	 * The executor for threads that invoke the listener.
 	 */
-	public AsyncListenableTaskExecutor listenerTaskExecutor;
+	private AsyncListenableTaskExecutor listenerTaskExecutor;
 
 	/**
 	 * The error handler to call when the listener throws an exception.
 	 */
-	public ErrorHandler errorHandler = new LoggingErrorHandler();
+	private ErrorHandler errorHandler = new LoggingErrorHandler();
 
 	/**
 	 * When using Kafka group management and {@link #setPauseEnabled(boolean)} is
 	 * true, the delay after which the consumer should be paused. Default 10000.
 	 */
-	public long pauseAfter = DEFAULT_PAUSE_AFTER;
+	private long pauseAfter = DEFAULT_PAUSE_AFTER;
 
 	/**
 	 * When true, avoids rebalancing when this consumer is slow or throws a
 	 * qualifying exception - pauses the consumer. Default: true.
 	 * @see #pauseAfter
 	 */
-	public boolean pauseEnabled = true;
+	private boolean pauseEnabled = true;
 
 	/**
 	 * A retry template to retry deliveries.
 	 */
-	public RetryTemplate retryTemplate;
+	private RetryTemplate retryTemplate;
 
 	/**
 	 * A recovery callback to be invoked when retries are exhausted. By default
 	 * the error handler is invoked.
 	 */
-	public RecoveryCallback<Void> recoveryCallback;
+	private RecoveryCallback<Void> recoveryCallback;
 
 	/**
 	 * Set the queue depth for handoffs from the consumer thread to the listener
 	 * thread. Default 1 (up to 2 in process).
 	 */
-	public int queueDepth = DEFAULT_QUEUE_DEPTH;
+	private int queueDepth = DEFAULT_QUEUE_DEPTH;
 
 	/**
 	 * The timeout for shutting down the container. This is the maximum amount of
 	 * time that the invocation to {@code #stop(Runnable)} will block for, before
 	 * returning.
 	 */
-	public long shutdownTimeout = DEFAULT_SHUTDOWN_TIMEOUT;
+	private long shutdownTimeout = DEFAULT_SHUTDOWN_TIMEOUT;
 
 	/**
 	 * The offset to this number of records back from the latest when starting.
 	 * Overrides any consumer properties (earliest, latest). Only applies when
 	 * explicit topic/partition assignment is provided.
 	 */
-	public long recentOffset;
+	private long recentOffset;
 
 	/**
 	 * A user defined {@link ConsumerRebalanceListener} implementation.
 	 */
-	public ConsumerRebalanceListener consumerRebalanceListener;
+	private ConsumerRebalanceListener consumerRebalanceListener;
 
 	/**
 	 * The commit callback; by default a simple logging callback is used to log
 	 * success at DEBUG level and failures at ERROR level.
 	 */
-	public OffsetCommitCallback commitCallback;
+	private OffsetCommitCallback commitCallback;
 
 	/**
 	 * Whether or not to call consumer.commitSync() or commitAsync() when the
@@ -179,7 +179,9 @@ public class ContainerProperties {
 	 * https://github.com/spring-projects/spring-kafka/issues/62 At the time of
 	 * writing, async commits are not entirely reliable.
 	 */
-	public boolean syncCommits = true;
+	private boolean syncCommits = true;
+
+	private Long idleEventInterval;
 
 	public ContainerProperties(String... topics) {
 		Assert.notEmpty(topics, "An array of topicPartitions must be provided");
@@ -374,10 +376,14 @@ public class ContainerProperties {
 		this.syncCommits = syncCommits;
 	}
 
-	/*
-	 * Although we generally use field access, we need the getters so we can copy
-	 * the properties from the factory when creating an annotated listener.
+	/**
+	 * Set the idle event interval; when set, an event is emitted if a poll returns
+	 * no records and this interval has elapsed since a record was returned.
+	 * @param idleEventInterval the interval.
 	 */
+	public void setIdleEventInterval(Long idleEventInterval) {
+		this.idleEventInterval = idleEventInterval;
+	}
 
 	public String[] getTopics() {
 		return this.topics;
@@ -461,6 +467,10 @@ public class ContainerProperties {
 
 	public boolean isSyncCommits() {
 		return this.syncCommits;
+	}
+
+	public Long getIdleEventInterval() {
+		return this.idleEventInterval;
 	}
 
 }

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -149,7 +149,7 @@ public KafkaMessageListenerContainer(ConsumerFactory<K, V> consumerFactory,
                                                         ContainerProperties containerProperties)
 
 public KafkaMessageListenerContainer(ConsumerFactory<K, V> consumerFactory,
-                        ContainerProperties containerProperties, TopicPartition... topicPartitions) {
+                        ContainerProperties containerProperties, TopicPartition... topicPartitions)
 
 ----
 
@@ -409,3 +409,89 @@ public void jsonListener(Foo foo) {
 ...
 }
 ----
+
+[[idle-containers]]
+===== Detecting Idle Asynchronous Consumers
+
+While efficient, one problem with asynchronous consumers is detecting when they are idle - users might want to take
+some action if no messages arrive for some period of time.
+
+You can configure the listener container to publish a `ListenerContainerIdleEvent` when some time passes with no message delivery.
+While the container is idle, an event will be published every `idleEventInterval` milliseconds.
+
+To configure this feature, set the `idleEventInterval` on the container:
+
+[source, java]
+----
+@Bean
+public KafKaMessageListenerContainer(ConnectionFactory connectionFactory) {
+    ContainerProperties containerProps = new ContainerProperties("topic1", "topic2");
+    ...
+    containerProps.setIdleEventInterval(60000L);
+    ...
+    KafKaMessageListenerContainer<String, String> container = new KafKaMessageListenerContainer<>(...);
+    return container;
+}
+----
+
+Or, for a `@KafkaListener`...
+
+[source, java]
+----
+@Bean
+public ConcurrentKafkaListenerContainerFactory kafkaListenerContainerFactory() {
+    ConcurrentKafkaListenerContainerFactory<String, String> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+    ...
+    factory.getContainerProperties().setIdleEventInterval(60000L);
+    ...
+    return factory;
+}
+----
+
+In each of these cases, an event will be published once per minute while the container is idle.
+
+====== Event Consumption
+
+You can capture these events by implementing `ApplicationListener` - either a general listener, or one narrowed to only receive this specific event.
+You can also use `@EventListener`, introduced in Spring Framework 4.2.
+
+The following example combines the `@KafkaListener` and `@EventListener` into a single class.
+It's important to understand that the application listener will get events for all containers so you may need to
+check the listener id if you want to take specific action based on which container is idle.
+You can also use the `@EventListener` `condition` for this purpose.
+
+The events have 4 properties:
+
+- `source` - the listener container instance
+- `id` - the listener id (or container bean name)
+- `idleTime` - the time the container had been idle when the event was published
+- `topcicPartitions` - the topics/partitions that the container was assigned at the time the event was generated
+
+[source, xml]
+----
+public class Listener {
+
+    @KafkaListener(id = "qux", topics = "annotated")
+    public void listen4(@Payload String foo, Acknowledgment ack) {
+        ...
+    }
+
+    @EventListener(condition = "event.listenerId.startsWith('qux-')")
+    public void eventHandler(ListenerContainerIdleEvent event) {
+        this.event = event;
+        eventLatch.countDown();
+    }
+
+}
+----
+
+IMPORTANT: Event listeners will see events for all containers; so, in the example above, we narrow the events received
+based on the listener ID.
+Since containers created for the `@KafkaListener` support concurrency, the actual containers are named `id-n` where the n is a unique value for each instance to support the concurrency.
+Hence we use `startsWith` in the condition.
+
+CAUTION: If you wish to use the idle event to stop the lister container, you should not call `container.stop()` on the
+thread that calls the listener - it will cause delays and unnecessary log messages.
+Instead, you should hand off the event to a different thread that can then stop the container.
+Also, you should not `stop()` the container instance in the event if it is a child container, you should stop the concurrent container instead.


### PR DESCRIPTION
Resolves #99

Also change `ContainerProperties` to use accessors

Also fix `stop(Runnable callback` logic for the container registry and
concurrent container.