### PR TITLE
GH-89: Add support for `seek` from the beginning

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
@@ -53,8 +53,8 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 
 	/**
 	 * Construct an instance with the supplied configuration properties and specific
-	 * topics/partitions - when using this constructor, {@link ContainerProperties#setRecentOffset(long)
-	 * recentOffset} can be specified.
+	 * topics/partitions - when using this constructor, {@link ContainerProperties#setOffset(long)
+	 * offset} can be specified.
 	 * The topic partitions are distributed evenly across the delegate
 	 * {@link KafkaMessageListenerContainer}s.
 	 * @param consumerFactory the consumer factory.

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/config/ContainerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/config/ContainerProperties.java
@@ -39,6 +39,7 @@ import org.springframework.util.Assert;
  * Contains runtime properties for a listener container.
  *
  * @author Gary Russell
+ * @author Artem Bilan
  */
 public class ContainerProperties {
 
@@ -156,11 +157,12 @@ public class ContainerProperties {
 	private long shutdownTimeout = DEFAULT_SHUTDOWN_TIMEOUT;
 
 	/**
-	 * The offset to this number of records back from the latest when starting.
+	 * The offset to this number of records from the beginning of the partition
+	 * or back from the latest committed offset if negative.
 	 * Overrides any consumer properties (earliest, latest). Only applies when
 	 * explicit topic/partition assignment is provided.
 	 */
-	private long recentOffset;
+	private long offset;
 
 	/**
 	 * A user defined {@link ConsumerRebalanceListener} implementation.
@@ -339,13 +341,14 @@ public class ContainerProperties {
 	}
 
 	/**
-	 * Set the offset to this number of records back from the latest when starting.
+	 * Set the offset to this number of records from the beginning of the partition
+	 * or back from the latest committed offset if negative.
 	 * Overrides any consumer properties (earliest, latest). Only applies when
 	 * explicit topic/partition assignment is provided.
-	 * @param recentOffset the offset from the latest; default 0.
+	 * @param offset the offset from the beginning if positive or back from latest if negative; default 0.
 	 */
-	public void setRecentOffset(long recentOffset) {
-		this.recentOffset = recentOffset;
+	public void setOffset(long offset) {
+		this.offset = offset;
 	}
 
 	/**
@@ -453,8 +456,8 @@ public class ContainerProperties {
 		return this.shutdownTimeout;
 	}
 
-	public long getRecentOffset() {
-		return this.recentOffset;
+	public long getOffset() {
+		return this.offset;
 	}
 
 	public ConsumerRebalanceListener getConsumerRebalanceListener() {


### PR DESCRIPTION
Fixes GH-89 (https://github.com/spring-projects/spring-kafka/issues/89)

* Rename `recentOffset` just to `offset`
* Add logic for the `offset` property when it is *positive* seek the consumer from the offset beginning;
when the `offset` is negative, seek from the end