### PR TITLE
GH-89: Add support for `seek` from the beginning

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/PartitionOffset.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/PartitionOffset.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.annotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Used to add partition/initial offset information to a {@code KafkaListener}.
+ *
+ * @author Artem Bilan
+ */
+@Target({})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PartitionOffset {
+
+	/**
+	 * The partition withing the topic to listen on.
+	 * Property place holders and SpEL expressions are supported,
+	 * which must resolve to Integer (or String that can be parsed as Integer).
+	 * @return partition withing the topic.
+	 */
+	String partition();
+
+	/**
+	 * The initial offset of the {@link #partition()}.
+	 * Property place holders and SpEL expressions are supported,
+	 * which must resolve to Long (or String that can be parsed as Long).
+	 * @return initial offset.
+	 */
+	String initialOffset();
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/TopicPartition.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/TopicPartition.java
@@ -24,6 +24,7 @@ import java.lang.annotation.Target;
  * Used to add topic/partition information to a {@code KafkaListener}.
  *
  * @author Gary Russell
+ * @author Artem Bilan
  *
  */
 @Target({})
@@ -40,11 +41,19 @@ public @interface TopicPartition {
 
 	/**
 	 * The partitions within the topic.
+	 * The partitions in this set can't be duplicated in the {@link #partitionOffsets()}.
 	 * @return the partitions within the topic. Property place
 	 * holders and SpEL expressions are supported, which must
 	 * resolve to Integers (or Strings that can be parsed as
 	 * Integers).
 	 */
 	String[] partitions() default {};
+
+	/**
+	 * The partitions with initial offsets within the topic.
+	 * The partitions in this set can't be duplicated in the {@link #partitions()}.
+	 * @return the {@link PartitionOffset} array.
+	 */
+	PartitionOffset[] partitionOffsets() default {};
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
@@ -22,8 +22,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.regex.Pattern;
 
-import org.apache.kafka.common.TopicPartition;
-
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
@@ -39,6 +37,7 @@ import org.springframework.kafka.listener.adapter.FilteringMessageListenerAdapte
 import org.springframework.kafka.listener.adapter.RecordFilterStrategy;
 import org.springframework.kafka.listener.adapter.RetryingAcknowledgingMessageListenerAdapter;
 import org.springframework.kafka.listener.adapter.RetryingMessageListenerAdapter;
+import org.springframework.kafka.support.TopicPartitionInitialOffset;
 import org.springframework.kafka.support.converter.MessageConverter;
 import org.springframework.retry.RecoveryCallback;
 import org.springframework.retry.support.RetryTemplate;
@@ -65,7 +64,7 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 
 	private Pattern topicPattern;
 
-	private final Collection<TopicPartition> topicPartitions = new ArrayList<>();
+	private final Collection<TopicPartitionInitialOffset> topicPartitions = new ArrayList<>();
 
 	private BeanFactory beanFactory;
 
@@ -117,7 +116,7 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 	 * Set the topics to use. Either these or 'topicPattern' or 'topicPartitions'
 	 * should be provided, but not a mixture.
 	 * @param topics to set.
-	 * @see #setTopicPartitions(TopicPartition...)
+	 * @see #setTopicPartitions(TopicPartitionInitialOffset...)
 	 * @see #setTopicPattern(Pattern)
 	 */
 	public void setTopics(String... topics) {
@@ -136,14 +135,14 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 	}
 
 	/**
-	 * Set the topics to use. Either these or 'topicPattern'
-	 * or 'topicPartitions'
+	 * Set the topicPartitions to use.
+	 * Either this or 'topic' or 'topicPattern'
 	 * should be provided, but not a mixture.
 	 * @param topicPartitions to set.
 	 * @see #setTopics(String...)
 	 * @see #setTopicPattern(Pattern)
 	 */
-	public void setTopicPartitions(TopicPartition... topicPartitions) {
+	public void setTopicPartitions(TopicPartitionInitialOffset... topicPartitions) {
 		Assert.notNull(topicPartitions, "'topics' must not be null");
 		this.topicPartitions.clear();
 		this.topicPartitions.addAll(Arrays.asList(topicPartitions));
@@ -154,7 +153,7 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 	 * @return the topicPartitions for this endpoint.
 	 */
 	@Override
-	public Collection<TopicPartition> getTopicPartitions() {
+	public Collection<TopicPartitionInitialOffset> getTopicPartitions() {
 		return Collections.unmodifiableCollection(this.topicPartitions);
 	}
 
@@ -162,7 +161,7 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 	 * Set the topic pattern to use. Cannot be used with
 	 * topics or topicPartitions.
 	 * @param topicPattern the pattern
-	 * @see #setTopicPartitions(TopicPartition...)
+	 * @see #setTopicPartitions(TopicPartitionInitialOffset...)
 	 * @see #setTopics(String...)
 	 */
 	public void setTopicPattern(Pattern topicPattern) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/ConcurrentKafkaListenerContainerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/ConcurrentKafkaListenerContainerFactory.java
@@ -18,10 +18,9 @@ package org.springframework.kafka.config;
 
 import java.util.Collection;
 
-import org.apache.kafka.common.TopicPartition;
-
 import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
 import org.springframework.kafka.listener.config.ContainerProperties;
+import org.springframework.kafka.support.TopicPartitionInitialOffset;
 
 /**
  * A {@link KafkaListenerContainerFactory} implementation to build a
@@ -54,10 +53,10 @@ public class ConcurrentKafkaListenerContainerFactory<K, V>
 
 	@Override
 	protected ConcurrentMessageListenerContainer<K, V> createContainerInstance(KafkaListenerEndpoint endpoint) {
-		Collection<TopicPartition> topicPartitions = endpoint.getTopicPartitions();
+		Collection<TopicPartitionInitialOffset> topicPartitions = endpoint.getTopicPartitions();
 		if (!topicPartitions.isEmpty()) {
 			ContainerProperties properties = new ContainerProperties(
-					topicPartitions.toArray(new TopicPartition[topicPartitions.size()]));
+					topicPartitions.toArray(new TopicPartitionInitialOffset[topicPartitions.size()]));
 			return new ConcurrentMessageListenerContainer<K, V>(getConsumerFactory(), properties);
 		}
 		else {

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpoint.java
@@ -19,9 +19,8 @@ package org.springframework.kafka.config;
 import java.util.Collection;
 import java.util.regex.Pattern;
 
-import org.apache.kafka.common.TopicPartition;
-
 import org.springframework.kafka.listener.MessageListenerContainer;
+import org.springframework.kafka.support.TopicPartitionInitialOffset;
 import org.springframework.kafka.support.converter.MessageConverter;
 
 /**
@@ -59,7 +58,7 @@ public interface KafkaListenerEndpoint {
 	 * Return the topicPartitions for this endpoint.
 	 * @return the topicPartitions for this endpoint.
 	 */
-	Collection<TopicPartition> getTopicPartitions();
+	Collection<TopicPartitionInitialOffset> getTopicPartitions();
 
 	/**
 	 * Return the topicPattern for this endpoint.

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/config/ContainerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/config/ContainerProperties.java
@@ -22,7 +22,6 @@ import java.util.regex.Pattern;
 
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.OffsetCommitCallback;
-import org.apache.kafka.common.TopicPartition;
 
 import org.springframework.core.task.AsyncListenableTaskExecutor;
 import org.springframework.kafka.listener.AbstractMessageListenerContainer;
@@ -31,12 +30,14 @@ import org.springframework.kafka.listener.AcknowledgingMessageListener;
 import org.springframework.kafka.listener.ErrorHandler;
 import org.springframework.kafka.listener.LoggingErrorHandler;
 import org.springframework.kafka.listener.MessageListener;
+import org.springframework.kafka.support.TopicPartitionInitialOffset;
 import org.springframework.util.Assert;
 
 /**
  * Contains runtime properties for a listener container.
  *
  * @author Gary Russell
+ * @author Artem Bilan
  */
 public class ContainerProperties {
 
@@ -57,9 +58,9 @@ public class ContainerProperties {
 	private final Pattern topicPattern;
 
 	/**
-	 * Topics/partitions.
+	 * Topics/partitions/initial offsets.
 	 */
-	private final TopicPartition[] topicPartitions;
+	private final TopicPartitionInitialOffset[] topicPartitions;
 
 	/**
 	 * The ack mode to use when auto ack (in the configuration properties) is false.
@@ -143,13 +144,6 @@ public class ContainerProperties {
 	private long shutdownTimeout = DEFAULT_SHUTDOWN_TIMEOUT;
 
 	/**
-	 * The offset to this number of records back from the latest when starting.
-	 * Overrides any consumer properties (earliest, latest). Only applies when
-	 * explicit topic/partition assignment is provided.
-	 */
-	private long recentOffset;
-
-	/**
 	 * A user defined {@link ConsumerRebalanceListener} implementation.
 	 */
 	private ConsumerRebalanceListener consumerRebalanceListener;
@@ -185,12 +179,12 @@ public class ContainerProperties {
 		this.topicPartitions = null;
 	}
 
-	public ContainerProperties(TopicPartition... topicPartitions) {
+	public ContainerProperties(TopicPartitionInitialOffset... topicPartitions) {
 		this.topics = null;
 		this.topicPattern = null;
 		Assert.notEmpty(topicPartitions, "An array of topicPartitions must be provided");
 		this.topicPartitions = new LinkedHashSet<>(Arrays.asList(topicPartitions))
-				.toArray(new TopicPartition[topicPartitions.length]);
+				.toArray(new TopicPartitionInitialOffset[topicPartitions.length]);
 	}
 
 	/**
@@ -311,16 +305,6 @@ public class ContainerProperties {
 	}
 
 	/**
-	 * Set the offset to this number of records back from the latest when starting.
-	 * Overrides any consumer properties (earliest, latest). Only applies when
-	 * explicit topic/partition assignment is provided.
-	 * @param recentOffset the offset from the latest; default 0.
-	 */
-	public void setRecentOffset(long recentOffset) {
-		this.recentOffset = recentOffset;
-	}
-
-	/**
 	 * Set the user defined {@link ConsumerRebalanceListener} implementation.
 	 * @param consumerRebalanceListener the {@link ConsumerRebalanceListener} instance
 	 */
@@ -380,7 +364,7 @@ public class ContainerProperties {
 		return this.topicPattern;
 	}
 
-	public TopicPartition[] getTopicPartitions() {
+	public TopicPartitionInitialOffset[] getTopicPartitions() {
 		return this.topicPartitions;
 	}
 
@@ -432,10 +416,6 @@ public class ContainerProperties {
 		return this.shutdownTimeout;
 	}
 
-	public long getRecentOffset() {
-		return this.recentOffset;
-	}
-
 	public ConsumerRebalanceListener getConsumerRebalanceListener() {
 		return this.consumerRebalanceListener;
 	}
@@ -455,4 +435,5 @@ public class ContainerProperties {
 	public boolean isAckOnError() {
 		return this.ackOnError;
 	}
+
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/TopicPartitionInitialOffset.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/TopicPartitionInitialOffset.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support;
+
+import java.util.Objects;
+
+import org.apache.kafka.common.TopicPartition;
+
+/**
+ * A configuration container to represent topic name, partition number and initial offset for it.
+ * The initial offset can be:
+ * - {@code null} - do nothing; rely on the {@code auto.offset.reset} of {@code Consumer} config;
+ * - positive (including {@code 0}) - absolute offset from the begging of partition;
+ * - negative - the offset from the end of partition: {@code consumer.seekToEnd() - initialOffset};
+ *
+ * @author Artem Bilan
+ */
+public class TopicPartitionInitialOffset {
+
+	private final TopicPartition topicPartition;
+
+	private final Long initialOffset;
+
+	public TopicPartitionInitialOffset(String topic, int partition) {
+		this(topic, partition, null);
+	}
+
+	public TopicPartitionInitialOffset(String topic, int partition, Long initialOffset) {
+		this.topicPartition = new TopicPartition(topic, partition);
+		this.initialOffset = initialOffset;
+	}
+
+	public TopicPartition topicPartition() {
+		return this.topicPartition;
+	}
+
+	public int partition() {
+		return this.topicPartition.partition();
+	}
+
+	public String topic() {
+		return this.topicPartition.topic();
+	}
+
+	public Long initialOffset() {
+		return this.initialOffset;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		TopicPartitionInitialOffset that = (TopicPartitionInitialOffset) o;
+		return Objects.equals(this.topicPartition, that.topicPartition) &&
+				Objects.equals(this.initialOffset, that.initialOffset);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(this.topicPartition, this.initialOffset);
+	}
+
+	@Override
+	public String toString() {
+		return "TopicPartitionInitialOffset{" +
+				"topicPartition=" + this.topicPartition +
+				", initialOffset=" + this.initialOffset +
+				'}';
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/TopicPartitionInitialOffset.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/TopicPartitionInitialOffset.java
@@ -69,13 +69,12 @@ public class TopicPartitionInitialOffset {
 			return false;
 		}
 		TopicPartitionInitialOffset that = (TopicPartitionInitialOffset) o;
-		return Objects.equals(this.topicPartition, that.topicPartition) &&
-				Objects.equals(this.initialOffset, that.initialOffset);
+		return Objects.equals(this.topicPartition, that.topicPartition);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(this.topicPartition, this.initialOffset);
+		return this.topicPartition.hashCode();
 	}
 
 	@Override

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -453,7 +453,8 @@ public class EnableKafkaIntegrationTests {
 
 		@KafkaListener(id = "fiz", topicPartitions = {
 				@TopicPartition(topic = "annotated5", partitions = { "#{'${foo:0,1}'.split(',')}" }),
-				@TopicPartition(topic = "annotated6", partitions = { "0", "1" })
+				@TopicPartition(topic = "annotated6", partitions = "0",
+						partitionOffsets = @PartitionOffset(partition = "1", initialOffset = "0") )
 		})
 		public void listen5(ConsumerRecord<?, ?> record) {
 			this.record = record;

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -149,31 +149,31 @@ public KafkaMessageListenerContainer(ConsumerFactory<K, V> consumerFactory,
                                                         ContainerProperties containerProperties)
 
 public KafkaMessageListenerContainer(ConsumerFactory<K, V> consumerFactory,
-                        ContainerProperties containerProperties, TopicPartition... topicPartitions)
+                    ContainerProperties containerProperties, TopicPartitionInitialOffset... topicPartitions)
 
 ----
 
 Each takes a `ConsumerFactory` and information about topics and partitions, as well as other configuration in a `ContainerProperties`
 object.
-The second constructor is used by the `ConcurrentMessageListenerContainer` (see below) to distribute `TopicPartitions` across the consumer instances.
+The second constructor is used by the `ConcurrentMessageListenerContainer` (see below) to distribute `TopicPartitionInitialOffset` across the consumer instances.
 `ContainerProperties` has the following constructors:
 
 [source, java]
 ----
-public ContainerProperties(TopicPartition... topicPartitions)
+public ContainerProperties(TopicPartitionInitialOffset... topicPartitions)
 
 public ContainerProperties(String... topics)
 
 public ContainerProperties(Pattern topicPattern)
 ----
 
-The first takes an array of `TopicPartition` arguments to explicitly instruct the container which partitions to use
-(using the consumer `assign()` method).
+The first takes an array of `TopicPartitionInitialOffset` arguments to explicitly instruct the container which partitions to use
+(using the consumer `assign()` method) and with which initial offset: positive value is absolute from the beginning; negative is from the end of partition.
 The second takes an array of topics and Kafka allocates the partitions based on the `group.id` property - distributing
 partitions across the group.
 The third uses a regex `Pattern` to select the topics.
 
-Refer to the javadocs for `ContainerProperties` for more information about the various properties that can be set.
+Refer to the JavaDocs for `ContainerProperties` for more information about the various properties that can be set.
 
 ====== ConcurrentMessageListenerContainer
 

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -290,13 +290,14 @@ public Map<String, Object> consumerConfigs() {
 Notice that to set container properties, you must use the `getContainerProperties()` method on the factory.
 It is used as a template for the actual properties injected into the container.
 
-You can also configure POJO listeners with explicit topics and partitions:
+You can also configure POJO listeners with explicit topics and partitions (and even their initial offsets):
 
 [source, java]
 ----
 @KafkaListener(id = "bar", topicPartitions =
         { @TopicPartition(topic = "topic1", partitions = { "0", "1" }),
-          @TopicPartition(topic = "topic2", partitions = { "0", "1" })
+          @TopicPartition(topic = "topic2", partitions = "0",
+             partitionOffsets = @PartitionOffset(partition = "1", initialOffset = "100"))
         })
 public void listen(ConsumerRecord<?, ?> record) {
     ...


### PR DESCRIPTION
Fixes GH-89 (https://github.com/spring-projects/spring-kafka/issues/89)

* Introduce `TopicPartitionInitialOffset`, where it utilize `TopicPartition` and `Long initialOffset`
* The `initialOffset` can be:
  - `null` - do nothing; rely on the `auto.offset.reset` of `Consumer` config;
  - positive (including `0`) - absolute offset from the begging of partition;
  - negative - the offset from the end of partition: `consumer.seekToEnd() - initialOffset`
* Rework everything around to rely on a new `TopicPartitionInitialOffset` abstraction
* The logic in the `KafkaMessageListenerContainer.ListenerConsumer.initPartitionsIfNeeded()` reworked to in favor of a new abstraction
* remove redundant `recentOffset`
* Reflect new `TopicPartitionInitialOffset` in the docs