### PR TITLE
GH-124: Validate `ackCount` and `ackTime`

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
@@ -37,6 +37,7 @@ import org.springframework.retry.support.RetryTemplate;
  *
  * @author Stephane Nicoll
  * @author Gary Russell
+ * @author Artem Bilan
  *
  * @see AbstractMessageListenerContainer
  */
@@ -204,7 +205,13 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 	protected void initializeContainer(C instance) {
 		ContainerProperties properties = instance.getContainerProperties();
 		BeanUtils.copyProperties(this.containerProperties, properties, "topics", "topicPartitions", "topicPattern",
-				"messageListener");
+				"messageListener", "ackCount", "ackTime");
+		if (this.containerProperties.getAckCount() > 0) {
+			properties.setAckCount(this.containerProperties.getAckCount());
+		}
+		if (this.containerProperties.getAckTime() > 0) {
+			properties.setAckTime(this.containerProperties.getAckTime());
+		}
 	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
@@ -85,6 +85,7 @@ public abstract class AbstractMessageListenerContainer<K, V>
 
 		/**
 		 * Same as {@link #COUNT_TIME} except for pending manual acks.
+		 * If no count or time are set, works as {@link #MANUAL_IMMEDIATE_SYNC}.
 		 */
 		MANUAL,
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -140,8 +140,19 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 		if (isRunning()) {
 			return;
 		}
-		setRunning(true);
-		Object messageListener = getContainerProperties().getMessageListener();
+		ContainerProperties containerProperties = getContainerProperties();
+
+		if (!this.consumerFactory.isAutoCommit()) {
+			AckMode ackMode = containerProperties.getAckMode();
+			if (ackMode.equals(AckMode.BATCH) || ackMode.equals(AckMode.COUNT) || ackMode.equals(AckMode.COUNT_TIME)) {
+				Assert.state(containerProperties.getAckCount() > 0, "'ackCount' must be > 0");
+			}
+			if (ackMode.equals(AckMode.TIME) || ackMode.equals(AckMode.COUNT_TIME)) {
+				Assert.state(containerProperties.getAckTime() > 0, "'ackTime' must be > 0");
+			}
+		}
+
+		Object messageListener = containerProperties.getMessageListener();
 		Assert.state(messageListener != null, "A MessageListener is required");
 		if (messageListener instanceof AcknowledgingMessageListener) {
 			this.acknowledgingMessageListener = (AcknowledgingMessageListener<K, V>) messageListener;
@@ -153,20 +164,21 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 			throw new IllegalStateException("messageListener must be 'MessageListener' "
 					+ "or 'AcknowledgingMessageListener', not " + messageListener.getClass().getName());
 		}
-		if (getContainerProperties().getConsumerTaskExecutor() == null) {
+		if (containerProperties.getConsumerTaskExecutor() == null) {
 			SimpleAsyncTaskExecutor consumerExecutor = new SimpleAsyncTaskExecutor(
 					(getBeanName() == null ? "" : getBeanName()) + "-kafka-consumer-");
-			getContainerProperties().setConsumerTaskExecutor(consumerExecutor);
+			containerProperties.setConsumerTaskExecutor(consumerExecutor);
 		}
-		if (getContainerProperties().getListenerTaskExecutor() == null) {
+		if (containerProperties.getListenerTaskExecutor() == null) {
 			SimpleAsyncTaskExecutor listenerExecutor = new SimpleAsyncTaskExecutor(
 					(getBeanName() == null ? "" : getBeanName()) + "-kafka-listener-");
-			getContainerProperties().setListenerTaskExecutor(listenerExecutor);
+			containerProperties.setListenerTaskExecutor(listenerExecutor);
 		}
 		this.listenerConsumer = new ListenerConsumer(this.listener, this.acknowledgingMessageListener);
-		this.listenerConsumerFuture = getContainerProperties()
+		this.listenerConsumerFuture = containerProperties
 				.getConsumerTaskExecutor()
 				.submitListenable(this.listenerConsumer);
+		setRunning(true);
 	}
 
 	@Override
@@ -615,7 +627,7 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 				if (ackMode.equals(AckMode.BATCH) || ackMode.equals(AckMode.COUNT) && countExceeded) {
 					if (this.logger.isDebugEnabled()) {
 						this.logger.debug("Committing in AckMode.COUNT because count " + this.count
-								+ " exceeds configured limit of" + this.containerProperties.getAckCount());
+								+ " exceeds configured limit of " + this.containerProperties.getAckCount());
 					}
 					commitIfNecessary();
 					this.count = 0;
@@ -626,8 +638,9 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 					if (ackMode.equals(AckMode.TIME) && elapsed) {
 						if (this.logger.isDebugEnabled()) {
 							this.logger
-									.debug("Committing in AckMode.TIME because time elapsed exceeds configured limit of "
-											+ this.containerProperties.getAckTime());
+									.debug("Committing in AckMode.TIME " +
+											"because time elapsed exceeds configured limit of " +
+											this.containerProperties.getAckTime());
 						}
 						commitIfNecessary();
 						this.last = now;
@@ -635,8 +648,9 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 					else if ((ackMode.equals(AckMode.COUNT_TIME) || this.isManualAck) && (elapsed || countExceeded)) {
 						if (this.logger.isDebugEnabled()) {
 							if (elapsed) {
-								this.logger.debug("Committing in AckMode." + ackMode.name() + " because time elapsed "
-										+ "exceeds configured limit of " + this.containerProperties.getAckTime());
+								this.logger.debug("Committing in AckMode." + ackMode.name() +
+										" because time elapsed exceeds configured limit of " +
+										this.containerProperties.getAckTime());
 							}
 							else {
 								this.logger.debug("Committing in AckMode." + ackMode.name() + " because count "

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/config/ContainerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/config/ContainerProperties.java
@@ -89,7 +89,7 @@ public class ContainerProperties {
 	 * {@link AckMode#TIME} or {@link AckMode#COUNT_TIME} is being used. Should be
 	 * larger than
 	 */
-	private long ackTime;
+	private long ackTime = 5000;
 
 	/**
 	 * The message listener; must be a {@link MessageListener} or

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/config/ContainerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/config/ContainerProperties.java
@@ -89,7 +89,7 @@ public class ContainerProperties {
 	 * {@link AckMode#TIME} or {@link AckMode#COUNT_TIME} is being used. Should be
 	 * larger than
 	 */
-	private long ackTime = 5000;
+	private long ackTime;
 
 	/**
 	 * The message listener; must be a {@link MessageListener} or
@@ -224,11 +224,11 @@ public class ContainerProperties {
 
 	/**
 	 * Set the number of outstanding record count after which offsets should be
-	 * committed when {@link AckMode#COUNT} or {@link AckMode#COUNT_TIME} is being
-	 * used.
+	 * committed when {@link AckMode#COUNT} or {@link AckMode#COUNT_TIME} is being used.
 	 * @param count the count
 	 */
 	public void setAckCount(int count) {
+		Assert.state(count > 0, "'ackCount' must be > 0");
 		this.ackCount = count;
 	}
 
@@ -236,10 +236,11 @@ public class ContainerProperties {
 	 * Set the time (ms) after which outstanding offsets should be committed when
 	 * {@link AckMode#TIME} or {@link AckMode#COUNT_TIME} is being used. Should be
 	 * larger than
-	 * @param millis the time
+	 * @param ackTime the time
 	 */
-	public void setAckTime(long millis) {
-		this.ackTime = millis;
+	public void setAckTime(long ackTime) {
+		Assert.state(ackTime > 0, "'ackTime' must be > 0");
+		this.ackTime = ackTime;
 	}
 
 	/**

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
@@ -198,7 +198,6 @@ public class ConcurrentMessageListenerContainerTests {
 			listenerThreadNames.add(Thread.currentThread().getName());
 			latch.countDown();
 		});
-		containerProps.setAckCount(1);
 		container.setConcurrency(2);
 		container.setBeanName("testBatch");
 		container.start();
@@ -255,7 +254,6 @@ public class ConcurrentMessageListenerContainerTests {
 			ConcurrentMessageListenerContainerTests.this.logger.info("auto part: " + message);
 			latch1.countDown();
 		});
-		container1Props.setAckCount(10);
 		container1.setBeanName("b1");
 		container1.start();
 
@@ -513,7 +511,6 @@ public class ConcurrentMessageListenerContainerTests {
 		ConcurrentMessageListenerContainer<Integer, String> container =
 				new ConcurrentMessageListenerContainer<>(cf, containerProps);
 		containerProps.setMessageListener((MessageListener<Integer, String>) message -> { });
-		containerProps.setAckCount(20);
 		container.setConcurrency(3);
 		container.start();
 		@SuppressWarnings("unchecked")
@@ -535,7 +532,8 @@ public class ConcurrentMessageListenerContainerTests {
 		ContainerProperties containerProps = new ContainerProperties(topic6);
 		containerProps.setAckCount(23);
 		ContainerProperties containerProps2 = new ContainerProperties(topic2);
-		BeanUtils.copyProperties(containerProps, containerProps2, "topics", "topicPartitions", "topicPattern");
+		BeanUtils.copyProperties(containerProps, containerProps2,
+				"topics", "topicPartitions", "topicPattern", "ackCount", "ackTime");
 		ConcurrentMessageListenerContainer<Integer, String> container =
 				new ConcurrentMessageListenerContainer<>(cf, containerProps);
 		final CountDownLatch latch = new CountDownLatch(4);
@@ -640,7 +638,6 @@ public class ConcurrentMessageListenerContainerTests {
 			listenerThreadNames.add(Thread.currentThread().getName());
 			latch.countDown();
 		});
-		containerProps.setAckCount(100);
 		container.setConcurrency(1);
 		container2.setConcurrency(1);
 		container.setBeanName("testAuto");

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
@@ -198,6 +198,7 @@ public class ConcurrentMessageListenerContainerTests {
 			listenerThreadNames.add(Thread.currentThread().getName());
 			latch.countDown();
 		});
+		containerProps.setAckCount(1);
 		container.setConcurrency(2);
 		container.setBeanName("testBatch");
 		container.start();
@@ -254,6 +255,7 @@ public class ConcurrentMessageListenerContainerTests {
 			ConcurrentMessageListenerContainerTests.this.logger.info("auto part: " + message);
 			latch1.countDown();
 		});
+		container1Props.setAckCount(10);
 		container1.setBeanName("b1");
 		container1.start();
 
@@ -511,6 +513,7 @@ public class ConcurrentMessageListenerContainerTests {
 		ConcurrentMessageListenerContainer<Integer, String> container =
 				new ConcurrentMessageListenerContainer<>(cf, containerProps);
 		containerProps.setMessageListener((MessageListener<Integer, String>) message -> { });
+		containerProps.setAckCount(20);
 		container.setConcurrency(3);
 		container.start();
 		@SuppressWarnings("unchecked")
@@ -637,6 +640,7 @@ public class ConcurrentMessageListenerContainerTests {
 			listenerThreadNames.add(Thread.currentThread().getName());
 			latch.countDown();
 		});
+		containerProps.setAckCount(100);
 		container.setConcurrency(1);
 		container2.setConcurrency(1);
 		container.setBeanName("testAuto");

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
@@ -113,7 +113,6 @@ public class KafkaMessageListenerContainerTests {
 		});
 		container.setBeanName("testSlow1");
 		containerProps.setPauseAfter(100);
-		containerProps.setAckCount(10);
 
 		container.start();
 		Consumer<?, ?> consumer = spyOnConsumer(container);
@@ -330,7 +329,6 @@ public class KafkaMessageListenerContainerTests {
 			}, buildRetry(), null);
 		containerProps.setMessageListener(adapter);
 		containerProps.setPauseAfter(100);
-		containerProps.setAckCount(10);
 		container.setBeanName("testSlow3");
 
 		container.start();
@@ -400,7 +398,6 @@ public class KafkaMessageListenerContainerTests {
 			}, buildRetry(), null);
 		containerProps.setMessageListener(adapter);
 		containerProps.setPauseAfter(100);
-		containerProps.setAckCount(10);
 		container.setBeanName("testSlow4");
 
 		container.start();

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
@@ -113,6 +113,7 @@ public class KafkaMessageListenerContainerTests {
 		});
 		container.setBeanName("testSlow1");
 		containerProps.setPauseAfter(100);
+		containerProps.setAckCount(10);
 
 		container.start();
 		Consumer<?, ?> consumer = spyOnConsumer(container);
@@ -329,6 +330,7 @@ public class KafkaMessageListenerContainerTests {
 			}, buildRetry(), null);
 		containerProps.setMessageListener(adapter);
 		containerProps.setPauseAfter(100);
+		containerProps.setAckCount(10);
 		container.setBeanName("testSlow3");
 
 		container.start();
@@ -398,6 +400,7 @@ public class KafkaMessageListenerContainerTests {
 			}, buildRetry(), null);
 		containerProps.setMessageListener(adapter);
 		containerProps.setPauseAfter(100);
+		containerProps.setAckCount(10);
 		container.setBeanName("testSlow4");
 
 		container.start();


### PR DESCRIPTION
Fixes GH-124 (https://github.com/spring-projects/spring-kafka/issues/124)

That doesn't look reasonable to have void `commitIfNecessary()` if we exceed default `0` for `ackCount` or `ackTime`.

* Add requirement to have `ackCount` and `ackTime` `> 0` in case appropriate `ackMode`
* Make `ackTime` as 5 secs by default - similar to default for `auto.commit.interval.ms`