### PR TITLE
GH-134: Ignore flush() if 'producer' is not inititalized yet

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
@@ -31,6 +31,7 @@ import org.springframework.kafka.support.SendResult;
 import org.springframework.kafka.support.converter.MessageConverter;
 import org.springframework.kafka.support.converter.MessagingMessageConverter;
 import org.springframework.messaging.Message;
+import org.springframework.util.Assert;
 import org.springframework.util.concurrent.ListenableFuture;
 import org.springframework.util.concurrent.SettableListenableFuture;
 
@@ -52,7 +53,7 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V> {
 
 	private MessageConverter messageConverter = new MessagingMessageConverter();
 
-private final boolean autoFlush;
+	private final boolean autoFlush;
 	private volatile Producer<K, V> producer;
 
 	private volatile String defaultTopic;
@@ -172,6 +173,7 @@ private final boolean autoFlush;
 
 	@Override
 	public void flush() {
+		Assert.state(this.producer != null, "'producer' must not be null for flushing.");
 		this.producer.flush();
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
@@ -35,7 +35,6 @@ import org.springframework.util.Assert;
 import org.springframework.util.concurrent.ListenableFuture;
 import org.springframework.util.concurrent.SettableListenableFuture;
 
-
 /**
  * A template for executing high-level operations.
  *
@@ -44,6 +43,7 @@ import org.springframework.util.concurrent.SettableListenableFuture;
  *
  * @author Marius Bogoevici
  * @author Gary Russell
+ * @author Igor Stepanov
  */
 public class KafkaTemplate<K, V> implements KafkaOperations<K, V> {
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTests.java
@@ -195,4 +195,14 @@ public class KafkaTemplateTests {
 		pf.createProducer().close();
 	}
 
+	@Test(expected = IllegalStateException.class)
+	public void flushWithoutSend() throws Exception {
+		Map<String, Object> senderProps = KafkaTestUtils.producerProps(embeddedKafka);
+		DefaultKafkaProducerFactory<String, String> pf = new DefaultKafkaProducerFactory<String, String>(senderProps);
+		pf.setKeySerializer(new StringSerializer());
+		KafkaTemplate<String, String> template = new KafkaTemplate<>(pf);
+		template.setDefaultTopic(STRING_KEY_TOPIC);
+		template.flush();
+		throw new AssertionError("IllegalStateException must be thrown upon flushing");
+	}
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTests.java
@@ -17,10 +17,12 @@
 package org.springframework.kafka.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.springframework.kafka.test.assertj.KafkaConditions.key;
 import static org.springframework.kafka.test.assertj.KafkaConditions.partition;
 import static org.springframework.kafka.test.assertj.KafkaConditions.value;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -46,10 +48,10 @@ import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.util.concurrent.ListenableFuture;
 import org.springframework.util.concurrent.ListenableFutureCallback;
 
-
 /**
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Igor Stepanov
  *
  */
 public class KafkaTemplateTests {
@@ -195,14 +197,12 @@ public class KafkaTemplateTests {
 		pf.createProducer().close();
 	}
 
-	@Test(expected = IllegalStateException.class)
+	@Test
 	public void flushWithoutSend() throws Exception {
-		Map<String, Object> senderProps = KafkaTestUtils.producerProps(embeddedKafka);
-		DefaultKafkaProducerFactory<String, String> pf = new DefaultKafkaProducerFactory<String, String>(senderProps);
-		pf.setKeySerializer(new StringSerializer());
-		KafkaTemplate<String, String> template = new KafkaTemplate<>(pf);
-		template.setDefaultTopic(STRING_KEY_TOPIC);
-		template.flush();
-		throw new AssertionError("IllegalStateException must be thrown upon flushing");
+		DefaultKafkaProducerFactory<String, String> pf = new DefaultKafkaProducerFactory<String, String>(Collections.emptyMap());
+		KafkaTemplate<String, String> template = new KafkaTemplate<String, String>(pf);
+		assertThatExceptionOfType(IllegalStateException.class)
+				.isThrownBy(() -> template.flush())
+				.withMessageContaining("'producer' must not be null for flushing.");
 	}
 }


### PR DESCRIPTION
Reworked based on comments from https://github.com/spring-projects/spring-kafka/pull/137