### PR TITLE
GH-135: Fix BATCH Acks

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -448,6 +448,9 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 					}
 				}
 				catch (WakeupException e) {
+					if (!this.autoCommit) {
+						processCommits();
+					}
 					this.unsent = checkPause(this.unsent);
 				}
 				catch (Exception e) {


### PR DESCRIPTION
Hi,

In reference to #135 
Described scenario still exists for ack mode = BATCH

When:
- pollTimeout = 10s
- ack mode = BATCH

Then:
- records processed by MessageListener are not commited
