### PR TITLE
GH-148: Initial Offsets Relative to Current

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
@@ -489,12 +489,26 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 			}
 			else {
 				throw new IllegalArgumentException(String.format(
-						"@PartitionOffset for topic '%s' can't resolve '%s' as an Long or String, resolved to '%s'",
+						"@PartitionOffset for topic '%s' can't resolve '%s' as a Long or String, resolved to '%s'",
 							topic, partitionOffset.initialOffset(), initialOffsetValue.getClass()));
 			}
 
+			Object relativeToCurrentValue = resolveExpression(partitionOffset.relativeToCurrent());
+			Boolean relativeToCurrent;
+			if (relativeToCurrentValue instanceof String) {
+				relativeToCurrent = Boolean.valueOf((String) relativeToCurrentValue);
+			}
+			else if (relativeToCurrentValue instanceof Boolean) {
+				relativeToCurrent = (Boolean) relativeToCurrentValue;
+			}
+			else {
+				throw new IllegalArgumentException(String.format(
+						"@PartitionOffset for topic '%s' can't resolve '%s' as a Boolean or String, resolved to '%s'",
+							topic, partitionOffset.relativeToCurrent(), relativeToCurrentValue.getClass()));
+			}
+
 			TopicPartitionInitialOffset topicPartitionOffset =
-					new TopicPartitionInitialOffset((String) topic, partition, initialOffset);
+					new TopicPartitionInitialOffset((String) topic, partition, initialOffset, relativeToCurrent);
 			if (!result.contains(topicPartitionOffset)) {
 				result.add(topicPartitionOffset);
 			}

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/PartitionOffset.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/PartitionOffset.java
@@ -45,4 +45,13 @@ public @interface PartitionOffset {
 	 */
 	String initialOffset();
 
+	/**
+	 * By default, positive {@link #initialOffset()} is absolute, negative
+	 * is relative to the current topic end. When this is 'true', the
+	 * initial offset (positive or negative) is relative to the current
+	 * consumer position.
+	 * @return whether or not the offset is relative to the current position.
+	 */
+	String relativeToCurrent() default "false";
+
 }

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -169,7 +169,9 @@ public ContainerProperties(Pattern topicPattern)
 ----
 
 The first takes an array of `TopicPartitionInitialOffset` arguments to explicitly instruct the container which partitions to use
-(using the consumer `assign()` method), and with an optional initial offset: a positive value is an absolute offset; a negative value is relative to the current last offset within a partition.
+(using the consumer `assign()` method), and with an optional initial offset: a positive value is an absolute offset by default; a negative value is relative to the current last offset within a partition by default.
+A constructor for `TopicPartitionInitialOffset` is provided that takes an additional `boolean` argument.
+If this is `true`, the initial offets (positive or negative) are relative to the current position for this consumer.
 The offsets are applied when the container is started.
 The second takes an array of topics and Kafka allocates the partitions based on the `group.id` property - distributing
 partitions across the group.

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -171,7 +171,7 @@ public ContainerProperties(Pattern topicPattern)
 The first takes an array of `TopicPartitionInitialOffset` arguments to explicitly instruct the container which partitions to use
 (using the consumer `assign()` method), and with an optional initial offset: a positive value is an absolute offset by default; a negative value is relative to the current last offset within a partition by default.
 A constructor for `TopicPartitionInitialOffset` is provided that takes an additional `boolean` argument.
-If this is `true`, the initial offets (positive or negative) are relative to the current position for this consumer.
+If this is `true`, the initial offsets (positive or negative) are relative to the current position for this consumer.
 The offsets are applied when the container is started.
 The second takes an array of topics and Kafka allocates the partitions based on the `group.id` property - distributing
 partitions across the group.


### PR DESCRIPTION
Resolves #148

Provide an option to set the initial offset relative to the current position.

__no backport; will need rebase and/or fixup after #147 is merged__
