### PR TITLE
GH-150: Don't eat errors in `AbstractAdaptableML`

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/AbstractAdaptableMessageListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/AbstractAdaptableMessageListener.java
@@ -42,11 +42,10 @@ public abstract class AbstractAdaptableMessageListener<K, V> implements MessageL
 
 	protected final Log logger = LogFactory.getLog(getClass()); //NOSONAR
 
-
 	/**
 	 * Kafka {@link MessageListener} entry point.
-	 * <p> Delegate the message to the target listener method, with appropriate conversion of the message argument.
-	 * In case of an exception, the {@link #handleListenerException(Throwable)} method will be invoked.
+	 * <p> Delegate the message to the target listener method,
+	 * with appropriate conversion of the message argument.
 	 * @param record the incoming Kafka {@link ConsumerRecord}.
 	 * @see #handleListenerException
 	 * @see AcknowledgingMessageListener#onMessage(ConsumerRecord, org.springframework.kafka.support.Acknowledgment)
@@ -58,16 +57,13 @@ public abstract class AbstractAdaptableMessageListener<K, V> implements MessageL
 
 	/**
 	 * Handle the given exception that arose during listener execution.
+	 * Can be used by inheritors from overridden {@link #onMessage(ConsumerRecord)}
+	 * or {@link #onMessage(ConsumerRecord, org.springframework.kafka.support.Acknowledgment)}
 	 * The default implementation logs the exception at error level.
-	 * <p> This method only applies when using a Kafka {@link MessageListener}. With
-	 * {@link AcknowledgingMessageListener}, exceptions get handled by the
-	 * caller instead.
 	 * @param ex the exception to handle
-	 * @see #onMessage(ConsumerRecord)
-	 * @deprecated with no-op. Will be removed in the next release.
 	 */
-	@Deprecated
 	protected void handleListenerException(Throwable ex) {
+		this.logger.error("Listener execution failed", ex);
 	}
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/AbstractAdaptableMessageListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/AbstractAdaptableMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.springframework.kafka.listener.MessageListener;
  *
  * @author Stephane Nicoll
  * @author Gary Russell
+ * @author Artem Bilan
  *
  * @see MessageListener
  * @see AcknowledgingMessageListener
@@ -52,12 +53,7 @@ public abstract class AbstractAdaptableMessageListener<K, V> implements MessageL
 	 */
 	@Override
 	public void onMessage(ConsumerRecord<K, V> record) {
-		try {
-			onMessage(record, null);
-		}
-		catch (Exception ex) {
-			handleListenerException(ex);
-		}
+		onMessage(record, null);
 	}
 
 	/**
@@ -68,9 +64,10 @@ public abstract class AbstractAdaptableMessageListener<K, V> implements MessageL
 	 * caller instead.
 	 * @param ex the exception to handle
 	 * @see #onMessage(ConsumerRecord)
+	 * @deprecated with no-op. Will be removed in the next release.
 	 */
+	@Deprecated
 	protected void handleListenerException(Throwable ex) {
-		this.logger.error("Listener execution failed", ex);
 	}
 
 	/**


### PR DESCRIPTION
Fixes: GH-150 (https://github.com/spring-projects/spring-kafka/issues/150)

In some corner cases the target `MessageListener` implementation may decide to invoke `AbstractAdaptableMessageListener.onMessage(message)` of its delegate.
In this case we can't receive any exceptions back into container for handling, because `handleListenerException()` just logs them.

* Deprecate `handleListenerException()` and don't wrap `onMessage(message, null)` call with `try...catch` to let exception bubble in container back,
like it is with regular `onMessage(message, null)` in the container.

(Consider to remove `handleListenerException()` altogether for current `1.1` `master`)

**Cherry-pick to 1.0.x**