### PR TITLE
GH-164: Document Log Compaction Support

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/converter/MessagingMessageConverter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/converter/MessagingMessageConverter.java
@@ -97,7 +97,13 @@ public class MessagingMessageConverter implements MessageConverter {
 	 * @return the payload.
 	 */
 	protected Object convertPayload(Message<?> message) {
-		return message.getPayload();
+		Object payload = message.getPayload();
+		if (payload instanceof KafkaNull) {
+			return null;
+		}
+		else {
+			return payload;
+		}
 	}
 
 	/**

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -512,3 +512,53 @@ Hence we use `startsWith` in the condition.
 CAUTION: If you wish to use the idle event to stop the lister container, you should not call `container.stop()` on the thread that calls the listener - it will cause delays and unnecessary log messages.
 Instead, you should hand off the event to a different thread that can then stop the container.
 Also, you should not `stop()` the container instance in the event if it is a child container, you should stop the concurrent container instead.
+
+==== Log Compaction
+
+When using https://cwiki.apache.org/confluence/display/KAFKA/Log+Compaction[Log Compaction], it is possible to send and receive messages with `null` payloads which identifies the deletion of a key.
+
+Starting with _version 1.0.3, this is now fully supported.
+
+To send a `null` payload using the `KafkaTemplate` simply pass null into the value argument of the `send()` methods.
+One exception to this is the `send(Message<?> message)` variant.
+Since `spring-messaging` `Message<?>` cannot have a `null` payload, a special payload type `KafkaNull` is used and the framework will send `null`.
+For convenience, the static `KafkaNull.INSTANCE` is provided.
+
+When using a message listener container, the received `ConsumerRecord` will have a `null` `value()`.
+
+To configure the `@KafkaListener` to handle `null` payloads, you must use the `@Payload` annotation with `required = false`; you will usually also need the key so your application knows which key was "deleted":
+
+[source, java]
+----
+@KafkaListener(id = "deletableListener", topics = "myTopic")
+public void listen(@Payload(required = false) String value, @Header(KafkaHeaders.RECEIVED_MESSAGE_KEY) String key) {
+    // value == null represents key deletion
+}
+----
+
+When using a class-level `@KafkaListener`, some additional configuration is needed - a `@KafkaHandler` method with a `KafkaNull` payload:
+
+[source, java]
+----
+@KafkaListener(id = "multi", topics = "myTopic")
+static class MultiListenerBean {
+
+    private final CountDownLatch latch1 = new CountDownLatch(2);
+
+    @KafkaHandler
+    public void listen(String foo) {
+        ...
+    }
+
+    @KafkaHandler
+    public void listen(Integer bar) {
+        ...
+    }
+
+    @KafkaHandler
+    public void delete(@Payload(required = false) KafkaNull nul, @Header(KafkaHeaders.RECEIVED_MESSAGE_KEY) int key) {
+        ...
+    }
+
+}
+----


### PR DESCRIPTION
Resolves #164

Also fix message conversion for `send(Message<?> m)`.

__cherry-pick to 1.0.x__