### PR TITLE
GH-175: Fix Acknowledgment with @KafkaListener

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -295,7 +295,81 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 				"Consumer cannot be configured for auto commit for ackMode " + this.containerProperties.getAckMode());
 			final Consumer<K, V> consumer = KafkaMessageListenerContainer.this.consumerFactory.createConsumer();
 
-			ConsumerRebalanceListener rebalanceListener = new ConsumerRebalanceListener() {
+			ConsumerRebalanceListener rebalanceListener = createRebalanceListener(consumer);
+
+			if (KafkaMessageListenerContainer.this.topicPartitions == null) {
+				if (this.containerProperties.getTopicPattern() != null) {
+					consumer.subscribe(this.containerProperties.getTopicPattern(), rebalanceListener);
+				}
+				else {
+					consumer.subscribe(Arrays.asList(this.containerProperties.getTopics()), rebalanceListener);
+				}
+			}
+			else {
+				List<TopicPartitionInitialOffset> topicPartitions =
+						Arrays.asList(KafkaMessageListenerContainer.this.topicPartitions);
+				this.definedPartitions = new HashMap<>(topicPartitions.size());
+				for (TopicPartitionInitialOffset topicPartition : topicPartitions) {
+					this.definedPartitions.put(topicPartition.topicPartition(),
+							new OffsetMetadata(topicPartition.initialOffset(), topicPartition.isRelativeToCurrent()));
+				}
+				consumer.assign(new ArrayList<>(this.definedPartitions.keySet()));
+			}
+			this.consumer = consumer;
+			Object theListener = listener == null ? ackListener : listener;
+			GenericErrorHandler<?> errHandler = this.containerProperties.getGenericErrorHandler();
+			if (theListener instanceof AcknowledgingMessageListener) {
+				this.listener = null;
+				this.acknowledgingMessageListener = (AcknowledgingMessageListener<K, V>) theListener;
+				this.batchListener = null;
+				this.batchAcknowledgingMessageListener = null;
+				this.isBatchListener = false;
+				validateErrorHandler(false);
+				this.errorHandler = errHandler == null ? new LoggingErrorHandler() : (ErrorHandler) errHandler;
+				this.batchErrorHandler = new BatchLoggingErrorHandler();
+			}
+			else if (theListener instanceof BatchAcknowledgingMessageListener) {
+				this.listener = null;
+				this.batchListener = null;
+				this.acknowledgingMessageListener = null;
+				this.batchAcknowledgingMessageListener = (BatchAcknowledgingMessageListener<K, V>) theListener;
+				this.isBatchListener = true;
+				validateErrorHandler(true);
+				this.errorHandler = new LoggingErrorHandler();
+				this.batchErrorHandler = errHandler == null ? new BatchLoggingErrorHandler()
+						: (BatchErrorHandler) errHandler;
+			}
+			else if (theListener instanceof MessageListener) {
+				this.listener = (MessageListener<K, V>) theListener;
+				this.batchListener = null;
+				this.acknowledgingMessageListener = null;
+				this.batchAcknowledgingMessageListener = null;
+				this.isBatchListener = false;
+				validateErrorHandler(false);
+				this.errorHandler = errHandler == null ? new LoggingErrorHandler() : (ErrorHandler) errHandler;
+				this.batchErrorHandler = new BatchLoggingErrorHandler();
+			}
+			else if (theListener instanceof BatchMessageListener) {
+				this.listener = null;
+				this.batchListener = (BatchMessageListener<K, V>) theListener;
+				this.acknowledgingMessageListener = null;
+				this.batchAcknowledgingMessageListener = null;
+				this.isBatchListener = true;
+				validateErrorHandler(true);
+				this.errorHandler = new LoggingErrorHandler();
+				this.batchErrorHandler = errHandler == null ? new BatchLoggingErrorHandler()
+						: (BatchErrorHandler) errHandler;
+			}
+			else {
+				throw new IllegalArgumentException("Listener must be one of 'MessageListener', "
+						+ "'BatchMessageListener', 'AcknowledgingMessageListener', "
+						+ "'BatchAcknowledgingMessageListener', not " + theListener.getClass().getName());
+			}
+			Assert.state(!this.isBatchListener || !this.isRecordAck, "Cannot use AckMode.RECORD with a batch listener");
+		}
+
+		public ConsumerRebalanceListener createRebalanceListener(final Consumer<K, V> consumer) {
+			return new ConsumerRebalanceListener() {
 
 				@Override
 				public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
@@ -364,76 +438,6 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 				}
 
 			};
-
-			if (KafkaMessageListenerContainer.this.topicPartitions == null) {
-				if (this.containerProperties.getTopicPattern() != null) {
-					consumer.subscribe(this.containerProperties.getTopicPattern(), rebalanceListener);
-				}
-				else {
-					consumer.subscribe(Arrays.asList(this.containerProperties.getTopics()), rebalanceListener);
-				}
-			}
-			else {
-				List<TopicPartitionInitialOffset> topicPartitions =
-						Arrays.asList(KafkaMessageListenerContainer.this.topicPartitions);
-				this.definedPartitions = new HashMap<>(topicPartitions.size());
-				for (TopicPartitionInitialOffset topicPartition : topicPartitions) {
-					this.definedPartitions.put(topicPartition.topicPartition(),
-							new OffsetMetadata(topicPartition.initialOffset(), topicPartition.isRelativeToCurrent()));
-				}
-				consumer.assign(new ArrayList<>(this.definedPartitions.keySet()));
-			}
-			this.consumer = consumer;
-			Object theListener = listener == null ? ackListener : listener;
-			GenericErrorHandler<?> errHandler = this.containerProperties.getGenericErrorHandler();
-			if (theListener instanceof MessageListener) {
-				this.listener = (MessageListener<K, V>) theListener;
-				this.batchListener = null;
-				this.acknowledgingMessageListener = null;
-				this.batchAcknowledgingMessageListener = null;
-				this.isBatchListener = false;
-				validateErrorHandler(false);
-				this.errorHandler = errHandler == null ? new LoggingErrorHandler() : (ErrorHandler) errHandler;
-				this.batchErrorHandler = new BatchLoggingErrorHandler();
-			}
-			else if (theListener instanceof BatchMessageListener) {
-				this.listener = null;
-				this.batchListener = (BatchMessageListener<K, V>) theListener;
-				this.acknowledgingMessageListener = null;
-				this.batchAcknowledgingMessageListener = null;
-				this.isBatchListener = true;
-				validateErrorHandler(true);
-				this.errorHandler = new LoggingErrorHandler();
-				this.batchErrorHandler = errHandler == null ? new BatchLoggingErrorHandler()
-						: (BatchErrorHandler) errHandler;
-			}
-			else if (theListener instanceof AcknowledgingMessageListener) {
-				this.listener = null;
-				this.acknowledgingMessageListener = (AcknowledgingMessageListener<K, V>) theListener;
-				this.batchListener = null;
-				this.batchAcknowledgingMessageListener = null;
-				this.isBatchListener = false;
-				validateErrorHandler(false);
-				this.errorHandler = errHandler == null ? new LoggingErrorHandler() : (ErrorHandler) errHandler;
-				this.batchErrorHandler = new BatchLoggingErrorHandler();
-			}
-			else if (theListener instanceof BatchAcknowledgingMessageListener) {
-				this.listener = null;
-				this.batchListener = null;
-				this.acknowledgingMessageListener = null;
-				this.batchAcknowledgingMessageListener = (BatchAcknowledgingMessageListener<K, V>) theListener;
-				this.isBatchListener = true;
-				validateErrorHandler(true);
-				this.errorHandler = new LoggingErrorHandler();
-				this.batchErrorHandler = errHandler == null ? new BatchLoggingErrorHandler()
-						: (BatchErrorHandler) errHandler;
-			}
-			else {
-				throw new IllegalArgumentException("Listener must be one of 'MessageListener', "
-						+ "'BatchMessageListener', 'AcknowledgingMessageListener', "
-						+ "'BatchAcknowledgingMessageListener', not " + theListener.getClass().getName());
-			}
-			Assert.state(!this.isBatchListener || !this.isRecordAck, "Cannot use AckMode.RECORD with a batch listener");
 		}
 
 		private void validateErrorHandler(boolean batch) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -324,9 +324,6 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 				this.batchListener = null;
 				this.batchAcknowledgingMessageListener = null;
 				this.isBatchListener = false;
-				validateErrorHandler(false);
-				this.errorHandler = errHandler == null ? new LoggingErrorHandler() : (ErrorHandler) errHandler;
-				this.batchErrorHandler = new BatchLoggingErrorHandler();
 			}
 			else if (theListener instanceof BatchAcknowledgingMessageListener) {
 				this.listener = null;
@@ -334,10 +331,6 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 				this.acknowledgingMessageListener = null;
 				this.batchAcknowledgingMessageListener = (BatchAcknowledgingMessageListener<K, V>) theListener;
 				this.isBatchListener = true;
-				validateErrorHandler(true);
-				this.errorHandler = new LoggingErrorHandler();
-				this.batchErrorHandler = errHandler == null ? new BatchLoggingErrorHandler()
-						: (BatchErrorHandler) errHandler;
 			}
 			else if (theListener instanceof MessageListener) {
 				this.listener = (MessageListener<K, V>) theListener;
@@ -345,9 +338,6 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 				this.acknowledgingMessageListener = null;
 				this.batchAcknowledgingMessageListener = null;
 				this.isBatchListener = false;
-				validateErrorHandler(false);
-				this.errorHandler = errHandler == null ? new LoggingErrorHandler() : (ErrorHandler) errHandler;
-				this.batchErrorHandler = new BatchLoggingErrorHandler();
 			}
 			else if (theListener instanceof BatchMessageListener) {
 				this.listener = null;
@@ -355,15 +345,22 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 				this.acknowledgingMessageListener = null;
 				this.batchAcknowledgingMessageListener = null;
 				this.isBatchListener = true;
+			}
+			else {
+				throw new IllegalArgumentException("Listener must be one of 'MessageListener', "
+						+ "'BatchMessageListener', 'AcknowledgingMessageListener', "
+						+ "'BatchAcknowledgingMessageListener', not " + theListener.getClass().getName());
+			}
+			if (isBatchListener) {
 				validateErrorHandler(true);
 				this.errorHandler = new LoggingErrorHandler();
 				this.batchErrorHandler = errHandler == null ? new BatchLoggingErrorHandler()
 						: (BatchErrorHandler) errHandler;
 			}
 			else {
-				throw new IllegalArgumentException("Listener must be one of 'MessageListener', "
-						+ "'BatchMessageListener', 'AcknowledgingMessageListener', "
-						+ "'BatchAcknowledgingMessageListener', not " + theListener.getClass().getName());
+				validateErrorHandler(false);
+				this.errorHandler = errHandler == null ? new LoggingErrorHandler() : (ErrorHandler) errHandler;
+				this.batchErrorHandler = new BatchLoggingErrorHandler();
 			}
 			Assert.state(!this.isBatchListener || !this.isRecordAck, "Cannot use AckMode.RECORD with a batch listener");
 		}

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -224,6 +224,7 @@ public class EnableKafkaIntegrationTests {
 				.build());
 		assertThat(this.listener.latch6.await(60, TimeUnit.SECONDS)).isTrue();
 		assertThat(this.listener.foo.getBar()).isEqualTo("bar");
+		assertThat(this.listener.ack).isNotNull();
 	}
 
 	@Test
@@ -493,9 +494,10 @@ public class EnableKafkaIntegrationTests {
 		}
 
 		@KafkaListener(id = "buz", topics = "annotated10", containerFactory = "kafkaJsonListenerContainerFactory")
-		public void listen6(Foo foo) {
+		public void listen6(Foo foo, Acknowledgment ack) {
 			this.foo = foo;
 			this.latch6.countDown();
+			this.ack = ack;
 		}
 
 		@KafkaListener(id = "rebalancerListener", topics = "annotated11",

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -496,8 +496,8 @@ public class EnableKafkaIntegrationTests {
 		@KafkaListener(id = "buz", topics = "annotated10", containerFactory = "kafkaJsonListenerContainerFactory")
 		public void listen6(Foo foo, Acknowledgment ack) {
 			this.foo = foo;
-			this.latch6.countDown();
 			this.ack = ack;
+			this.latch6.countDown();
 		}
 
 		@KafkaListener(id = "rebalancerListener", topics = "annotated11",


### PR DESCRIPTION
Fixes #175

The `MessagingMessageListenerAdapter` implements both `AcknowledgingMessageListener`
and `MessageListener`.

Since the batch support was added, we check for ML before AML so the `Acknowledgment`
will not be passed in.

Previously, we checked for AML before ML when deciding which method to call.

Also, move the creation of the rebalance listener out of the constructor
to make it smaller.