### PR TITLE
GH-185: Dont Populate Ack for Non-Manual Ack Modes

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -717,8 +717,8 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 			if (recordList.size() > 0) {
 				try {
 					if (this.batchAcknowledgingMessageListener != null) {
-						this.batchAcknowledgingMessageListener.onMessage(recordList,
-								new ConsumerBatchAcknowledgment(recordList, this.isManualImmediateAck));
+						this.batchAcknowledgingMessageListener.onMessage(recordList, this.isAnyManualAck
+								? new ConsumerBatchAcknowledgment(recordList, this.isManualImmediateAck) : null);
 					}
 					else {
 						this.batchListener.onMessage(recordList);
@@ -758,8 +758,8 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 				}
 				try {
 					if (this.acknowledgingMessageListener != null) {
-						this.acknowledgingMessageListener.onMessage(record,
-								new ConsumerAcknowledgment(record, this.isManualImmediateAck));
+						this.acknowledgingMessageListener.onMessage(record, this.isAnyManualAck
+								? new ConsumerAcknowledgment(record, this.isManualImmediateAck) : null);
 					}
 					else {
 						this.listener.onMessage(record);

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
@@ -63,6 +63,7 @@ import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.listener.AbstractMessageListenerContainer.AckMode;
 import org.springframework.kafka.listener.adapter.RetryingMessageListenerAdapter;
 import org.springframework.kafka.listener.config.ContainerProperties;
+import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.kafka.support.TopicPartitionInitialOffset;
 import org.springframework.kafka.test.rule.KafkaEmbedded;
 import org.springframework.kafka.test.utils.ContainerTestUtils;
@@ -125,7 +126,8 @@ public class KafkaMessageListenerContainerTests {
 
 		final CountDownLatch latch = new CountDownLatch(6);
 		final BitSet bitSet = new BitSet(6);
-		containerProps.setMessageListener((MessageListener<Integer, String>) message -> {
+		final AtomicReference<Acknowledgment> ackNull = new AtomicReference<>();
+		containerProps.setMessageListener((AcknowledgingMessageListener<Integer, String>) (message, ack) -> {
 			logger.info("slow1: " + message);
 			bitSet.set((int) (message.partition() * 3 + message.offset()));
 			try {
@@ -134,6 +136,7 @@ public class KafkaMessageListenerContainerTests {
 			catch (InterruptedException e) {
 				Thread.currentThread().interrupt();
 			}
+			ackNull.set(ack);
 			latch.countDown();
 		});
 		containerProps.setPauseAfter(100);
@@ -160,6 +163,7 @@ public class KafkaMessageListenerContainerTests {
 		template.sendDefault(2, "buz");
 		template.flush();
 		assertThat(latch.await(60, TimeUnit.SECONDS)).isTrue();
+		assertThat(ackNull.get()).isNull();
 		assertThat(bitSet.cardinality()).isEqualTo(6);
 		verify(consumer, atLeastOnce()).pause(anyObject());
 		verify(consumer, atLeastOnce()).resume(anyObject());


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-kafka/issues/185

If a listener is an `AcknowledgingMessageListener`, do not provide an ack if
the container is not configured for manual acks.