### PR TITLE
GH-185: Dont Populate Ack for Non-Manual Ack Modes - 1.0.x BackPort

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -594,8 +594,8 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 				}
 				try {
 					if (this.acknowledgingMessageListener != null) {
-						this.acknowledgingMessageListener.onMessage(record,
-								new ConsumerAcknowledgment(record, this.isManualImmediateAck));
+						this.acknowledgingMessageListener.onMessage(record, this.isAnyManualAck
+								? new ConsumerAcknowledgment(record, this.isManualImmediateAck) : null);
 					}
 					else {
 						this.listener.onMessage(record);

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
@@ -393,10 +393,10 @@ public class ConcurrentMessageListenerContainerTests {
 			latch.countDown();
 		});
 
+		containerProps.setAckMode(ackMode);
 		ConcurrentMessageListenerContainer<Integer, String> container =
 				new ConcurrentMessageListenerContainer<>(cf, containerProps);
 		container.setConcurrency(2);
-		containerProps.setAckMode(ackMode);
 		container.setBeanName("test" + ackMode);
 		container.start();
 


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-kafka/issues/185

If a listener is an `AcknowledgingMessageListener`, do not provide an ack if
the container is not configured for manual acks.