### PR TITLE
GH-199: Do not wakeup consumer after queueing ack

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -772,9 +772,6 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 					if (!this.isAnyManualAck && !this.autoCommit) {
 						this.acks.add(record);
 					}
-					if (this.isRecordAck) {
-						this.consumer.wakeup();
-					}
 				}
 				catch (Exception e) {
 					if (this.containerProperties.isAckOnError() && !this.autoCommit) {
@@ -791,9 +788,6 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 						throw er;
 					}
 				}
-			}
-			if (this.isManualAck || this.isBatchAck) {
-				this.consumer.wakeup();
 			}
 		}
 
@@ -994,9 +988,6 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 							else {
 								ListenerConsumer.this.logger.debug("Interrupt ignored");
 							}
-						}
-						if (!ListenerConsumer.this.isManualImmediateAck && this.active) {
-							ListenerConsumer.this.consumer.wakeup();
 						}
 					}
 				}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
@@ -571,7 +571,7 @@ public class KafkaMessageListenerContainerTests {
 		});
 		containerProps.setSyncCommits(true);
 		containerProps.setAckMode(AckMode.BATCH);
-		containerProps.setPollTimeout(10000);
+		containerProps.setPollTimeout(1000);
 		containerProps.setAckOnError(false);
 
 		KafkaMessageListenerContainer<Integer, String> container = new KafkaMessageListenerContainer<>(cf,
@@ -640,7 +640,7 @@ public class KafkaMessageListenerContainerTests {
 		});
 		containerProps.setSyncCommits(true);
 		containerProps.setAckMode(AckMode.BATCH);
-		containerProps.setPollTimeout(10000);
+		containerProps.setPollTimeout(1000);
 		containerProps.setAckOnError(false);
 
 		KafkaMessageListenerContainer<Integer, String> container = new KafkaMessageListenerContainer<>(cf,


### PR DESCRIPTION
Waking up the consumer too often will trigger a rebalance and messages are not actually committed

Please patch this on the 1.0.x branch as well for kafka 0.9 users