### PR TITLE
Missing item in documentation

### DIFF
--- a/src/reference/asciidoc/si-kafka.adoc
+++ b/src/reference/asciidoc/si-kafka.adoc
@@ -173,6 +173,11 @@ public ConsumerFactory<String, String> consumerFactory() {
     // set more properties
     return new DefaultKafkaConsumerFactory<>(props);
 }
+
+@Bean
+public PollableChannel received() {
+    return new QueueChannel();
+}
 ----
 
 [[message-conversion]]


### PR DESCRIPTION
Channel 'received' was missing in the documentation even though it was referenced through a method call (line 158).