### PR TITLE
GH-213: Fix sample inconsistency in "quick tour"

### DIFF
--- a/src/reference/asciidoc/quick-tour.adoc
+++ b/src/reference/asciidoc/quick-tour.adoc
@@ -44,7 +44,6 @@ Using plain Java to send and receive a message:
 public void testAutoCommit() throws Exception {
     logger.info("Start auto");
     ContainerProperties containerProps = new ContainerProperties("topic1", "topic2");
-    KafkaMessageListenerContainer<Integer, String> container = createContainer(containerProps);
     final CountDownLatch latch = new CountDownLatch(4);
     containerProps.setMessageListener(new MessageListener<Integer, String>() {
 
@@ -55,6 +54,7 @@ public void testAutoCommit() throws Exception {
         }
 
     });
+    KafkaMessageListenerContainer<Integer, String> container = createContainer(containerProps);
     container.setBeanName("testAuto");
     container.start();
     Thread.sleep(1000); // wait a bit for the container to start


### PR DESCRIPTION
Fixes GH-213 (https://github.com/spring-projects/spring-kafka/issues/213)

After introduction copying of `ContainerProperties` instance in the `AbstractMessageListenerContainer` the sample in the Reference Manual ins't valid any more.

* Move `containerProps.setMessageListener()` before `createContainer()` where copying is happened already and we can't affect container with original `ContainerProperties` modifications afterwards.

**Cherry pick to 1.0.x**