### PR TITLE
GH-215: Fix `quick-tour.adoc` sample obsolete code

### DIFF
--- a/src/reference/asciidoc/quick-tour.adoc
+++ b/src/reference/asciidoc/quick-tour.adoc
@@ -131,8 +131,8 @@ private KafkaTemplate<Integer, String> template;
 
 @Test
 public void testSimple() throws Exception {
-    waitListening("foo");
     template.send("annotated1", 0, "foo");
+    template.flush();
     assertTrue(this.listener.latch1.await(10, TimeUnit.SECONDS));
 }
 


### PR DESCRIPTION
Fixes GH-215 (https://github.com/spring-projects/spring-kafka/issues/215)

**Cherry-pick to 1.0.x**