### PR TITLE
GH-217: Fix obsolete docs and race condition

### DIFF
--- a/src/reference/asciidoc/si-kafka.adoc
+++ b/src/reference/asciidoc/si-kafka.adoc
@@ -142,7 +142,12 @@ An example of xml configuration variant is shown here:
             </constructor-arg>
         </bean>
     </constructor-arg>
-    <constructor-arg name="topics" value="foo" />
+    <constructor-arg>
+        <bean class="org.springframework.kafka.listener.config.ContainerProperties">
+            <constructor-arg name="topics" value="foo" />
+        </bean>
+    </constructor-arg>
+
 </bean>
 ----
 


### PR DESCRIPTION
Fixes: GH-217 (https://github.com/spring-projects/spring-kafka/issues/217)

Now we have to provide `ContainerProperties` object instead of direct `topics` for the `KafkaMessageListenerContainer`

Fix race condition in the `KafkaMessageListenerContainerTests` where a `commitSync()` can be performed before spying a consumer.

Since `consumer` is available only after `container.start()` and several barriers to ensure that `consumer` is created but isn't executed yet to let the `spy` be ready for the subsequent `commitSync()` during `run()`