### PR TITLE
GH-221: Fix KafkaListenerBPP.resolveAsString()

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -537,7 +537,7 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 				resolveAsString(object, result);
 			}
 		}
-		if (resolvedValue instanceof String) {
+		else if (resolvedValue instanceof String) {
 			result.add((String) resolvedValue);
 		}
 		else if (resolvedValue instanceof Iterable) {

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,7 +92,8 @@ public class EnableKafkaIntegrationTests {
 	public Listener listener;
 
 	@ClassRule
-	public static KafkaEmbedded embeddedKafka = new KafkaEmbedded(1, true, "annotated1", "annotated2", "annotated3",
+	public static KafkaEmbedded embeddedKafka = new KafkaEmbedded(1, true,
+			"annotated1", "annotated2", "annotated3",
 			"annotated4", "annotated5", "annotated6", "annotated7", "annotated8", "annotated9", "annotated10",
 			"annotated11", "annotated12", "annotated13", "annotated14", "annotated15", "annotated16", "annotated17",
 			"annotated18", "annotated19");
@@ -576,7 +577,7 @@ public class EnableKafkaIntegrationTests {
 		public void manualStart(String foo) {
 		}
 
-		@KafkaListener(id = "foo", topics = "${topicOne:annotated1}")
+		@KafkaListener(id = "foo", topics = "#{'${topicOne:annotated1,foo}'.split(',')}")
 		public void listen1(String foo) {
 			this.latch1.countDown();
 		}


### PR DESCRIPTION
Fixes GH-221 (https://github.com/spring-projects/spring-kafka/issues/221)

When the value is `String[]` we iterate it for the `if (resolvedValue instanceof String[]) {` and then just go to a new `if` block instead of `else if` or `return`

* Fix `KafkaListenerBPP.resolveAsString()` as an `else if` for the second condition
* Confirm the fix with the  `EnableKafkaIntegrationTests` test modification to resolve `topics` to the `String[]`