### PR TITLE
GH-230: Commit batch acks properly

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -725,10 +725,10 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 					}
 					else {
 						this.batchListener.onMessage(recordList);
-						if (!this.isAnyManualAck && !this.autoCommit) {
-							for (ConsumerRecord<K, V> record : recordList) {
-								this.acks.put(record);
-							}
+					}
+					if (!this.isAnyManualAck && !this.autoCommit) {
+						for (ConsumerRecord<K, V> record : recordList) {
+							this.acks.put(record);
 						}
 					}
 				}


### PR DESCRIPTION
Fixes GH-230  (https://github.com/spring-projects/spring-kafka/issues/230)

The offsets never got commited by when we don't use MANUAL mode and rely on the `(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false)`

* Move `this.acks.put(record)` outside of the `else` branch for the regular listener.
This way the acks will be placed for the commits even if we use `batchListener` and don't use `isAnyManualAck` mode-

**Cherry-pick to 1.1.x**