### PR TITLE
GH-262: In a batch only commit highest offset for each partition  Fix…

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -1084,7 +1084,7 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 					Map<Integer, ConsumerRecord<K, V>> highestOffsetMap = new HashMap<>();
 
 					for (ConsumerRecord<K, V> record : this.records) {
-						if(record != null) {
+						if (record != null) {
 							ConsumerRecord<K, V> consumerRecord = highestOffsetMap.get(record.partition());
 
 							if (consumerRecord == null || record.offset() > consumerRecord.offset()) {
@@ -1093,7 +1093,7 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 						}
 					}
 
-					for(ConsumerRecord<K, V> record: highestOffsetMap.values()){
+					for (ConsumerRecord<K, V> record: highestOffsetMap.values()) {
 						ListenerConsumer.this.acks.put(record);
 					}
 				}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -74,6 +74,7 @@ import org.springframework.util.concurrent.ListenableFutureCallback;
  * @author Marius Bogoevici
  * @author Martin Dam
  * @author Artem Bilan
+ * @author Loic Talhouarne
  */
 public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListenerContainer<K, V> {
 
@@ -1079,7 +1080,20 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 				try {
 					Assert.state(ListenerConsumer.this.isAnyManualAck,
 							"A manual ackmode is required for an acknowledging listener");
+
+					Map<Integer, ConsumerRecord<K, V>> highestOffsetMap = new HashMap<>();
+
 					for (ConsumerRecord<K, V> record : this.records) {
+						if(record != null) {
+							ConsumerRecord<K, V> consumerRecord = highestOffsetMap.get(record.partition());
+
+							if (consumerRecord == null || record.offset() > consumerRecord.offset()) {
+								highestOffsetMap.put(record.partition(), record);
+							}
+						}
+					}
+
+					for(ConsumerRecord<K, V> record: highestOffsetMap.values()){
 						ListenerConsumer.this.acks.put(record);
 					}
 				}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
@@ -729,8 +729,12 @@ public class KafkaMessageListenerContainerTests {
 				return invocation.callRealMethod();
 			}
 			finally {
+				boolean smallOffsetCommitted = false;
 				for (Entry<TopicPartition, OffsetAndMetadata> entry : map.entrySet()) {
-					if (entry.getValue().offset() == 2) {
+					if (entry.getValue().offset() == 1) {
+						smallOffsetCommitted = true;
+						logger.error("The highest offset should be the only one committed.");
+					} else if (!smallOffsetCommitted && entry.getValue().offset() == 2) {
 						commitLatch.countDown();
 					}
 				}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
@@ -734,7 +734,8 @@ public class KafkaMessageListenerContainerTests {
 					if (entry.getValue().offset() == 1) {
 						smallOffsetCommitted = true;
 						logger.error("The highest offset should be the only one committed.");
-					} else if (!smallOffsetCommitted && entry.getValue().offset() == 2) {
+					}
+					else if (!smallOffsetCommitted && entry.getValue().offset() == 2) {
 						commitLatch.countDown();
 					}
 				}


### PR DESCRIPTION
…es GH-262 (https://github.com/spring-projects/spring-kafka/issues/262)  Committing each offset in a batch hinders the performance. Only the highest offset for a partition should be committed from a batch.