### PR TITLE
GH-244: Update to Kafka 0.10.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ subprojects { subproject ->
 		hamcrestVersion = '1.3'
 		jacksonVersion = '2.8.6'
 		junitVersion = '4.12'
-		kafkaVersion = '0.10.1.1'
+		kafkaVersion = '0.10.2.0'
 		mockitoVersion = '2.5.4'
 		scalaVersion = '2.11'
 		slf4jVersion = '1.7.22'

--- a/classes/test/spring-kafka/log4j.properties
+++ b/classes/test/spring-kafka/log4j.properties
@@ -1,9 +1,0 @@
-log4j.rootCategory=WARN, stdout
-
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d{HH:mm:ss.SSS} %-5p [%t][%c] %m%n
-log4j.category.org.springframework.kafka=WARN
-log4j.category.org.apache.kafka.clients=WARN
-log4j.category.org.apache.kafka.common.network.Selector=ERROR
-log4j.category.kafka.server.ReplicaFetcherThread=ERROR


### PR DESCRIPTION
Resolves #244

I had to change the `KafkaEmbedded` port aquisition code - `kafkaServer.config().port()`
now always returns 9092, regardless of the actual port used.

Save off the randomport in a list.

Remove Bogus log4j.properties File