### PR TITLE
GH-265: Improved Default Thread Naming

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -170,12 +170,12 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 		}
 		if (containerProperties.getConsumerTaskExecutor() == null) {
 			SimpleAsyncTaskExecutor consumerExecutor = new SimpleAsyncTaskExecutor(
-					"kafka-consumer-" + (getBeanName() == null ? "" : getBeanName()) + "-C-");
+					(getBeanName() == null ? "" : getBeanName()) + "-C-");
 			containerProperties.setConsumerTaskExecutor(consumerExecutor);
 		}
 		if (containerProperties.getListenerTaskExecutor() == null) {
 			SimpleAsyncTaskExecutor listenerExecutor = new SimpleAsyncTaskExecutor(
-					"kafka-listener-" + (getBeanName() == null ? "" : getBeanName()) + "-L-");
+					(getBeanName() == null ? "" : getBeanName()) + "-L-");
 			containerProperties.setListenerTaskExecutor(listenerExecutor);
 		}
 		this.listenerConsumer = new ListenerConsumer(this.listener, this.acknowledgingMessageListener);

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -170,12 +170,12 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 		}
 		if (containerProperties.getConsumerTaskExecutor() == null) {
 			SimpleAsyncTaskExecutor consumerExecutor = new SimpleAsyncTaskExecutor(
-					(getBeanName() == null ? "" : getBeanName()) + "-kafka-consumer-");
+					"kafka-consumer-" + (getBeanName() == null ? "" : getBeanName()) + "-C-");
 			containerProperties.setConsumerTaskExecutor(consumerExecutor);
 		}
 		if (containerProperties.getListenerTaskExecutor() == null) {
 			SimpleAsyncTaskExecutor listenerExecutor = new SimpleAsyncTaskExecutor(
-					(getBeanName() == null ? "" : getBeanName()) + "-kafka-listener-");
+					"kafka-listener-" + (getBeanName() == null ? "" : getBeanName()) + "-L-");
 			containerProperties.setListenerTaskExecutor(listenerExecutor);
 		}
 		this.listenerConsumer = new ListenerConsumer(this.listener, this.acknowledgingMessageListener);

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
@@ -129,7 +129,7 @@ public class ConcurrentMessageListenerContainerTests {
 		template.flush();
 		assertThat(latch.await(60, TimeUnit.SECONDS)).isTrue();
 		for (String threadName : listenerThreadNames) {
-			assertThat(threadName).contains("-consumer-");
+			assertThat(threadName).contains("-C-");
 		}
 		@SuppressWarnings("unchecked")
 		List<KafkaMessageListenerContainer<Integer, String>> containers = KafkaTestUtils.getPropertyValue(container,
@@ -196,7 +196,7 @@ public class ConcurrentMessageListenerContainerTests {
 		assertThat(rebalancePartitionsAssignedLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		assertThat(rebalancePartitionsRevokedLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		for (String threadName : listenerThreadNames) {
-			assertThat(threadName).contains("-consumer-");
+			assertThat(threadName).contains("-C-");
 		}
 		container.stop();
 		this.logger.info("Stop auto");
@@ -236,7 +236,7 @@ public class ConcurrentMessageListenerContainerTests {
 		template.flush();
 		assertThat(latch.await(60, TimeUnit.SECONDS)).isTrue();
 		for (String threadName : listenerThreadNames) {
-			assertThat(threadName).contains("-listener-");
+			assertThat(threadName).contains("-L-");
 		}
 		container.stop();
 		this.logger.info("Stop manual");

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -490,6 +490,18 @@ public void listen(List<ConsumerRecord<Integer, String>> list, Acknowledgment ac
 }
 ----
 
+===== Container Thread Naming
+
+Listener containers currently use two task executors, one to invoke the consumer and another which will be used to invoke the listener, when the kafka consumer property `enable.auto.commit` is `false`.
+You can provide custom executors by setting the `consumerExecutor` and `listenerExecutor` properties of the container's `ContainerProperties`.
+When using pooled executors, be sure that enough threads are available to handle the concurrency across all the containers in which they are used.
+When using the `ConcurrentMessageListenerContainer`, a thread from each is used for each consumer (`concurrency`).
+
+If you don't provide executors, `SimpleAsyncTaskExecutor` s are used; these executors create threads with names `<beanName>-C-1` (consumer thread) and `<beanName>-L-1` (listener thread).
+For the `ConcurrentMessageListenerContainer`, the `<beanName>` part of the thread name becomes `<beanName>-m`, where `m` represents the consumer instance.
+So, with a bean name of `container`, threads in this container will be named `container-0-C-1` and `container-0-L-1`, `container-1-C-1` etc.
+The trailing number is always 1 because a new executor is created each time the container is stopped/started.
+
 ===== Filtering Messages
 
 In certain scenarios, such as rebalancing, a message may be redelivered that has already been processed.


### PR DESCRIPTION
Resolves #265

Spring Boot truncates the thread name by default, giving the appearance that all messages
are processed on the same thread.

Example:

With `[%thread]` in logback config:

    11:25:09.029 [container-0-kafka-listener-1] ...
    11:25:09.029 [container-1-kafka-listener-1] ...

With default Boot logging:

    11:25:09.029 ... [afka-listener-1] ...
    11:25:09.029 ... [afka-listener-1] ...

With this commit:

    11:33:30.337 ... [container-0-C-1] ... : Discovered ...
    11:33:30.337 ... [container-1-C-1] ... : Discovered ...
    11:33:30.441 ... [container-0-L-1] ...
    11:33:30.441 ... [container-1-L-1] ...

__cherry-pick to 1.1.x__