### PR TITLE
GH-262: In a batch only commit highest offset for each partition  Fix…

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -728,14 +728,14 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 						this.batchListener.onMessage(recordList);
 					}
 					if (!this.isAnyManualAck && !this.autoCommit) {
-						for (ConsumerRecord<K, V> record : recordList) {
+						for (ConsumerRecord<K, V> record : getHighestOffsetRecords(recordList)) {
 							this.acks.put(record);
 						}
 					}
 				}
 				catch (Exception e) {
 					if (this.containerProperties.isAckOnError() && !this.autoCommit) {
-						for (ConsumerRecord<K, V> record : recordList) {
+						for (ConsumerRecord<K, V> record : getHighestOffsetRecords(recordList)) {
 							this.acks.add(record);
 						}
 					}
@@ -910,7 +910,13 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 			if (!this.offsets.containsKey(record.topic())) {
 				this.offsets.put(record.topic(), new HashMap<Integer, Long>());
 			}
-			this.offsets.get(record.topic()).put(record.partition(), record.offset());
+
+			Map<Integer, Long> highestOffsetMap = this.offsets.get(record.topic());
+			Long offset = highestOffsetMap.get(record.partition());
+
+			if (offset == null || record.offset() > offset) {
+				highestOffsetMap.put(record.partition(), record.offset());
+			}
 		}
 
 		private void commitIfNecessary() {
@@ -944,6 +950,22 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 					}
 				}
 			}
+		}
+
+		private Collection<ConsumerRecord<K, V>> getHighestOffsetRecords(List<ConsumerRecord<K, V>> records) {
+			Map<Integer, ConsumerRecord<K, V>> highestOffsetMap = new HashMap<>();
+
+			for (ConsumerRecord<K, V> record : records) {
+				if (record != null) {
+					ConsumerRecord<K, V> consumerRecord = highestOffsetMap.get(record.partition());
+
+					if (consumerRecord == null || record.offset() > consumerRecord.offset()) {
+						highestOffsetMap.put(record.partition(), record);
+					}
+				}
+			}
+
+			return highestOffsetMap.values();
 		}
 
 		@Override
@@ -1081,19 +1103,7 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 					Assert.state(ListenerConsumer.this.isAnyManualAck,
 							"A manual ackmode is required for an acknowledging listener");
 
-					Map<Integer, ConsumerRecord<K, V>> highestOffsetMap = new HashMap<>();
-
-					for (ConsumerRecord<K, V> record : this.records) {
-						if (record != null) {
-							ConsumerRecord<K, V> consumerRecord = highestOffsetMap.get(record.partition());
-
-							if (consumerRecord == null || record.offset() > consumerRecord.offset()) {
-								highestOffsetMap.put(record.partition(), record);
-							}
-						}
-					}
-
-					for (ConsumerRecord<K, V> record: highestOffsetMap.values()) {
+					for (ConsumerRecord<K, V> record : getHighestOffsetRecords(this.records)) {
 						ListenerConsumer.this.acks.put(record);
 					}
 				}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
@@ -722,6 +722,7 @@ public class KafkaMessageListenerContainerTests {
 		container.start();
 		Consumer<?, ?> containerConsumer = spyOnConsumer(container);
 		final CountDownLatch commitLatch = new CountDownLatch(2);
+		AtomicBoolean smallOffsetCommitted = new AtomicBoolean(false);
 		willAnswer(invocation -> {
 
 			@SuppressWarnings({ "unchecked" })
@@ -732,7 +733,7 @@ public class KafkaMessageListenerContainerTests {
 			finally {
 				for (Entry<TopicPartition, OffsetAndMetadata> entry : map.entrySet()) {
 					if (entry.getValue().offset() == 1) {
-						throw new IllegalStateException("The highest offset should be the only one committed.");
+						smallOffsetCommitted.set(true);
 					}
 					else if (entry.getValue().offset() == 2) {
 						commitLatch.countDown();
@@ -745,6 +746,7 @@ public class KafkaMessageListenerContainerTests {
 
 		assertThat(latch.await(60, TimeUnit.SECONDS)).isTrue();
 		assertThat(commitLatch.await(60, TimeUnit.SECONDS)).isTrue();
+		assertThat(smallOffsetCommitted.get()).isFalse();
 		Consumer<Integer, String> consumer = cf.createConsumer();
 		consumer.assign(Arrays.asList(new TopicPartition(topic9, 0), new TopicPartition(topic9, 1)));
 		assertThat(consumer.position(new TopicPartition(topic9, 0))).isEqualTo(2);


### PR DESCRIPTION
…es GH-262 (https://github.com/spring-projects/spring-kafka/issues/262)

This commit adds the highest offset logic to batch listener with non-manual commits. It also adds the logic to the addOffset method to prevent any assumptions from being made.