### PR TITLE
Fix Executor Documentation

### DIFF
--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -497,10 +497,10 @@ You can provide custom executors by setting the `consumerExecutor` and `listener
 When using pooled executors, be sure that enough threads are available to handle the concurrency across all the containers in which they are used.
 When using the `ConcurrentMessageListenerContainer`, a thread from each is used for each consumer (`concurrency`).
 
-If you don't provide executors, `SimpleAsyncTaskExecutor` s are used; these executors create threads with names `<beanName>-C-1` (consumer thread) and `<beanName>-L-1` (listener thread).
+If you don't provide executors, `SimpleAsyncTaskExecutor` s are used; these executors create threads with names `<beanName>-C-n` (consumer thread) and `<beanName>-L-n` (listener thread).
 For the `ConcurrentMessageListenerContainer`, the `<beanName>` part of the thread name becomes `<beanName>-m`, where `m` represents the consumer instance.
-So, with a bean name of `container`, threads in this container will be named `container-0-C-1` and `container-0-L-1`, `container-1-C-1` etc.
-The trailing number is always 1 because a new executor is created each time the container is stopped/started.
+`n` increments each time the container is started.
+So, with a bean name of `container`, threads in this container will be named `container-0-C-1` and `container-0-L-1`, `container-1-C-1` etc., after the container is started the first time.
 
 ===== Filtering Messages
 


### PR DESCRIPTION
The recent clarification of the default thread names incorrectly stated the
threads always end `-1` - the default executor is put into the container properties
while starting so subsequent starts will find an existing executor.


__cherry-pick to 1.2.x, 1.1.x__