### PR TITLE
Adds errorHandler property to KafkaListener

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
@@ -143,6 +143,7 @@ public @interface KafkaListener {
 	 * Set an {@link KafkaListenerErrorHandler} to invoke if the listener method throws
 	 * an exception.
 	 * @return the error handler.
+	 * @since 2.0
 	 */
 	String errorHandler() default "";
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
@@ -23,6 +23,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.springframework.kafka.listener.KafkaListenerErrorHandler;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 
 /**

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,6 +76,7 @@ import org.springframework.messaging.handler.annotation.MessageMapping;
  * {@link org.springframework.kafka.config.MultiMethodKafkaListenerEndpoint}.
  *
  * @author Gary Russell
+ * @author Venil Noronha
  *
  * @see EnableKafka
  * @see KafkaListenerAnnotationBeanPostProcessor
@@ -137,5 +138,12 @@ public @interface KafkaListener {
 	 * @return the bean name for the group.
 	 */
 	String group() default "";
+
+	/**
+	 * Set an {@link KafkaListenerErrorHandler} to invoke if the listener method throws
+	 * an exception.
+	 * @return the error handler.
+	 */
+	String errorHandler() default "";
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
@@ -96,8 +96,10 @@ import org.springframework.util.StringUtils;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Dariusz Szablinski
+ * @author Venil Noronha
  *
  * @see KafkaListener
+ * @see KafkaListenerErrorHandler
  * @see EnableKafka
  * @see KafkaListenerConfigurer
  * @see KafkaListenerEndpointRegistrar
@@ -336,6 +338,10 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 		MethodKafkaListenerEndpoint<K, V> endpoint = new MethodKafkaListenerEndpoint<K, V>();
 		endpoint.setMethod(methodToUse);
 		endpoint.setBeanFactory(this.beanFactory);
+		String errorHandlerBeanName = resolveExpressionAsString(kafkaListener.errorHandler(), "errorHandler");
+		if (StringUtils.hasText(errorHandlerBeanName)) {
+			endpoint.setErrorHandler(this.beanFactory.getBean(errorHandlerBeanName, KafkaListenerErrorHandler.class));
+		}
 		processListener(endpoint, kafkaListener, bean, methodToUse, beanName);
 	}
 
@@ -580,6 +586,17 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 		else {
 			throw new IllegalArgumentException(String.format(
 					"@KafKaListener for topic '%s' can't resolve '%s' as an Integer or String", topic, resolvedValue));
+		}
+	}
+
+	private String resolveExpressionAsString(String value, String attribute) {
+		Object resolved = resolveExpression(value);
+		if (resolved instanceof String) {
+			return (String) resolved;
+		}
+		else {
+			throw new IllegalStateException("The [" + attribute + "] must resolve to a String. "
+					+ "Resolved to [" + resolved.getClass() + "] for [" + value + "]");
 		}
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
@@ -57,6 +57,7 @@ import org.springframework.kafka.config.KafkaListenerEndpointRegistrar;
 import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
 import org.springframework.kafka.config.MethodKafkaListenerEndpoint;
 import org.springframework.kafka.config.MultiMethodKafkaListenerEndpoint;
+import org.springframework.kafka.listener.KafkaListenerErrorHandler;
 import org.springframework.kafka.support.KafkaNull;
 import org.springframework.kafka.support.TopicPartitionInitialOffset;
 import org.springframework.messaging.converter.GenericMessageConverter;

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerErrorHandler.java
@@ -25,6 +25,7 @@ import org.springframework.messaging.Message;
  * listener container's error handler.
  *
  * @author Venil Noronha
+ * @since 2.0
  */
 @FunctionalInterface
 public interface KafkaListenerErrorHandler {
@@ -34,8 +35,9 @@ public interface KafkaListenerErrorHandler {
 	 * @param message the spring-messaging message.
 	 * @param exception the exception the listener threw, wrapped in a
 	 * {@link ListenerExecutionFailedException}.
+	 * @return the return value is ignored.
 	 * @throws Exception an exception which may be the original or different.
 	 */
-	void handleError(Message<?> message, ListenerExecutionFailedException exception) throws Exception;
+	Object handleError(Message<?> message, ListenerExecutionFailedException exception) throws Exception;
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerErrorHandler.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.annotation;
+
+import org.springframework.kafka.listener.ListenerExecutionFailedException;
+import org.springframework.messaging.Message;
+
+/**
+ * An error handler which is called when a {code @KafkaListener} method
+ * throws an exception. This is invoked higher up the stack than the
+ * listener container's error handler.
+ *
+ * @author Venil Noronha
+ */
+@FunctionalInterface
+public interface KafkaListenerErrorHandler {
+
+	/**
+	 * Handle the error.
+	 * @param message the spring-messaging message.
+	 * @param exception the exception the listener threw, wrapped in a
+	 * {@link ListenerExecutionFailedException}.
+	 * @throws Exception an exception which may be the original or different.
+	 */
+	void handleError(Message<?> message, ListenerExecutionFailedException exception) throws Exception;
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/MethodKafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/MethodKafkaListenerEndpoint.java
@@ -18,7 +18,7 @@ package org.springframework.kafka.config;
 
 import java.lang.reflect.Method;
 
-import org.springframework.kafka.annotation.KafkaListenerErrorHandler;
+import org.springframework.kafka.listener.KafkaListenerErrorHandler;
 import org.springframework.kafka.listener.MessageListenerContainer;
 import org.springframework.kafka.listener.adapter.BatchMessagingMessageListenerAdapter;
 import org.springframework.kafka.listener.adapter.HandlerAdapter;

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/MethodKafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/MethodKafkaListenerEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.kafka.config;
 
 import java.lang.reflect.Method;
 
+import org.springframework.kafka.annotation.KafkaListenerErrorHandler;
 import org.springframework.kafka.listener.MessageListenerContainer;
 import org.springframework.kafka.listener.adapter.BatchMessagingMessageListenerAdapter;
 import org.springframework.kafka.listener.adapter.HandlerAdapter;
@@ -40,6 +41,7 @@ import org.springframework.util.Assert;
  * @author Stephane Nicoll
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Venil Noronha
  */
 public class MethodKafkaListenerEndpoint<K, V> extends AbstractKafkaListenerEndpoint<K, V> {
 
@@ -49,6 +51,7 @@ public class MethodKafkaListenerEndpoint<K, V> extends AbstractKafkaListenerEndp
 
 	private MessageHandlerMethodFactory messageHandlerMethodFactory;
 
+	private KafkaListenerErrorHandler errorHandler;
 
 	/**
 	 * Set the object instance that should manage this endpoint.
@@ -82,6 +85,15 @@ public class MethodKafkaListenerEndpoint<K, V> extends AbstractKafkaListenerEndp
 	 */
 	public void setMessageHandlerMethodFactory(MessageHandlerMethodFactory messageHandlerMethodFactory) {
 		this.messageHandlerMethodFactory = messageHandlerMethodFactory;
+	}
+
+	/**
+	 * Set the {@link KafkaListenerErrorHandler} to invoke if the listener method
+	 * throws an exception.
+	 * @param errorHandler the error handler.
+	 */
+	public void setErrorHandler(KafkaListenerErrorHandler errorHandler) {
+		this.errorHandler = errorHandler;
 	}
 
 	/**
@@ -121,15 +133,15 @@ public class MethodKafkaListenerEndpoint<K, V> extends AbstractKafkaListenerEndp
 	protected MessagingMessageListenerAdapter<K, V> createMessageListenerInstance(MessageConverter messageConverter) {
 		if (isBatchListener()) {
 			BatchMessagingMessageListenerAdapter<K, V> messageListener = new BatchMessagingMessageListenerAdapter<K, V>(
-					this.bean, this.method);
+					this.bean, this.method, this.errorHandler);
 			if (messageConverter instanceof BatchMessageConverter) {
 				messageListener.setBatchMessageConverter((BatchMessageConverter) messageConverter);
 			}
 			return messageListener;
 		}
 		else {
-			RecordMessagingMessageListenerAdapter<K, V> messageListener =
-					new RecordMessagingMessageListenerAdapter<K, V>(this.bean, this.method);
+			RecordMessagingMessageListenerAdapter<K, V> messageListener = new RecordMessagingMessageListenerAdapter<K, V>(
+					this.bean, this.method, this.errorHandler);
 			if (messageConverter instanceof RecordMessageConverter) {
 				messageListener.setMessageConverter((RecordMessageConverter) messageConverter);
 			}

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/MethodKafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/MethodKafkaListenerEndpoint.java
@@ -91,6 +91,7 @@ public class MethodKafkaListenerEndpoint<K, V> extends AbstractKafkaListenerEndp
 	 * Set the {@link KafkaListenerErrorHandler} to invoke if the listener method
 	 * throws an exception.
 	 * @param errorHandler the error handler.
+	 * @since 2.0
 	 */
 	public void setErrorHandler(KafkaListenerErrorHandler errorHandler) {
 		this.errorHandler = errorHandler;

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaListenerErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaListenerErrorHandler.java
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-package org.springframework.kafka.annotation;
+package org.springframework.kafka.listener;
 
-import org.springframework.kafka.listener.ListenerExecutionFailedException;
 import org.springframework.messaging.Message;
 
 /**

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/BatchMessagingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/BatchMessagingMessageListenerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,8 +22,10 @@ import java.util.List;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
+import org.springframework.kafka.annotation.KafkaListenerErrorHandler;
 import org.springframework.kafka.listener.BatchAcknowledgingMessageListener;
 import org.springframework.kafka.listener.BatchMessageListener;
+import org.springframework.kafka.listener.ListenerExecutionFailedException;
 import org.springframework.kafka.listener.MessageListener;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.kafka.support.KafkaNull;
@@ -51,6 +53,7 @@ import org.springframework.messaging.support.MessageBuilder;
  * @author Stephane Nicoll
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Venil Noronha
  * @since 1.1
  */
 public class BatchMessagingMessageListenerAdapter<K, V> extends MessagingMessageListenerAdapter<K, V>
@@ -60,9 +63,15 @@ public class BatchMessagingMessageListenerAdapter<K, V> extends MessagingMessage
 
 	private BatchMessageConverter messageConverter = new BatchMessagingMessageConverter();
 
+	private KafkaListenerErrorHandler errorHandler;
 
 	public BatchMessagingMessageListenerAdapter(Object bean, Method method) {
+		this(bean, method, null);
+	}
+
+	public BatchMessagingMessageListenerAdapter(Object bean, Method method, KafkaListenerErrorHandler errorHandler) {
 		super(bean, method);
+		this.errorHandler = errorHandler;
 	}
 
 	/**
@@ -115,7 +124,24 @@ public class BatchMessagingMessageListenerAdapter<K, V> extends MessagingMessage
 		if (logger.isDebugEnabled()) {
 			logger.debug("Processing [" + message + "]");
 		}
-		invokeHandler(records, acknowledgment, message);
+		try {
+			invokeHandler(records, acknowledgment, message);
+		}
+		catch (ListenerExecutionFailedException e) {
+			if (this.errorHandler != null) {
+				try {
+					this.errorHandler.handleError(message, e);
+				}
+				catch (Exception ex) {
+					throw new ListenerExecutionFailedException(createMessagingErrorMessage(
+							"Listener error handler threw an exception for the incoming message",
+							message.getPayload()), ex);
+				}
+			}
+			else {
+				throw e;
+			}
+		}
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/BatchMessagingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/BatchMessagingMessageListenerAdapter.java
@@ -22,9 +22,9 @@ import java.util.List;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
-import org.springframework.kafka.annotation.KafkaListenerErrorHandler;
 import org.springframework.kafka.listener.BatchAcknowledgingMessageListener;
 import org.springframework.kafka.listener.BatchMessageListener;
+import org.springframework.kafka.listener.KafkaListenerErrorHandler;
 import org.springframework.kafka.listener.ListenerExecutionFailedException;
 import org.springframework.kafka.listener.MessageListener;
 import org.springframework.kafka.support.Acknowledgment;

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ import org.springframework.util.Assert;
  * @author Stephane Nicoll
  * @author Gary Russell
  * @author Artem Bilan
- *
+ * @author Venil Noronha
  */
 public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerSeekAware {
 
@@ -189,7 +189,7 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 		}
 	}
 
-	private String createMessagingErrorMessage(String description, Object payload) {
+	protected final String createMessagingErrorMessage(String description, Object payload) {
 		return description + "\n"
 				+ "Endpoint handler details:\n"
 				+ "Method [" + this.handlerMethod.getMethodAsString(payload) + "]\n"

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/RecordMessagingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/RecordMessagingMessageListenerAdapter.java
@@ -20,8 +20,8 @@ import java.lang.reflect.Method;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
-import org.springframework.kafka.annotation.KafkaListenerErrorHandler;
 import org.springframework.kafka.listener.AcknowledgingMessageListener;
+import org.springframework.kafka.listener.KafkaListenerErrorHandler;
 import org.springframework.kafka.listener.ListenerExecutionFailedException;
 import org.springframework.kafka.listener.MessageListener;
 import org.springframework.kafka.support.Acknowledgment;

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/RecordMessagingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/RecordMessagingMessageListenerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2016 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,9 @@ import java.lang.reflect.Method;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
+import org.springframework.kafka.annotation.KafkaListenerErrorHandler;
 import org.springframework.kafka.listener.AcknowledgingMessageListener;
+import org.springframework.kafka.listener.ListenerExecutionFailedException;
 import org.springframework.kafka.listener.MessageListener;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.messaging.Message;
@@ -43,13 +45,20 @@ import org.springframework.messaging.Message;
  * @author Stephane Nicoll
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Venil Noronha
  */
 public class RecordMessagingMessageListenerAdapter<K, V> extends MessagingMessageListenerAdapter<K, V>
 		implements MessageListener<K, V>, AcknowledgingMessageListener<K, V> {
 
+	private KafkaListenerErrorHandler errorHandler;
 
 	public RecordMessagingMessageListenerAdapter(Object bean, Method method) {
+		this(bean, method, null);
+	}
+
+	public RecordMessagingMessageListenerAdapter(Object bean, Method method, KafkaListenerErrorHandler errorHandler) {
 		super(bean, method);
+		this.errorHandler = errorHandler;
 	}
 
 	/**
@@ -69,7 +78,24 @@ public class RecordMessagingMessageListenerAdapter<K, V> extends MessagingMessag
 		if (logger.isDebugEnabled()) {
 			logger.debug("Processing [" + message + "]");
 		}
-		invokeHandler(record, acknowledgment, message);
+		try {
+			invokeHandler(record, acknowledgment, message);
+		}
+		catch (ListenerExecutionFailedException e) {
+			if (this.errorHandler != null) {
+				try {
+					this.errorHandler.handleError(message, e);
+				}
+				catch (Exception ex) {
+					throw new ListenerExecutionFailedException(createMessagingErrorMessage(
+							"Listener error handler threw an exception for the incoming message",
+							message.getPayload()), ex);
+				}
+			}
+			else {
+				throw e;
+			}
+		}
 	}
 
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -558,6 +558,7 @@ public class EnableKafkaIntegrationTests {
 		public KafkaListenerErrorHandler consumeException(Listener listener) {
 			return (m, e) -> {
 				listener.latch16.countDown();
+				return null;
 			};
 		}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -56,6 +56,7 @@ import org.springframework.kafka.event.ListenerContainerIdleEvent;
 import org.springframework.kafka.listener.AbstractMessageListenerContainer.AckMode;
 import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
 import org.springframework.kafka.listener.ConsumerSeekAware;
+import org.springframework.kafka.listener.KafkaListenerErrorHandler;
 import org.springframework.kafka.listener.KafkaMessageListenerContainer;
 import org.springframework.kafka.listener.MessageListenerContainer;
 import org.springframework.kafka.listener.adapter.FilteringAcknowledgingMessageListenerAdapter;

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -808,3 +808,29 @@ static class MultiListenerBean {
 
 }
 ----
+
+[[annotation-error-handling]]
+====== Handling Exceptions
+
+By default, if an annotated listener method throws an exception, it is thrown to the container, and the message will handled according to the container configuration.
+Nothing is returned to the sender.
+
+Starting with _version 2.0_, the `@KafkaListener` annotation has a new attribute: `errorHandler`.
+
+This attribute is not configured by default.
+
+Use the `errorHandler` to provide the bean name of a `KafkaListenerErrorHandler` implementation.
+This functional interface has one method:
+
+[source, java]
+----
+@FunctionalInterface
+public interface KafkaListenerErrorHandler {
+
+    Object handleError(Message<?> message, ListenerExecutionFailedException exception) throws Exception;
+
+}
+----
+
+As you can see, you have access to the spring-messaging `Message<?>` object produced by the message converter and the exception that was thrown by the listener, wrapped in a `ListenerExecutionFailedException`.
+The error handler can throw the original or a new exception which will be thrown to the container. Anything returned by the error handler is ignored.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -6,3 +6,8 @@
 New `KafkaHeaders` have been introduced regarding `timestamp` support.
 Also new `KafkaConditions.timestamp()` and `KafkaMatchers.hasTimestamp()` testing utilities have been added.
 See <<kafka-template>>, <<kafka-listener-annotation>> and <<testing>> for more details.
+
+===== @KafkaListener Changes
+
+You can now configure a `KafkaListenerErrorHandler` to handle exceptions.
+See <<annotation-error-handling>> for more information.


### PR DESCRIPTION
This PR adds the `errorHandler` property of type `KafkaListenerErrorHandler`, to `@KafkaListener`. See #256 for more information.

I've signed the CLA. Please review and merge.

Thanks,
Venil