### PR TITLE
GH-286: Support @SendTo on @KafkaListener

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,7 @@ import org.springframework.beans.BeanUtils;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.listener.AbstractMessageListenerContainer;
 import org.springframework.kafka.listener.adapter.RecordFilterStrategy;
 import org.springframework.kafka.listener.config.ContainerProperties;
@@ -68,6 +69,7 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 
 	private ApplicationEventPublisher applicationEventPublisher;
 
+	private KafkaTemplate<K, V> replyTemplate;
 	/**
 	 * Specify a {@link ConsumerFactory} to use.
 	 * @param consumerFactory The consumer factory.
@@ -163,6 +165,15 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 	}
 
 	/**
+	 * Set the {@link KafkaTemplate} to use to send replies.
+	 * @param replyTemplate the template.
+	 * @since 2.0
+	 */
+	public void setReplyTemplate(KafkaTemplate<K, V> replyTemplate) {
+		this.replyTemplate = replyTemplate;
+	}
+
+	/**
 	 * Obtain the properties template for this factory - set properties as needed
 	 * and they will be copied to a final properties instance for the endpoint.
 	 * @return the properties.
@@ -205,6 +216,9 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 			}
 			if (this.batchListener != null) {
 				aklEndpoint.setBatchListener(this.batchListener);
+			}
+			if (this.replyTemplate != null) {
+				aklEndpoint.setReplyTemplate(this.replyTemplate);
 			}
 		}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/MethodKafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/MethodKafkaListenerEndpoint.java
@@ -17,7 +17,9 @@
 package org.springframework.kafka.config;
 
 import java.lang.reflect.Method;
+import java.util.Arrays;
 
+import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.kafka.listener.KafkaListenerErrorHandler;
 import org.springframework.kafka.listener.MessageListenerContainer;
 import org.springframework.kafka.listener.adapter.BatchMessagingMessageListenerAdapter;
@@ -27,6 +29,7 @@ import org.springframework.kafka.listener.adapter.RecordMessagingMessageListener
 import org.springframework.kafka.support.converter.BatchMessageConverter;
 import org.springframework.kafka.support.converter.MessageConverter;
 import org.springframework.kafka.support.converter.RecordMessageConverter;
+import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.handler.annotation.support.MessageHandlerMethodFactory;
 import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
 import org.springframework.util.Assert;
@@ -97,6 +100,22 @@ public class MethodKafkaListenerEndpoint<K, V> extends AbstractKafkaListenerEndp
 		this.errorHandler = errorHandler;
 	}
 
+	private String getReplyTopic() {
+		Method method = getMethod();
+		if (method != null) {
+			SendTo ann = AnnotationUtils.getAnnotation(method, SendTo.class);
+			if (ann != null) {
+				String[] destinations = ann.value();
+				if (destinations.length > 1) {
+					throw new IllegalStateException("Invalid @" + SendTo.class.getSimpleName() + " annotation on '"
+							+ method + "' one destination must be set (got " + Arrays.toString(destinations) + ")");
+				}
+				return destinations.length == 1 ? resolve(destinations[0]) : "";
+			}
+		}
+		return null;
+	}
+
 	/**
 	 * Return the {@link MessageHandlerMethodFactory}.
 	 * @return the messageHandlerMethodFactory
@@ -112,6 +131,14 @@ public class MethodKafkaListenerEndpoint<K, V> extends AbstractKafkaListenerEndp
 				"Could not create message listener - MessageHandlerMethodFactory not set");
 		MessagingMessageListenerAdapter<K, V> messageListener = createMessageListenerInstance(messageConverter);
 		messageListener.setHandlerMethod(configureListenerAdapter(messageListener));
+		String replyTopic = getReplyTopic();
+		if (replyTopic != null) {
+			Assert.state(getReplyTemplate() != null, "a KafkaTemplate is required to support replies");
+			messageListener.setReplyTopic(replyTopic);
+		}
+		if (getReplyTemplate() != null) {
+			messageListener.setReplyTemplate(getReplyTemplate());
+		}
 		return messageListener;
 	}
 
@@ -132,13 +159,14 @@ public class MethodKafkaListenerEndpoint<K, V> extends AbstractKafkaListenerEndp
 	 * @return the {@link MessagingMessageListenerAdapter} instance.
 	 */
 	protected MessagingMessageListenerAdapter<K, V> createMessageListenerInstance(MessageConverter messageConverter) {
+		MessagingMessageListenerAdapter<K, V> listener;
 		if (isBatchListener()) {
 			BatchMessagingMessageListenerAdapter<K, V> messageListener = new BatchMessagingMessageListenerAdapter<K, V>(
 					this.bean, this.method, this.errorHandler);
 			if (messageConverter instanceof BatchMessageConverter) {
 				messageListener.setBatchMessageConverter((BatchMessageConverter) messageConverter);
 			}
-			return messageListener;
+			listener = messageListener;
 		}
 		else {
 			RecordMessagingMessageListenerAdapter<K, V> messageListener = new RecordMessagingMessageListenerAdapter<K, V>(
@@ -146,7 +174,22 @@ public class MethodKafkaListenerEndpoint<K, V> extends AbstractKafkaListenerEndp
 			if (messageConverter instanceof RecordMessageConverter) {
 				messageListener.setMessageConverter((RecordMessageConverter) messageConverter);
 			}
-			return messageListener;
+			listener = messageListener;
+		}
+		if (getBeanResolver() != null) {
+			listener.setBeanResolver(getBeanResolver());
+		}
+		return listener;
+	}
+
+	private String resolve(String value) {
+		if (getResolver() != null) {
+			Object newValue = this.getResolver().evaluate(value, getBeanExpressionContext());
+			Assert.isInstanceOf(String.class, newValue, "Invalid @SendTo expression");
+			return (String) newValue;
+		}
+		else {
+			return value;
 		}
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/MultiMethodKafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/MultiMethodKafkaListenerEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,8 +53,8 @@ public class MultiMethodKafkaListenerEndpoint<K, V> extends MethodKafkaListenerE
 			invocableHandlerMethods.add(getMessageHandlerMethodFactory()
 					.createInvocableHandlerMethod(getBean(), method));
 		}
-		DelegatingInvocableHandler delegatingHandler =
-				new DelegatingInvocableHandler(invocableHandlerMethods, getBean());
+		DelegatingInvocableHandler delegatingHandler = new DelegatingInvocableHandler(invocableHandlerMethods,
+				getBean(), getResolver(), getBeanExpressionContext());
 		return new HandlerAdapter(delegatingHandler);
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.kafka.core;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -62,6 +63,16 @@ public class DefaultKafkaConsumerFactory<K, V> implements ConsumerFactory<K, V> 
 
 	public void setValueDeserializer(Deserializer<V> valueDeserializer) {
 		this.valueDeserializer = valueDeserializer;
+	}
+
+	/**
+	 * Return an unmodifiable reference to the configuration map for this factory.
+	 * Useful for cloning to make a similar factory.
+	 * @return the configs.
+	 * @since 2.0
+	 */
+	public Map<String, Object> getConfigurationProperties() {
+		return Collections.unmodifiableMap(this.configs);
 	}
 
 	@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.kafka.core;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -24,7 +25,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
@@ -88,6 +88,16 @@ public class DefaultKafkaProducerFactory<K, V> implements ProducerFactory<K, V>,
 
 	public void setValueSerializer(Serializer<V> valueSerializer) {
 		this.valueSerializer = valueSerializer;
+	}
+
+	/**
+	 * Return an unmodifiable reference to the configuration map for this factory.
+	 * Useful for cloning to make a similar factory.
+	 * @return the configs.
+	 * @since 2.0
+	 */
+	public Map<String, Object> getConfigurationProperties() {
+		return Collections.unmodifiableMap(this.configs);
 	}
 
 	@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/BatchMessagingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/BatchMessagingMessageListenerAdapter.java
@@ -125,12 +125,18 @@ public class BatchMessagingMessageListenerAdapter<K, V> extends MessagingMessage
 			logger.debug("Processing [" + message + "]");
 		}
 		try {
-			invokeHandler(records, acknowledgment, message);
+			Object result = invokeHandler(records, acknowledgment, message);
+			if (result != null) {
+				handleResult(result, records, message);
+			}
 		}
 		catch (ListenerExecutionFailedException e) {
 			if (this.errorHandler != null) {
 				try {
-					this.errorHandler.handleError(message, e);
+					Object result = this.errorHandler.handleError(message, e);
+					if (result != null) {
+						handleResult(result, records, message);
+					}
 				}
 				catch (Exception ex) {
 					throw new ListenerExecutionFailedException(createMessagingErrorMessage(

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/DelegatingInvocableHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/DelegatingInvocableHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,15 +19,27 @@ package org.springframework.kafka.listener.adapter;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
+import org.springframework.beans.factory.config.BeanExpressionContext;
+import org.springframework.beans.factory.config.BeanExpressionResolver;
 import org.springframework.core.MethodParameter;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.expression.Expression;
+import org.springframework.expression.ParserContext;
+import org.springframework.expression.common.TemplateParserContext;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.kafka.KafkaException;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
+import org.springframework.util.Assert;
 
 
 /**
@@ -40,21 +52,37 @@ import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
  */
 public class DelegatingInvocableHandler {
 
+	private static final SpelExpressionParser PARSER = new SpelExpressionParser();
+
+	private static final ParserContext PARSER_CONTEXT = new TemplateParserContext("!{", "}");
+
 	private final List<InvocableHandlerMethod> handlers;
 
 	private final ConcurrentMap<Class<?>, InvocableHandlerMethod> cachedHandlers =
 			new ConcurrentHashMap<Class<?>, InvocableHandlerMethod>();
 
+	private final Map<InvocableHandlerMethod, Expression> handlerSendTo =
+			new HashMap<InvocableHandlerMethod, Expression>();
+
 	private final Object bean;
+
+	private final BeanExpressionResolver resolver;
+
+	private final BeanExpressionContext beanExpressionContext;
 
 	/**
 	 * Construct an instance with the supplied handlers for the bean.
 	 * @param handlers the handlers.
 	 * @param bean the bean.
+	 * @param beanExpressionResolver the expression resolver.
+	 * @param beanExpressionContext the expresion context.
 	 */
-	public DelegatingInvocableHandler(List<InvocableHandlerMethod> handlers, Object bean) {
+	public DelegatingInvocableHandler(List<InvocableHandlerMethod> handlers, Object bean,
+			BeanExpressionResolver beanExpressionResolver, BeanExpressionContext beanExpressionContext) {
 		this.handlers = new ArrayList<InvocableHandlerMethod>(handlers);
 		this.bean = bean;
+		this.resolver = beanExpressionResolver;
+		this.beanExpressionContext = beanExpressionContext;
 	}
 
 	/**
@@ -76,7 +104,12 @@ public class DelegatingInvocableHandler {
 	public Object invoke(Message<?> message, Object... providedArgs) throws Exception { //NOSONAR
 		Class<? extends Object> payloadClass = message.getPayload().getClass();
 		InvocableHandlerMethod handler = getHandlerForPayload(payloadClass);
-		return handler.invoke(message, providedArgs);
+		Object result = handler.invoke(message, providedArgs);
+		Expression replyTo = this.handlerSendTo.get(handler);
+		if (replyTo != null) {
+			result = new MessagingMessageListenerAdapter.ResultHolder(result, replyTo);
+		}
+		return result;
 	}
 
 	/**
@@ -92,8 +125,49 @@ public class DelegatingInvocableHandler {
 				throw new KafkaException("No method found for " + payloadClass);
 			}
 			this.cachedHandlers.putIfAbsent(payloadClass, handler); //NOSONAR
+			setupReplyTo(handler);
 		}
 		return handler;
+	}
+
+	private void setupReplyTo(InvocableHandlerMethod handler) {
+		String replyTo = null;
+		Method method = handler.getMethod();
+		if (method != null) {
+			SendTo ann = AnnotationUtils.getAnnotation(method, SendTo.class);
+			replyTo = extractSendTo(method.toString(), ann);
+		}
+		if (replyTo == null) {
+			SendTo ann = AnnotationUtils.getAnnotation(this.bean.getClass(), SendTo.class);
+			replyTo = extractSendTo(this.getBean().getClass().getSimpleName(), ann);
+		}
+		if (replyTo != null) {
+			this.handlerSendTo.put(handler, PARSER.parseExpression(replyTo, PARSER_CONTEXT));
+		}
+	}
+
+	private String extractSendTo(String element, SendTo ann) {
+		String replyTo = null;
+		if (ann != null) {
+			String[] destinations = ann.value();
+			if (destinations.length > 1) {
+				throw new IllegalStateException("Invalid @" + SendTo.class.getSimpleName() + " annotation on '"
+						+ element + "' one destination must be set (got " + Arrays.toString(destinations) + ")");
+			}
+			replyTo = destinations.length == 1 ? resolve(destinations[0]) : null;
+		}
+		return replyTo;
+	}
+
+	private String resolve(String value) {
+		if (this.resolver != null) {
+			Object newValue = this.resolver.evaluate(value, this.beanExpressionContext);
+			Assert.isInstanceOf(String.class, newValue, "Invalid @SendTo expression");
+			return (String) newValue;
+		}
+		else {
+			return value;
+		}
 	}
 
 	protected InvocableHandlerMethod findHandlerForPayload(Class<? extends Object> payloadClass) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
@@ -20,6 +20,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.lang.reflect.WildcardType;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
@@ -28,7 +29,17 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.TopicPartition;
 
+import org.springframework.context.expression.MapAccessor;
 import org.springframework.core.MethodParameter;
+import org.springframework.expression.BeanResolver;
+import org.springframework.expression.Expression;
+import org.springframework.expression.ParserContext;
+import org.springframework.expression.common.LiteralExpression;
+import org.springframework.expression.common.TemplateParserContext;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+import org.springframework.expression.spel.support.StandardTypeConverter;
+import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.listener.ConsumerSeekAware;
 import org.springframework.kafka.listener.ListenerExecutionFailedException;
 import org.springframework.kafka.listener.MessageListener;
@@ -55,11 +66,17 @@ import org.springframework.util.Assert;
  */
 public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerSeekAware {
 
+	private static final SpelExpressionParser PARSER = new SpelExpressionParser();
+
+	private static final ParserContext PARSER_CONTEXT = new TemplateParserContext("!{", "}");
+
 	private final Object bean;
 
 	protected final Log logger = LogFactory.getLog(getClass()); //NOSONAR
 
 	private final Type inferredType;
+
+	private final StandardEvaluationContext evaluationContext = new StandardEvaluationContext();
 
 	private HandlerAdapter handlerMethod;
 
@@ -71,6 +88,9 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 
 	private Type fallbackType = Object.class;
 
+	private Expression replyTopicExpression;
+
+	private KafkaTemplate<K, V> replyTemplate;
 
 	public MessagingMessageListenerAdapter(Object bean, Method method) {
 		this.bean = bean;
@@ -126,6 +146,42 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 
 	protected boolean isConsumerRecordList() {
 		return this.isConsumerRecordList;
+	}
+
+	/**
+	 * Set the topic to which to send any result from the method invocation.
+	 * May be a SpEL expression {@code !{...}} evaluated at runtime.
+	 * @param replyTopic the topic or expression.
+	 * @since 2.0
+	 */
+	public void setReplyTopic(String replyTopic) {
+		if (replyTopic.startsWith(PARSER_CONTEXT.getExpressionPrefix())) {
+			this.replyTopicExpression = PARSER.parseExpression(replyTopic, PARSER_CONTEXT);
+		}
+		else {
+			this.replyTopicExpression = new LiteralExpression(replyTopic);
+		}
+	}
+
+	/**
+	 * Set the template to use to send any result from the method invocation.
+	 * @param replyTemplate the template.
+	 * @since 2.0
+	 */
+	public void setReplyTemplate(KafkaTemplate<K, V> replyTemplate) {
+		this.replyTemplate = replyTemplate;
+	}
+
+	/**
+	 * Set a bean resolver for runtime SpEL expressions. Also configures the evaluation
+	 * context with a standard type converter and map accessor.
+	 * @param beanResolver the resolver.
+	 * @since 2.0
+	 */
+	public void setBeanResolver(BeanResolver beanResolver) {
+		this.evaluationContext.setBeanResolver(beanResolver);
+		this.evaluationContext.setTypeConverter(new StandardTypeConverter());
+		this.evaluationContext.addPropertyAccessor(new MapAccessor());
 	}
 
 	protected boolean isMessageList() {
@@ -186,6 +242,67 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 		catch (Exception ex) {
 			throw new ListenerExecutionFailedException("Listener method '" +
 					this.handlerMethod.getMethodAsString(message.getPayload()) + "' threw exception", ex);
+		}
+	}
+
+	/**
+	 * Handle the given result object returned from the listener method, sending a
+	 * response message to the SendTo topic.
+	 * @param resultArg the result object to handle (never <code>null</code>)
+	 * @param request the original request message
+	 * @param source the source data for the method invocation - e.g.
+	 * {@code o.s.messaging.Message<?>}; may be null
+	 * @throws Exception if thrown by Rabbit API methods
+	 */
+	protected void handleResult(Object resultArg, Object request, Object source) {
+		if (this.logger.isDebugEnabled()) {
+			this.logger.debug("Listener method returned result [" + resultArg
+					+ "] - generating response message for it");
+		}
+		Object result = resultArg instanceof ResultHolder ? ((ResultHolder) resultArg).result : resultArg;
+		if (this.replyTemplate == null) {
+			this.logger.debug("No replyTemplate to handle the reply: " + result);
+		}
+		String replyTopic = evaluateReplyTopic(request, source, resultArg);
+		sendResponse(result, replyTopic);
+	}
+
+	private String evaluateReplyTopic(Object request, Object source, Object result) {
+		String replyTo = null;
+		if (result instanceof ResultHolder) {
+			replyTo = evaluateTopic(request, source, result, ((ResultHolder) result).sendTo);
+		}
+		else if (this.replyTopicExpression != null) {
+			replyTo = evaluateTopic(request, source, result, this.replyTopicExpression);
+		}
+		return replyTo;
+	}
+
+	private String evaluateTopic(Object request, Object source, Object result, Expression sendTo) {
+		if (sendTo instanceof LiteralExpression) {
+			return sendTo.getValue(String.class);
+		}
+		else {
+			Object value = sendTo.getValue(this.evaluationContext, new ReplyExpressionRoot(request, source, result));
+			Assert.state(value instanceof String, "replyTopic expression must evaluate to a String or Address");
+			return (String) value;
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	protected void sendResponse(Object result, String topic) {
+		if (topic == null && this.logger.isDebugEnabled()) {
+			this.logger.debug("No replyTopic to handle the reply: " + result);
+		}
+		else {
+			if (result instanceof Collection) {
+				((Collection<V>) result).forEach(v -> {
+					this.replyTemplate.send(topic, v);
+				});
+			}
+			else {
+				this.replyTemplate.send(topic, (V) result);
+			}
 		}
 	}
 
@@ -281,4 +398,57 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 		return !parameterType.equals(Message.class); // could be Message without a generic type
 	}
 
+	/**
+	 * Result holder.
+	 * @since 2.0
+	 */
+	public static final class ResultHolder {
+
+		private final Object result;
+
+		private final Expression sendTo;
+
+		public ResultHolder(Object result, Expression sendTo) {
+			this.result = result;
+			this.sendTo = sendTo;
+		}
+
+		@Override
+		public String toString() {
+			return this.result.toString();
+		}
+
+	}
+
+	/**
+	 * Root object for reply expression evaluation.
+	 * @since 2.0
+	 */
+	public static final class ReplyExpressionRoot {
+
+		private final Object request;
+
+		private final Object source;
+
+		private final Object result;
+
+		public ReplyExpressionRoot(Object request, Object source, Object result) {
+			this.request = request;
+			this.source = source;
+			this.result = result;
+		}
+
+		public Object getRequest() {
+			return this.request;
+		}
+
+		public Object getSource() {
+			return this.source;
+		}
+
+		public Object getResult() {
+			return this.result;
+		}
+
+	}
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/RecordMessagingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/RecordMessagingMessageListenerAdapter.java
@@ -79,12 +79,18 @@ public class RecordMessagingMessageListenerAdapter<K, V> extends MessagingMessag
 			logger.debug("Processing [" + message + "]");
 		}
 		try {
-			invokeHandler(record, acknowledgment, message);
+			Object result = invokeHandler(record, acknowledgment, message);
+			if (result != null) {
+				handleResult(result, record, message);
+			}
 		}
 		catch (ListenerExecutionFailedException e) {
 			if (this.errorHandler != null) {
 				try {
-					this.errorHandler.handleError(message, e);
+					Object result = this.errorHandler.handleError(message, e);
+					if (result != null) {
+						handleResult(result, record, message);
+					}
 				}
 				catch (Exception ex) {
 					throw new ListenerExecutionFailedException(createMessagingErrorMessage(

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -23,15 +23,19 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.OffsetCommitCallback;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -67,6 +71,7 @@ import org.springframework.kafka.listener.config.ContainerProperties;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.support.KafkaNull;
+import org.springframework.kafka.support.SendResult;
 import org.springframework.kafka.support.TopicPartitionInitialOffset;
 import org.springframework.kafka.support.converter.StringJsonMessageConverter;
 import org.springframework.kafka.test.rule.KafkaEmbedded;
@@ -74,6 +79,7 @@ import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.retry.RecoveryCallback;
 import org.springframework.retry.RetryContext;
@@ -84,6 +90,7 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.concurrent.ListenableFuture;
 
 /**
  * @author Gary Russell
@@ -104,7 +111,9 @@ public class EnableKafkaIntegrationTests {
 			"annotated1", "annotated2", "annotated3",
 			"annotated4", "annotated5", "annotated6", "annotated7", "annotated8", "annotated9", "annotated10",
 			"annotated11", "annotated12", "annotated13", "annotated14", "annotated15", "annotated16", "annotated17",
-			"annotated18", "annotated19", "annotated20");
+			"annotated18", "annotated19", "annotated20", "annotated21", "annotated21reply", "annotated22",
+			"annotated22reply", "annotated23", "annotated23reply", "annotated24", "annotated24reply",
+			"annotated25", "annotated25reply1", "annotated25reply2");
 
 	@Autowired
 	public IfaceListenerImpl ifaceListener;
@@ -123,6 +132,9 @@ public class EnableKafkaIntegrationTests {
 
 	@Autowired
 	private RecordFilterImpl recordFilter;
+
+	@Autowired
+	private DefaultKafkaConsumerFactory<Integer, String> consumerFactory;
 
 	@Test
 	public void testSimple() throws Exception {
@@ -208,13 +220,6 @@ public class EnableKafkaIntegrationTests {
 		template.send("annotated7", 0, "foo");
 		template.flush();
 		assertThat(this.ifaceListener.getLatch1().await(60, TimeUnit.SECONDS)).isTrue();
-	}
-
-	@Test
-	public void testListenerErrorHandler() throws Exception {
-		template.send("annotated20", 0, "foo");
-		template.flush();
-		assertThat(this.listener.latch16.await(60, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
@@ -363,6 +368,110 @@ public class EnableKafkaIntegrationTests {
 		assertThat(this.listener.ack).isNotNull();
 	}
 
+	@Test
+	public void testListenerErrorHandler() throws Exception {
+		template.send("annotated20", 0, "foo");
+		template.flush();
+		assertThat(this.listener.latch16.await(60, TimeUnit.SECONDS)).isTrue();
+	}
+
+	@Test
+	public void testReplyingListener() throws Exception {
+		template.send("annotated21", 0, "annotated21reply");
+		template.flush();
+		Map<String, Object> consumerProps = new HashMap<>(this.consumerFactory.getConfigurationProperties());
+		consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, "testReplying");
+		ConsumerFactory<Integer, String> cf = new DefaultKafkaConsumerFactory<>(consumerProps);
+		Consumer<Integer, String> consumer = cf.createConsumer();
+		embeddedKafka.consumeFromAnEmbeddedTopic(consumer, "annotated21reply");
+		ConsumerRecord<Integer, String> reply = KafkaTestUtils.getSingleRecord(consumer, "annotated21reply");
+		assertThat(reply.value()).isEqualTo("ANNOTATED21REPLY");
+		consumer.close();
+	}
+
+	@Test
+	public void testReplyingBatchListener() throws Exception {
+		template.send("annotated22", 0, 0, "foo");
+		template.send("annotated22", 0, 0, "bar");
+		template.flush();
+		Map<String, Object> consumerProps = new HashMap<>(this.consumerFactory.getConfigurationProperties());
+		consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, "testBatchReplying");
+		ConsumerFactory<Integer, String> cf = new DefaultKafkaConsumerFactory<>(consumerProps);
+		Consumer<Integer, String> consumer = cf.createConsumer();
+		embeddedKafka.consumeFromAnEmbeddedTopic(consumer, "annotated22reply");
+		ConsumerRecords<Integer, String> replies = KafkaTestUtils.getRecords(consumer);
+		assertThat(replies.count()).isGreaterThanOrEqualTo(1);
+		Iterator<ConsumerRecord<Integer, String>> iterator = replies.iterator();
+		assertThat(iterator.next().value()).isEqualTo("FOO");
+		if (iterator.hasNext()) {
+			assertThat(iterator.next().value()).isEqualTo("BAR");
+		}
+		else {
+			replies = KafkaTestUtils.getRecords(consumer);
+			assertThat(replies.count()).isGreaterThanOrEqualTo(1);
+			iterator = replies.iterator();
+			assertThat(iterator.next().value()).isEqualTo("BAR");
+		}
+		consumer.close();
+	}
+
+	@Test
+	public void testReplyingListenerWithErrorHandler() throws Exception {
+		template.send("annotated23", 0, "FoO");
+		template.flush();
+		Map<String, Object> consumerProps = new HashMap<>(this.consumerFactory.getConfigurationProperties());
+		consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, "testReplying");
+		ConsumerFactory<Integer, String> cf = new DefaultKafkaConsumerFactory<>(consumerProps);
+		Consumer<Integer, String> consumer = cf.createConsumer();
+		embeddedKafka.consumeFromAnEmbeddedTopic(consumer, "annotated23reply");
+		ConsumerRecord<Integer, String> reply = KafkaTestUtils.getSingleRecord(consumer, "annotated23reply");
+		assertThat(reply.value()).isEqualTo("foo");
+		consumer.close();
+	}
+
+	@Test
+	public void testReplyingBatchListenerWithErrorHandler() throws Exception {
+		template.send("annotated24", 0, 0, "FoO");
+		template.send("annotated24", 0, 0, "BaR");
+		template.flush();
+		Map<String, Object> consumerProps = new HashMap<>(this.consumerFactory.getConfigurationProperties());
+		consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, "testBatchReplying");
+		ConsumerFactory<Integer, String> cf = new DefaultKafkaConsumerFactory<>(consumerProps);
+		Consumer<Integer, String> consumer = cf.createConsumer();
+		embeddedKafka.consumeFromAnEmbeddedTopic(consumer, "annotated24reply");
+		ConsumerRecords<Integer, String> replies = KafkaTestUtils.getRecords(consumer);
+		assertThat(replies.count()).isGreaterThanOrEqualTo(1);
+		Iterator<ConsumerRecord<Integer, String>> iterator = replies.iterator();
+		assertThat(iterator.next().value()).isEqualTo("foo");
+		if (iterator.hasNext()) {
+			assertThat(iterator.next().value()).isEqualTo("bar");
+		}
+		else {
+			replies = KafkaTestUtils.getRecords(consumer);
+			assertThat(replies.count()).isGreaterThanOrEqualTo(1);
+			iterator = replies.iterator();
+			assertThat(iterator.next().value()).isEqualTo("bar");
+		}
+		consumer.close();
+	}
+
+	@Test
+	public void testMultiReplyTo() throws Exception {
+		template.send("annotated25", 0, 1, "foo");
+		template.flush();
+		Map<String, Object> consumerProps = new HashMap<>(this.consumerFactory.getConfigurationProperties());
+		consumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, "testMultiReplying");
+		ConsumerFactory<Integer, String> cf = new DefaultKafkaConsumerFactory<>(consumerProps);
+		Consumer<Integer, String> consumer = cf.createConsumer();
+		embeddedKafka.consumeFromEmbeddedTopics(consumer, "annotated25reply1", "annotated25reply2");
+		ConsumerRecord<Integer, String> reply = KafkaTestUtils.getSingleRecord(consumer, "annotated25reply1");
+		assertThat(reply.value()).isEqualTo("FOO");
+		template.send("annotated25", 0, 1, null);
+		reply = KafkaTestUtils.getSingleRecord(consumer, "annotated25reply2");
+		assertThat(reply.value()).isEqualTo("BAR");
+		consumer.close();
+	}
+
 	private Consumer<?, ?> spyOnConsumer(KafkaMessageListenerContainer<Integer, String> container) {
 		Consumer<?, ?> consumer = spy(
 				KafkaTestUtils.getPropertyValue(container, "listenerConsumer.consumer", Consumer.class));
@@ -393,6 +502,7 @@ public class EnableKafkaIntegrationTests {
 					new ConcurrentKafkaListenerContainerFactory<>();
 			factory.setConsumerFactory(consumerFactory());
 			factory.setRecordFilterStrategy(recordFilter());
+			factory.setReplyTemplate(partitionZeroReplyingTemplate());
 			return factory;
 		}
 
@@ -421,6 +531,8 @@ public class EnableKafkaIntegrationTests {
 					new ConcurrentKafkaListenerContainerFactory<>();
 			factory.setConsumerFactory(consumerFactory());
 			factory.setBatchListener(true);
+			// always send to the same partition so the replies are in order for the test
+			factory.setReplyTemplate(partitionZeroReplyingTemplate());
 			return factory;
 		}
 
@@ -484,7 +596,7 @@ public class EnableKafkaIntegrationTests {
 		}
 
 		@Bean
-		public ConsumerFactory<Integer, String> consumerFactory() {
+		public DefaultKafkaConsumerFactory<Integer, String> consumerFactory() {
 			return new DefaultKafkaConsumerFactory<>(consumerConfigs());
 		}
 
@@ -518,6 +630,11 @@ public class EnableKafkaIntegrationTests {
 		}
 
 		@Bean
+		public MultiListenerSendTo multiListenerSendTo() {
+			return new MultiListenerSendTo();
+		}
+
+		@Bean
 		public ProducerFactory<Integer, String> producerFactory() {
 			return new DefaultKafkaProducerFactory<>(producerConfigs());
 		}
@@ -530,6 +647,19 @@ public class EnableKafkaIntegrationTests {
 		@Bean
 		public KafkaTemplate<Integer, String> template() {
 			return new KafkaTemplate<Integer, String>(producerFactory());
+		}
+
+		@Bean
+		public KafkaTemplate<Integer, String> partitionZeroReplyingTemplate() {
+			// reply always uses the no-partition, no-key method; subclasses can be used
+			return new KafkaTemplate<Integer, String>(producerFactory()) {
+
+				@Override
+				public ListenableFuture<SendResult<Integer, String>> send(String topic, String data) {
+					return super.send(topic, 0, null, data);
+				}
+
+			};
 		}
 
 		@Bean
@@ -560,6 +690,22 @@ public class EnableKafkaIntegrationTests {
 			return (m, e) -> {
 				listener.latch16.countDown();
 				return null;
+			};
+		}
+
+		@Bean
+		public KafkaListenerErrorHandler replyErrorHandler() {
+			return (m, e) -> {
+				return ((String) m.getPayload()).toLowerCase();
+			};
+		}
+
+		@SuppressWarnings("unchecked")
+		@Bean
+		public KafkaListenerErrorHandler replyBatchErrorHandler() {
+			return (m, e) -> {
+				return ((Collection<String>) m.getPayload()).stream().map(v -> v.toLowerCase())
+						.collect(Collectors.toList());
 			};
 		}
 
@@ -759,6 +905,32 @@ public class EnableKafkaIntegrationTests {
 			throw new Exception("return this");
 		}
 
+		@KafkaListener(id = "replyingListener", topics = "annotated21")
+		@SendTo("!{request.value()}") // runtime SpEL - test payload is the reply queue
+		public String replyingListener(String in) {
+			return in.toUpperCase();
+		}
+
+		@KafkaListener(id = "replyingBatchListener", topics = "annotated22", containerFactory = "batchFactory")
+		@SendTo("#{'annotated22reply'}") // config time SpEL
+		public Collection<String> replyingBatchListener(List<String> in) {
+			return in.stream().map(v -> v.toUpperCase()).collect(Collectors.toList());
+		}
+
+		@KafkaListener(id = "replyingListenerWithErrorHandler", topics = "annotated23",
+				errorHandler = "replyErrorHandler")
+		@SendTo("annotated23reply")
+		public String replyingListenerWithErrorHandler(String in) {
+			throw new RuntimeException("return this");
+		}
+
+		@KafkaListener(id = "replyingBatchListenerWithErrorHandler", topics = "annotated24",
+				containerFactory = "batchFactory", errorHandler = "replyBatchErrorHandler")
+		@SendTo("annotated24reply")
+		public Collection<String> replyingBatchListenerWithErrorHandler(List<String> in) {
+			throw new RuntimeException("return this");
+		}
+
 		@Override
 		public void registerSeekCallback(ConsumerSeekCallback callback) {
 			this.seekCallBack.set(callback);
@@ -828,6 +1000,24 @@ public class EnableKafkaIntegrationTests {
 		}
 
 		public void foo(String bar) {
+		}
+
+	}
+
+	@KafkaListener(id = "multiSendTo", topics = "annotated25")
+	@SendTo("annotated25reply1")
+	static class MultiListenerSendTo {
+
+		@KafkaHandler
+		public String foo(String in) {
+			return in.toUpperCase();
+		}
+
+		@KafkaHandler
+		@SendTo("!{'annotated25reply2'}")
+		public String bar(@Payload(required = false) KafkaNull nul,
+				@Header(KafkaHeaders.RECEIVED_MESSAGE_KEY) int key) {
+			return "BAR";
 		}
 
 	}

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -517,6 +517,66 @@ For the `ConcurrentMessageListenerContainer`, the `<beanName>` part of the threa
 `n` increments each time the container is started.
 So, with a bean name of `container`, threads in this container will be named `container-0-C-1`, `container-1-C-1` etc., after the container is started the first time; `container-0-C-2`, `container-1-C-2` etc., after a stop/start.
 
+[[class-level-kafkalistener]]
+===== @KafkaListener on a class
+
+When using `@KafkaListener` at the class-level, you specify `@KafkaHandler` at the method level.
+When messages are delivered, the converted message payload type is used to determine which method to call.
+
+[source, java]
+----
+@KafkaListener(id = "multi", topics = "myTopic")
+static class MultiListenerBean {
+
+    @KafkaHandler
+    public void listen(String foo) {
+        ...
+    }
+
+    @KafkaHandler
+    public void listen(Integer bar) {
+        ...
+    }
+
+}
+----
+
+[[annotation-send-to]]
+===== Forwarding Listener Results using @SendTo
+
+Starting with _version 2.0_, if you also annotate a `@KafkaListener` with a `@SendTo` annotation and the method invocation returns a result, the result will be forwared to the topic specified by the `@SendTo`.
+
+The `@SendTo` value can have several forms:
+
+- `@SendTo("someTopic")` routes to the literal topic
+- `@SendTo("#{someExpression}")` routes to the topic determined by evaluating the expression once during application context initialization.
+- `@SendTo("!{someExpression}")` routes to the topic determined by evaluating the expression at runtime.
+The `#root` object for the evaluation has 4 properties:
+  - request - the inbound `ConsumerRecord` (or `ConsumerRecords` object for a batch listener))
+  - source - the `org.springframework.messaging.Message<?>` converted from the `request`.
+  - result - the method return result.
+The expression must return a `String` representing the topic name.
+
+When using `@SendTo`, the `ConcurrentKafkaListenerContainerFactory` must be configured with a `KafkaTemplate` in its `replyTemplate` property, to perform the send.
+Note: only the simple `send(topic, value)` method is used, so you may wish to create a subclass to generate the partition and/or key...
+
+[source, java]
+----
+@Bean
+public KafkaTemplate<String, String> myReplyingTemplate() {
+    return new KafkaTemplate<Integer, String>(producerFactory()) {
+
+        @Override
+        public ListenableFuture<SendResult<String, String>> send(String topic, String data) {
+            return super.send(topic, partitionForData(data), keyForData(data), data);
+        }
+
+        ...
+
+    };
+}
+----
+
 ===== Filtering Messages
 
 In certain scenarios, such as rebalancing, a message may be redelivered that has already been processed.
@@ -624,8 +684,7 @@ public class Listener {
 
     @EventListener(condition = "event.listenerId.startsWith('qux-')")
     public void eventHandler(ListenerContainerIdleEvent event) {
-        this.event = event;
-        eventLatch.countDown();
+        ...
     }
 
 }
@@ -788,8 +847,6 @@ When using a class-level `@KafkaListener`, some additional configuration is need
 ----
 @KafkaListener(id = "multi", topics = "myTopic")
 static class MultiListenerBean {
-
-    private final CountDownLatch latch1 = new CountDownLatch(2);
 
     @KafkaHandler
     public void listen(String foo) {

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -11,3 +11,7 @@ See <<kafka-template>>, <<kafka-listener-annotation>> and <<testing>> for more d
 
 You can now configure a `KafkaListenerErrorHandler` to handle exceptions.
 See <<annotation-error-handling>> for more information.
+
+You can now annotate `@KafkaListener` methods (and classes, and `@KafkaHandler` methods) with `@SendTo`.
+If the method returns a result, it is forwarded to the specified topic.
+See <<annotation-send-to>> for more information.


### PR DESCRIPTION
Resolves: https://github.com/spring-projects/spring-kafka/issues/286

Forward method result to a topic.

Mostly a port of the Spring AMQP logic, with some tweaks for data types and the lack
of a replyTo header with Kafka.