### PR TITLE
GH-288: Fix autoCommit Default Return Value

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,7 +77,7 @@ public class DefaultKafkaConsumerFactory<K, V> implements ConsumerFactory<K, V> 
 	public boolean isAutoCommit() {
 		Object auto = this.configs.get(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG);
 		return auto instanceof Boolean ? (Boolean) auto
-				: auto instanceof String ? Boolean.valueOf((String) auto) : false;
+				: auto instanceof String ? Boolean.valueOf((String) auto) : true;
 	}
 
 }


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-kafka/issues/288

The `DefaultKafkaConsumerFactory` incorrectly returns `false` if no `enable.auto.commit`
property is present. This causes the container to issue commits, which causes strange
offset behavior. Unread partitions are set to the end so messages can be lost.

Work-around is to explicitly add the property.

See: http://stackoverflow.com/questions/43405009/kafka-stop-consuming-message-from-new-assigned-patitions-after-rebalancing/43413899#43413899

__cherry-pick to 1.2.x, 1.1.x, 1.0.x__
