### PR TITLE
Change RecoveryCallback from <Void> to <Object>

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
@@ -62,7 +62,7 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 
 	private RetryTemplate retryTemplate;
 
-	private RecoveryCallback<Void> recoveryCallback;
+	private RecoveryCallback<? extends Object> recoveryCallback;
 
 	private Boolean batchListener;
 
@@ -135,7 +135,7 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 	 * retryTemplate}.
 	 * @param recoveryCallback the callback.
 	 */
-	public void setRecoveryCallback(RecoveryCallback<Void> recoveryCallback) {
+	public void setRecoveryCallback(RecoveryCallback<? extends Object> recoveryCallback) {
 		this.recoveryCallback = recoveryCallback;
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
@@ -80,7 +80,7 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 
 	private RetryTemplate retryTemplate;
 
-	private RecoveryCallback<Void> recoveryCallback;
+	private RecoveryCallback<? extends Object> recoveryCallback;
 
 	private boolean batchListener;
 
@@ -273,7 +273,7 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 	 * retryTemplate}.
 	 * @param recoveryCallback the callback.
 	 */
-	public void setRecoveryCallback(RecoveryCallback<Void> recoveryCallback) {
+	public void setRecoveryCallback(RecoveryCallback<? extends Object> recoveryCallback) {
 		this.recoveryCallback = recoveryCallback;
 	}
 
@@ -304,7 +304,7 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 			}
 			else {
 				messageListener = new RetryingMessageListenerAdapter<>((MessageListener<K, V>) messageListener,
-						this.retryTemplate, this.recoveryCallback);
+						this.retryTemplate, (RecoveryCallback<Object>) this.recoveryCallback);
 			}
 		}
 		if (this.recordFilterStrategy != null) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/AbstractRetryingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/AbstractRetryingMessageListenerAdapter.java
@@ -34,7 +34,7 @@ public abstract class AbstractRetryingMessageListenerAdapter<K, V, T> extends Ab
 
 	private final RetryTemplate retryTemplate;
 
-	private final RecoveryCallback<Void> recoveryCallback;
+	private final RecoveryCallback<? extends Object> recoveryCallback;
 
 	/**
 	 * Construct an instance with the supplied retry template. The exception will be
@@ -54,7 +54,7 @@ public abstract class AbstractRetryingMessageListenerAdapter<K, V, T> extends Ab
 	 * thrown to the container after retries are exhausted.
 	 */
 	public AbstractRetryingMessageListenerAdapter(T delegate, RetryTemplate retryTemplate,
-			RecoveryCallback<Void> recoveryCallback) {
+			RecoveryCallback<? extends Object> recoveryCallback) {
 		super(delegate);
 		Assert.notNull(retryTemplate, "'retryTemplate' cannot be null");
 		this.retryTemplate = retryTemplate;
@@ -65,7 +65,7 @@ public abstract class AbstractRetryingMessageListenerAdapter<K, V, T> extends Ab
 		return this.retryTemplate;
 	}
 
-	public RecoveryCallback<Void> getRecoveryCallback() {
+	public RecoveryCallback<? extends Object> getRecoveryCallback() {
 		return this.recoveryCallback;
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/RetryingAcknowledgingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/RetryingAcknowledgingMessageListenerAdapter.java
@@ -61,15 +61,16 @@ public class RetryingAcknowledgingMessageListenerAdapter<K, V>
 	 * thrown to the container after retries are exhausted.
 	 */
 	public RetryingAcknowledgingMessageListenerAdapter(AcknowledgingMessageListener<K, V> messageListener,
-			RetryTemplate retryTemplate, RecoveryCallback<Void> recoveryCallback) {
+			RetryTemplate retryTemplate, RecoveryCallback<? extends Object> recoveryCallback) {
 		super(messageListener, retryTemplate, recoveryCallback);
 		Assert.notNull(messageListener, "'messageListener' cannot be null");
 		this.delegate = messageListener;
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public void onMessage(final ConsumerRecord<K, V> record, final Acknowledgment acknowledgment) {
-		getRetryTemplate().execute(new RetryCallback<Void, KafkaException>() {
+		getRetryTemplate().execute(new RetryCallback<Object, KafkaException>() {
 
 			@Override
 			public Void doWithRetry(RetryContext context) throws KafkaException {
@@ -78,7 +79,7 @@ public class RetryingAcknowledgingMessageListenerAdapter<K, V>
 				return null;
 			}
 
-		}, getRecoveryCallback());
+		}, (RecoveryCallback<Object>) getRecoveryCallback());
 	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/RetryingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/RetryingMessageListenerAdapter.java
@@ -57,14 +57,15 @@ public class RetryingMessageListenerAdapter<K, V>
 	 * thrown to the container after retries are exhausted.
 	 */
 	public RetryingMessageListenerAdapter(MessageListener<K, V> messageListener, RetryTemplate retryTemplate,
-			RecoveryCallback<Void> recoveryCallback) {
+			RecoveryCallback<Object> recoveryCallback) {
 		super(messageListener, retryTemplate, recoveryCallback);
 		Assert.notNull(messageListener, "'messageListener' cannot be null");
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public void onMessage(final ConsumerRecord<K, V> record) {
-		getRetryTemplate().execute(new RetryCallback<Void, KafkaException>() {
+		getRetryTemplate().execute(new RetryCallback<Object, KafkaException>() {
 
 			@Override
 			public Void doWithRetry(RetryContext context) throws KafkaException {
@@ -73,7 +74,7 @@ public class RetryingMessageListenerAdapter<K, V>
 				return null;
 			}
 
-		}, getRecoveryCallback());
+		}, (RecoveryCallback<Object>) getRecoveryCallback());
 	}
 
 }


### PR DESCRIPTION
Actually <? extends Object> for backwards compatibility.

__cherry-pick to 1.2.x, 1.1.x__