### PR TITLE
GH-194: Make `KafkaEmbedded` as a bean

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -167,7 +167,7 @@ project ('spring-kafka-test') {
 	description = 'Spring Kafka Test Support'
 
 	dependencies {
-		compile "org.springframework:spring-beans:$springVersion"
+		compile "org.springframework:spring-context:$springVersion"
 		compile "org.springframework:spring-test:$springVersion"
 		compile "org.springframework.retry:spring-retry:$springRetryVersion"
 

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafka.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafka.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.test.context;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.kafka.test.rule.KafkaEmbedded;
+
+/**
+ * Annotation that can be specified on a test class that runs Spring Kafka based tests.
+ * Provides the following features over and above the regular <em>Spring TestContext
+ * Framework</em>:
+ * <ul>
+ * <li>Registers a {@link KafkaEmbedded} bean with the {@link KafkaEmbedded#BEAN_NAME} bean name.
+ * </li>
+ * </ul>
+ * <p>
+ * The typical usage of this annotation is like:
+ * <pre class="code">
+ * &#064;RunWith(SpringRunner.class)
+ * &#064;EmbeddedKafka
+ * public class MyKafkaTests {
+ *
+ *    &#064;Autowired
+ *    private KafkaEmbedded kafkaEmbedded;
+ *
+ *    &#064;Value("${spring.embedded.kafka.brokers}")
+ *    private String brokerAddresses;
+ * }
+ * </pre>
+ *
+ * @author Artem Bilan
+ *
+ * @since 2.0
+ *
+ * @see KafkaEmbedded
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Inherited
+public @interface EmbeddedKafka {
+
+	/**
+	 * @return the number of brokers
+	 */
+	@AliasFor("count")
+	int value() default 1;
+
+	/**
+	 * @return the number of brokers
+	 */
+	@AliasFor("value")
+	int count() default 1;
+
+	/**
+	 * @return  passed into {@code kafka.utils.TestUtils.createBrokerConfig())
+	 */
+	boolean controlledShutdown() default false;
+
+	/**
+	 * @return  partitions per topic.
+	 */
+	int partitions() default 2;
+
+	/**
+	 * @return the topics to create..
+	 */
+	String[] topics() default {};
+
+}
+

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizer.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizer.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.test.context;
+
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.DefaultSingletonBeanRegistry;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.kafka.test.rule.KafkaEmbedded;
+import org.springframework.test.context.ContextCustomizer;
+import org.springframework.test.context.MergedContextConfiguration;
+import org.springframework.util.Assert;
+
+/**
+ * The {@link ContextCustomizer} implementation for Spring Integration specific environment.
+ * <p>
+ * Registers {@link KafkaEmbedded} bean.
+ *
+ * @author Artem Bilan
+ *
+ * @since 2.0
+ */
+class EmbeddedKafkaContextCustomizer implements ContextCustomizer {
+
+	private final EmbeddedKafka embeddedKafka;
+
+	EmbeddedKafkaContextCustomizer(EmbeddedKafka embeddedKafka) {
+		this.embeddedKafka = embeddedKafka;
+	}
+
+	@Override
+	public void customizeContext(ConfigurableApplicationContext context, MergedContextConfiguration mergedConfig) {
+		ConfigurableListableBeanFactory beanFactory = context.getBeanFactory();
+		Assert.isInstanceOf(DefaultSingletonBeanRegistry.class, beanFactory);
+
+		KafkaEmbedded kafkaEmbedded = new KafkaEmbedded(this.embeddedKafka.count(),
+				this.embeddedKafka.controlledShutdown(),
+				this.embeddedKafka.partitions(),
+				this.embeddedKafka.topics());
+
+		beanFactory.initializeBean(kafkaEmbedded, KafkaEmbedded.BEAN_NAME);
+		beanFactory.registerSingleton(KafkaEmbedded.BEAN_NAME, kafkaEmbedded);
+		((DefaultSingletonBeanRegistry) beanFactory).registerDisposableBean(KafkaEmbedded.BEAN_NAME, kafkaEmbedded);
+	}
+
+}
+

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizerFactory.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizerFactory.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.test.context;
+
+import java.util.List;
+
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.test.context.ContextConfigurationAttributes;
+import org.springframework.test.context.ContextCustomizer;
+import org.springframework.test.context.ContextCustomizerFactory;
+
+/**
+ * The {@link ContextCustomizerFactory} implementation to produce a
+ * {@link EmbeddedKafkaContextCustomizer} if a {@link EmbeddedKafka} annotation
+ * is present on the test class.
+ *
+ * @author Artem Bilan
+ *
+ * @since 2.0
+ */
+class EmbeddedKafkaContextCustomizerFactory implements ContextCustomizerFactory {
+
+	@Override
+	public ContextCustomizer createContextCustomizer(Class<?> testClass,
+			List<ContextConfigurationAttributes> configAttributes) {
+		EmbeddedKafka embeddedKafka =
+				AnnotatedElementUtils.findMergedAnnotation(testClass, EmbeddedKafka.class);
+		return embeddedKafka != null ? new EmbeddedKafkaContextCustomizer(embeddedKafka) : null;
+	}
+
+}

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/rule/KafkaEmbedded.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/rule/KafkaEmbedded.java
@@ -43,8 +43,8 @@ import org.apache.kafka.common.requests.MetadataResponse;
 import org.apache.kafka.common.utils.Time;
 import org.junit.rules.ExternalResource;
 
+import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.InitializingBean;
-import org.springframework.context.Lifecycle;
 import org.springframework.kafka.test.core.BrokerAddress;
 import org.springframework.retry.RetryCallback;
 import org.springframework.retry.RetryContext;
@@ -75,7 +75,9 @@ import scala.collection.Set;
  * @author Gary Russell
  */
 @SuppressWarnings("serial")
-public class KafkaEmbedded extends ExternalResource implements KafkaRule, InitializingBean, Lifecycle {
+public class KafkaEmbedded extends ExternalResource implements KafkaRule, InitializingBean, DisposableBean {
+
+	public static final String BEAN_NAME = "kafkaEmbedded";
 
 	public static final String SPRING_EMBEDDED_KAFKA_BROKERS = "spring.embedded.kafka.brokers";
 
@@ -96,8 +98,6 @@ public class KafkaEmbedded extends ExternalResource implements KafkaRule, Initia
 	private ZkClient zookeeperClient;
 
 	private String zkConnect;
-
-	private volatile boolean running;
 
 	public KafkaEmbedded(int count) {
 		this(count, false);
@@ -135,25 +135,7 @@ public class KafkaEmbedded extends ExternalResource implements KafkaRule, Initia
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
-		start();
-	}
-
-	@Override
-	public synchronized void start() {
-		if (!this.running) {
-			try {
-				before();
-			}
-			catch (Exception e) {
-				throw new IllegalStateException("Cannot start: " + this, e);
-			}
-			this.running = true;
-		}
-	}
-
-	@Override
-	public boolean isRunning() {
-		return this.running;
+		before();
 	}
 
 	@Override
@@ -191,12 +173,10 @@ public class KafkaEmbedded extends ExternalResource implements KafkaRule, Initia
 		System.setProperty(SPRING_EMBEDDED_KAFKA_BROKERS, getBrokersAsString());
 	}
 
+
 	@Override
-	public void stop() {
-		if (this.running) {
-			after();
-			this.running = false;
-		}
+	public void destroy() throws Exception {
+		after();
 	}
 
 	@Override

--- a/spring-kafka-test/src/main/resources/META-INF/spring.factories
+++ b/spring-kafka-test/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,3 @@
+# Spring Test ContextCustomizerFactories
+org.springframework.test.context.ContextCustomizerFactory=\
+org.springframework.kafka.test.context.EmbeddedKafkaContextCustomizerFactory

--- a/spring-kafka/src/test/java/org/springframework/kafka/kstream/KafkaStreamsTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/kstream/KafkaStreamsTests.java
@@ -31,7 +31,6 @@ import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KStreamBuilder;
 import org.apache.kafka.streams.kstream.TimeWindows;
 import org.apache.kafka.streams.processor.WallclockTimestampExtractor;
-import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -69,9 +68,6 @@ public class KafkaStreamsTests {
 
 	private static final String STREAMING_TOPIC2 = "streamingTopic2";
 
-	@ClassRule
-	public static KafkaEmbedded embeddedKafka = new KafkaEmbedded(1, true, 1, STREAMING_TOPIC1, STREAMING_TOPIC2);
-
 	@Autowired
 	private KafkaTemplate<Integer, String> kafkaTemplate;
 
@@ -99,6 +95,14 @@ public class KafkaStreamsTests {
 	@EnableKafkaStreams
 	public static class KafkaStreamsConfiguration {
 
+		@Autowired
+		private KafkaEmbedded embeddedKafka;
+
+		@Bean
+		public static KafkaEmbedded embeddedKafka() {
+			return new KafkaEmbedded(1, true, 1, STREAMING_TOPIC1, STREAMING_TOPIC2);
+		}
+
 		@Bean
 		public ProducerFactory<Integer, String> producerFactory() {
 			return new DefaultKafkaProducerFactory<>(producerConfigs());
@@ -106,7 +110,7 @@ public class KafkaStreamsTests {
 
 		@Bean
 		public Map<String, Object> producerConfigs() {
-			return KafkaTestUtils.producerProps(embeddedKafka);
+			return KafkaTestUtils.producerProps(this.embeddedKafka);
 		}
 
 		@Bean
@@ -120,7 +124,7 @@ public class KafkaStreamsTests {
 		public StreamsConfig kStreamsConfigs() {
 			Map<String, Object> props = new HashMap<>();
 			props.put(StreamsConfig.APPLICATION_ID_CONFIG, "testStreams");
-			props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, embeddedKafka.getBrokersAsString());
+			props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, this.embeddedKafka.getBrokersAsString());
 			props.put(StreamsConfig.KEY_SERDE_CLASS_CONFIG, Serdes.Integer().getClass().getName());
 			props.put(StreamsConfig.VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
 			props.put(StreamsConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG, WallclockTimestampExtractor.class.getName());
@@ -148,7 +152,7 @@ public class KafkaStreamsTests {
 
 		@Bean
 		public Map<String, Object> consumerConfigs() {
-			Map<String, Object> consumerProps = KafkaTestUtils.consumerProps("testGroup", "false", embeddedKafka);
+			Map<String, Object> consumerProps = KafkaTestUtils.consumerProps("testGroup", "false", this.embeddedKafka);
 			consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 			return consumerProps;
 		}

--- a/src/reference/asciidoc/testing.adoc
+++ b/src/reference/asciidoc/testing.adoc
@@ -94,9 +94,58 @@ ConsumerRecord<Integer, String> received = KafkaTestUtils.getSingleRecord(consum
 ...
 ----
 
-When the embedded server is started by JUnit, it sets a system property `spring.embedded.kafka.brokers` to the address
-of the broker(s).
+When the embedded server is started by JUnit, it sets a system property `spring.embedded.kafka.brokers` to the address of the broker(s).
 A convenient constant `KafkaEmbedded.SPRING_EMBEDDED_KAFKA_BROKERS` is provided for this property.
+
+==== @EmbeddedKafka annotation
+It is generally recommended to use the rule as a `@ClassRule` to avoid starting/stopping the broker between tests (and use a different topic for each test).
+Starting with _version 2.0_, if you are using Spring's test application context caching, you can also declare a `KafkaEmbedded` bean, so a single broker can be used across multiple test classes.
+The JUnit `ExternalResource` `before()/after()` lifecycle is wrapped to the `afterPropertiesSet()` and `destroy()` Spring infrastructure hooks.
+For convenience a test class level `@EmbeddedKafka` annotation is provided with the purpose to register `KafkaEmbedded` bean:
+
+[source, java]
+----
+@RunWith(SpringRunner.class)
+@DirtiesContext
+@EmbeddedKafka(partitions = 1,
+         topics = {
+                 KafkaStreamsTests.STREAMING_TOPIC1,
+                 KafkaStreamsTests.STREAMING_TOPIC2 })
+public class KafkaStreamsTests {
+
+    @Autowired
+    private KafkaEmbedded kafkaEmbedded;
+
+	@Test
+	public void someTest() {
+	    Map<String, Object> consumerProps = KafkaTestUtils.consumerProps("testGroup", "true", this.kafkaEmbedded);
+        consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        ConsumerFactory<Integer, String> cf = new DefaultKafkaConsumerFactory<>(consumerProps);
+        Consumer<Integer, String> consumer = cf.createConsumer();
+        this.embeddedKafka.consumeFromAnEmbeddedTopic(consumer, KafkaStreamsTests.STREAMING_TOPIC2);
+        ConsumerRecords<Integer, String> replies = KafkaTestUtils.getRecords(consumer);
+        assertThat(replies.count()).isGreaterThanOrEqualTo(1);
+	}
+
+    @Configuration
+    @EnableKafkaStreams
+    public static class KafkaStreamsConfiguration {
+
+        @Value("${" + KafkaEmbedded.SPRING_EMBEDDED_KAFKA_BROKERS + "}")
+        private String brokerAddresses;
+
+        @Bean(name = KafkaStreamsDefaultConfiguration.DEFAULT_STREAMS_CONFIG_BEAN_NAME)
+        public StreamsConfig kStreamsConfigs() {
+            Map<String, Object> props = new HashMap<>();
+            props.put(StreamsConfig.APPLICATION_ID_CONFIG, "testStreams");
+            props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, this.brokerAddresses);
+            return new StreamsConfig(props);
+        }
+
+    }
+
+}
+----
 
 ==== Hamcrest Matchers
 


### PR DESCRIPTION
Fixes: spring-projects/spring-kafka#194

To avoid concurrent calls of the shutdown hooks make an `KafkaEmbedded`
as a `Lifecycle` to let ApplicationContext to call `stop()` before
destroying itself

That way the Kafka servers and zookeeper and also working directory
are destroyed and removed before JMV shutdown hooks
and `FileNotFoundException /tmp/kafka-3266968904825284552/replication-offset-checkpoint.tmp`
should disappear