### PR TITLE
GH-295: Unique client.id for Concurrent Container

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/ClientIdSuffixAware.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/ClientIdSuffixAware.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.core;
+
+import org.apache.kafka.clients.consumer.Consumer;
+
+/**
+ * If a {@code ConsumerFactory} implements this interface, it supports customizing the
+ * {@code client.id} by adding a suffix, if a {@code client.id} property is provided.
+ *
+ * @deprecated - in 2.0, this method will move to {@link ConsumerFactory}.
+ *
+ * @param <K> the key type.
+ * @param <V> the value type.
+ *
+ * @author Gary Russell
+ * @since 1.0.6
+ *
+ */
+@Deprecated
+public interface ClientIdSuffixAware<K, V> {
+
+	/**
+	 * Create a consumer, appending the suffix to the {@code client.id} property,
+	 * if present.
+	 * @param clientIdSuffix the suffix.
+	 * @return the consumer.
+	 */
+	Consumer<K, V> createConsumer(String clientIdSuffix);
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
@@ -16,6 +16,7 @@
 
 package org.springframework.kafka.core;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -36,7 +37,8 @@ import org.apache.kafka.common.serialization.Deserializer;
  * @author Gary Russell
  * @author Murali Reddy
  */
-public class DefaultKafkaConsumerFactory<K, V> implements ConsumerFactory<K, V> {
+@SuppressWarnings("deprecation")
+public class DefaultKafkaConsumerFactory<K, V> implements ConsumerFactory<K, V>, ClientIdSuffixAware<K, V> {
 
 	private final Map<String, Object> configs;
 
@@ -64,13 +66,44 @@ public class DefaultKafkaConsumerFactory<K, V> implements ConsumerFactory<K, V> 
 		this.valueDeserializer = valueDeserializer;
 	}
 
+	/**
+	 * Return an unmodifiable reference to the configuration map for this factory.
+	 * Useful for cloning to make a similar factory.
+	 * @return the configs.
+	 * @since 1.0.6
+	 */
+	public Map<String, Object> getConfigurationProperties() {
+		return Collections.unmodifiableMap(this.configs);
+	}
+
 	@Override
 	public Consumer<K, V> createConsumer() {
 		return createKafkaConsumer();
 	}
 
+	@Override
+	public Consumer<K, V> createConsumer(String clientIdSuffix) {
+		return createKafkaConsumer(clientIdSuffix);
+	}
+
 	protected KafkaConsumer<K, V> createKafkaConsumer() {
-		return new KafkaConsumer<K, V>(this.configs, this.keyDeserializer, this.valueDeserializer);
+		return createKafkaConsumer(this.configs);
+	}
+
+	protected KafkaConsumer<K, V> createKafkaConsumer(String clientIdSuffix) {
+		if (!this.configs.containsKey(ConsumerConfig.CLIENT_ID_CONFIG) || clientIdSuffix == null) {
+			return createKafkaConsumer();
+		}
+		else {
+			Map<String, Object> modifiedClientIdConfigs = new HashMap<>(this.configs);
+			modifiedClientIdConfigs.put(ConsumerConfig.CLIENT_ID_CONFIG,
+					modifiedClientIdConfigs.get(ConsumerConfig.CLIENT_ID_CONFIG) + clientIdSuffix);
+			return createKafkaConsumer(modifiedClientIdConfigs);
+		}
+	}
+
+	protected KafkaConsumer<K, V> createKafkaConsumer(Map<String, Object> configs) {
+		return new KafkaConsumer<K, V>(configs, this.keyDeserializer, this.valueDeserializer);
 	}
 
 	@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
@@ -121,6 +121,7 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 				if (getApplicationEventPublisher() != null) {
 					container.setApplicationEventPublisher(getApplicationEventPublisher());
 				}
+				container.setClientIdSuffix("-" + i);
 				container.start();
 				this.containers.add(container);
 			}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -48,6 +48,7 @@ import org.apache.kafka.common.errors.WakeupException;
 
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.kafka.KafkaException;
+import org.springframework.kafka.core.ClientIdSuffixAware;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.event.ListenerContainerIdleEvent;
 import org.springframework.kafka.listener.ConsumerSeekAware.ConsumerSeekCallback;
@@ -90,6 +91,8 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 
 	private GenericAcknowledgingMessageListener<?> acknowledgingMessageListener;
 
+	private String clientIdSuffix;
+
 	/**
 	 * Construct an instance with the supplied configuration properties.
 	 * @param consumerFactory the consumer factory.
@@ -118,6 +121,15 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 		else {
 			this.topicPartitions = containerProperties.getTopicPartitions();
 		}
+	}
+
+	/**
+	 * Set a suffix to add to the {@code client.id} consumer property (if the consumer
+	 * factory supports it).
+	 * @param clientIdSuffix the suffix to add.
+	 */
+	public void setClientIdSuffix(String clientIdSuffix) {
+		this.clientIdSuffix = clientIdSuffix;
 	}
 
 	/**
@@ -223,7 +235,9 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 
 	@Override
 	public String toString() {
-		return "KafkaMessageListenerContainer [id=" + getBeanName() + ", topicPartitions=" + getAssignedPartitions()
+		return "KafkaMessageListenerContainer [id=" + getBeanName()
+				+ (this.clientIdSuffix != null ? ", clientIndex=" + this.clientIdSuffix : "")
+				+ ", topicPartitions=" + getAssignedPartitions()
 				+ "]";
 	}
 
@@ -300,10 +314,15 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 		private boolean paused;
 
 		@SuppressWarnings("unchecked")
-		private ListenerConsumer(GenericMessageListener<?> listener, GenericAcknowledgingMessageListener<?> ackListener) {
+		ListenerConsumer(GenericMessageListener<?> listener, GenericAcknowledgingMessageListener<?> ackListener) {
 			Assert.state(!this.isAnyManualAck || !this.autoCommit,
 					"Consumer cannot be configured for auto commit for ackMode " + this.containerProperties.getAckMode());
-			final Consumer<K, V> consumer = KafkaMessageListenerContainer.this.consumerFactory.createConsumer();
+			@SuppressWarnings("deprecation")
+			final Consumer<K, V> consumer =
+					KafkaMessageListenerContainer.this.consumerFactory instanceof ClientIdSuffixAware
+						? ((ClientIdSuffixAware<K, V>) KafkaMessageListenerContainer.this.consumerFactory)
+								.createConsumer(KafkaMessageListenerContainer.this.clientIdSuffix)
+						: KafkaMessageListenerContainer.this.consumerFactory.createConsumer();
 
 			this.theListener = listener == null ? ackListener : listener;
 			ConsumerRebalanceListener rebalanceListener = createRebalanceListener(consumer);
@@ -987,6 +1006,10 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 
 			private volatile Thread executingThread;
 
+			ListenerInvoker() {
+				super();
+			}
+
 			@Override
 			public void run() {
 				Assert.isTrue(this.active, "This instance is not active anymore");
@@ -1063,7 +1086,7 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 
 			private final boolean immediate;
 
-			private ConsumerAcknowledgment(ConsumerRecord<K, V> record, boolean immediate) {
+			ConsumerAcknowledgment(ConsumerRecord<K, V> record, boolean immediate) {
 				this.record = record;
 				this.immediate = immediate;
 			}
@@ -1097,7 +1120,7 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 
 			private final boolean immediate;
 
-			private ConsumerBatchAcknowledgment(List<ConsumerRecord<K, V>> records, boolean immediate) {
+			ConsumerBatchAcknowledgment(List<ConsumerRecord<K, V>> records, boolean immediate) {
 				// make a copy in case the listener alters the list
 				this.records = new LinkedList<ConsumerRecord<K, V>>(records);
 				this.immediate = immediate;
@@ -1135,6 +1158,10 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 
 		private static final Log logger = LogFactory.getLog(LoggingCommitCallback.class);
 
+		LoggingCommitCallback() {
+			super();
+		}
+
 		@Override
 		public void onComplete(Map<TopicPartition, OffsetAndMetadata> offsets, Exception exception) {
 			if (exception != null) {
@@ -1153,7 +1180,7 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 
 		private final boolean relativeToCurrent;
 
-		private OffsetMetadata(Long offset, boolean relativeToCurrent) {
+		OffsetMetadata(Long offset, boolean relativeToCurrent) {
 			this.offset = offset;
 			this.relativeToCurrent = relativeToCurrent;
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -48,7 +48,6 @@ import org.apache.kafka.common.errors.WakeupException;
 
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.kafka.KafkaException;
-import org.springframework.kafka.core.ClientIdSuffixAware;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.event.ListenerContainerIdleEvent;
 import org.springframework.kafka.listener.ConsumerSeekAware.ConsumerSeekCallback;
@@ -319,10 +318,12 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 					"Consumer cannot be configured for auto commit for ackMode " + this.containerProperties.getAckMode());
 			@SuppressWarnings("deprecation")
 			final Consumer<K, V> consumer =
-					KafkaMessageListenerContainer.this.consumerFactory instanceof ClientIdSuffixAware
-						? ((ClientIdSuffixAware<K, V>) KafkaMessageListenerContainer.this.consumerFactory)
-								.createConsumer(KafkaMessageListenerContainer.this.clientIdSuffix)
-						: KafkaMessageListenerContainer.this.consumerFactory.createConsumer();
+					KafkaMessageListenerContainer.this.consumerFactory instanceof
+									org.springframework.kafka.core.ClientIdSuffixAware
+							? ((org.springframework.kafka.core.ClientIdSuffixAware<K, V>) KafkaMessageListenerContainer
+									.this.consumerFactory)
+										.createConsumer(KafkaMessageListenerContainer.this.clientIdSuffix)
+							: KafkaMessageListenerContainer.this.consumerFactory.createConsumer();
 
 			this.theListener = listener == null ? ackListener : listener;
 			ConsumerRebalanceListener rebalanceListener = createRebalanceListener(consumer);

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.junit.Test;
+
+/**
+ * @author Gary Russell
+ * @since 1.0.6
+ *
+ */
+public class DefaultKafkaConsumerFactoryTests {
+
+	@Test
+	public void testClientId() {
+		Map<String, Object> configs = Collections.singletonMap(ConsumerConfig.CLIENT_ID_CONFIG, "foo");
+		DefaultKafkaConsumerFactory<String, String> factory = new DefaultKafkaConsumerFactory<String, String>(configs) {
+
+			@Override
+			protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configs) {
+				assertThat(configs.get(ConsumerConfig.CLIENT_ID_CONFIG)).isEqualTo("foo-1");
+				return null;
+			}
+
+		};
+		factory.createConsumer("-1");
+	}
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
@@ -983,7 +983,7 @@ public class KafkaMessageListenerContainerTests {
 		DefaultKafkaConsumerFactory<Integer, String> cf = new DefaultKafkaConsumerFactory<Integer, String>(props) {
 
 			@Override
-			public Consumer<Integer, String> createConsumer() {
+			public Consumer<Integer, String> createConsumer(String clientIdPrefix) {
 				return new KafkaConsumer<Integer, String>(props) {
 
 					@Override

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -265,6 +265,9 @@ For 5 `TopicPartition` s, 2 containers will get 2 partitions and the third will 
 If the `concurrency` is greater than the number of `TopicPartitions`, the `concurrency` will be adjusted down such that
 each container will get one partition.
 
+NOTE: The `client.id` property (if set) will be appended with `-n` where `n` is the consumer instance according to the concurrency.
+This is required to provide unique names for MBeans when JMX is enabled.
+
 [[committing-offsets]]
 ====== Committing Offsets
 


### PR DESCRIPTION
Resolves: https://github.com/spring-projects/spring-kafka/issues/295

When JMX is enabled and a `client.id` property provided, we get an `InstanceAlreadyExistsException`
when using the `ConcurrentMessageListenerContainer` with `concurrency > 1`.

Add a mechanism to append the client index to the client.id.

Also fix private inner class ctors -> package to avoid synthetic ctor.

__cherry-pick to all 1.x branches; after the merge, I will port to master and remove the new interface__