### PR TITLE
Change to RecoveryCallback<? extends Object>

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/RetryingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/RetryingMessageListenerAdapter.java
@@ -57,7 +57,7 @@ public class RetryingMessageListenerAdapter<K, V>
 	 * thrown to the container after retries are exhausted.
 	 */
 	public RetryingMessageListenerAdapter(MessageListener<K, V> messageListener, RetryTemplate retryTemplate,
-			RecoveryCallback<Object> recoveryCallback) {
+			RecoveryCallback<? extends Object> recoveryCallback) {
 		super(messageListener, retryTemplate, recoveryCallback);
 		Assert.notNull(messageListener, "'messageListener' cannot be null");
 	}


### PR DESCRIPTION
It looks `? extends ` part missed in 6d2e7341265bd3ce0dd7d3b5aa1ff1fc875e78a8 .