### PR TITLE
Add JsonSerde

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerde.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerde.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support.serializer;
+
+import java.util.Map;
+
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * A {@link org.apache.kafka.common.serialization.Serde} that provides serialization and
+ * deserialization in JSON format.
+ * <p>
+ * The implementation delegates to underlying {@link JsonSerializer} and
+ * {@link JsonDeserializer} implementations.
+ *
+ * @param <T> target class for serialization/deserialization
+ *
+ * @author Marius Bogoevici
+ * @since 2.0
+ */
+public class JsonSerde<T> implements Serde<T> {
+
+	private final JsonSerializer<T> jsonSerializer;
+
+	private final JsonDeserializer<T> jsonDeserializer;
+
+	public JsonSerde() {
+		this(null, null);
+	}
+
+	public JsonSerde(Class<T> targetType) {
+		this(targetType, null);
+	}
+
+	public JsonSerde(ObjectMapper objectMapper) {
+		this(null, objectMapper);
+	}
+
+	public JsonSerde(Class<T> targetType, ObjectMapper objectMapper) {
+		this.jsonSerializer = objectMapper == null ? new JsonSerializer<>() : new JsonSerializer<>(objectMapper);
+		if (objectMapper == null) {
+			this.jsonDeserializer = targetType == null ? new JsonDeserializer<>() : new JsonDeserializer<>(targetType);
+		}
+		else {
+			this.jsonDeserializer = targetType == null ? new JsonDeserializer<>(objectMapper)
+					: new JsonDeserializer<>(targetType, objectMapper);
+		}
+	}
+
+	@Override
+	public void configure(Map<String, ?> configs, boolean isKey) {
+		this.jsonSerializer.configure(configs, isKey);
+		this.jsonDeserializer.configure(configs, isKey);
+	}
+
+	@Override
+	public void close() {
+		this.jsonSerializer.close();
+		this.jsonDeserializer.close();
+	}
+
+	@Override
+	public Serializer<T> serializer() {
+		return this.jsonSerializer;
+	}
+
+	@Override
+	public Deserializer<T> deserializer() {
+		return this.jsonDeserializer;
+	}
+}

--- a/src/reference/asciidoc/streams.adoc
+++ b/src/reference/asciidoc/streams.adoc
@@ -74,6 +74,17 @@ If you would like to control lifecycle manually (e.g. stop and start by some con
 Since `KStreamBuilderFactoryBean` utilize its internal `KafkaStreams` instance, it is safe to stop and restart it again - a new `KafkaStreams` is created on each `start()`.
 Also consider using different `KStreamBuilderFactoryBean` s, if you would like to control lifecycles for `KStream` instances separately.
 
+==== JSON Serdes
+
+For serializing and deserializing data when reading or writing to topics or state stores in JSON format, Spring Kafka provides a `JsonSerde` implementation using JSON, delegating to the `JsonSerializer` and `JsonDeserializer` described in <<serdes, the serialization/deserialization section>>.
+The `JsonSerde` provides the same configuration options via its constructor (target type and/or `ObjectMapper`).
+In the following example we use the `JsonSerde` to serialize and deserialize the `Foo` payload of a Kafka stream - the `JsonSerde` can be used in a similar fashion wherever an instance is required.
+
+[source,java]
+----
+stream.through(Serdes.Integer(), new JsonSerde<>(Foo.class), "foos");
+----
+
 ==== Configuration
 
 To configure the Kafka Streams environment, the `KStreamBuilderFactoryBean` requires a `Map` of particular properties or a `StreamsConfig` instance.


### PR DESCRIPTION
Fix #301

Adds a `JsonSerde` wrapper for `JsonSerializer` and
`JsonDeserializer`.

Increase commit frequency for `KafkaStream` tests to
make them publish updates more frequently (thus reducing
test duration)

(Would nice to have it backported to 1.1.x since it's not 2.0-dependent).