### PR TITLE
GH-201: Polishing - enum for ControlFlag Values

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/security/jaas/KafkaJaasLoginModuleInitializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/security/jaas/KafkaJaasLoginModuleInitializer.java
@@ -41,6 +41,44 @@ import org.springframework.util.Assert;
  */
 public class KafkaJaasLoginModuleInitializer implements SmartInitializingSingleton, DisposableBean {
 
+	/**
+	 * Control flag values for login configuration.
+	 */
+	public enum ControlFlag {
+
+		/**
+		 * Required - The {@code LoginModule} is required to succeed. If it succeeds or
+		 * fails, authentication still continues to proceed down the {@code LoginModule}
+		 * list.
+		 *
+		 */
+		REQUIRED,
+
+		/**
+		 * Requisite - The {@code LoginModule} is required to succeed. If it succeeds,
+		 * authentication continues down the {@code LoginModule} list. If it fails,
+		 * control immediately returns to the application (authentication does not proceed
+		 * down the {@code LoginModule} list).
+		 */
+		REQUISITE,
+
+		/**
+		 * Sufficient - The {@code LoginModule} is not required to succeed. If it does
+		 * succeed, control immediately returns to the application (authentication does
+		 * not proceed down the {@code LoginModule} list). If it fails, authentication
+		 * continues down the {@code LoginModule} list.
+		 */
+		SUFFICIENT,
+
+		/**
+		 * Optional - The {@code LoginModule} is not required to succeed. If it succeeds
+		 * or fails, authentication still continues to proceed down the
+		 * {@code LoginModule} list.
+		 */
+		OPTIONAL
+
+	}
+
 	private final boolean ignoreJavaLoginConfigParamSystemProperty;
 
 	private final File placeholderJaasConfiguration;
@@ -64,23 +102,19 @@ public class KafkaJaasLoginModuleInitializer implements SmartInitializingSinglet
 		this.loginModule = loginModule;
 	}
 
-	public String getLoginModule() {
-		return this.loginModule;
-	}
-
-	public void setControlFlag(String controlFlag) {
+	public void setControlFlag(ControlFlag controlFlag) {
 		Assert.notNull(controlFlag, "cannot be null");
-		switch (controlFlag.toUpperCase()) {
-		case "OPTIONAL":
+		switch (controlFlag) {
+		case OPTIONAL:
 			this.controlFlag = AppConfigurationEntry.LoginModuleControlFlag.OPTIONAL;
 			break;
-		case "REQUIRED":
+		case REQUIRED:
 			this.controlFlag = AppConfigurationEntry.LoginModuleControlFlag.REQUIRED;
 			break;
-		case "REQUISITE":
+		case REQUISITE:
 			this.controlFlag = AppConfigurationEntry.LoginModuleControlFlag.REQUISITE;
 			break;
-		case "SUFFICIENT":
+		case SUFFICIENT:
 			this.controlFlag = AppConfigurationEntry.LoginModuleControlFlag.SUFFICIENT;
 			break;
 		default:
@@ -88,21 +122,9 @@ public class KafkaJaasLoginModuleInitializer implements SmartInitializingSinglet
 		}
 	}
 
-	public String getControlFlag() {
-		return this.controlFlag.toString();
-	}
-
-	public AppConfigurationEntry.LoginModuleControlFlag getControlFlagValue() {
-		return this.controlFlag;
-	}
-
 	public void setOptions(Map<String, String> options) {
 		this.options.clear();
 		this.options.putAll(options);
-	}
-
-	public Map<String, String> getOptions() {
-		return this.options;
 	}
 
 	@Override

--- a/spring-kafka/src/test/java/org/springframework/kafka/security/jaas/KafkaJaasLoginModuleInitializerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/security/jaas/KafkaJaasLoginModuleInitializerTests.java
@@ -33,6 +33,7 @@ import org.junit.runner.RunWith;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.kafka.security.jaas.KafkaJaasLoginModuleInitializer.ControlFlag;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import com.sun.security.auth.login.ConfigFile;
@@ -75,7 +76,7 @@ public class KafkaJaasLoginModuleInitializerTests {
 		@Bean
 		public KafkaJaasLoginModuleInitializer jaasConfig() throws IOException {
 			KafkaJaasLoginModuleInitializer jaasConfig = new KafkaJaasLoginModuleInitializer();
-			jaasConfig.setControlFlag("REQUIRED");
+			jaasConfig.setControlFlag(ControlFlag.REQUIRED);
 			Map<String, String> options = new HashMap<>();
 			options.put("useKeyTab", "true");
 			options.put("storeKey", "true");


### PR DESCRIPTION
See: https://github.com/spring-projects/spring-kafka/issues/201

Use an enum for the values for content assist in IDEs when we add boot autoconfiguration.

Remove getters (no longer needed now that we have a single class).