### PR TITLE
GH-313: Configure group.id on @KafkaListener

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
@@ -138,7 +138,7 @@ public @interface KafkaListener {
 	 * of containers.
 	 * @return the bean name for the group.
 	 */
-	String group() default "";
+	String containerGroup() default "";
 
 	/**
 	 * Set an {@link KafkaListenerErrorHandler} to invoke if the listener method throws

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
@@ -148,4 +148,21 @@ public @interface KafkaListener {
 	 */
 	String errorHandler() default "";
 
+	/**
+	 * Override the {@code group.id} property for the consumer factory with this value
+	 * for this listener only.
+	 * @return the group id.
+	 * @since 2.0
+	 */
+	String groupId() default "";
+
+	/**
+	 * When {@link #groupId() groupId} is not provided, use the {@link #id() id} (if
+	 * provided) as the {@code group.id} property for the consumer. Set to false, to use
+	 * the {@code group.id} from the consumer factory.
+	 * @return false to disable.
+	 * @since 2.0
+	 */
+	boolean idIsGroup() default true;
+
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
@@ -387,7 +387,7 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 		endpoint.setTopicPartitions(resolveTopicPartitions(kafkaListener));
 		endpoint.setTopics(resolveTopics(kafkaListener));
 		endpoint.setTopicPattern(resolvePattern(kafkaListener));
-		String group = kafkaListener.group();
+		String group = kafkaListener.containerGroup();
 		if (StringUtils.hasText(group)) {
 			Object resolvedGroup = resolveExpression(group);
 			if (resolvedGroup instanceof String) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
@@ -383,6 +383,7 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 		endpoint.setBean(bean);
 		endpoint.setMessageHandlerMethodFactory(this.messageHandlerMethodFactory);
 		endpoint.setId(getEndpointId(kafkaListener));
+		endpoint.setGroupId(getEndpointGroupId(kafkaListener, endpoint.getId()));
 		endpoint.setTopicPartitions(resolveTopicPartitions(kafkaListener));
 		endpoint.setTopics(resolveTopics(kafkaListener));
 		endpoint.setTopicPattern(resolvePattern(kafkaListener));
@@ -418,6 +419,17 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 		else {
 			return "org.springframework.kafka.KafkaListenerEndpointContainer#" + this.counter.getAndIncrement();
 		}
+	}
+
+	private String getEndpointGroupId(KafkaListener kafkaListener, String id) {
+		String groupId = null;
+		if (StringUtils.hasText(kafkaListener.groupId())) {
+			groupId = resolveExpressionAsString(kafkaListener.groupId(), "groupId");
+		}
+		if (groupId == null && kafkaListener.idIsGroup()) {
+			groupId = id;
+		}
+		return groupId;
 	}
 
 	private TopicPartitionInitialOffset[] resolveTopicPartitions(KafkaListener kafkaListener) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
@@ -224,6 +224,7 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 
 		endpoint.setupListenerContainer(instance, this.messageConverter);
 		initializeContainer(instance);
+		instance.getContainerProperties().setGroupId(endpoint.getGroupId());
 
 		return instance;
 	}

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
@@ -60,6 +60,8 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 
 	private String id;
 
+	private String groupId;
+
 	private final Collection<String> topics = new ArrayList<>();
 
 	private Pattern topicPattern;
@@ -121,6 +123,21 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 	@Override
 	public String getId() {
 		return this.id;
+	}
+
+	/**
+	 * Set the group id to override the {@code group.id} property in the
+	 * connectionFactory.
+	 * @param groupId the group id.
+	 * @since 2.0
+	 */
+	public void setGroupId(String groupId) {
+		this.groupId = groupId;
+	}
+
+	@Override
+	public String getGroupId() {
+		return this.groupId;
 	}
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2015 the original author or authors.
+ * Copyright 2002-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,14 @@ public interface KafkaListenerEndpoint {
 	 * @see KafkaListenerContainerFactory#createListenerContainer
 	 */
 	String getId();
+
+	/**
+	 * Return the groupId of this endpoint - if present, overrides the the
+	 * {@code group.id} property of the consumer factory.
+	 * @return the group id; may be null.
+	 * @since 2.0
+	 */
+	String getGroupId();
 
 	/**
 	 * Return the group of this endpoint or null if not in a group.

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/ConsumerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/ConsumerFactory.java
@@ -16,7 +16,10 @@
 
 package org.springframework.kafka.core;
 
+import java.util.Map;
+
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.common.serialization.Deserializer;
 
 /**
  * The strategy to produce a {@link Consumer} instance(s).
@@ -29,8 +32,7 @@ import org.apache.kafka.clients.consumer.Consumer;
 public interface ConsumerFactory<K, V> {
 
 	/**
-	 * Create a consumer, with the configured {@code client.id} property,
-	 * if present.
+	 * Create a consumer with the group id and client id as configured in the properties.
 	 * @return the consumer.
 	 */
 	Consumer<K, V> createConsumer();
@@ -45,9 +47,50 @@ public interface ConsumerFactory<K, V> {
 	Consumer<K, V> createConsumer(String clientIdSuffix);
 
 	/**
+	 * Create a consumer with an explicit group id; in addition, the
+	 * client id suffix is appended to the {@code client.id} property, if both
+	 * are present.
+	 * @param groupId the group id.
+	 * @param clientIdSuffix the suffix.
+	 * @return the consumer.
+	 * @since 2.0
+	 */
+	Consumer<K, V> createConsumer(String groupId, String clientIdSuffix);
+
+	/**
 	 * Return true if consumers created by this factory use auto commit.
 	 * @return true if auto commit.
 	 */
 	boolean isAutoCommit();
+
+	/**
+	 * Return an unmodifiable reference to the configuration map for this factory.
+	 * Useful for cloning to make a similar factory.
+	 * @return the configs.
+	 * @since 2.0
+	 */
+	default Map<String, Object> getConfigurationProperties() {
+		throw new UnsupportedOperationException("'getConfigurationProperties()' is not supported");
+	}
+
+	/**
+	 * Return the configured key deserializer (if provided as an object instead
+	 * of a class name in the properties).
+	 * @return the deserializer.
+	 * @since 2.0
+	 */
+	default Deserializer<K> getKeyDeserializer() {
+		throw new UnsupportedOperationException("'getKeyDeserializer()' is not supported");
+	}
+
+	/**
+	 * Return the configured value deserializer (if provided as an object instead
+	 * of a class name in the properties).
+	 * @return the deserializer.
+	 * @since 2.0
+	 */
+	default Deserializer<V> getValueDeserializer() {
+		throw new UnsupportedOperationException("'getKeyDeserializer()' is not supported");
+	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
@@ -65,14 +65,19 @@ public class DefaultKafkaConsumerFactory<K, V> implements ConsumerFactory<K, V> 
 		this.valueDeserializer = valueDeserializer;
 	}
 
-	/**
-	 * Return an unmodifiable reference to the configuration map for this factory.
-	 * Useful for cloning to make a similar factory.
-	 * @return the configs.
-	 * @since 1.0.6
-	 */
+	@Override
 	public Map<String, Object> getConfigurationProperties() {
 		return Collections.unmodifiableMap(this.configs);
+	}
+
+	@Override
+	public Deserializer<K> getKeyDeserializer() {
+		return this.keyDeserializer;
+	}
+
+	@Override
+	public Deserializer<V> getValueDeserializer() {
+		return this.valueDeserializer;
 	}
 
 	@Override
@@ -82,22 +87,32 @@ public class DefaultKafkaConsumerFactory<K, V> implements ConsumerFactory<K, V> 
 
 	@Override
 	public Consumer<K, V> createConsumer(String clientIdSuffix) {
-		return createKafkaConsumer(clientIdSuffix);
+		return createKafkaConsumer(null, clientIdSuffix);
+	}
+
+	@Override
+	public Consumer<K, V> createConsumer(String groupId, String clientIdSuffix) {
+		return createKafkaConsumer(groupId, clientIdSuffix);
 	}
 
 	protected KafkaConsumer<K, V> createKafkaConsumer() {
 		return createKafkaConsumer(this.configs);
 	}
 
-	protected KafkaConsumer<K, V> createKafkaConsumer(String clientIdSuffix) {
-		if (!this.configs.containsKey(ConsumerConfig.CLIENT_ID_CONFIG) || clientIdSuffix == null) {
+	protected KafkaConsumer<K, V> createKafkaConsumer(String groupId, String clientIdSuffix) {
+		if (groupId == null && (!this.configs.containsKey(ConsumerConfig.CLIENT_ID_CONFIG) || clientIdSuffix == null)) {
 			return createKafkaConsumer();
 		}
 		else {
-			Map<String, Object> modifiedClientIdConfigs = new HashMap<>(this.configs);
-			modifiedClientIdConfigs.put(ConsumerConfig.CLIENT_ID_CONFIG,
-					modifiedClientIdConfigs.get(ConsumerConfig.CLIENT_ID_CONFIG) + clientIdSuffix);
-			return createKafkaConsumer(modifiedClientIdConfigs);
+			Map<String, Object> modifiedConfigs = new HashMap<>(this.configs);
+			if (groupId != null) {
+				modifiedConfigs.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+			}
+			if (clientIdSuffix != null) {
+				modifiedConfigs.put(ConsumerConfig.CLIENT_ID_CONFIG,
+					modifiedConfigs.get(ConsumerConfig.CLIENT_ID_CONFIG) + clientIdSuffix);
+			}
+			return createKafkaConsumer(modifiedConfigs);
 		}
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -286,8 +286,8 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 		ListenerConsumer(GenericMessageListener<?> listener, ListenerType listenerType) {
 			Assert.state(!this.isAnyManualAck || !this.autoCommit,
 				"Consumer cannot be configured for auto commit for ackMode " + this.containerProperties.getAckMode());
-			final Consumer<K, V> consumer = KafkaMessageListenerContainer.this.consumerFactory
-					.createConsumer(KafkaMessageListenerContainer.this.clientIdSuffix);
+			final Consumer<K, V> consumer = KafkaMessageListenerContainer.this.consumerFactory.createConsumer(
+					this.containerProperties.getGroupId(), KafkaMessageListenerContainer.this.clientIdSuffix);
 
 			ConsumerRebalanceListener rebalanceListener = createRebalanceListener(consumer);
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/config/ContainerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/config/ContainerProperties.java
@@ -137,6 +137,8 @@ public class ContainerProperties {
 
 	private Long idleEventInterval;
 
+	private String groupId;
+
 	public ContainerProperties(String... topics) {
 		Assert.notEmpty(topics, "An array of topicPartitions must be provided");
 		this.topics = Arrays.asList(topics).toArray(new String[topics.length]);
@@ -305,6 +307,16 @@ public class ContainerProperties {
 		this.ackOnError = ackOnError;
 	}
 
+	/**
+	 * Set the group id for this container. Overrides any {@code group.id} property
+	 * provided by the consumer factory configuration.
+	 * @param groupId the group id.
+	 * @since 2.0
+	 */
+	public void setGroupId(String groupId) {
+		this.groupId = groupId;
+	}
+
 	public String[] getTopics() {
 		return this.topics;
 	}
@@ -368,6 +380,10 @@ public class ContainerProperties {
 	public boolean isAckOnError() {
 		return this.ackOnError &&
 				!(AckMode.MANUAL_IMMEDIATE.equals(this.ackMode) || AckMode.MANUAL.equals(this.ackMode));
+	}
+
+	public String getGroupId() {
+		return this.groupId;
 	}
 
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -143,6 +143,9 @@ public class EnableKafkaIntegrationTests {
 	@Autowired
 	private AtomicReference<Consumer<?, ?>> consumerRef;
 
+	@Autowired
+	private List<?> quxGroup;
+
 	@Test
 	public void testSimple() throws Exception {
 		template.send("annotated1", 0, "foo");
@@ -185,6 +188,8 @@ public class EnableKafkaIntegrationTests {
 		assertThat(this.listener.consumer).isSameAs(KafkaTestUtils.getPropertyValue(KafkaTestUtils
 						.getPropertyValue(this.registry.getListenerContainer("qux"), "containers", List.class).get(0),
 				"listenerConsumer.consumer"));
+		assertThat(this.quxGroup.size()).isEqualTo(1);
+		assertThat(this.quxGroup.get(0)).isSameAs(manualContainer);
 
 		template.send("annotated5", 0, 0, "foo");
 		template.send("annotated5", 1, 0, "bar");
@@ -838,7 +843,8 @@ public class EnableKafkaIntegrationTests {
 			this.latch3.countDown();
 		}
 
-		@KafkaListener(id = "qux", topics = "annotated4", containerFactory = "kafkaManualAckListenerContainerFactory")
+		@KafkaListener(id = "qux", topics = "annotated4", containerFactory = "kafkaManualAckListenerContainerFactory",
+				containerGroup = "quxGroup")
 		public void listen4(@Payload String foo, Acknowledgment ack, Consumer<?, ?> consumer) {
 			this.ack = ack;
 			this.ack.acknowledge();

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -202,6 +202,8 @@ public class EnableKafkaIntegrationTests {
 		offset = KafkaTestUtils.getPropertyValue(fizContainer, "topicPartitions",
 				TopicPartitionInitialOffset[].class)[3];
 		assertThat(offset.isRelativeToCurrent()).isTrue();
+		assertThat(KafkaTestUtils.getPropertyValue(fizContainer, "listenerConsumer.consumer.coordinator.groupId"))
+				.isEqualTo("fiz");
 
 		template.send("annotated11", 0, "foo");
 		template.flush();
@@ -209,6 +211,13 @@ public class EnableKafkaIntegrationTests {
 		assertThat(this.consumerRef.get()).isNotNull();
 
 		assertThat(this.recordFilter.called).isTrue();
+
+		MessageListenerContainer rebalanceConcurrentContainer = registry.getListenerContainer("rebalanceListener");
+		assertThat(rebalanceConcurrentContainer).isNotNull();
+		MessageListenerContainer rebalanceContainer = (MessageListenerContainer) KafkaTestUtils
+				.getPropertyValue(rebalanceConcurrentContainer, "containers", List.class).get(0);
+		assertThat(KafkaTestUtils.getPropertyValue(rebalanceContainer, "listenerConsumer.consumer.coordinator.groupId"))
+				.isNotEqualTo("rebalanceListener");
 	}
 
 	@Test
@@ -260,6 +269,12 @@ public class EnableKafkaIntegrationTests {
 				.build());
 		assertThat(this.listener.latch6.await(60, TimeUnit.SECONDS)).isTrue();
 		assertThat(this.listener.foo.getBar()).isEqualTo("bar");
+		MessageListenerContainer buzConcurrentContainer = registry.getListenerContainer("buz");
+		assertThat(buzConcurrentContainer).isNotNull();
+		MessageListenerContainer buzContainer = (MessageListenerContainer) KafkaTestUtils
+				.getPropertyValue(buzConcurrentContainer, "containers", List.class).get(0);
+		assertThat(KafkaTestUtils.getPropertyValue(buzContainer, "listenerConsumer.consumer.coordinator.groupId"))
+				.isEqualTo("buz.explicitGroupId");
 	}
 
 	@Test
@@ -848,13 +863,14 @@ public class EnableKafkaIntegrationTests {
 			this.latch5.countDown();
 		}
 
-		@KafkaListener(id = "buz", topics = "annotated10", containerFactory = "kafkaJsonListenerContainerFactory")
+		@KafkaListener(id = "buz", topics = "annotated10", containerFactory = "kafkaJsonListenerContainerFactory",
+				groupId = "buz.explicitGroupId")
 		public void listen6(Foo foo) {
 			this.foo = foo;
 			this.latch6.countDown();
 		}
 
-		@KafkaListener(id = "rebalancerListener", topics = "annotated11",
+		@KafkaListener(id = "rebalanceListener", topics = "annotated11", idIsGroup = false,
 				containerFactory = "kafkaRebalanceListenerContainerFactory")
 		public void listen7(String foo) {
 			this.latch7.countDown();

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
@@ -19,6 +19,7 @@ package org.springframework.kafka.listener;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
@@ -392,7 +393,7 @@ public class ConcurrentMessageListenerContainerTests {
 		};
 		ConsumerFactory<Integer, String> cf = mock(ConsumerFactory.class);
 		Consumer<Integer, String> consumer = mock(Consumer.class);
-		given(cf.createConsumer(anyString())).willReturn(consumer);
+		given(cf.createConsumer(isNull(), anyString())).willReturn(consumer);
 		given(consumer.poll(anyLong()))
 			.willAnswer(new Answer<ConsumerRecords<Integer, String>>() {
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
@@ -863,7 +863,7 @@ public class KafkaMessageListenerContainerTests {
 		DefaultKafkaConsumerFactory<Integer, String> cf = new DefaultKafkaConsumerFactory<Integer, String>(props) {
 
 			@Override
-			public Consumer<Integer, String> createConsumer(String clientIdPrefix) {
+			public Consumer<Integer, String> createConsumer(String groupId, String clientIdPrefix) {
 				return new KafkaConsumer<Integer, String>(props) {
 
 					@Override

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -551,6 +551,9 @@ public void listen(List<ConsumerRecord<Integer, String>> list, Acknowledgment ac
 }
 ----
 
+Starting with _version 2.0_, the `id` attribute (if present) is used as the Kafka `group.id` property, overriding the configured property in the consumer factory, if present.
+You can also set `groupId` explicitly, or set `idIsGroup` to false, to restore the previous behavior of using the consumer factory `group.id`.
+
 ===== Container Thread Naming
 
 Listener containers currently use two task executors, one to invoke the consumer and another which will be used to invoke the listener, when the kafka consumer property `enable.auto.commit` is `false`.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -16,6 +16,11 @@ You can now annotate `@KafkaListener` methods (and classes, and `@KafkaHandler` 
 If the method returns a result, it is forwarded to the specified topic.
 See <<annotation-send-to>> for more information.
 
+By default, the `@KafkaListener` `id` property is now used as the `group.id` property, overriding the property configured in the consumer factory (if present).
+Further, you can explicitly configure the `groupId` on the annotation.
+Previously, you would have needed a separate container factory (and consumer factory) to use different `group.id` s for listeners.
+To restore the previous behavior of using the factory configured `group.id`, set the `idIsGroup` property on the annotation to `false`.
+
 ==== Message Listeners
 
 Message listeners can now be aware of the `Consumer` object.


### PR DESCRIPTION
Resolves: https://github.com/spring-projects/spring-kafka/issues/313

Allow configuration of the `group.id` property on the annotation.