### PR TITLE
GH-313: Prepare: Rename @KafkaListener.group

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
@@ -23,6 +23,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.springframework.core.annotation.AliasFor;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 
 /**
@@ -130,12 +131,23 @@ public @interface KafkaListener {
 	TopicPartition[] topicPartitions() default {};
 
 	/**
+	 * Use containerGroup instead.
+	 * @return the bean name for the container group.
+	 * @see #containerGroup()
+	 * @deprecated use containerGroup.
+	 */
+	@AliasFor("containerGroup")
+	@Deprecated
+	String group() default "";
+
+	/**
 	 * If provided, the listener container for this listener will be added to a bean
 	 * with this value as its name, of type {@code Collection<MessageListenerContainer>}.
 	 * This allows, for example, iteration over the collection to start/stop a subset
 	 * of containers.
 	 * @return the bean name for the group.
 	 */
-	String group() default "";
+	@AliasFor("group")
+	String containerGroup() default "";
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
@@ -379,7 +379,7 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 		endpoint.setTopicPartitions(resolveTopicPartitions(kafkaListener));
 		endpoint.setTopics(resolveTopics(kafkaListener));
 		endpoint.setTopicPattern(resolvePattern(kafkaListener));
-		String group = kafkaListener.group();
+		String group = kafkaListener.containerGroup();
 		if (StringUtils.hasText(group)) {
 			Object resolvedGroup = resolveExpression(group);
 			if (resolvedGroup instanceof String) {

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -18,7 +18,7 @@ package org.springframework.kafka.annotation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.willAnswer;
-import static org.mockito.Mockito.any;
+import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
@@ -122,6 +122,9 @@ public class EnableKafkaIntegrationTests {
 	@Autowired
 	private RecordFilterImpl recordFilter;
 
+	@Autowired
+	private List<?> quxGroup;
+
 	@Test
 	public void testSimple() throws Exception {
 		template.send("annotated1", 0, "foo");
@@ -160,6 +163,8 @@ public class EnableKafkaIntegrationTests {
 		assertThat(KafkaTestUtils.getPropertyValue(manualContainer,
 				"containerProperties.messageListener.delegate.delegate"))
 				.isInstanceOf(MessagingMessageListenerAdapter.class);
+		assertThat(this.quxGroup.size()).isEqualTo(1);
+		assertThat(this.quxGroup.get(0)).isSameAs(manualContainer);
 
 		template.send("annotated5", 0, 0, "foo");
 		template.send("annotated5", 1, 0, "bar");
@@ -639,7 +644,8 @@ public class EnableKafkaIntegrationTests {
 			this.latch3.countDown();
 		}
 
-		@KafkaListener(id = "qux", topics = "annotated4", containerFactory = "kafkaManualAckListenerContainerFactory")
+		@KafkaListener(id = "qux", topics = "annotated4", containerFactory = "kafkaManualAckListenerContainerFactory",
+				containerGroup = "quxGroup")
 		public void listen4(@Payload String foo, Acknowledgment ack) {
 			this.ack = ack;
 			this.ack.acknowledge();


### PR DESCRIPTION
See: https://github.com/spring-projects/spring-kafka/issues/313

In 2.0 we introduce the ability to set the Kafka group.id property on
the annotation; rename the `group` attribute to `containerGroup` to
avoid confusion - deprecate `group` and remove in 2.0.