### PR TITLE
GH-319: Add Ack and Consumer to Retry Context

### DIFF
--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/adapter/FilteringAdapterTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/adapter/FilteringAdapterTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.kafka.adapter;
+package org.springframework.kafka.listener.adapter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -32,7 +32,6 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.Test;
 
 import org.springframework.kafka.listener.BatchAcknowledgingMessageListener;
-import org.springframework.kafka.listener.adapter.FilteringBatchMessageListenerAdapter;
 import org.springframework.kafka.support.Acknowledgment;
 
 /**

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapterTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapterTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.kafka.adapter;
+package org.springframework.kafka.listener.adapter;
 
 import static org.mockito.BDDMockito.willReturn;
 import static org.mockito.Mockito.mock;
@@ -24,7 +24,6 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.Test;
 
 import org.springframework.kafka.listener.AcknowledgingMessageListener;
-import org.springframework.kafka.listener.adapter.MessagingMessageListenerAdapter;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.kafka.support.converter.RecordMessageConverter;
 import org.springframework.messaging.support.GenericMessage;

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/adapter/RetryingMessageListenerAdapterTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/adapter/RetryingMessageListenerAdapterTests.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.Test;
+
+import org.springframework.kafka.listener.AcknowledgingConsumerAwareMessageListener;
+import org.springframework.kafka.listener.AcknowledgingMessageListener;
+import org.springframework.kafka.listener.ConsumerAwareMessageListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.support.RetryTemplate;
+
+/**
+ * @author Gary Russell
+ * @since 2.0
+ *
+ */
+public class RetryingMessageListenerAdapterTests {
+
+	@Test
+	public void testRecoveryCallbackSimple() {
+		final AtomicReference<RetryContext> context = new AtomicReference<>();
+		RetryingMessageListenerAdapter<String, String> adapter = new RetryingMessageListenerAdapter<>(
+				r -> {
+					throw new RuntimeException();
+				}, new RetryTemplate(), c -> {
+					context.set(c);
+					return null;
+				});
+		@SuppressWarnings("unchecked")
+		ConsumerRecord<String, String> record = mock(ConsumerRecord.class);
+		adapter.onMessage(record, mock(Acknowledgment.class), mock(Consumer.class));
+		assertThat(context.get()).isNotNull();
+		assertThat(context.get().getAttribute(RetryingMessageListenerAdapter.CONTEXT_ACKNOWLEDGMENT)).isNull();
+		assertThat(context.get().getAttribute(RetryingMessageListenerAdapter.CONTEXT_RECORD)).isSameAs(record);
+		assertThat(context.get().getAttribute(RetryingMessageListenerAdapter.CONTEXT_CONSUMER)).isNull();
+	}
+
+	@Test
+	public void testRecoveryCallbackConsumerOnly() {
+		final AtomicReference<RetryContext> context = new AtomicReference<>();
+		RetryingMessageListenerAdapter<String, String> adapter = new RetryingMessageListenerAdapter<>(
+				(ConsumerAwareMessageListener<String, String>) (r, c) -> {
+					throw new RuntimeException();
+				}, new RetryTemplate(), c -> {
+					context.set(c);
+					return null;
+				});
+		@SuppressWarnings("unchecked")
+		ConsumerRecord<String, String> record = mock(ConsumerRecord.class);
+		Consumer<?, ?> consumer = mock(Consumer.class);
+		adapter.onMessage(record, mock(Acknowledgment.class), consumer);
+		assertThat(context.get()).isNotNull();
+		assertThat(context.get().getAttribute(RetryingMessageListenerAdapter.CONTEXT_ACKNOWLEDGMENT)).isNull();
+		assertThat(context.get().getAttribute(RetryingMessageListenerAdapter.CONTEXT_RECORD)).isSameAs(record);
+		assertThat(context.get().getAttribute(RetryingMessageListenerAdapter.CONTEXT_CONSUMER)).isSameAs(consumer);
+	}
+
+	@Test
+	public void testRecoveryCallbackAckOnly() {
+		final AtomicReference<RetryContext> context = new AtomicReference<>();
+		RetryingMessageListenerAdapter<String, String> adapter = new RetryingMessageListenerAdapter<>(
+				(AcknowledgingMessageListener<String, String>) (r, a) -> {
+					throw new RuntimeException();
+				}, new RetryTemplate(), c -> {
+					context.set(c);
+					return null;
+				});
+		@SuppressWarnings("unchecked")
+		ConsumerRecord<String, String> record = mock(ConsumerRecord.class);
+		Acknowledgment ack = mock(Acknowledgment.class);
+		adapter.onMessage(record, ack, mock(Consumer.class));
+		assertThat(context.get()).isNotNull();
+		assertThat(context.get().getAttribute(RetryingMessageListenerAdapter.CONTEXT_ACKNOWLEDGMENT)).isSameAs(ack);
+		assertThat(context.get().getAttribute(RetryingMessageListenerAdapter.CONTEXT_RECORD)).isSameAs(record);
+		assertThat(context.get().getAttribute(RetryingMessageListenerAdapter.CONTEXT_CONSUMER)).isNull();
+	}
+
+	@Test
+	public void testRecoveryCallbackAckAndConsumer() {
+		final AtomicReference<RetryContext> context = new AtomicReference<>();
+		RetryingMessageListenerAdapter<String, String> adapter = new RetryingMessageListenerAdapter<>(
+				(AcknowledgingConsumerAwareMessageListener<String, String>) (r, a, c) -> {
+					throw new RuntimeException();
+				}, new RetryTemplate(), c -> {
+					context.set(c);
+					return null;
+				});
+		@SuppressWarnings("unchecked")
+		ConsumerRecord<String, String> record = mock(ConsumerRecord.class);
+		Acknowledgment ack = mock(Acknowledgment.class);
+		Consumer<?, ?> consumer = mock(Consumer.class);
+		adapter.onMessage(record, ack, consumer);
+		assertThat(context.get()).isNotNull();
+		assertThat(context.get().getAttribute(RetryingMessageListenerAdapter.CONTEXT_ACKNOWLEDGMENT)).isSameAs(ack);
+		assertThat(context.get().getAttribute(RetryingMessageListenerAdapter.CONTEXT_RECORD)).isSameAs(record);
+		assertThat(context.get().getAttribute(RetryingMessageListenerAdapter.CONTEXT_CONSUMER)).isSameAs(consumer);
+	}
+
+}

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -750,6 +750,12 @@ In that case, the `ErrorHandler` will be invoked, if configured, or logged other
 
 When using `@KafkaListener`, set the `RetryTemplate` (and optionally `recoveryCallback`) on the container factory and the listener will be wrapped in the appropriate retrying adapter.
 
+The contents of the `RetryContext` passed into the `RecoveryCallback` will depend on the type of listener.
+The context will always have an attribute `record` which is the record for which the failure occurred.
+If your listener is acknowledging and/or consumer aware, additional attributes `acknowledgment` and/or `consumer` will be available.
+For convenience, the `RetryingAcknowledgingMessageListenerAdapter` provides static constants for these keys.
+See its javadocs for more information.
+
 A retry adapter is not provided for any of the batch <<message-listeners, message listeners>> because the framework has no knowledge of where, in a batch, the failure occurred.
 Users wishing retry capabilities, when using a batch listener, are advised to use a `RetryTemplate` within the listener itself.
 


### PR DESCRIPTION
Fixes GH-319

Add the `Acknowledgment` and/or `Consumer` to the retry context if the listener
type warrants it.