### PR TITLE
GH-319: Add Acknowledgment to Retry Context [1.x]

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/AbstractRetryingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/AbstractRetryingMessageListenerAdapter.java
@@ -32,6 +32,17 @@ import org.springframework.util.Assert;
  */
 public abstract class AbstractRetryingMessageListenerAdapter<K, V, T> extends AbstractMessageListenerAdapter<K, V, T> {
 
+	/**
+	 * {@link org.springframework.retry.RetryContext} attribute key for an acknowledgment
+	 * if the listener is capable of acknowledging.
+	 */
+	public static final String CONTEXT_ACKNOWLEDGMENT = "acknowledgment";
+
+	/**
+	 * {@link org.springframework.retry.RetryContext} attribute key for the record.
+	 */
+	public static final String CONTEXT_RECORD = "record";
+
 	private final RetryTemplate retryTemplate;
 
 	private final RecoveryCallback<? extends Object> recoveryCallback;

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/RetryingAcknowledgingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/RetryingAcknowledgingMessageListenerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,7 +74,8 @@ public class RetryingAcknowledgingMessageListenerAdapter<K, V>
 
 			@Override
 			public Void doWithRetry(RetryContext context) throws KafkaException {
-				context.setAttribute("record", record);
+				context.setAttribute(CONTEXT_RECORD, record);
+				context.setAttribute(CONTEXT_ACKNOWLEDGMENT, acknowledgment);
 				RetryingAcknowledgingMessageListenerAdapter.this.delegate.onMessage(record, acknowledgment);
 				return null;
 			}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/RetryingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/RetryingMessageListenerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@ public class RetryingMessageListenerAdapter<K, V>
 
 			@Override
 			public Void doWithRetry(RetryContext context) throws KafkaException {
-				context.setAttribute("record", record);
+				context.setAttribute(CONTEXT_RECORD, record);
 				RetryingMessageListenerAdapter.this.delegate.onMessage(record);
 				return null;
 			}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapterTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapterTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.kafka.adapter;
+package org.springframework.kafka.listener.adapter;
 
 import static org.mockito.BDDMockito.willReturn;
 import static org.mockito.Mockito.mock;
@@ -24,7 +24,6 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.Test;
 
 import org.springframework.kafka.listener.AcknowledgingMessageListener;
-import org.springframework.kafka.listener.adapter.MessagingMessageListenerAdapter;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.kafka.support.converter.RecordMessageConverter;
 import org.springframework.messaging.support.GenericMessage;

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/adapter/RetryingMessageListenerAdapterTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/adapter/RetryingMessageListenerAdapterTests.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.Test;
+
+import org.springframework.kafka.listener.AcknowledgingMessageListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.support.RetryTemplate;
+
+/**
+ * @author Gary Russell
+ * @since 1.0.7
+ *
+ */
+public class RetryingMessageListenerAdapterTests {
+
+	@Test
+	public void testRecoveryCallbackSimple() {
+		final AtomicReference<RetryContext> context = new AtomicReference<>();
+		RetryingMessageListenerAdapter<String, String> adapter = new RetryingMessageListenerAdapter<>(
+				r -> {
+					throw new RuntimeException();
+				}, new RetryTemplate(), c -> {
+					context.set(c);
+					return null;
+				});
+		@SuppressWarnings("unchecked")
+		ConsumerRecord<String, String> record = mock(ConsumerRecord.class);
+		adapter.onMessage(record);
+		assertThat(context.get()).isNotNull();
+		assertThat(context.get().getAttribute(RetryingMessageListenerAdapter.CONTEXT_ACKNOWLEDGMENT)).isNull();
+		assertThat(context.get().getAttribute(RetryingMessageListenerAdapter.CONTEXT_RECORD)).isSameAs(record);
+	}
+
+	@Test
+	public void testRecoveryCallbackAckOnly() {
+		final AtomicReference<RetryContext> context = new AtomicReference<>();
+		RetryingAcknowledgingMessageListenerAdapter<String, String> adapter =
+			new RetryingAcknowledgingMessageListenerAdapter<>(
+				(AcknowledgingMessageListener<String, String>) (r, a) -> {
+					throw new RuntimeException();
+				}, new RetryTemplate(), c -> {
+					context.set(c);
+					return null;
+				});
+		@SuppressWarnings("unchecked")
+		ConsumerRecord<String, String> record = mock(ConsumerRecord.class);
+		Acknowledgment ack = mock(Acknowledgment.class);
+		adapter.onMessage(record, ack);
+		assertThat(context.get()).isNotNull();
+		assertThat(context.get().getAttribute(RetryingMessageListenerAdapter.CONTEXT_ACKNOWLEDGMENT)).isSameAs(ack);
+		assertThat(context.get().getAttribute(RetryingMessageListenerAdapter.CONTEXT_RECORD)).isSameAs(record);
+	}
+
+}

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -521,6 +521,12 @@ In that case, the `ErrorHandler` will be invoked, if configured, or logged other
 
 When using `@KafkaListener`, set the `RetryTemplate` (and optionally `recoveryCallback`) on the container factory and the listener will be wrapped in the appropriate retrying adapter.
 
+The contents of the `RetryContext` passed into the `RecoveryCallback` will depend on the type of listener.
+The context will always have an attribute `record` which is the record for which the failure occurred.
+If your listener is acknowledging the additional `acknowledgment` attribute is provided.
+For convenience, the `AbstractRetryingMessageListenerAdapter` provides static constants for these keys.
+See its javadocs for more information.
+
 A retry adapter is not provided for any of the batch <<message-listeners, message listeners>>.
 
 [[idle-containers]]


### PR DESCRIPTION
Fixes #319

Add the `Acknowledgment` to the retry context if the listener type warrants it.

__cherry-pick to 1.1.x, 1.0.x__