### PR TITLE
Reactive PoC Initial Commit [DO NOT MERGE]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,7 @@ subprojects { subproject ->
 		junitVersion = '4.12'
 		kafkaVersion = '0.10.2.0'
 		mockitoVersion = '2.5.4'
+		reactorKafkaVersion = "1.0.0.M2"
 		scalaVersion = '2.11'
 		slf4jVersion = '1.7.22'
 		springRetryVersion = '1.2.0.RELEASE'
@@ -150,7 +151,7 @@ project ('spring-kafka') {
 			exclude group: 'org.slf4j', module: 'slf4j-api'
 			exclude group: 'org.slf4j', module: 'slf4j-log4j12'
 		}
-
+		compile "io.projectreactor.kafka:reactor-kafka:$reactorKafkaVersion"
 		compile ("com.fasterxml.jackson.core:jackson-core:$jacksonVersion", optional)
 		compile ("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion", optional)
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
@@ -162,7 +162,7 @@ public class DefaultKafkaProducerFactory<K, V> implements ProducerFactory<K, V>,
 	@Override
 	public KafkaSender<K, V> createReactiveSender() {
 		if (this.sender == null) {
-			synchronized(this) {
+			synchronized (this) {
 				if (this.sender == null) {
 					this.sender = createSender();
 				}

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
@@ -38,6 +38,10 @@ import org.apache.kafka.common.serialization.Serializer;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.context.Lifecycle;
 
+import reactor.kafka.sender.KafkaSender;
+import reactor.kafka.sender.SenderOptions;
+import reactor.kafka.sender.internals.DefaultKafkaSender;
+
 /**
  * The {@link ProducerFactory} implementation for the {@code singleton} shared {@link Producer}
  * instance.
@@ -64,6 +68,8 @@ public class DefaultKafkaProducerFactory<K, V> implements ProducerFactory<K, V>,
 	private final Map<String, Object> configs;
 
 	private volatile CloseSafeProducer<K, V> producer;
+
+	private volatile CloseSafeKafkaSender<K, V> sender;
 
 	private Serializer<K> keySerializer;
 
@@ -107,6 +113,11 @@ public class DefaultKafkaProducerFactory<K, V> implements ProducerFactory<K, V>,
 		if (producer != null) {
 			producer.delegate.close();
 		}
+		CloseSafeKafkaSender<K, V> sender = this.sender;
+		this.sender = null;
+		if (sender != null) {
+			sender.destroy();
+		}
 	}
 
 
@@ -146,6 +157,23 @@ public class DefaultKafkaProducerFactory<K, V> implements ProducerFactory<K, V>,
 
 	protected KafkaProducer<K, V> createKafkaProducer() {
 		return new KafkaProducer<K, V>(this.configs, this.keySerializer, this.valueSerializer);
+	}
+
+	@Override
+	public KafkaSender<K, V> createReactiveSender() {
+		if (this.sender == null) {
+			synchronized(this) {
+				if (this.sender == null) {
+					this.sender = createSender();
+				}
+			}
+		}
+		return this.sender;
+	}
+
+	protected CloseSafeKafkaSender<K, V> createSender() {
+		SenderOptions<K, V> options = SenderOptions.create(this.configs);
+		return new CloseSafeKafkaSender<>(reactor.kafka.sender.internals.ProducerFactory.INSTANCE, options);
 	}
 
 	private static class CloseSafeProducer<K, V> implements Producer<K, V> {
@@ -191,4 +219,20 @@ public class DefaultKafkaProducerFactory<K, V> implements ProducerFactory<K, V>,
 
 	}
 
+	private static class CloseSafeKafkaSender<K, V> extends DefaultKafkaSender<K, V> {
+
+		CloseSafeKafkaSender(reactor.kafka.sender.internals.ProducerFactory producerFactory,
+				SenderOptions<K, V> options) {
+			super(producerFactory, options);
+		}
+
+		@Override
+		public void close() {
+		}
+
+		public void destroy() {
+			super.close();
+		}
+
+	}
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaOperations.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaOperations.java
@@ -170,7 +170,8 @@ public interface KafkaOperations<K, V> {
 	 * Send a Flux of SenderRecords.
 	 * @param flux the flux.
 	 * @param <T> correlation metadata type.
-	 * @return a flux of sendresults.
+	 * @param t the class for the correlation metadata
+	 * @return a flux of SenderResults.
 	 */
 	<T> Flux<SenderResult<T>> send(Flux<SenderRecord<K, V, T>> flux, Class<T> t);
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaOperations.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaOperations.java
@@ -28,6 +28,10 @@ import org.springframework.kafka.support.SendResult;
 import org.springframework.messaging.Message;
 import org.springframework.util.concurrent.ListenableFuture;
 
+import reactor.core.publisher.Flux;
+import reactor.kafka.sender.SenderRecord;
+import reactor.kafka.sender.SenderResult;
+
 /**
  * The basic Kafka operations contract returning {@link ListenableFuture}s.
  *
@@ -161,6 +165,14 @@ public interface KafkaOperations<K, V> {
 	 * Flush the producer.
 	 */
 	void flush();
+
+	/**
+	 * Send a Flux of SenderRecords.
+	 * @param flux the flux.
+	 * @param <T> correlation metadata type.
+	 * @return a flux of sendresults.
+	 */
+	<T> Flux<SenderResult<T>> send(Flux<SenderRecord<K, V, T>> flux, Class<T> t);
 
 	/**
 	 * A callback for executing arbitrary operations on the {@link Producer}.

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
@@ -39,6 +39,11 @@ import org.springframework.messaging.Message;
 import org.springframework.util.concurrent.ListenableFuture;
 import org.springframework.util.concurrent.SettableListenableFuture;
 
+import reactor.core.publisher.Flux;
+import reactor.kafka.sender.KafkaSender;
+import reactor.kafka.sender.SenderRecord;
+import reactor.kafka.sender.SenderResult;
+
 
 /**
  * A template for executing high-level operations.
@@ -233,6 +238,12 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V> {
 		}
 	}
 
+	@Override
+	public <T> Flux<SenderResult<T>> send(Flux<SenderRecord<K, V, T>> flux, Class<T> t) {
+		KafkaSender<K, V> sender = getTheSender();
+		return sender.send(flux);
+	}
+
 	/**
 	 * Send the producer record.
 	 * @param producerRecord the producer record.
@@ -285,6 +296,10 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V> {
 
 	private Producer<K, V> getTheProducer() {
 		return this.producerFactory.createProducer();
+	}
+
+	private KafkaSender<K, V> getTheSender() {
+		return this.producerFactory.createReactiveSender();
 	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/ProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/ProducerFactory.java
@@ -18,6 +18,8 @@ package org.springframework.kafka.core;
 
 import org.apache.kafka.clients.producer.Producer;
 
+import reactor.kafka.sender.KafkaSender;
+
 /**
  * The strategy to produce a {@link Producer} instance(s).
  *
@@ -29,5 +31,7 @@ import org.apache.kafka.clients.producer.Producer;
 public interface ProducerFactory<K, V> {
 
 	Producer<K, V> createProducer();
+
+	KafkaSender<K, V> createReactiveSender();
 
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTests.java
@@ -160,7 +160,7 @@ public class KafkaTemplateTests {
 		final CountDownLatch latch = new CountDownLatch(10);
 		template.send(Flux.range(1, 10)
 				.map(i -> SenderRecord
-						.<Integer, String, Integer> create(new ProducerRecord<>(INT_KEY_TOPIC, i, "Message_" + i), i)),
+						.<Integer, String, Integer>create(new ProducerRecord<>(INT_KEY_TOPIC, i, "Message_" + i), i)),
 				Integer.class)
 			.doOnError(e -> {
 				exception.set(e);

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTests.java
@@ -32,7 +32,9 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
@@ -56,6 +58,9 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.util.concurrent.ListenableFuture;
 import org.springframework.util.concurrent.ListenableFutureCallback;
+
+import reactor.core.publisher.Flux;
+import reactor.kafka.sender.SenderRecord;
 
 /**
  * @author Gary Russell
@@ -143,6 +148,36 @@ public class KafkaTemplateTests {
 		List<PartitionInfo> partitions = template.partitionsFor(INT_KEY_TOPIC);
 		assertThat(partitions).isNotNull();
 		assertThat(partitions.size()).isEqualTo(2);
+		pf.destroy();
+	}
+
+	@Test
+	public void testTemplateReactive() throws Exception {
+		Map<String, Object> senderProps = KafkaTestUtils.producerProps(embeddedKafka);
+		DefaultKafkaProducerFactory<Integer, String> pf = new DefaultKafkaProducerFactory<>(senderProps);
+		KafkaTemplate<Integer, String> template = new KafkaTemplate<>(pf, true);
+		final AtomicReference<Throwable> exception = new AtomicReference<>();
+		final CountDownLatch latch = new CountDownLatch(10);
+		template.send(Flux.range(1, 10)
+				.map(i -> SenderRecord
+						.<Integer, String, Integer> create(new ProducerRecord<>(INT_KEY_TOPIC, i, "Message_" + i), i)),
+				Integer.class)
+			.doOnError(e -> {
+				exception.set(e);
+			})
+			.subscribe(r -> {
+				latch.countDown();
+			});
+		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+		ConsumerRecords<Integer, String> records = KafkaTestUtils.getRecords(consumer);
+		int count = records.count();
+		int n = 0;
+		while (count < 10 && n++ < 10) {
+			records = KafkaTestUtils.getRecords(consumer);
+			count += records.count();
+		}
+		assertThat(count).isEqualTo(10);
+		assertThat(exception.get()).isNull();
 		pf.destroy();
 	}
 


### PR DESCRIPTION
Initial PoC (sender side).

It doesn't add much value over the pure reactive client, although it does mean that the boot autoconfigured properties can be used.

cc/ @rajinisivaram @artembilan @mbogoevici 