### PR TITLE
Fix Broken null-check for client.id

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
@@ -100,7 +100,9 @@ public class DefaultKafkaConsumerFactory<K, V> implements ConsumerFactory<K, V> 
 	}
 
 	protected KafkaConsumer<K, V> createKafkaConsumer(String groupId, String clientIdSuffix) {
-		if (groupId == null && (!this.configs.containsKey(ConsumerConfig.CLIENT_ID_CONFIG) || clientIdSuffix == null)) {
+		boolean shouldModifyClientId = this.configs.containsKey(ConsumerConfig.CLIENT_ID_CONFIG)
+				&& clientIdSuffix != null;
+		if (groupId == null && !shouldModifyClientId) {
 			return createKafkaConsumer();
 		}
 		else {
@@ -108,7 +110,7 @@ public class DefaultKafkaConsumerFactory<K, V> implements ConsumerFactory<K, V> 
 			if (groupId != null) {
 				modifiedConfigs.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
 			}
-			if (clientIdSuffix != null) {
+			if (shouldModifyClientId) {
 				modifiedConfigs.put(ConsumerConfig.CLIENT_ID_CONFIG,
 					modifiedConfigs.get(ConsumerConfig.CLIENT_ID_CONFIG) + clientIdSuffix);
 			}


### PR DESCRIPTION
Adding the group broke the client.id logic when no client.id configured.

`EnableKafkaIntegrationTests`...

13:51:01.196 WARN  [main][org.apache.kafka.common.utils.AppInfoParser] Error registering AppInfo mbean
javax.management.InstanceAlreadyExistsException: kafka.consumer:type=app-info,id=null-0