### PR TITLE
GH-328: Add Consumer-Aware Error Handlers

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerAwareBatchErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerAwareBatchErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,34 +17,25 @@
 package org.springframework.kafka.listener;
 
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
 
 /**
- * A generic error handler.
- *
- * @param <T> the data type.
+ * An error handler that has access to the consumer, for example to adjust
+ * offsets after an error.
  *
  * @author Gary Russell
- * @since 1.1
+ * @since 2.0
  *
  */
 @FunctionalInterface
-public interface GenericErrorHandler<T> {
+public interface ConsumerAwareBatchErrorHandler extends BatchErrorHandler {
 
-	/**
-	 * Handle the exception.
-	 * @param thrownException The exception.
-	 * @param data the data.
-	 */
-	void handle(Exception thrownException, T data);
-
-	/**
-	 * Handle the exception.
-	 * @param thrownException The exception.
-	 * @param data the data.
-	 * @param consumer the consumer.
-	 */
-	default void handle(Exception thrownException, T data, Consumer<?, ?> consumer) {
-		handle(thrownException, data);
+	@Override
+	default void handle(Exception thrownException, ConsumerRecords<?, ?> data) {
+		throw new UnsupportedOperationException("Container should never call this");
 	}
+
+	@Override
+	void handle(Exception thrownException, ConsumerRecords<?, ?> data, Consumer<?, ?> consumer);
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerAwareErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerAwareErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,34 +17,25 @@
 package org.springframework.kafka.listener;
 
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 
 /**
- * A generic error handler.
- *
- * @param <T> the data type.
+ * An error handler that has access to the consumer, for example to adjust
+ * offsets after an error.
  *
  * @author Gary Russell
- * @since 1.1
+ * @since 2.0
  *
  */
 @FunctionalInterface
-public interface GenericErrorHandler<T> {
+public interface ConsumerAwareErrorHandler extends ErrorHandler {
 
-	/**
-	 * Handle the exception.
-	 * @param thrownException The exception.
-	 * @param data the data.
-	 */
-	void handle(Exception thrownException, T data);
-
-	/**
-	 * Handle the exception.
-	 * @param thrownException The exception.
-	 * @param data the data.
-	 * @param consumer the consumer.
-	 */
-	default void handle(Exception thrownException, T data, Consumer<?, ?> consumer) {
-		handle(thrownException, data);
+	@Override
+	default void handle(Exception thrownException, ConsumerRecord<?, ?> data) {
+		throw new UnsupportedOperationException("Container should never call this");
 	}
+
+	@Override
+	void handle(Exception thrownException, ConsumerRecord<?, ?> data, Consumer<?, ?> consumer);
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerAwareListenerErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerAwareListenerErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2017 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,33 +18,25 @@ package org.springframework.kafka.listener;
 
 import org.apache.kafka.clients.consumer.Consumer;
 
+import org.springframework.messaging.Message;
+
 /**
- * A generic error handler.
- *
- * @param <T> the data type.
+ * An error handler that has access to the consumer, for example to adjust
+ * offsets after an error.
  *
  * @author Gary Russell
- * @since 1.1
+ * @since 2.0
  *
  */
 @FunctionalInterface
-public interface GenericErrorHandler<T> {
+public interface ConsumerAwareListenerErrorHandler extends KafkaListenerErrorHandler {
 
-	/**
-	 * Handle the exception.
-	 * @param thrownException The exception.
-	 * @param data the data.
-	 */
-	void handle(Exception thrownException, T data);
-
-	/**
-	 * Handle the exception.
-	 * @param thrownException The exception.
-	 * @param data the data.
-	 * @param consumer the consumer.
-	 */
-	default void handle(Exception thrownException, T data, Consumer<?, ?> consumer) {
-		handle(thrownException, data);
+	@Override
+	default Object handleError(Message<?> message, ListenerExecutionFailedException exception) throws Exception {
+		throw new UnsupportedOperationException("Container should never call this");
 	}
+
+	@Override
+	Object handleError(Message<?> message, ListenerExecutionFailedException exception, Consumer<?, ?> consumer);
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ErrorHandler.java
@@ -26,11 +26,4 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
  */
 public interface ErrorHandler extends GenericErrorHandler<ConsumerRecord<?, ?>> {
 
-	/*
-	 * Explicitly overridden to avoid AbstractMethodError when calling from code compiled
-	 * against 1.0.x
-	 */
-	@Override
-	void handle(Exception thrownException, ConsumerRecord<?, ?> data);
-
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaListenerErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaListenerErrorHandler.java
@@ -16,6 +16,8 @@
 
 package org.springframework.kafka.listener;
 
+import org.apache.kafka.clients.consumer.Consumer;
+
 import org.springframework.messaging.Message;
 
 /**
@@ -24,6 +26,7 @@ import org.springframework.messaging.Message;
  * listener container's error handler.
  *
  * @author Venil Noronha
+ * @author Gary Russell
  * @since 2.0
  */
 @FunctionalInterface
@@ -38,5 +41,19 @@ public interface KafkaListenerErrorHandler {
 	 * @throws Exception an exception which may be the original or different.
 	 */
 	Object handleError(Message<?> message, ListenerExecutionFailedException exception) throws Exception;
+
+	/**
+	 * Handle the error.
+	 * @param message the spring-messaging message.
+	 * @param exception the exception the listener threw, wrapped in a
+	 * {@link ListenerExecutionFailedException}.
+	 * @param consumer the consumer.
+	 * @return the return value is ignored.
+	 * @throws Exception an exception which may be the original or different.
+	 */
+	default Object handleError(Message<?> message, ListenerExecutionFailedException exception,
+			Consumer<?, ?> consumer) throws Exception {
+		return handleError(message, exception);
+	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -637,7 +637,7 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 						}
 					}
 					try {
-						this.batchErrorHandler.handle(e, records);
+						this.batchErrorHandler.handle(e, records, this.consumer);
 					}
 					catch (Exception ee) {
 						this.logger.error("Error handler threw an exception", ee);
@@ -687,7 +687,7 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 						this.acks.add(record);
 					}
 					try {
-						this.errorHandler.handle(e, record);
+						this.errorHandler.handle(e, record, this.consumer);
 					}
 					catch (Exception ee) {
 						this.logger.error("Error handler threw an exception", ee);

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/BatchMessagingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/BatchMessagingMessageListenerAdapter.java
@@ -116,7 +116,7 @@ public class BatchMessagingMessageListenerAdapter<K, V> extends MessagingMessage
 			}
 		}
 		else {
-			message = NULL_MESSAGE;
+			message = NULL_MESSAGE; // optimization since we won't need any conversion to invoke
 		}
 		if (logger.isDebugEnabled()) {
 			logger.debug("Processing [" + message + "]");
@@ -130,6 +130,9 @@ public class BatchMessagingMessageListenerAdapter<K, V> extends MessagingMessage
 		catch (ListenerExecutionFailedException e) {
 			if (this.errorHandler != null) {
 				try {
+					if (message.equals(NULL_MESSAGE)) {
+						message = new GenericMessage<>(records);
+					}
 					Object result = this.errorHandler.handleError(message, e, consumer);
 					if (result != null) {
 						handleResult(result, records, message);

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/BatchMessagingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/BatchMessagingMessageListenerAdapter.java
@@ -130,7 +130,7 @@ public class BatchMessagingMessageListenerAdapter<K, V> extends MessagingMessage
 		catch (ListenerExecutionFailedException e) {
 			if (this.errorHandler != null) {
 				try {
-					Object result = this.errorHandler.handleError(message, e);
+					Object result = this.errorHandler.handleError(message, e, consumer);
 					if (result != null) {
 						handleResult(result, records, message);
 					}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/RecordMessagingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/RecordMessagingMessageListenerAdapter.java
@@ -85,7 +85,7 @@ public class RecordMessagingMessageListenerAdapter<K, V> extends MessagingMessag
 		catch (ListenerExecutionFailedException e) {
 			if (this.errorHandler != null) {
 				try {
-					Object result = this.errorHandler.handleError(message, e);
+					Object result = this.errorHandler.handleError(message, e, consumer);
 					if (result != null) {
 						handleResult(result, record, message);
 					}

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -1013,6 +1013,22 @@ static class MultiListenerBean {
 [[annotation-error-handling]]
 ==== Handling Exceptions
 
+You can specify a global error handler used for all listeners in the container factory.
+
+[source, java]
+----
+@Bean
+public KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<Integer, String>>
+        kafkaListenerContainerFactory() {
+    ConcurrentKafkaListenerContainerFactory<Integer, String> factory =
+            new ConcurrentKafkaListenerContainerFactory<>();
+    ...
+    factory.getContainerProperties().setErrorHandler(myErrorHandler);
+    ...
+    return factory;
+}
+----
+
 By default, if an annotated listener method throws an exception, it is thrown to the container, and the message will handled according to the container configuration.
 Nothing is returned to the sender.
 
@@ -1035,6 +1051,73 @@ public interface KafkaListenerErrorHandler {
 
 As you can see, you have access to the spring-messaging `Message<?>` object produced by the message converter and the exception that was thrown by the listener, wrapped in a `ListenerExecutionFailedException`.
 The error handler can throw the original or a new exception which will be thrown to the container. Anything returned by the error handler is ignored.
+
+It has a sub-interface `ConsumerAwareListenerErrorHandler` that has access to the consumer object, via the method:
+
+[source, java]
+----
+Object handleError(Message<?> message, ListenerExecutionFailedException exception, Consumer<?, ?> consumer);
+----
+
+If your error handler implements this interface you can, for example, adjust the offsets accordingly.
+For example, to reset the offset to replay the failed message, you could do something like the following; note however, these are simplistic implementations and you would probably want more checking in the error handler.
+
+[source, java]
+----
+@Bean
+public ConsumerAwareListenerErrorHandler listen3ErrorHandler() {
+    return (m, e, c) -> {
+        this.listen3Exception = e;
+        MessageHeaders headers = m.getHeaders();
+        c.seek(new org.apache.kafka.common.TopicPartition(
+                headers.get(KafkaHeaders.RECEIVED_TOPIC, String.class),
+                headers.get(KafkaHeaders.RECEIVED_PARTITION_ID, Integer.class)),
+                headers.get(KafkaHeaders.OFFSET, Long.class));
+        return null;
+    };
+}
+----
+
+And for a batch listener:
+
+[source, java]
+----
+@Bean
+public ConsumerAwareListenerErrorHandler listen10ErrorHandler() {
+    return (m, e, c) -> {
+        this.listen10Exception = e;
+        MessageHeaders headers = m.getHeaders();
+        List<String> topics = headers.get(KafkaHeaders.RECEIVED_TOPIC, List.class);
+        List<Integer> partitions = headers.get(KafkaHeaders.RECEIVED_PARTITION_ID, List.class);
+        List<Long> offsets = headers.get(KafkaHeaders.OFFSET, List.class);
+        Map<TopicPartition, Long> offsetsToReset = new HashMap<>();
+        for (int i = 0; i < topics.size(); i++) {
+            int index = i;
+            offsetsToReset.compute(new TopicPartition(topics.get(i), partitions.get(i)),
+                    (k, v) -> v == null ? offsets.get(index) : Math.min(v, offsets.get(index)));
+        }
+        offsetsToReset.forEach((k, v) -> c.seek(k, v));
+        return null;
+    };
+}
+----
+
+This resets each topic/partition in the batch to the lowest offset in the batch.
+
+Similarly, the container-level error handler (`ErrorHandler` and `BatchErrorHandler`) have sub-interfaces `ConsumerAwareErrorHandler` and `ConsumerAwareBatchErrorHandler` with method signatures:
+
+[source, java]
+----
+void handle(Exception thrownException, ConsumerRecord<?, ?> data, Consumer<?, ?> consumer);
+
+void handle(Exception thrownException, ConsumerRecords<?, ?> data, Consumer<?, ?> consumer);
+----
+
+respectively.
+
+Similar to the `@KafkaListener` error handlers, you can reset the offsets as needed based on the data the failed.
+
+NOTE: Unlike the listener-level error handlers, however, you should set the container property `ackOnError` to false when making adjustments; otherwise any pending acks will be applied after your repositioning.
 
 [[kerberos]]
 ==== Kerberos


### PR DESCRIPTION
Resolves #328

Add consumer-aware versions of error handlers, at the container and `@KafkaListener` level.