### PR TITLE
Typo : Remove duplicate KafkaHeaders

### DIFF
--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -464,7 +464,6 @@ Finally, metadata about the message is available from message headers, the follo
 - `KafkaHeaders.RECEIVED_MESSAGE_KEY`
 - `KafkaHeaders.RECEIVED_TOPIC`
 - `KafkaHeaders.RECEIVED_PARTITION_ID`
-- `KafkaHeaders.RECEIVED_MESSAGE_KEY`
 - `KafkaHeaders.RECEIVED_TIMESTAMP`
 - `KafkaHeaders.TIMESTAMP_TYPE`
 


### PR DESCRIPTION
KafkaHeaders.RECEIVED_MESSAGE_KEY was written twice in the list of header names that can be used for retrieving the headers of a message.