### PR TITLE
GH-335: Fix Class Cast with Batch Filter

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
@@ -32,8 +32,10 @@ import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.context.expression.BeanFactoryResolver;
 import org.springframework.expression.BeanResolver;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.BatchMessageListener;
 import org.springframework.kafka.listener.MessageListener;
 import org.springframework.kafka.listener.MessageListenerContainer;
+import org.springframework.kafka.listener.adapter.FilteringBatchMessageListenerAdapter;
 import org.springframework.kafka.listener.adapter.FilteringMessageListenerAdapter;
 import org.springframework.kafka.listener.adapter.MessagingMessageListenerAdapter;
 import org.springframework.kafka.listener.adapter.RecordFilterStrategy;
@@ -340,8 +342,14 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 					this.retryTemplate, (RecoveryCallback<Object>) this.recoveryCallback);
 		}
 		if (this.recordFilterStrategy != null) {
-			messageListener = new FilteringMessageListenerAdapter<>((MessageListener<K, V>) messageListener,
-					this.recordFilterStrategy, this.ackDiscarded);
+			if (this.batchListener) {
+				messageListener = new FilteringBatchMessageListenerAdapter<>(
+						(BatchMessageListener<K, V>) messageListener, this.recordFilterStrategy, this.ackDiscarded);
+			}
+			else {
+				messageListener = new FilteringMessageListenerAdapter<>((MessageListener<K, V>) messageListener,
+						this.recordFilterStrategy, this.ackDiscarded);
+			}
 		}
 		container.setupMessageListener(messageListener);
 	}

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -732,7 +732,7 @@ This has an additional property `ackDiscarded` which indicates whether the adapt
 
 When using `@KafkaListener`, set the `RecordFilterStrategy` (and optionally `ackDiscarded`) on the container factory and the listener will be wrapped in the appropriate filtering adapter.
 
-Finally, `FilteringBatchMessageListenerAdapter` and `FilteringBatchAcknowledgingMessageListenerAdapter` are provided, for when using a batch <<message-listeners, message listener>>.
+In addition, a `FilteringBatchMessageListenerAdapter` is provided, for when using a batch <<message-listeners, message listener>>.
 
 ===== Retrying Deliveries
 


### PR DESCRIPTION
Fixes #335

Failed to check `batchListener` field when casting listener to apply filter.