### PR TITLE
Example should include use of @Rule to ensure clean shutdown GH-345

### DIFF
--- a/src/reference/asciidoc/testing.adoc
+++ b/src/reference/asciidoc/testing.adoc
@@ -114,7 +114,8 @@ For convenience a test class level `@EmbeddedKafka` annotation is provided with 
 public class KafkaStreamsTests {
 
     @Autowired
-    private KafkaEmbedded kafkaEmbedded;
+    @Rule
+    public KafkaEmbedded kafkaEmbedded;
 
 	@Test
 	public void someTest() {


### PR DESCRIPTION
Applying the Rule to KafkaEmbedded ensures it is properly shut down and does not System.exit(1)
#345 