### PR TITLE
GH-380: Add timeout parameter to record-getting test utils

### DIFF
--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/utils/KafkaTestUtils.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/utils/KafkaTestUtils.java
@@ -108,30 +108,46 @@ public final class KafkaTestUtils {
 	}
 
 	/**
+	 * Same as {@link #getSingleRecord(Consumer, String, long)} with a timeout of 60 seconds.
+	 */
+	public static <K, V> ConsumerRecord<K, V> getSingleRecord(Consumer<K, V> consumer, String topic) {
+		return getSingleRecord(consumer, topic, 60000);
+	}
+
+	/**
 	 * Poll the consumer, expecting a single record for the specified topic.
 	 * @param consumer the consumer.
 	 * @param topic the topic.
+	 * @param timeout max time in milliseconds to wait for records; forwarded to {@link Consumer#poll(long)}.
 	 * @param <K> the key type.
 	 * @param <V> the value type.
 	 * @return the record.
 	 * @throws org.junit.ComparisonFailure if exactly one record is not received.
 	 */
-	public static <K, V> ConsumerRecord<K, V> getSingleRecord(Consumer<K, V> consumer, String topic) {
-		ConsumerRecords<K, V> received = getRecords(consumer);
+	public static <K, V> ConsumerRecord<K, V> getSingleRecord(Consumer<K, V> consumer, String topic, long timeout) {
+		ConsumerRecords<K, V> received = getRecords(consumer, timeout);
 		assertThat(received.count()).as("Incorrect results returned", received.count()).isEqualTo(1);
 		return received.records(topic).iterator().next();
 	}
 
 	/**
+	 * Same as {@link #getRecords(Consumer, long)} with a timeout of 60 seconds.
+	 */
+	public static <K, V> ConsumerRecords<K, V> getRecords(Consumer<K, V> consumer) {
+		return getRecords(consumer, 60000);
+	}
+
+	/**
 	 * Poll the consumer for records.
 	 * @param consumer the consumer.
+	 * @param timeout max time in milliseconds to wait for records; forwarded to {@link Consumer#poll(long)}.
 	 * @param <K> the key type.
 	 * @param <V> the value type.
 	 * @return the records.
 	 */
-	public static <K, V> ConsumerRecords<K, V> getRecords(Consumer<K, V> consumer) {
+	public static <K, V> ConsumerRecords<K, V> getRecords(Consumer<K, V> consumer, long timeout) {
 		logger.debug("Polling...");
-		ConsumerRecords<K, V> received = consumer.poll(60000);
+		ConsumerRecords<K, V> received = consumer.poll(timeout);
 		if (logger.isDebugEnabled()) {
 			logger.debug("Received: " + received.count());
 		}

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/utils/KafkaTestUtils.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/utils/KafkaTestUtils.java
@@ -108,7 +108,14 @@ public final class KafkaTestUtils {
 	}
 
 	/**
-	 * Same as {@link #getSingleRecord(Consumer, String, long)} with a timeout of 60 seconds.
+	 * Poll the consumer, expecting a single record for the specified topic.
+	 * @param consumer the consumer.
+	 * @param topic the topic.
+	 * @param <K> the key type.
+	 * @param <V> the value type.
+	 * @return the record.
+	 * @throws org.junit.ComparisonFailure if exactly one record is not received.
+	 * @see #getSingleRecord(Consumer, String, long)
 	 */
 	public static <K, V> ConsumerRecord<K, V> getSingleRecord(Consumer<K, V> consumer, String topic) {
 		return getSingleRecord(consumer, topic, 60000);
@@ -131,7 +138,12 @@ public final class KafkaTestUtils {
 	}
 
 	/**
-	 * Same as {@link #getRecords(Consumer, long)} with a timeout of 60 seconds.
+	 * Poll the consumer for records.
+	 * @param consumer the consumer.
+	 * @param <K> the key type.
+	 * @param <V> the value type.
+	 * @return the records.
+	 * @see #getRecords(Consumer, long) 
 	 */
 	public static <K, V> ConsumerRecords<K, V> getRecords(Consumer<K, V> consumer) {
 		return getRecords(consumer, 60000);

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/utils/KafkaTestUtils.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/utils/KafkaTestUtils.java
@@ -130,6 +130,7 @@ public final class KafkaTestUtils {
 	 * @param <V> the value type.
 	 * @return the record.
 	 * @throws org.junit.ComparisonFailure if exactly one record is not received.
+	 * @since 2.0
 	 */
 	public static <K, V> ConsumerRecord<K, V> getSingleRecord(Consumer<K, V> consumer, String topic, long timeout) {
 		ConsumerRecords<K, V> received = getRecords(consumer, timeout);
@@ -143,7 +144,7 @@ public final class KafkaTestUtils {
 	 * @param <K> the key type.
 	 * @param <V> the value type.
 	 * @return the records.
-	 * @see #getRecords(Consumer, long) 
+	 * @see #getRecords(Consumer, long)
 	 */
 	public static <K, V> ConsumerRecords<K, V> getRecords(Consumer<K, V> consumer) {
 		return getRecords(consumer, 60000);
@@ -156,6 +157,7 @@ public final class KafkaTestUtils {
 	 * @param <K> the key type.
 	 * @param <V> the value type.
 	 * @return the records.
+	 * @since 2.0
 	 */
 	public static <K, V> ConsumerRecords<K, V> getRecords(Consumer<K, V> consumer, long timeout) {
 		logger.debug("Polling...");

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/utils/KafkaTestUtils.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/utils/KafkaTestUtils.java
@@ -41,7 +41,7 @@ import org.springframework.util.Assert;
  * Kafka testing utilities.
  *
  * @author Gary Russell
- *
+ * @author Hugo Wood
  */
 public final class KafkaTestUtils {
 


### PR DESCRIPTION
This parameter is useful when the test expects messages to be there but they
are not because the tested code is not correct. In this case the test will
run for a minute waiting for a message before it fails. With a custom timeout,
a test can specify a shorter timeout to fail faster.

Closes GH-380.