### PR TITLE
GH-378: @KafkaListener: Fix Group Id When No id

### DIFF
--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/rule/KafkaEmbedded.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/rule/KafkaEmbedded.java
@@ -74,7 +74,6 @@ import scala.collection.Set;
  * @author Artem Bilan
  * @author Gary Russell
  */
-@SuppressWarnings("serial")
 public class KafkaEmbedded extends ExternalResource implements KafkaRule, InitializingBean, DisposableBean {
 
 	private static final Log logger = LogFactory.getLog(KafkaEmbedded.class);

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
@@ -111,6 +111,8 @@ import org.springframework.util.StringUtils;
 public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 		implements BeanPostProcessor, Ordered, BeanFactoryAware, SmartInitializingSingleton {
 
+	private static final String GENERATED_ID_PREFIX = "org.springframework.kafka.KafkaListenerEndpointContainer#";
+
 	/**
 	 * The bean name of the default {@link org.springframework.kafka.config.KafkaListenerContainerFactory}.
 	 */
@@ -411,7 +413,7 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 			return resolve(kafkaListener.id());
 		}
 		else {
-			return "org.springframework.kafka.KafkaListenerEndpointContainer#" + this.counter.getAndIncrement();
+			return GENERATED_ID_PREFIX + this.counter.getAndIncrement();
 		}
 	}
 
@@ -420,7 +422,7 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 		if (StringUtils.hasText(kafkaListener.groupId())) {
 			groupId = resolveExpressionAsString(kafkaListener.groupId(), "groupId");
 		}
-		if (groupId == null && kafkaListener.idIsGroup()) {
+		if (groupId == null && kafkaListener.idIsGroup() && StringUtils.hasText(kafkaListener.id())) {
 			groupId = id;
 		}
 		return groupId;

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -33,6 +33,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -293,7 +294,10 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 
 		private final TransactionTemplate transactionTemplate;
 
-		private final String consumerGroupId = this.containerProperties.getGroupId();
+		private final String consumerGroupId = this.containerProperties.getGroupId() == null
+				? (String) KafkaMessageListenerContainer.this.consumerFactory.getConfigurationProperties()
+						.get(ConsumerConfig.GROUP_ID_CONFIG)
+				: this.containerProperties.getGroupId();
 
 		private volatile Map<TopicPartition, OffsetMetadata> definedPartitions;
 
@@ -310,7 +314,7 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 			Assert.state(!this.isAnyManualAck || !this.autoCommit,
 					"Consumer cannot be configured for auto commit for ackMode " + this.containerProperties.getAckMode());
 			final Consumer<K, V> consumer = KafkaMessageListenerContainer.this.consumerFactory.createConsumer(
-					this.containerProperties.getGroupId(), KafkaMessageListenerContainer.this.clientIdSuffix);
+					this.consumerGroupId, KafkaMessageListenerContainer.this.clientIdSuffix);
 			this.consumer = consumer;
 
 			ConsumerRebalanceListener rebalanceListener = createRebalanceListener(consumer);


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-kafka/issues/378

Don't use a generated container id as the group id if no `id` property provided.

Also fixes `sendToTransaction()` by always populating `consumerGroupId` regardless of source.

__cherry-pick to 1.3.x__