### PR TITLE
GH-342: Allow KLErrorHandler to Return a Result

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaListenerErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaListenerErrorHandler.java
@@ -23,7 +23,8 @@ import org.springframework.messaging.Message;
 /**
  * An error handler which is called when a {code @KafkaListener} method
  * throws an exception. This is invoked higher up the stack than the
- * listener container's error handler.
+ * listener container's error handler. For methods annotated with
+ * {@code @SendTo}, the error handler can return a result.
  *
  * @author Venil Noronha
  * @author Gary Russell
@@ -37,7 +38,8 @@ public interface KafkaListenerErrorHandler {
 	 * @param message the spring-messaging message.
 	 * @param exception the exception the listener threw, wrapped in a
 	 * {@link ListenerExecutionFailedException}.
-	 * @return the return value is ignored.
+	 * @return the return value is ignored unless the annoated method has a
+	 * {@code @SendTo} annotation.
 	 * @throws Exception an exception which may be the original or different.
 	 */
 	Object handleError(Message<?> message, ListenerExecutionFailedException exception) throws Exception;
@@ -48,7 +50,8 @@ public interface KafkaListenerErrorHandler {
 	 * @param exception the exception the listener threw, wrapped in a
 	 * {@link ListenerExecutionFailedException}.
 	 * @param consumer the consumer.
-	 * @return the return value is ignored.
+	 * @return the return value is ignored unless the annoated method has a
+	 * {@code @SendTo} annotation.
 	 * @throws Exception an exception which may be the original or different.
 	 */
 	default Object handleError(Message<?> message, ListenerExecutionFailedException exception,

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
@@ -270,8 +270,9 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 					+ "] - generating response message for it");
 		}
 		Object result = resultArg instanceof ResultHolder ? ((ResultHolder) resultArg).result : resultArg;
-		Assert.state(this.replyTemplate != null, "a KafkaTemplate is required to support replies");
 		String replyTopic = evaluateReplyTopic(request, source, resultArg);
+		Assert.state(replyTopic == null || this.replyTemplate != null,
+				"a KafkaTemplate is required to support replies");
 		sendResponse(result, replyTopic);
 	}
 
@@ -299,8 +300,10 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 
 	@SuppressWarnings("unchecked")
 	protected void sendResponse(Object result, String topic) {
-		if (topic == null && this.logger.isDebugEnabled()) {
-			this.logger.debug("No replyTopic to handle the reply: " + result);
+		if (topic == null) {
+			if (this.logger.isDebugEnabled()) {
+				this.logger.debug("No replyTopic to handle the reply: " + result);
+			}
 		}
 		else {
 			if (result instanceof Collection) {

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -716,7 +716,7 @@ public Collection<String> replyingBatchListener(List<String> in) {
     ...
 }
 
-@KafkaListener(topics = "annotated23")
+@KafkaListener(topics = "annotated23", errorHandler = "replyErrorHandler")
 @SendTo("annotated23reply") // static reply topic definition
 public String replyingListenerWithErrorHandler(String in) {
     ...
@@ -760,6 +760,28 @@ public KafkaTemplate<String, String> myReplyingTemplate() {
     };
 }
 ----
+
+NOTE: You can annotate a `@KafkaListener` method with `@SendTo` even if no result is returned.
+This is to allow the configuration of an `errorHandler` that can forward information about a failed message delivery to some topic.
+
+[source, java]
+----
+@KafkaListener(id = "voidListenerWithReplyingErrorHandler", topics = "someTopic",
+        errorHandler = "voidSendToErrorHandler")
+@SendTo("failures")
+public void voidListenerWithReplyingErrorHandler(String in) {
+    throw new RuntimeException("fail");
+}
+
+@Bean
+public KafkaListenerErrorHandler voidSendToErrorHandler() {
+    return (m, e) -> {
+        return ... // some information about the failure and input data
+    };
+}
+----
+
+See <<annotation-error-handling>> for more information.
 
 ===== Filtering Messages
 


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/342

Allow no reply template when an error handler returns a result; the result is ignored.

Also add a note (and test) about a `void` method that has a `@SendTo` - which allows information
about the exception in a `void` method to be sent to a topic.