### PR TITLE
GH-390: GH-391: Header Mapper Fixes

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/DefaultKafkaHeaderMapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/DefaultKafkaHeaderMapper.java
@@ -77,6 +77,8 @@ public class DefaultKafkaHeaderMapper implements KafkaHeaderMapper {
 		new SimplePatternBasedHeaderMatcher("!" + KafkaHeaders.RECEIVED_TOPIC),
 		new SimplePatternBasedHeaderMatcher("!" + KafkaHeaders.TIMESTAMP),
 		new SimplePatternBasedHeaderMatcher("!" + KafkaHeaders.TIMESTAMP_TYPE),
+		new SimplePatternBasedHeaderMatcher("!" + KafkaHeaders.BATCH_CONVERTED_HEADERS),
+		new SimplePatternBasedHeaderMatcher("!" + KafkaHeaders.NATIVE_HEADERS),
 		new SimplePatternBasedHeaderMatcher("!" + KafkaHeaders.TOPIC));
 
 	private final ObjectMapper objectMapper;

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/JacksonPresent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/JacksonPresent.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support;
+
+import org.springframework.util.ClassUtils;
+
+/**
+ * The utility to check if Jackson JSON processor is present in the classpath.
+ *
+ * @author Artem Bilan
+ * @author Gary Russell
+ *
+ * @since 1.3
+ */
+public final class JacksonPresent {
+
+	private static final ClassLoader classLoader = JacksonPresent.class.getClassLoader();
+
+	private static final boolean jackson2Present =
+			ClassUtils.isPresent("com.fasterxml.jackson.databind.ObjectMapper", classLoader) &&
+					ClassUtils.isPresent("com.fasterxml.jackson.core.JsonGenerator", classLoader);
+
+	public static boolean isJackson2Present() {
+		return jackson2Present;
+	}
+
+	private JacksonPresent() {
+		super();
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/KafkaHeaders.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/KafkaHeaders.java
@@ -94,4 +94,17 @@ public abstract class KafkaHeaders {
 	 */
 	public static final String RECEIVED_TIMESTAMP = PREFIX + "receivedTimestamp";
 
+	/**
+	 * The header for holding the native headers of the consumer record; only provided
+	 * if no header mapper is present.
+	 */
+	public static final String NATIVE_HEADERS = PREFIX + "nativeHeaders";
+
+	/**
+	 * The header for a list of Maps of converted native Kafka headers. Used for batch
+	 * listeners; the map at a particular list position corresponds to the data in the
+	 * payload list position.
+	 */
+	public static final String BATCH_CONVERTED_HEADERS = PREFIX + "convertedHeaders";
+
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/KafkaHeaders.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/KafkaHeaders.java
@@ -105,6 +105,6 @@ public abstract class KafkaHeaders {
 	 * listeners; the map at a particular list position corresponds to the data in the
 	 * payload list position.
 	 */
-	public static final String BATCH_CONVERTED_HEADERS = PREFIX + "convertedHeaders";
+	public static final String BATCH_CONVERTED_HEADERS = PREFIX + "batchConvertedHeaders";
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/converter/BatchMessagingMessageConverter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/converter/BatchMessagingMessageConverter.java
@@ -18,14 +18,21 @@ package org.springframework.kafka.support.converter;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.Headers;
 
 import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.kafka.support.DefaultKafkaHeaderMapper;
+import org.springframework.kafka.support.JacksonPresent;
+import org.springframework.kafka.support.KafkaHeaderMapper;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.support.KafkaNull;
 import org.springframework.messaging.Message;
@@ -48,9 +55,19 @@ import org.springframework.messaging.support.MessageBuilder;
  */
 public class BatchMessagingMessageConverter implements BatchMessageConverter {
 
+	protected final Log logger = LogFactory.getLog(getClass());
+
 	private boolean generateMessageId = false;
 
 	private boolean generateTimestamp = false;
+
+	private KafkaHeaderMapper headerMapper;
+
+	public BatchMessagingMessageConverter() {
+		if (JacksonPresent.isJackson2Present()) {
+			this.headerMapper = new DefaultKafkaHeaderMapper();
+		}
+	}
 
 	/**
 	 * Generate {@link Message} {@code ids} for produced messages. If set to {@code false},
@@ -70,6 +87,15 @@ public class BatchMessagingMessageConverter implements BatchMessageConverter {
 		this.generateTimestamp = generateTimestamp;
 	}
 
+	/**
+	 * Set the header mapper to map headers.
+	 * @param headerMapper the mapper.
+	 * @since 1.3
+	 */
+	public void setHeaderMapper(KafkaHeaderMapper headerMapper) {
+		this.headerMapper = headerMapper;
+	}
+
 	@Override
 	public Message<?> toMessage(List<ConsumerRecord<?, ?>> records, Acknowledgment acknowledgment,
 			Consumer<?, ?> consumer, Type type) {
@@ -84,12 +110,20 @@ public class BatchMessagingMessageConverter implements BatchMessageConverter {
 		List<Long> offsets = new ArrayList<>();
 		List<String> timestampTypes = new ArrayList<>();
 		List<Long> timestamps = new ArrayList<>();
+		List<Map<String, Object>> convertedHeaders = new ArrayList<>();
+		List<Headers> natives = new ArrayList<>();
 		rawHeaders.put(KafkaHeaders.RECEIVED_MESSAGE_KEY, keys);
 		rawHeaders.put(KafkaHeaders.RECEIVED_TOPIC, topics);
 		rawHeaders.put(KafkaHeaders.RECEIVED_PARTITION_ID, partitions);
 		rawHeaders.put(KafkaHeaders.OFFSET, offsets);
 		rawHeaders.put(KafkaHeaders.TIMESTAMP_TYPE, timestampTypes);
 		rawHeaders.put(KafkaHeaders.RECEIVED_TIMESTAMP, timestamps);
+		if (this.headerMapper != null) {
+			rawHeaders.put(KafkaHeaders.BATCH_CONVERTED_HEADERS, convertedHeaders);
+		}
+		else {
+			rawHeaders.put(KafkaHeaders.NATIVE_HEADERS, natives);
+		}
 
 		if (acknowledgment != null) {
 			rawHeaders.put(KafkaHeaders.ACKNOWLEDGMENT, acknowledgment);
@@ -106,6 +140,20 @@ public class BatchMessagingMessageConverter implements BatchMessageConverter {
 			offsets.add(record.offset());
 			timestampTypes.add(record.timestampType().name());
 			timestamps.add(record.timestamp());
+			if (this.headerMapper != null) {
+				Map<String, Object> converted = new HashMap<>();
+				this.headerMapper.toHeaders(record.headers(), converted);
+				convertedHeaders.add(converted);
+			}
+			else {
+				if (record.headers().iterator().hasNext() && logger.isWarnEnabled()) {
+					logger.warn(
+						"Headers are present, but no header mapper is available; "
+						+ "Jackson is required for the default mapper; headers are not mapped but provided raw in "
+						+ KafkaHeaders.NATIVE_HEADERS);
+				}
+				natives.add(record.headers());
+			}
 		}
 		return MessageBuilder.createMessage(payloads, kafkaMessageHeaders);
 	}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/converter/BatchMessagingMessageConverter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/converter/BatchMessagingMessageConverter.java
@@ -147,10 +147,10 @@ public class BatchMessagingMessageConverter implements BatchMessageConverter {
 				convertedHeaders.add(converted);
 			}
 			else {
-				if (record.headers().iterator().hasNext() && logger.isDebugEnabled() && !logged) {
+				if (logger.isDebugEnabled() && !logged) {
 					logger.debug(
-						"Headers are present, but no header mapper is available; "
-						+ "Jackson is required for the default mapper; headers are not mapped but provided raw in "
+						"No header mapper is available; Jackson is required for the default mapper; "
+						+ "headers (if present) are not mapped but provided raw in "
 						+ KafkaHeaders.NATIVE_HEADERS);
 					logged = true;
 				}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/converter/BatchMessagingMessageConverter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/converter/BatchMessagingMessageConverter.java
@@ -132,6 +132,7 @@ public class BatchMessagingMessageConverter implements BatchMessageConverter {
 			rawHeaders.put(KafkaHeaders.CONSUMER, consumer);
 		}
 
+		boolean logged = false;
 		for (ConsumerRecord<?, ?> record : records) {
 			payloads.add(extractAndConvertValue(record, type));
 			keys.add(record.key());
@@ -146,11 +147,12 @@ public class BatchMessagingMessageConverter implements BatchMessageConverter {
 				convertedHeaders.add(converted);
 			}
 			else {
-				if (record.headers().iterator().hasNext() && logger.isDebugEnabled()) {
+				if (record.headers().iterator().hasNext() && logger.isDebugEnabled() && !logged) {
 					logger.debug(
 						"Headers are present, but no header mapper is available; "
 						+ "Jackson is required for the default mapper; headers are not mapped but provided raw in "
 						+ KafkaHeaders.NATIVE_HEADERS);
+					logged = true;
 				}
 				natives.add(record.headers());
 			}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/converter/BatchMessagingMessageConverter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/converter/BatchMessagingMessageConverter.java
@@ -146,8 +146,8 @@ public class BatchMessagingMessageConverter implements BatchMessageConverter {
 				convertedHeaders.add(converted);
 			}
 			else {
-				if (record.headers().iterator().hasNext() && logger.isWarnEnabled()) {
-					logger.warn(
+				if (record.headers().iterator().hasNext() && logger.isDebugEnabled()) {
+					logger.debug(
 						"Headers are present, but no header mapper is available; "
 						+ "Jackson is required for the default mapper; headers are not mapped but provided raw in "
 						+ KafkaHeaders.NATIVE_HEADERS);

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/converter/MessagingMessageConverter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/converter/MessagingMessageConverter.java
@@ -102,8 +102,8 @@ public class MessagingMessageConverter implements RecordMessageConverter {
 			this.headerMapper.toHeaders(record.headers(), rawHeaders);
 		}
 		else {
-			if (record.headers().iterator().hasNext() && logger.isWarnEnabled()) {
-				logger.warn(
+			if (record.headers().iterator().hasNext() && logger.isDebugEnabled()) {
+				logger.debug(
 					"Headers are present, but no header mapper is available; "
 					+ "Jackson is required for the default mapper; headers are not mapped but provided raw in "
 					+ KafkaHeaders.NATIVE_HEADERS);

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/converter/MessagingMessageConverter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/converter/MessagingMessageConverter.java
@@ -102,11 +102,11 @@ public class MessagingMessageConverter implements RecordMessageConverter {
 			this.headerMapper.toHeaders(record.headers(), rawHeaders);
 		}
 		else {
-			if (record.headers().iterator().hasNext() && logger.isDebugEnabled()) {
+			if (logger.isDebugEnabled()) {
 				logger.debug(
-					"Headers are present, but no header mapper is available; "
-					+ "Jackson is required for the default mapper; headers are not mapped but provided raw in "
-					+ KafkaHeaders.NATIVE_HEADERS);
+						"No header mapper is available; Jackson is required for the default mapper; "
+						+ "headers (if present) are not mapped but provided raw in "
+						+ KafkaHeaders.NATIVE_HEADERS);
 			}
 			rawHeaders.put(KafkaHeaders.NATIVE_HEADERS, record.headers());
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/converter/MessagingMessageConverter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/converter/MessagingMessageConverter.java
@@ -19,6 +19,8 @@ package org.springframework.kafka.support.converter;
 import java.lang.reflect.Type;
 import java.util.Map;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -26,6 +28,7 @@ import org.apache.kafka.common.header.internals.RecordHeaders;
 
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.kafka.support.DefaultKafkaHeaderMapper;
+import org.springframework.kafka.support.JacksonPresent;
 import org.springframework.kafka.support.KafkaHeaderMapper;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.support.KafkaNull;
@@ -47,11 +50,19 @@ import org.springframework.messaging.support.MessageBuilder;
  */
 public class MessagingMessageConverter implements RecordMessageConverter {
 
+	protected final Log logger = LogFactory.getLog(getClass());
+
 	private boolean generateMessageId = false;
 
 	private boolean generateTimestamp = false;
 
-	private KafkaHeaderMapper headerMapper = new DefaultKafkaHeaderMapper();
+	private KafkaHeaderMapper headerMapper;
+
+	public MessagingMessageConverter() {
+		if (JacksonPresent.isJackson2Present()) {
+			this.headerMapper = new DefaultKafkaHeaderMapper();
+		}
+	}
 
 	/**
 	 * Generate {@link Message} {@code ids} for produced messages. If set to {@code false},
@@ -87,7 +98,18 @@ public class MessagingMessageConverter implements RecordMessageConverter {
 				this.generateTimestamp);
 
 		Map<String, Object> rawHeaders = kafkaMessageHeaders.getRawHeaders();
-		this.headerMapper.toHeaders(record.headers(), rawHeaders);
+		if (this.headerMapper != null) {
+			this.headerMapper.toHeaders(record.headers(), rawHeaders);
+		}
+		else {
+			if (record.headers().iterator().hasNext() && logger.isWarnEnabled()) {
+				logger.warn(
+					"Headers are present, but no header mapper is available; "
+					+ "Jackson is required for the default mapper; headers are not mapped but provided raw in "
+					+ KafkaHeaders.NATIVE_HEADERS);
+			}
+			rawHeaders.put(KafkaHeaders.NATIVE_HEADERS, record.headers());
+		}
 		rawHeaders.put(KafkaHeaders.RECEIVED_MESSAGE_KEY, record.key());
 		rawHeaders.put(KafkaHeaders.RECEIVED_TOPIC, record.topic());
 		rawHeaders.put(KafkaHeaders.RECEIVED_PARTITION_ID, record.partition());

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/converter/BatchMessageConverterTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/converter/BatchMessageConverterTests.java
@@ -21,10 +21,16 @@ import static org.mockito.Mockito.mock;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.record.TimestampType;
 import org.junit.Test;
 
@@ -41,15 +47,45 @@ public class BatchMessageConverterTests {
 
 	@Test
 	public void testBatchConverters() throws Exception {
+		BatchMessageConverter batchMessageConverter = new BatchMessagingMessageConverter();
+
+		MessageHeaders headers = testGuts(batchMessageConverter);
+		@SuppressWarnings("unchecked")
+		List<Map<String, Object>> converted = (List<Map<String, Object>>) headers
+				.get(KafkaHeaders.BATCH_CONVERTED_HEADERS);
+		assertThat(converted.size()).isEqualTo(3);
+		Map<String, Object> map = converted.get(0);
+		assertThat(map.size()).isEqualTo(1);
+		assertThat(new String((byte[]) map.get("foo"))).isEqualTo("bar");
+	}
+
+	@Test
+	public void testNoMapper() {
+		BatchMessagingMessageConverter batchMessageConverter = new BatchMessagingMessageConverter();
+		batchMessageConverter.setHeaderMapper(null);
+
+		MessageHeaders headers = testGuts(batchMessageConverter);
+		@SuppressWarnings("unchecked")
+		List<Headers> natives = (List<Headers>) headers.get(KafkaHeaders.NATIVE_HEADERS);
+		assertThat(natives.size()).isEqualTo(3);
+		Iterator<Header> iterator = natives.get(0).iterator();
+		assertThat(iterator.hasNext()).isEqualTo(true);
+		Header next = iterator.next();
+		assertThat(next.key()).isEqualTo("foo");
+		assertThat(new String(next.value())).isEqualTo("bar");
+	}
+
+	private MessageHeaders testGuts(BatchMessageConverter batchMessageConverter) {
+		Header header = new RecordHeader("foo", "bar".getBytes());
+		Headers kHeaders = new RecordHeaders(new Header[] { header });
 		List<ConsumerRecord<?, ?>> consumerRecords = new ArrayList<>();
 		consumerRecords.add(new ConsumerRecord<>("topic1", 0, 1, 1487694048607L,
-				TimestampType.CREATE_TIME, 123L, 2, 3, "key1", "value1"));
+				TimestampType.CREATE_TIME, 123L, 2, 3, "key1", "value1", kHeaders));
 		consumerRecords.add(new ConsumerRecord<>("topic1", 0, 2, 1487694048608L,
-				TimestampType.CREATE_TIME, 123L, 2, 3, "key2", "value2"));
+				TimestampType.CREATE_TIME, 123L, 2, 3, "key2", "value2", kHeaders));
 		consumerRecords.add(new ConsumerRecord<>("topic1", 0, 3, 1487694048609L,
-				TimestampType.CREATE_TIME, 123L, 2, 3, "key3", "value3"));
+				TimestampType.CREATE_TIME, 123L, 2, 3, "key3", "value3", kHeaders));
 
-		BatchMessageConverter batchMessageConverter = new BatchMessagingMessageConverter();
 
 		Acknowledgment ack = mock(Acknowledgment.class);
 		Consumer<?, ?> consumer = mock(Consumer.class);
@@ -73,6 +109,7 @@ public class BatchMessageConverterTests {
 				.isEqualTo(Arrays.asList(1487694048607L, 1487694048608L, 1487694048609L));
 		assertThat(headers.get(KafkaHeaders.ACKNOWLEDGMENT)).isSameAs(ack);
 		assertThat(headers.get(KafkaHeaders.CONSUMER)).isSameAs(consumer);
+		return headers;
 	}
 
 }

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -1112,7 +1112,7 @@ To trust all packages use `mapper.addTrustedPackages("*")`.
 
 The `DefaultKafkaHeaderMapper` is used in the `MessagingMessageConverter` and `BatchMessagingMessageConverter` by default, as long as Jackson is on the class path.
 
-With the batch converter, the converted headers are available in the `KafkaHeaders.BATCH_CONVERTED_HEADERS` as a `List<Map<String, Object>` where the map in a position of the list corresponds to the data position in the payload.
+With the batch converter, the converted headers are available in the `KafkaHeaders.BATCH_CONVERTED_HEADERS` as a `List<Map<String, Object>>` where the map in a position of the list corresponds to the data position in the payload.
 
 If the converter has no converter (either because Jackson is not present, or it is explicitly set to `null`), the headers from the consumer record are provided unconverted in the `KafkaHeaders.NATIVE_HEADERS` header (a `Headers` object, or a `List<Headers>` in the case of the batch converter, where the position in the list corresponds to the data position in the payload).
 

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -1110,7 +1110,11 @@ You can trust other (or all) packages by adding trusted packages using the `addT
 If you are receiving messages from untrusted sources, you may wish to add just those packages that you trust.
 To trust all packages use `mapper.addTrustedPackages("*")`.
 
-The `DefaultKafkaHeaderMapper` is used in the `MessagingMessageConverter` by default.
+The `DefaultKafkaHeaderMapper` is used in the `MessagingMessageConverter` and `BatchMessagingMessageConverter` by default, as long as Jackson is on the class path.
+
+With the batch converter, the converted headers are available in the `KafkaHeaders.BATCH_CONVERTED_HEADERS` as a `List<Map<String, Object>` where the map in a position of the list corresponds to the data position in the payload.
+
+If the converter has no converter (either because Jackson is not present, or it is explicitly set to `null`), the headers from the consumer record are provided unconverted in the `KafkaHeaders.NATIVE_HEADERS` header (a `Headers` object, or a `List<Headers>` in the case of the batch converter, where the position in the list corresponds to the data position in the payload).
 
 ==== Log Compaction
 


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-kafka/issues/390
Fixes https://github.com/spring-projects/spring-kafka/issues/391

The `DefaultKafkaHeaderMapper` has a hard dependency on Jackson; don't use it as a default
if Jackson is not present.

Add header mapping for batch listeners.

__cherry-pick to 1.3.x__