### PR TITLE
GH-352: Add General send() with ProducerRecord

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaOperations.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaOperations.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
@@ -123,6 +124,14 @@ public interface KafkaOperations<K, V> {
 	 * @since 1.3
 	 */
 	ListenableFuture<SendResult<K, V>> send(String topic, Integer partition, Long timestamp, K key, V data);
+
+	/**
+	 * Send the provided {@link ProducerRecord}.
+	 * @param record the record.
+	 * @return a Future for the {@link SendResult}.
+	 * @since 1.3
+	 */
+	ListenableFuture<SendResult<K, V>> send(ProducerRecord<K, V> record);
 
 	/**
 	 * Send a message with routing information in message headers. The message payload

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
@@ -184,6 +184,12 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V> {
 		return doSend(producerRecord);
 	}
 
+
+	@Override
+	public ListenableFuture<SendResult<K, V>> send(ProducerRecord<K, V> record) {
+		return doSend(record);
+	}
+
 	@SuppressWarnings("unchecked")
 	@Override
 	public ListenableFuture<SendResult<K, V>> send(Message<?> message) {

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -59,6 +59,8 @@ ListenableFuture<SendResult<K, V>> send(String topic, Integer partition, K key, 
 
 ListenableFuture<SendResult<K, V>> send(String topic, Integer partition, Long timestamp, K key, V data);
 
+ListenableFuture<SendResult<K, V>> send(ProducerRecord<K, V> record);
+
 ListenableFuture<SendResult<K, V>> send(Message<?> message);
 
 Map<MetricName, ? extends Metric> metrics();


### PR DESCRIPTION
Needed to support headers.

Adding overloaded send methods is getting out of hand, consider deprecating the parameterized sends.

__cherry-pick to 1.3.x__