### PR TITLE
GH-418: KafkaAdmin Improvements

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaAdmin.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaAdmin.java
@@ -61,6 +61,10 @@ public class KafkaAdmin implements ApplicationContextAware, SmartInitializingSin
 
 	private boolean fatalIfBrokerNotAvailable;
 
+	private boolean autoCreate = true;
+
+	private boolean initializingContext;
+
 	/**
 	 * Create an instance with an {@link AdminClient} based on the supplied
 	 * configuration.
@@ -93,6 +97,15 @@ public class KafkaAdmin implements ApplicationContextAware, SmartInitializingSin
 	}
 
 	/**
+	 * Set to false to suppress auto creation of topics during context initialization.
+	 * @param autoCreate
+	 * @see #initialize()
+	 */
+	public void setAutoCreate(boolean autoCreate) {
+		this.autoCreate = autoCreate;
+	}
+
+	/**
 	 * Get an unmodifiable copy of this admin's configuration.
 	 * @return the configuration map.
 	 */
@@ -102,43 +115,59 @@ public class KafkaAdmin implements ApplicationContextAware, SmartInitializingSin
 
 	@Override
 	public void afterSingletonsInstantiated() {
-		if (!initialize()) {
-			if (this.fatalIfBrokerNotAvailable) {
-				throw new IllegalStateException("Could not configure topics");
-			}
+		this.initializingContext = true;
+		if (this.autoCreate) {
+			initialize();
 		}
 	}
 
 	/**
 	 * Call this method to check/add topics; this might be needed if the broker was not
 	 * available when the application context was initialized, and
-	 * {@link #setFatalIfBrokerNotAvailable(boolean) fatalIfBrokenNotAvailable} is false.
+	 * {@link #setFatalIfBrokerNotAvailable(boolean) fatalIfBrokenNotAvailable} is false,
+	 * or {@link #setAutoCreate(boolean) autoCreate} was set to false.
 	 * @return true if successful.
+	 * @see #setFatalIfBrokerNotAvailable(boolean)
+	 * @see #setAutoCreate(boolean)
 	 */
 	public final boolean initialize() {
-		AdminClient adminClient = null;
-		try {
-			adminClient = AdminClient.create(this.config);
-		}
-		catch (Exception e) {
-			logger.error("Failed to create AdminClient", e);
-		}
-		if (adminClient != null) {
+		Collection<NewTopic> newTopics = this.applicationContext.getBeansOfType(NewTopic.class, false, false).values();
+		if (newTopics.size() > 0) {
+			AdminClient adminClient = null;
 			try {
-				if (this.applicationContext != null) {
-					addTopicsIfNeeded(adminClient,
-							this.applicationContext.getBeansOfType(NewTopic.class, false, false).values());
-				}
-				return true;
+				adminClient = AdminClient.create(this.config);
 			}
-			finally {
-				adminClient.close(this.closeTimeout, TimeUnit.SECONDS);
+			catch (Exception e) {
+				if ((this.initializingContext && this.fatalIfBrokerNotAvailable)
+						|| !this.initializingContext) {
+					throw new IllegalStateException("Could not create admin", e);
+				}
+			}
+			if (adminClient != null) {
+				try {
+					addTopicsIfNeeded(adminClient, newTopics);
+					return true;
+				}
+				catch (Throwable e) {
+					if (e instanceof Error) {
+						throw (Error) e;
+					}
+					if ((this.initializingContext && this.fatalIfBrokerNotAvailable)
+							|| !this.initializingContext) {
+						throw new IllegalStateException("Could not configure topics", e);
+					}
+				}
+				finally {
+					this.initializingContext = false;
+					adminClient.close(this.closeTimeout, TimeUnit.SECONDS);
+				}
 			}
 		}
+		this.initializingContext = false;
 		return false;
 	}
 
-	private void addTopicsIfNeeded(AdminClient adminClient, Collection<NewTopic> topics) {
+	private void addTopicsIfNeeded(AdminClient adminClient, Collection<NewTopic> topics) throws Throwable {
 		if (topics.size() > 0) {
 			Map<String, NewTopic> topicNameToTopic = new HashMap<>();
 			topics.forEach(t -> topicNameToTopic.compute(t.name(), (k, v) -> v = t));
@@ -176,6 +205,7 @@ public class KafkaAdmin implements ApplicationContextAware, SmartInitializingSin
 				}
 				catch (ExecutionException e) {
 					logger.error("Failed to create topics", e.getCause());
+					throw e.getCause();
 				}
 			}
 		}

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaAdminBadContextTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaAdminBadContextTests.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.junit.Test;
+
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.test.rule.KafkaEmbedded;
+
+/**
+ * @author Gary Russell
+ * @since 1.3
+ *
+ */
+public class KafkaAdminBadContextTests {
+
+	@Test
+	public void testContextNotLoaded() {
+		try {
+			AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext(BadConfig.class);
+			fail("Expected Exception");
+			ctx.close();
+		}
+		catch (IllegalStateException e) {
+			assertThat(e.getMessage()).isEqualTo("Could not create admin");
+		}
+	}
+
+	@Configuration
+	public static class BadConfig {
+
+		@Bean
+		public KafkaEmbedded kafkaEmbedded() {
+			return new KafkaEmbedded(1);
+		}
+
+		@Bean
+		public KafkaAdmin admin() {
+			Map<String, Object> configs = new HashMap<>();
+			configs.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, "junk.host.ajshasdjasdk:1234");
+			// use the following to get the "Could not configure topics" variant
+			// can't be a CI test
+//			configs.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:1234");
+			configs.put(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, "100");
+			KafkaAdmin kafkaAdmin = new KafkaAdmin(configs);
+			kafkaAdmin.setFatalIfBrokerNotAvailable(true);
+			return kafkaAdmin;
+		}
+
+		@Bean
+		public NewTopic topic1() {
+			return new NewTopic("baz", 1, (short) 1);
+		}
+
+	}
+
+}


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/418

Depending on the nature of the problem, `fatalIfBrokerNotAvailable` did not always work.

With a bad broker address, the client is not created.
With a good broker address, but the broker is down, the add fails.

Add more robust logic to the initialization code.

Also add the `autoCreate` flag, allowing users to suppress auto creation during
context initialization.

__cherry-pick to 1.3.x__