### PR TITLE
GH-439: Container Lifecycle Fixes

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
@@ -203,10 +203,12 @@ public abstract class AbstractMessageListenerContainer<K, V>
 	@Override
 	public final void start() {
 		synchronized (this.lifecycleMonitor) {
-			Assert.isTrue(
-					this.containerProperties.getMessageListener() instanceof GenericMessageListener,
-					"A " + GenericMessageListener.class.getName() + " implementation must be provided");
-			doStart();
+			if (!isRunning()) {
+				Assert.isTrue(
+						this.containerProperties.getMessageListener() instanceof GenericMessageListener,
+						"A " + GenericMessageListener.class.getName() + " implementation must be provided");
+				doStart();
+			}
 		}
 	}
 
@@ -214,25 +216,31 @@ public abstract class AbstractMessageListenerContainer<K, V>
 
 	@Override
 	public final void stop() {
-		final CountDownLatch latch = new CountDownLatch(1);
-		stop(new Runnable() {
+		synchronized (this.lifecycleMonitor) {
+			if (isRunning()) {
+				final CountDownLatch latch = new CountDownLatch(1);
+				stop(new Runnable() {
 
-			@Override
-			public void run() {
-				latch.countDown();
+					@Override
+					public void run() {
+						latch.countDown();
+					}
+				});
+				try {
+					latch.await(this.containerProperties.getShutdownTimeout(), TimeUnit.MILLISECONDS);
+				}
+				catch (InterruptedException e) {
+				}
 			}
-		});
-		try {
-			latch.await(this.containerProperties.getShutdownTimeout(), TimeUnit.MILLISECONDS);
-		}
-		catch (InterruptedException e) {
 		}
 	}
 
 	@Override
 	public void stop(Runnable callback) {
 		synchronized (this.lifecycleMonitor) {
-			doStop(callback);
+			if (isRunning()) {
+				doStop(callback);
+			}
 		}
 	}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
@@ -132,6 +132,7 @@ public class KafkaMessageListenerContainerTests {
 		props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 		DefaultKafkaConsumerFactory<Integer, String> cf = new DefaultKafkaConsumerFactory<>(props);
 		ContainerProperties containerProps = new ContainerProperties(topic3);
+		containerProps.setShutdownTimeout(60_000L);
 		final AtomicReference<StackTraceElement[]> trace = new AtomicReference<>();
 		final CountDownLatch latch1 = new CountDownLatch(1);
 		containerProps.setMessageListener((MessageListener<Integer, String>) record -> {
@@ -197,6 +198,9 @@ public class KafkaMessageListenerContainerTests {
 //		assertThat(trace.get()[i + 2].getMethodName()).contains("onMessage"); // bridge
 //		assertThat(trace.get()[i + 3].getMethodName()).contains("invokeRecordListener");
 		container.stop();
+		long t = System.currentTimeMillis();
+		container.stop();
+		assertThat(System.currentTimeMillis() - t).isLessThan(5000L);
 
 		pf.destroy();
 	}


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-kafka/issues/439

Ignore `stop()` if container is not running, `start()` if container is running.

__cherry-pick to all branches__