### PR TITLE
GH-444: Adds a `disabled` attribute to EmbeddedKafka

### DIFF
--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafka.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafka.java
@@ -96,5 +96,14 @@ public @interface EmbeddedKafka {
 	 */
 	String[] brokerProperties() default { };
 
+	/**
+	 * When {@code true} no {@code KafkaEmbedded} instance is created, bypassing the {@link
+	 * EmbeddedKafkaContextCustomizer}.  Used to override the use of a Kafka broker in a subclass, where the parent
+	 * has defined {@code EmbeddedKafka}.
+	 *
+	 * @return {@code false}, by default
+	 */
+	boolean disabled() default false;
+
 }
 

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizer.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizer.java
@@ -49,6 +49,11 @@ class EmbeddedKafkaContextCustomizer implements ContextCustomizer {
 	@Override
 	@SuppressWarnings("unchecked")
 	public void customizeContext(ConfigurableApplicationContext context, MergedContextConfiguration mergedConfig) {
+
+		if (this.embeddedKafka.disabled()) {
+			return;
+		}
+
 		ConfigurableListableBeanFactory beanFactory = context.getBeanFactory();
 		Assert.isInstanceOf(DefaultSingletonBeanRegistry.class, beanFactory);
 


### PR DESCRIPTION
Allows classes to disable the instantiation of KafkaEmbedded on a case-by-case basis.

Resolves https://github.com/spring-projects/spring-kafka/issues/444