### PR TITLE
Allow templating SpEL in @KafkaListener

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
@@ -612,10 +612,6 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 	private Object resolveExpression(String value) {
 		String resolvedValue = resolve(value);
 
-		if (!(resolvedValue.startsWith("#{") && value.endsWith("}"))) {
-			return resolvedValue;
-		}
-
 		return this.resolver.evaluate(resolvedValue, this.expressionContext);
 	}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -1037,7 +1037,7 @@ public class EnableKafkaIntegrationTests {
 		}
 
 		@KafkaListener(id = "qux", topics = "annotated4", containerFactory = "kafkaManualAckListenerContainerFactory",
-				containerGroup = "quxGroup")
+				containerGroup = "qux#{'Group'}")
 		public void listen4(@Payload String foo, Acknowledgment ack, Consumer<?, ?> consumer) {
 			this.ack = ack;
 			this.ack.acknowledge();


### PR DESCRIPTION
The `StandardBeanExpressionResolver` is based on the
`TemplateAwareExpressionParser` which can parse any string to the
`LiteralExpression` or to the `CompositeStringExpression` if
template tokens (`#{` & `}`) are present in the source expression.
This way we don't need to deal with literal concatenations within
templated expression.
The expression like `#{'foo.' + myBean.bar}` can be replaced
with the `foo.#{myBean.bar}`

See: https://github.com/spring-projects/spring-amqp/issues/672