### PR TITLE
GH-463: Expose EmbeddedZookeeper zookeeper.connect into system proper…

### DIFF
--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/rule/KafkaEmbedded.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/rule/KafkaEmbedded.java
@@ -78,6 +78,7 @@ import scala.collection.Set;
  * @author Marius Bogoevici
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Kamill Sokol
  */
 public class KafkaEmbedded extends ExternalResource implements KafkaRule, InitializingBean, DisposableBean {
 
@@ -86,6 +87,8 @@ public class KafkaEmbedded extends ExternalResource implements KafkaRule, Initia
 	public static final String BEAN_NAME = "kafkaEmbedded";
 
 	public static final String SPRING_EMBEDDED_KAFKA_BROKERS = "spring.embedded.kafka.brokers";
+
+	public static final String SPRING_EMBEDDED_ZOOKEEPER_CONNECT = "spring.embedded.zookeeper.connect";
 
 	public static final long METADATA_PROPAGATION_TIMEOUT = 10000L;
 
@@ -213,6 +216,7 @@ public class KafkaEmbedded extends ExternalResource implements KafkaRule, Initia
 		createTopics.all().get();
 		admin.close();
 		System.setProperty(SPRING_EMBEDDED_KAFKA_BROKERS, getBrokersAsString());
+		System.setProperty(SPRING_EMBEDDED_ZOOKEEPER_CONNECT, getZookeeperConnectionString());
 	}
 
 
@@ -224,6 +228,7 @@ public class KafkaEmbedded extends ExternalResource implements KafkaRule, Initia
 	@Override
 	public void after() {
 		System.getProperties().remove(SPRING_EMBEDDED_KAFKA_BROKERS);
+		System.getProperties().remove(SPRING_EMBEDDED_ZOOKEEPER_CONNECT);
 		for (KafkaServer kafkaServer : this.kafkaServers) {
 			try {
 				if (kafkaServer.brokerState().currentState() != (NotRunning.state())) {

--- a/spring-kafka-test/src/test/java/org/springframework/kafka/test/hamcrest/AddressableEmbeddedZookeeperTests.java
+++ b/spring-kafka-test/src/test/java/org/springframework/kafka/test/hamcrest/AddressableEmbeddedZookeeperTests.java
@@ -16,63 +16,42 @@
 
 package org.springframework.kafka.test.hamcrest;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import java.io.IOException;
-import java.net.ServerSocket;
-
-import javax.net.ServerSocketFactory;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.test.rule.KafkaEmbedded;
 import org.springframework.test.context.junit4.SpringRunner;
 
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
- * @author Gary Russell
  * @author Kamill Sokol
- * @since 1.3
+ * @since 2.0
  *
  */
 @RunWith(SpringRunner.class)
-public class AddressableEmbeddedBrokerTests {
-
-	@Autowired
-	private Config config;
+public class AddressableEmbeddedZookeeperTests {
 
 	@Autowired
 	private KafkaEmbedded broker;
 
 	@Test
-	public void testPort() {
-		assertThat(broker.getBrokersAsString()).isEqualTo("127.0.0.1:" + this.config.port);
-	}
-
-	@Test
-	public void testSystemPropertyKafkaBrokers() {
-		assertThat(broker.getBrokersAsString())
-				.isEqualTo(System.getProperty(KafkaEmbedded.SPRING_EMBEDDED_KAFKA_BROKERS));
+	public void testSystemPropertyZookeeperConnect() {
+		assertThat(broker.getZookeeperConnectionString())
+				.isEqualTo(System.getProperty(KafkaEmbedded.SPRING_EMBEDDED_ZOOKEEPER_CONNECT));
 	}
 
 	@Configuration
 	public static class Config {
 
-		private int port;
-
 		@Bean
 		public KafkaEmbedded broker() throws IOException {
-			KafkaEmbedded broker = new KafkaEmbedded(1);
-			ServerSocket ss = ServerSocketFactory.getDefault().createServerSocket(0);
-			this.port = ss.getLocalPort();
-			ss.close();
-			broker.setKafkaPorts(this.port);
-			return broker;
+			return new KafkaEmbedded(1);
 		}
 
 	}
-
 }

--- a/src/reference/asciidoc/testing.adoc
+++ b/src/reference/asciidoc/testing.adoc
@@ -29,7 +29,7 @@ public static Map<String, Object> consumerProps(String group, String autoCommit,
 public static Map<String, Object> senderProps(KafkaEmbedded embeddedKafka) { ... }
 ----
 
-A JUnit `@Rule` is provided that creates an embedded Kafka server.
+A JUnit `@Rule` is provided that creates an embedded Kafka and an embedded Zookeeper server.
 
 [source, java]
 ----
@@ -94,8 +94,8 @@ ConsumerRecord<Integer, String> received = KafkaTestUtils.getSingleRecord(consum
 ...
 ----
 
-When the embedded server is started by JUnit, it sets a system property `spring.embedded.kafka.brokers` to the address of the broker(s).
-A convenient constant `KafkaEmbedded.SPRING_EMBEDDED_KAFKA_BROKERS` is provided for this property.
+When the embedded Kafka and embedded Zookeeper server are started by JUnit, a system property `spring.embedded.kafka.brokers` is set to the address of the Kafka broker(s) and a system property `spring.embedded.zookeeper.connect` is set to the address of Zookeeper.
+Convenient constants `KafkaEmbedded.SPRING_EMBEDDED_KAFKA_BROKERS` and `KafkaEmbedded.SPRING_EMBEDDED_ZOOKEEPER_CONNECT` are provided for this property.
 
 With the `KafkaEmbedded.brokerProperties(Map<String, String>)` you can provide additional properties for the Kafka server(s).
 See https://kafka.apache.org/documentation/#brokerconfigs[Kafka Config] for more information about possible broker properties.


### PR DESCRIPTION
Fixes GH-463 (https://github.com/spring-projects/spring-kafka/issues/463)

* expose embedded Zookeeper connection url into system properties
* add test cases for `spring.embedded.kafka.brokers` and `spring.embedded.zookeeper.connect` system properties