### PR TITLE
GH-466: Add NonResponsiveConsumerEvent

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/event/NonResponsiveConsumerEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/NonResponsiveConsumerEvent.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.event;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.common.TopicPartition;
+
+/**
+ * An event that is emitted when a consumer is not responding to
+ * the poll; a possible indication that the broker is down.
+ *
+ * @author Gary Russell
+ * @since 1.3.1
+ *
+ */
+@SuppressWarnings("serial")
+public class NonResponsiveConsumerEvent extends KafkaEvent {
+
+	private final long timeSinceLastPoll;
+
+	private final String listenerId;
+
+	private final List<TopicPartition> topicPartitions;
+
+	private transient Consumer<?, ?> consumer;
+
+	public NonResponsiveConsumerEvent(Object source, long timeSinceLastPoll, String id,
+			Collection<TopicPartition> topicPartitions, Consumer<?, ?> consumer) {
+		super(source);
+		this.timeSinceLastPoll = timeSinceLastPoll;
+		this.listenerId = id;
+		this.topicPartitions = new ArrayList<>(topicPartitions);
+		this.consumer = consumer;
+	}
+
+	/**
+	 * How long since the last poll.
+	 * @return the time in milliseconds.
+	 */
+	public long getTimeSinceLastPoll() {
+		return this.timeSinceLastPoll;
+	}
+
+	/**
+	 * The TopicPartitions the container is listening to.
+	 * @return the TopicPartition list.
+	 */
+	public Collection<TopicPartition> getTopicPartitions() {
+		return Collections.unmodifiableList(this.topicPartitions);
+	}
+
+	/**
+	 * The id of the listener (if {@code @KafkaListener}) or the container bean name.
+	 * @return the id.
+	 */
+	public String getListenerId() {
+		return this.listenerId;
+	}
+
+	/**
+	 * Retrieve the consumer. Only populated if the listener is consumer-aware.
+	 * Allows the listener to resume a paused consumer.
+	 * @return the consumer.
+	 */
+	public Consumer<?, ?> getConsumer() {
+		return this.consumer;
+	}
+
+	@Override
+	public String toString() {
+		return "ListenerContainerIdleEvent [timeSinceLastPoll="
+				+ ((float) this.timeSinceLastPoll / 1000) + "s, listenerId=" + this.listenerId
+				+ ", container=" + getSource()
+				+ ", topicPartitions=" + this.topicPartitions + "]";
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ScheduledFuture;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -51,6 +52,7 @@ import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.KafkaResourceHolder;
 import org.springframework.kafka.core.ProducerFactoryUtils;
 import org.springframework.kafka.event.ListenerContainerIdleEvent;
+import org.springframework.kafka.event.NonResponsiveConsumerEvent;
 import org.springframework.kafka.listener.ConsumerSeekAware.ConsumerSeekCallback;
 import org.springframework.kafka.listener.config.ContainerProperties;
 import org.springframework.kafka.support.Acknowledgment;
@@ -58,6 +60,8 @@ import org.springframework.kafka.support.TopicPartitionInitialOffset;
 import org.springframework.kafka.support.TopicPartitionInitialOffset.SeekPosition;
 import org.springframework.kafka.transaction.KafkaTransactionManager;
 import org.springframework.scheduling.SchedulingAwareRunnable;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.support.TransactionCallbackWithoutResult;
@@ -247,6 +251,14 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 		}
 	}
 
+	private void publishNonResponsiveConsumerEvent(long timeSinceLastPoll, Consumer<?, ?> consumer) {
+		if (getApplicationEventPublisher() != null) {
+			getApplicationEventPublisher().publishEvent(
+					new NonResponsiveConsumerEvent(KafkaMessageListenerContainer.this, timeSinceLastPoll,
+							getBeanName(), getAssignedPartitions(), consumer));
+		}
+	}
+
 	@Override
 	public String toString() {
 		return "KafkaMessageListenerContainer [id=" + getBeanName()
@@ -316,6 +328,10 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 				? (String) KafkaMessageListenerContainer.this.consumerFactory.getConfigurationProperties()
 				.get(ConsumerConfig.GROUP_ID_CONFIG)
 				: this.containerProperties.getGroupId();
+
+		private final TaskScheduler taskScheduler;
+
+		private final ScheduledFuture<?> monitorTask;
 
 		private volatile Map<TopicPartition, OffsetMetadata> definedPartitions;
 
@@ -392,6 +408,24 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 			}
 			else {
 				this.transactionTemplate = null;
+			}
+			if (this.containerProperties.getScheduler() != null) {
+				this.taskScheduler = this.containerProperties.getScheduler();
+			}
+			else {
+				ThreadPoolTaskScheduler threadPoolTaskScheduler = new ThreadPoolTaskScheduler();
+				threadPoolTaskScheduler.initialize();
+				this.taskScheduler = threadPoolTaskScheduler;
+			}
+			this.monitorTask = this.taskScheduler.scheduleAtFixedRate(() -> checkConsumer(),
+					this.containerProperties.getMonitorInterval() * 1000);
+		}
+
+		protected void checkConsumer() {
+			long timeSinceLastPoll = System.currentTimeMillis() - last;
+			if (((float) timeSinceLastPoll) / (float) this.containerProperties.getPollTimeout()
+					> this.containerProperties.getNoPollThreshold()) {
+				publishNonResponsiveConsumerEvent(timeSinceLastPoll, consumer);
 			}
 		}
 
@@ -626,6 +660,7 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 				ListenerConsumer.this.logger.error("No offset and no reset policy; stopping container");
 				KafkaMessageListenerContainer.this.stop();
 			}
+			this.monitorTask.cancel(true);
 			this.consumer.close();
 			if (this.logger.isInfoEnabled()) {
 				this.logger.info("Consumer stopped");

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -425,7 +425,7 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 			long timeSinceLastPoll = System.currentTimeMillis() - last;
 			if (((float) timeSinceLastPoll) / (float) this.containerProperties.getPollTimeout()
 					> this.containerProperties.getNoPollThreshold()) {
-				publishNonResponsiveConsumerEvent(timeSinceLastPoll, consumer);
+				publishNonResponsiveConsumerEvent(timeSinceLastPoll, this.consumer);
 			}
 		}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/config/ContainerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/config/ContainerProperties.java
@@ -30,6 +30,7 @@ import org.springframework.kafka.listener.BatchErrorHandler;
 import org.springframework.kafka.listener.ErrorHandler;
 import org.springframework.kafka.listener.GenericErrorHandler;
 import org.springframework.kafka.support.TopicPartitionInitialOffset;
+import org.springframework.scheduling.TaskScheduler;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.util.Assert;
 
@@ -142,6 +143,12 @@ public class ContainerProperties {
 	private String groupId;
 
 	private PlatformTransactionManager transactionManager;
+
+	private int monitorInterval = 30;
+
+	private TaskScheduler scheduler;
+
+	private float noPollThreshold;
 
 	public ContainerProperties(String... topics) {
 		Assert.notEmpty(topics, "An array of topicPartitions must be provided");
@@ -401,6 +408,49 @@ public class ContainerProperties {
 	 */
 	public void setTransactionManager(PlatformTransactionManager transactionManager) {
 		this.transactionManager = transactionManager;
+	}
+
+	public int getMonitorInterval() {
+		return this.monitorInterval;
+	}
+
+	/**
+	 * The interval between checks for a non-responsive consumer in
+	 * seconds; default 30.
+	 * @param monitorInterval the interval.
+	 * @since 1.3.1
+	 */
+	public void setMonitorInterval(int monitorInterval) {
+		this.monitorInterval = monitorInterval;
+	}
+
+	public TaskScheduler getScheduler() {
+		return this.scheduler;
+	}
+
+	/**
+	 * A scheduler used with the monitor interval.
+	 * @param scheduler the scheduler.
+	 * @since 1.3.1
+	 * @see #setMonitorInterval(int)
+	 */
+	public void setScheduler(TaskScheduler scheduler) {
+		this.scheduler = scheduler;
+	}
+
+	public float getNoPollThreshold() {
+		return this.noPollThreshold;
+	}
+
+	/**
+	 * If the time since the last poll / {@link pollTimeout #setPollTimeout(long)}
+	 * exceeds this value, a NonResponsiveConsumerEvent is published.
+	 * Default 3.0.
+	 * @param noPollThreshold the threshold
+	 * @since 1.3.1
+	 */
+	public void setNoPollThreshold(float noPollThreshold) {
+		this.noPollThreshold = noPollThreshold;
 	}
 
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
@@ -53,6 +53,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.WakeupException;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -68,6 +69,7 @@ import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.event.NonResponsiveConsumerEvent;
 import org.springframework.kafka.listener.AbstractMessageListenerContainer.AckMode;
 import org.springframework.kafka.listener.adapter.FilteringMessageListenerAdapter;
 import org.springframework.kafka.listener.config.ContainerProperties;
@@ -525,6 +527,45 @@ public class KafkaMessageListenerContainerTests {
 		inOrder.verify(consumer).commitSync(any(Map.class));
 		inOrder.verify(messageListener).onMessage(any(ConsumerRecord.class));
 		inOrder.verify(consumer).commitSync(any(Map.class));
+		container.stop();
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testBrokerDownEvent() throws Exception {
+		ConsumerFactory<Integer, String> cf = mock(ConsumerFactory.class);
+		Consumer<Integer, String> consumer = mock(Consumer.class);
+		given(cf.createConsumer(isNull(), isNull())).willReturn(consumer);
+		final Map<TopicPartition, List<ConsumerRecord<Integer, String>>> records = new HashMap<>();
+		records.put(new TopicPartition("foo", 0), Arrays.asList(
+				new ConsumerRecord<>("foo", 0, 0L, 1, "foo"),
+				new ConsumerRecord<>("foo", 0, 1L, 1, "bar")));
+		final CountDownLatch deadLatch = new CountDownLatch(1);
+		given(consumer.poll(anyLong())).willAnswer(i -> {
+			deadLatch.await(10, TimeUnit.SECONDS);
+			throw new WakeupException();
+		});
+		willAnswer(i -> {
+			deadLatch.countDown();
+			return null;
+		}).given(consumer).wakeup();
+		TopicPartitionInitialOffset[] topicPartition = new TopicPartitionInitialOffset[] {
+				new TopicPartitionInitialOffset("foo", 0) };
+		ContainerProperties containerProps = new ContainerProperties(topicPartition);
+		containerProps.setNoPollThreshold(2.0f);
+		containerProps.setPollTimeout(10);
+		containerProps.setMonitorInterval(1);
+		containerProps.setMessageListener(mock(MessageListener.class));
+		KafkaMessageListenerContainer<Integer, String> container =
+				new KafkaMessageListenerContainer<>(cf, containerProps);
+		final CountDownLatch latch = new CountDownLatch(1);
+		container.setApplicationEventPublisher(e -> {
+			if (e instanceof NonResponsiveConsumerEvent) {
+				latch.countDown();
+			}
+		});
+		container.start();
+		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
 		container.stop();
 	}
 

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -957,7 +957,7 @@ A retry adapter is not provided for any of the batch <<message-listeners, messag
 Users wishing retry capabilities, when using a batch listener, are advised to use a `RetryTemplate` within the listener itself.
 
 [[idle-containers]]
-===== Detecting Idle Asynchronous Consumers
+===== Detecting Idle and Non-Responsive Consumers
 
 While efficient, one problem with asynchronous consumers is detecting when they are idle - users might want to take
 some action if no messages arrive for some period of time.
@@ -996,6 +996,12 @@ public ConcurrentKafkaListenerContainerFactory kafkaListenerContainerFactory() {
 ----
 
 In each of these cases, an event will be published once per minute while the container is idle.
+
+In addition, if the broker is unreachable (at the time of writing), the consumer `poll()` method does not exit, so no messages are received, and idle events can't be generated.
+To solve this issue, the container will publish a `NonResponsiveConsumerEvent` if a poll does not return within 3x the `pollInterval` property.
+By default, this check is performed once every 30 seconds in each container.
+You can modify the behavior by setting the `monitorInterval` and `noPollThreshold` properties in the `ContainerProperties` when configuring the listener container.
+Receiveing such an event will allow you to stop the container(s), thus waking the consumer so it can terminate.
 
 ====== Event Consumption
 


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/466

Users might consider `stop()`ing the container under this condition,
which will wake the consumer.

__cherry-pick to 1.3.x__