### PR TITLE
Upgrade to kafka-clients 1.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ subprojects { subproject ->
 		hamcrestVersion = '1.3'
 		jacksonVersion = '2.9.1'
 		junitVersion = '4.12'
-		kafkaVersion = '0.11.0.0'
+		kafkaVersion = '1.0.0'
 		mockitoVersion = '2.9.0'
 		scalaVersion = '2.11'
 		slf4jVersion = '1.7.25'

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/rule/KafkaEmbedded.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/rule/KafkaEmbedded.java
@@ -43,10 +43,7 @@ import org.apache.kafka.clients.admin.CreateTopicsResult;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
-import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.protocol.Errors;
-import org.apache.kafka.common.requests.MetadataResponse;
 import org.apache.kafka.common.utils.Time;
 import org.junit.rules.ExternalResource;
 
@@ -59,7 +56,6 @@ import org.springframework.retry.backoff.ExponentialBackOffPolicy;
 import org.springframework.retry.policy.SimpleRetryPolicy;
 import org.springframework.retry.support.RetryTemplate;
 
-import kafka.admin.AdminUtils$;
 import kafka.server.KafkaConfig;
 import kafka.server.KafkaConfig$;
 import kafka.server.KafkaServer;
@@ -67,10 +63,7 @@ import kafka.server.NotRunning;
 import kafka.utils.CoreUtils;
 import kafka.utils.TestUtils;
 import kafka.utils.ZKStringSerializer$;
-import kafka.utils.ZkUtils;
 import kafka.zk.EmbeddedZookeeper;
-import scala.collection.JavaConversions;
-import scala.collection.Set;
 
 /**
  * The {@link KafkaRule} implementation for the embedded Kafka Broker and Zookeeper.
@@ -192,7 +185,7 @@ public class KafkaEmbedded extends ExternalResource implements KafkaRule, Initia
 					scala.Option.apply(null),
 					scala.Option.apply(null),
 					scala.Option.apply(null),
-					true, false, 0, false, 0, false, 0, scala.Option.apply(null));
+					true, false, 0, false, 0, false, 0, scala.Option.apply(null), 1);
 			brokerConfigProperties.setProperty(KafkaConfig$.MODULE$.PortProp(), "" + port);
 			brokerConfigProperties.setProperty("replica.socket.timeout.ms", "1000");
 			brokerConfigProperties.setProperty("controller.socket.timeout.ms", "1000");
@@ -310,42 +303,12 @@ public class KafkaEmbedded extends ExternalResource implements KafkaRule, Initia
 		this.zookeeper = new EmbeddedZookeeper();
 	}
 
+	@Deprecated
 	public void bounce(int index, boolean waitForPropagation) {
-		this.kafkaServers.get(index).shutdown();
-		if (waitForPropagation) {
-			long initialTime = System.currentTimeMillis();
-			boolean canExit = false;
-			do {
-				try {
-					Thread.sleep(100);
-				}
-				catch (InterruptedException e) {
-					break;
-				}
-				canExit = true;
-				ZkUtils zkUtils = new ZkUtils(getZkClient(), null, false);
-				scala.collection.Map<String, Properties> topicProperties =
-						AdminUtils$.MODULE$.fetchAllTopicConfigs(zkUtils);
-				Set<MetadataResponse.TopicMetadata> topicMetadatas =
-						AdminUtils$.MODULE$.fetchTopicMetadataFromZk(topicProperties.keySet(), zkUtils);
-				for (MetadataResponse.TopicMetadata topicMetadata : JavaConversions.asJavaCollection(topicMetadatas)) {
-					if (Errors.forCode(topicMetadata.error().code()).exception() == null) {
-						for (MetadataResponse.PartitionMetadata partitionMetadata : topicMetadata.partitionMetadata()) {
-							Collection<Node> inSyncReplicas = partitionMetadata.isr();
-							for (Node node : inSyncReplicas) {
-								if (node.id() == index) {
-									canExit = false;
-								}
-							}
-						}
-					}
-				}
-			}
-			while (!canExit && (System.currentTimeMillis() - initialTime < METADATA_PROPAGATION_TIMEOUT));
-		}
-
+		throw new UnsupportedOperationException();
 	}
 
+	@Deprecated
 	public void bounce(int index) {
 		bounce(index, true);
 	}
@@ -377,36 +340,9 @@ public class KafkaEmbedded extends ExternalResource implements KafkaRule, Initia
 		});
 	}
 
+	@Deprecated
 	public void waitUntilSynced(String topic, int brokerId) {
-		long initialTime = System.currentTimeMillis();
-		boolean canExit = false;
-		do {
-			try {
-				Thread.sleep(100);
-			}
-			catch (InterruptedException e) {
-				break;
-			}
-			canExit = true;
-			ZkUtils zkUtils = new ZkUtils(getZkClient(), null, false);
-			MetadataResponse.TopicMetadata topicMetadata = AdminUtils$.MODULE$.fetchTopicMetadataFromZk(topic, zkUtils);
-			if (Errors.forCode(topicMetadata.error().code()).exception() == null) {
-				for (MetadataResponse.PartitionMetadata partitionMetadata : topicMetadata.partitionMetadata()) {
-					Collection<Node> isr = partitionMetadata.isr();
-					boolean containsIndex = false;
-					for (Node node : isr) {
-						if (node.id() == brokerId) {
-							containsIndex = true;
-						}
-					}
-					if (!containsIndex) {
-						canExit = false;
-					}
-
-				}
-			}
-		}
-		while (!canExit && (System.currentTimeMillis() - initialTime < METADATA_PROPAGATION_TIMEOUT));
+		throw new UnsupportedOperationException();
 	}
 
 	@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KStreamBuilderFactoryBean.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KStreamBuilderFactoryBean.java
@@ -21,8 +21,8 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.kstream.KStreamBuilder;
 import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
 
 import org.springframework.beans.factory.config.AbstractFactoryBean;
@@ -31,7 +31,7 @@ import org.springframework.kafka.KafkaException;
 import org.springframework.util.Assert;
 
 /**
- * An {@link AbstractFactoryBean} for the {@link KStreamBuilder} instance
+ * An {@link AbstractFactoryBean} for the {@link StreamsBuilder} instance
  * and lifecycle control for the internal {@link KafkaStreams} instance.
  *
  * @author Artem Bilan
@@ -39,7 +39,7 @@ import org.springframework.util.Assert;
  *
  * @since 1.1.4
  */
-public class KStreamBuilderFactoryBean extends AbstractFactoryBean<KStreamBuilder> implements SmartLifecycle {
+public class KStreamBuilderFactoryBean extends AbstractFactoryBean<StreamsBuilder> implements SmartLifecycle {
 
 	private static final int DEFAULT_CLOSE_TIMEOUT = 10;
 
@@ -96,12 +96,12 @@ public class KStreamBuilderFactoryBean extends AbstractFactoryBean<KStreamBuilde
 
 	@Override
 	public Class<?> getObjectType() {
-		return KStreamBuilder.class;
+		return StreamsBuilder.class;
 	}
 
 	@Override
-	protected KStreamBuilder createInstance() throws Exception {
-		return new KStreamBuilder();
+	protected StreamsBuilder createInstance() throws Exception {
+		return new StreamsBuilder();
 	}
 
 
@@ -130,7 +130,7 @@ public class KStreamBuilderFactoryBean extends AbstractFactoryBean<KStreamBuilde
 	public synchronized void start() {
 		if (!this.running) {
 			try {
-				this.kafkaStreams = new KafkaStreams(getObject(), this.streamsConfig, this.clientSupplier);
+				this.kafkaStreams = new KafkaStreams(getObject().build(), this.streamsConfig, this.clientSupplier);
 				this.kafkaStreams.setStateListener(this.stateListener);
 				this.kafkaStreams.setUncaughtExceptionHandler(this.exceptionHandler);
 				this.kafkaStreams.start();

--- a/spring-kafka/src/test/java/org/springframework/kafka/kstream/KafkaStreamsTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/kstream/KafkaStreamsTests.java
@@ -29,9 +29,12 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.KStream;
-import org.apache.kafka.streams.kstream.KStreamBuilder;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.kstream.Printed;
+import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.kstream.TimeWindows;
 import org.apache.kafka.streams.processor.WallclockTimestampExtractor;
 import org.apache.kafka.streams.processor.internals.StreamThread;
@@ -177,21 +180,22 @@ public class KafkaStreamsTests {
 		}
 
 		@Bean
-		public KStream<Integer, String> kStream(KStreamBuilder kStreamBuilder) {
+		public KStream<Integer, String> kStream(StreamsBuilder kStreamBuilder) {
 			KStream<Integer, String> stream = kStreamBuilder.stream(STREAMING_TOPIC1);
 			stream.mapValues(String::toUpperCase)
 					.mapValues(Foo::new)
-					.through(Serdes.Integer(), new JsonSerde<Foo>() {
+					.through(FOOS, Produced.with(Serdes.Integer(), new JsonSerde<Foo>() {
 
-					}, FOOS)
+					}))
 					.mapValues(Foo::getName)
 					.groupByKey()
-					.reduce((value1, value2) -> value1 + value2, TimeWindows.of(1000), "windowStore")
+					.windowedBy(TimeWindows.of(1000))
+					.reduce((value1, value2) -> value1 + value2, Materialized.as("windowStore"))
 					.toStream()
 					.map((windowedId, value) -> new KeyValue<>(windowedId.key(), value))
 					.filter((i, s) -> s.length() > 40).to(STREAMING_TOPIC2);
 
-			stream.print();
+			stream.print(Printed.toSysOut());
 
 			return stream;
 		}

--- a/src/reference/asciidoc/quick-tour.adoc
+++ b/src/reference/asciidoc/quick-tour.adoc
@@ -28,7 +28,7 @@ compile 'org.springframework.kafka:spring-kafka:{spring-kafka-version}'
 [[compatibility]]
 ===== Compatibility
 
-- Apache Kafka 0.11.0.x
+- Apache Kafka Clients 1.0.0
 - Spring Framework 5.0.x
 - Minimum Java version: 8
 


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/468

- update client version
- fix KStreams deprecations
- fix `KafkaEmbedded` to be compatible with 1.0.0
  - deprecate unused methods where the `AdminUtils` is used but has been removed