### PR TITLE
Fix NPE in events when no assigned topics

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/event/ListenerContainerIdleEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/ListenerContainerIdleEvent.java
@@ -47,7 +47,7 @@ public class ListenerContainerIdleEvent extends KafkaEvent {
 		super(source);
 		this.idleTime = idleTime;
 		this.listenerId = id;
-		this.topicPartitions = new ArrayList<>(topicPartitions);
+		this.topicPartitions = topicPartitions == null ? null : new ArrayList<>(topicPartitions);
 		this.consumer = consumer;
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/event/NonResponsiveConsumerEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/NonResponsiveConsumerEvent.java
@@ -48,7 +48,7 @@ public class NonResponsiveConsumerEvent extends KafkaEvent {
 		super(source);
 		this.timeSinceLastPoll = timeSinceLastPoll;
 		this.listenerId = id;
-		this.topicPartitions = new ArrayList<>(topicPartitions);
+		this.topicPartitions = topicPartitions == null ? null : new ArrayList<>(topicPartitions);
 		this.consumer = consumer;
 	}
 


### PR DESCRIPTION
    java.lang.NullPointerException: null
	at java.util.ArrayList.<init>(ArrayList.java:177) ~[na:1.8.0_131]
	at org.springframework.kafka.event.NonResponsiveConsumerEvent.<init>(NonResponsiveConsumerEvent.java:51) ~[spring-kafka-1.3.1.BUILD-SNAPSHOT.jar:na]

__cherry-pick to 2.0.x, 1.3.x__