### PR TITLE
GH-470: Add SeekToCurrentErrorHandler

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/event/ListenerContainerIdleEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/ListenerContainerIdleEvent.java
@@ -64,7 +64,7 @@ public class ListenerContainerIdleEvent extends KafkaEvent {
 	 * @return the TopicPartition list.
 	 */
 	public Collection<TopicPartition> getTopicPartitions() {
-		return Collections.unmodifiableList(this.topicPartitions);
+		return this.topicPartitions == null ? null : Collections.unmodifiableList(this.topicPartitions);
 	}
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/event/NonResponsiveConsumerEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/NonResponsiveConsumerEvent.java
@@ -65,7 +65,7 @@ public class NonResponsiveConsumerEvent extends KafkaEvent {
 	 * @return the TopicPartition list.
 	 */
 	public Collection<TopicPartition> getTopicPartitions() {
-		return Collections.unmodifiableList(this.topicPartitions);
+		return this.topicPartitions == null ? null : Collections.unmodifiableList(this.topicPartitions);
 	}
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -405,6 +405,8 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 			Assert.state(!this.isBatchListener || !this.isRecordAck, "Cannot use AckMode.RECORD with a batch listener");
 			if (this.transactionManager != null) {
 				this.transactionTemplate = new TransactionTemplate(this.transactionManager);
+				Assert.state(!(this.errorHandler instanceof RemainingRecordsErrorHandler),
+							"You cannot use a 'RemainingRecordsErrorHandler' with transactions");
 			}
 			else {
 				this.transactionTemplate = null;
@@ -419,9 +421,6 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 			}
 			this.monitorTask = this.taskScheduler.scheduleAtFixedRate(() -> checkConsumer(),
 					this.containerProperties.getMonitorInterval() * 1000);
-			Assert.state(this.transactionTemplate == null
-					|| !(this.errorHandler instanceof RemainingRecordsErrorHandler),
-						"You cannot use a 'RemainingRecordsErrorHandler' with transactions");
 		}
 
 		protected void checkConsumer() {

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/RemainingRecordsErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/RemainingRecordsErrorHandler.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import java.util.List;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+/**
+ * An error handler that has access to the unprocessed records from the last poll
+ * (including the failed record) and the consumer, for example to adjust offsets after an
+ * error. The records passed to the handler will not be passed to the listener
+ * (unless re-fetched if the handler performs seeks).
+ *
+ * @author Gary Russell
+ * @since 2.0.1
+ *
+ */
+@FunctionalInterface
+public interface RemainingRecordsErrorHandler extends ConsumerAwareErrorHandler {
+
+	@Override
+	default void handle(Exception thrownException, ConsumerRecord<?, ?> data, Consumer<?, ?> consumer) {
+		throw new UnsupportedOperationException("Container should never call this");
+	}
+
+	/**
+	 * Handle the exception.
+	 * @param thrownException the exception.
+	 * @param records the remaining records including the one that failed.
+	 * @param consumer the consumer.
+	 */
+	void handle(Exception thrownException, List<ConsumerRecord<?, ?>> records, Consumer<?, ?> consumer);
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/SeekToCurrentErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/SeekToCurrentErrorHandler.java
@@ -41,7 +41,7 @@ public class SeekToCurrentErrorHandler implements RemainingRecordsErrorHandler {
 		Map<TopicPartition, Long> offsets = new LinkedHashMap<>();
 		records.forEach(r ->
 			offsets.computeIfAbsent(new TopicPartition(r.topic(), r.partition()), k -> r.offset()));
-		offsets.entrySet().forEach(e -> consumer.seek(e.getKey(), e.getValue()));
+		offsets.forEach(consumer::seek);
 	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/SeekToCurrentErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/SeekToCurrentErrorHandler.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
+
+/**
+ * An error handler that seeks to the current offset for each topic in the remaining
+ * records. Used to rewind partitions after a message failure so that it can be
+ * replayed.
+ *
+ * @author Gary Russell
+ * @since 2.0.1
+ *
+ */
+public class SeekToCurrentErrorHandler implements RemainingRecordsErrorHandler {
+
+	@Override
+	public void handle(Exception thrownException, List<ConsumerRecord<?, ?>> records,
+			Consumer<?, ?> consumer) {
+		Map<TopicPartition, Long> offsets = new LinkedHashMap<>();
+		records.forEach(r ->
+			offsets.computeIfAbsent(new TopicPartition(r.topic(), r.partition()), k -> r.offset()));
+		offsets.entrySet().forEach(e -> consumer.seek(e.getKey(), e.getValue()));
+	}
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentOnErrorBatchModeTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentOnErrorBatchModeTests.java
@@ -119,7 +119,7 @@ public class SeekToCurrentOnErrorBatchModeTests {
 
 		private final CountDownLatch deliveryLatch = new CountDownLatch(7);
 
-		private final CountDownLatch commitLatch = new CountDownLatch(2);
+		private final CountDownLatch commitLatch = new CountDownLatch(3);
 
 		private final CountDownLatch closeLatch = new CountDownLatch(1);
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentOnErrorBatchModeTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentOnErrorBatchModeTests.java
@@ -85,6 +85,7 @@ public class SeekToCurrentOnErrorBatchModeTests {
 	@Test
 	public void discardRemainingRecordsFromPollAndSeek() throws Exception {
 		assertThat(this.config.deliveryLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(this.config.commitLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		this.registry.stop();
 		assertThat(this.config.closeLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		InOrder inOrder = inOrder(this.consumer);
@@ -116,6 +117,8 @@ public class SeekToCurrentOnErrorBatchModeTests {
 		private final CountDownLatch deliveryLatch = new CountDownLatch(7);
 
 		private final CountDownLatch closeLatch = new CountDownLatch(1);
+
+		private final CountDownLatch commitLatch = new CountDownLatch(2);
 
 		private int count;
 
@@ -184,6 +187,10 @@ public class SeekToCurrentOnErrorBatchModeTests {
 							return new ConsumerRecords(Collections.emptyMap());
 					}
 			}).given(consumer).poll(1000);
+			willAnswer(i -> {
+				this.commitLatch.countDown();
+				return null;
+			}).given(consumer).commitSync(any(Map.class));
 			willAnswer(i -> {
 				this.closeLatch.countDown();
 				return null;

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentOnErrorBatchModeTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentOnErrorBatchModeTests.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willAnswer;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.record.TimestampType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.listener.AbstractMessageListenerContainer.AckMode;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+/**
+ * @author Gary Russell
+ * @since 2.0.1
+ *
+ */
+@RunWith(SpringRunner.class)
+@DirtiesContext
+public class SeekToCurrentOnErrorBatchModeTests {
+
+	@SuppressWarnings("rawtypes")
+	@Autowired
+	private Consumer consumer;
+
+	@Autowired
+	private CountDownLatch latch;
+
+	@Autowired
+	private Config config;
+
+	/*
+	 * Deliver 6 records from three partitions, fail on the second record second
+	 * partition, first attempt; verify partition 0,1 committed and a total of 7 records
+	 * handled after seek.
+	 */
+	@SuppressWarnings("unchecked")
+	@Test
+	public void discardRemainingRecordsFromPollAndSeek() throws Exception {
+		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+		InOrder inOrder = inOrder(this.consumer);
+		inOrder.verify(this.consumer).subscribe(any(Collection.class), any(ConsumerRebalanceListener.class));
+		inOrder.verify(this.consumer).poll(1000);
+		Map<TopicPartition, OffsetAndMetadata> offsets = new LinkedHashMap<>();
+		offsets.put(new TopicPartition("foo", 0), new OffsetAndMetadata(2L));
+		offsets.put(new TopicPartition("foo", 1), new OffsetAndMetadata(1L));
+		inOrder.verify(this.consumer).commitSync(offsets);
+		inOrder.verify(this.consumer).seek(new TopicPartition("foo", 1), 1L);
+		inOrder.verify(this.consumer).seek(new TopicPartition("foo", 2), 0L);
+		inOrder.verify(this.consumer).poll(1000);
+		offsets = new LinkedHashMap<>();
+		offsets.put(new TopicPartition("foo", 1), new OffsetAndMetadata(2L));
+		offsets.put(new TopicPartition("foo", 2), new OffsetAndMetadata(2L));
+		inOrder.verify(this.consumer).commitSync(offsets);
+		inOrder.verify(this.consumer).poll(1000);
+		assertThat(this.config.count).isEqualTo(7);
+		assertThat(this.config.contents.toArray()).isEqualTo(new String[]
+				{ "foo", "bar", "baz", "qux", "qux", "fiz", "buz" });
+	}
+
+	@Configuration
+	@EnableKafka
+	public static class Config {
+
+		private final List<String> contents = new ArrayList<>();
+
+		private int count;
+
+		@KafkaListener(topics = "foo")
+		public void foo(String in) {
+			this.contents.add(in);
+			latch().countDown();
+			if (++this.count == 4) { // part 1, offset 1, first time
+				throw new RuntimeException("foo");
+			}
+		}
+
+		@SuppressWarnings({ "rawtypes" })
+		@Bean
+		public ConsumerFactory consumerFactory() {
+			ConsumerFactory consumerFactory = mock(ConsumerFactory.class);
+			final Consumer consumer = consumer();
+			given(consumerFactory.createConsumer(null, "-0")).willReturn(consumer);
+			return consumerFactory;
+		}
+
+		@SuppressWarnings({ "rawtypes", "unchecked" })
+		@Bean
+		public Consumer consumer() {
+			final Consumer consumer = mock(Consumer.class);
+			final TopicPartition topicPartition0 = new TopicPartition("foo", 0);
+			final TopicPartition topicPartition1 = new TopicPartition("foo", 1);
+			final TopicPartition topicPartition2 = new TopicPartition("foo", 2);
+			willAnswer(i -> {
+				((ConsumerRebalanceListener) i.getArgument(1)).onPartitionsAssigned(
+						Collections.singletonList(topicPartition1));
+				return null;
+			}).given(consumer).subscribe(any(Collection.class), any(ConsumerRebalanceListener.class));
+			Map<TopicPartition, List<ConsumerRecord>> records1 = new LinkedHashMap<>();
+			records1.put(topicPartition0, Arrays.asList(new ConsumerRecord[] {
+					new ConsumerRecord("foo", 0, 0L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "foo"),
+					new ConsumerRecord("foo", 0, 1L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "bar")
+					}));
+			records1.put(topicPartition1, Arrays.asList(new ConsumerRecord[] {
+					new ConsumerRecord("foo", 1, 0L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "baz"),
+					new ConsumerRecord("foo", 1, 1L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "qux")
+					}));
+			records1.put(topicPartition2, Arrays.asList(new ConsumerRecord[] {
+					new ConsumerRecord("foo", 2, 0L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "fiz"),
+					new ConsumerRecord("foo", 2, 1L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "buz")
+					}));
+			Map<TopicPartition, List<ConsumerRecord>> records2 = new LinkedHashMap<>(records1);
+			records2.remove(topicPartition0);
+			records2.put(topicPartition1, Arrays.asList(new ConsumerRecord[] {
+					new ConsumerRecord("foo", 1, 1L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "qux")
+					}));
+			final AtomicInteger which = new AtomicInteger();
+			willAnswer(i -> {
+					switch (which.getAndIncrement()) {
+						case 0:
+							return new ConsumerRecords(records1);
+						case 1:
+							return new ConsumerRecords(records2);
+						default:
+							try {
+								Thread.sleep(1000);
+							}
+							catch (InterruptedException e) {
+								Thread.currentThread().interrupt();
+							}
+							return new ConsumerRecords(Collections.emptyMap());
+					}
+			}).given(consumer).poll(1000);
+			return consumer;
+		}
+
+		@SuppressWarnings({ "rawtypes", "unchecked" })
+		@Bean
+		public ConcurrentKafkaListenerContainerFactory kafkaListenerContainerFactory() {
+			ConcurrentKafkaListenerContainerFactory factory = new ConcurrentKafkaListenerContainerFactory();
+			factory.setConsumerFactory(consumerFactory());
+			factory.getContainerProperties().setAckOnError(false);
+			factory.getContainerProperties().setErrorHandler(new SeekToCurrentErrorHandler());
+			factory.getContainerProperties().setAckMode(AckMode.BATCH);
+			return factory;
+		}
+
+		@Bean
+		public CountDownLatch latch() {
+			return new CountDownLatch(7);
+		}
+
+	}
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentOnErrorBatchModeTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentOnErrorBatchModeTests.java
@@ -51,6 +51,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.listener.AbstractMessageListenerContainer.AckMode;
 import org.springframework.test.annotation.DirtiesContext;
@@ -70,10 +71,10 @@ public class SeekToCurrentOnErrorBatchModeTests {
 	private Consumer consumer;
 
 	@Autowired
-	private CountDownLatch latch;
+	private Config config;
 
 	@Autowired
-	private Config config;
+	private KafkaListenerEndpointRegistry registry;
 
 	/*
 	 * Deliver 6 records from three partitions, fail on the second record second
@@ -83,7 +84,9 @@ public class SeekToCurrentOnErrorBatchModeTests {
 	@SuppressWarnings("unchecked")
 	@Test
 	public void discardRemainingRecordsFromPollAndSeek() throws Exception {
-		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(this.config.deliveryLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		this.registry.stop();
+		assertThat(this.config.closeLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		InOrder inOrder = inOrder(this.consumer);
 		inOrder.verify(this.consumer).subscribe(any(Collection.class), any(ConsumerRebalanceListener.class));
 		inOrder.verify(this.consumer).poll(1000);
@@ -110,12 +113,16 @@ public class SeekToCurrentOnErrorBatchModeTests {
 
 		private final List<String> contents = new ArrayList<>();
 
+		private final CountDownLatch deliveryLatch = new CountDownLatch(7);
+
+		private final CountDownLatch closeLatch = new CountDownLatch(1);
+
 		private int count;
 
 		@KafkaListener(topics = "foo")
 		public void foo(String in) {
 			this.contents.add(in);
-			latch().countDown();
+			this.deliveryLatch.countDown();
 			if (++this.count == 4) { // part 1, offset 1, first time
 				throw new RuntimeException("foo");
 			}
@@ -177,6 +184,10 @@ public class SeekToCurrentOnErrorBatchModeTests {
 							return new ConsumerRecords(Collections.emptyMap());
 					}
 			}).given(consumer).poll(1000);
+			willAnswer(i -> {
+				this.closeLatch.countDown();
+				return null;
+			}).given(consumer).close();
 			return consumer;
 		}
 
@@ -189,11 +200,6 @@ public class SeekToCurrentOnErrorBatchModeTests {
 			factory.getContainerProperties().setErrorHandler(new SeekToCurrentErrorHandler());
 			factory.getContainerProperties().setAckMode(AckMode.BATCH);
 			return factory;
-		}
-
-		@Bean
-		public CountDownLatch latch() {
-			return new CountDownLatch(7);
 		}
 
 	}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentOnErrorBatchModeTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentOnErrorBatchModeTests.java
@@ -156,23 +156,19 @@ public class SeekToCurrentOnErrorBatchModeTests {
 				return null;
 			}).given(consumer).subscribe(any(Collection.class), any(ConsumerRebalanceListener.class));
 			Map<TopicPartition, List<ConsumerRecord>> records1 = new LinkedHashMap<>();
-			records1.put(topicPartition0, Arrays.asList(new ConsumerRecord[] {
+			records1.put(topicPartition0, Arrays.asList(
 					new ConsumerRecord("foo", 0, 0L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "foo"),
-					new ConsumerRecord("foo", 0, 1L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "bar")
-					}));
-			records1.put(topicPartition1, Arrays.asList(new ConsumerRecord[] {
+					new ConsumerRecord("foo", 0, 1L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "bar")));
+			records1.put(topicPartition1, Arrays.asList(
 					new ConsumerRecord("foo", 1, 0L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "baz"),
-					new ConsumerRecord("foo", 1, 1L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "qux")
-					}));
-			records1.put(topicPartition2, Arrays.asList(new ConsumerRecord[] {
+					new ConsumerRecord("foo", 1, 1L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "qux")));
+			records1.put(topicPartition2, Arrays.asList(
 					new ConsumerRecord("foo", 2, 0L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "fiz"),
-					new ConsumerRecord("foo", 2, 1L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "buz")
-					}));
+					new ConsumerRecord("foo", 2, 1L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "buz")));
 			Map<TopicPartition, List<ConsumerRecord>> records2 = new LinkedHashMap<>(records1);
 			records2.remove(topicPartition0);
-			records2.put(topicPartition1, Arrays.asList(new ConsumerRecord[] {
-					new ConsumerRecord("foo", 1, 1L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "qux")
-					}));
+			records2.put(topicPartition1, Arrays.asList(
+					new ConsumerRecord("foo", 1, 1L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "qux")));
 			final AtomicInteger which = new AtomicInteger();
 			willAnswer(i -> {
 				this.pollLatch.countDown();

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentOnErrorRecordModeTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentOnErrorRecordModeTests.java
@@ -86,6 +86,7 @@ public class SeekToCurrentOnErrorRecordModeTests {
 	public void discardRemainingRecordsFromPollAndSeek() throws Exception {
 		assertThat(this.config.deliveryLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(this.config.commitLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(this.config.pollLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		this.registry.stop();
 		assertThat(this.config.closeLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		InOrder inOrder = inOrder(this.consumer);
@@ -117,6 +118,8 @@ public class SeekToCurrentOnErrorRecordModeTests {
 	public static class Config {
 
 		private final List<String> contents = new ArrayList<>();
+
+		private final CountDownLatch pollLatch = new CountDownLatch(3);
 
 		private final CountDownLatch deliveryLatch = new CountDownLatch(7);
 
@@ -176,20 +179,21 @@ public class SeekToCurrentOnErrorRecordModeTests {
 					}));
 			final AtomicInteger which = new AtomicInteger();
 			willAnswer(i -> {
-					switch (which.getAndIncrement()) {
-						case 0:
-							return new ConsumerRecords(records1);
-						case 1:
-							return new ConsumerRecords(records2);
-						default:
-							try {
-								Thread.sleep(1000);
-							}
-							catch (InterruptedException e) {
-								Thread.currentThread().interrupt();
-							}
-							return new ConsumerRecords(Collections.emptyMap());
-					}
+				this.pollLatch.countDown();
+				switch (which.getAndIncrement()) {
+					case 0:
+						return new ConsumerRecords(records1);
+					case 1:
+						return new ConsumerRecords(records2);
+					default:
+						try {
+							Thread.sleep(1000);
+						}
+						catch (InterruptedException e) {
+							Thread.currentThread().interrupt();
+						}
+						return new ConsumerRecords(Collections.emptyMap());
+				}
 			}).given(consumer).poll(1000);
 			willAnswer(i -> {
 				this.commitLatch.countDown();

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentOnErrorRecordModeTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentOnErrorRecordModeTests.java
@@ -160,23 +160,19 @@ public class SeekToCurrentOnErrorRecordModeTests {
 				return null;
 			}).given(consumer).subscribe(any(Collection.class), any(ConsumerRebalanceListener.class));
 			Map<TopicPartition, List<ConsumerRecord>> records1 = new LinkedHashMap<>();
-			records1.put(topicPartition0, Arrays.asList(new ConsumerRecord[] {
+			records1.put(topicPartition0, Arrays.asList(
 					new ConsumerRecord("foo", 0, 0L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "foo"),
-					new ConsumerRecord("foo", 0, 1L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "bar")
-					}));
-			records1.put(topicPartition1, Arrays.asList(new ConsumerRecord[] {
+					new ConsumerRecord("foo", 0, 1L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "bar")));
+			records1.put(topicPartition1, Arrays.asList(
 					new ConsumerRecord("foo", 1, 0L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "baz"),
-					new ConsumerRecord("foo", 1, 1L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "qux")
-					}));
-			records1.put(topicPartition2, Arrays.asList(new ConsumerRecord[] {
+					new ConsumerRecord("foo", 1, 1L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "qux")));
+			records1.put(topicPartition2, Arrays.asList(
 					new ConsumerRecord("foo", 2, 0L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "fiz"),
-					new ConsumerRecord("foo", 2, 1L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "buz")
-					}));
+					new ConsumerRecord("foo", 2, 1L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "buz")));
 			Map<TopicPartition, List<ConsumerRecord>> records2 = new LinkedHashMap<>(records1);
 			records2.remove(topicPartition0);
-			records2.put(topicPartition1, Arrays.asList(new ConsumerRecord[] {
-					new ConsumerRecord("foo", 1, 1L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "qux")
-					}));
+			records2.put(topicPartition1, Arrays.asList(
+					new ConsumerRecord("foo", 1, 1L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "qux")));
 			final AtomicInteger which = new AtomicInteger();
 			willAnswer(i -> {
 				this.pollLatch.countDown();

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentOnErrorRecordModeTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentOnErrorRecordModeTests.java
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willAnswer;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.record.TimestampType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.listener.AbstractMessageListenerContainer.AckMode;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+/**
+ * @author Gary Russell
+ * @since 2.0.1
+ *
+ */
+@RunWith(SpringRunner.class)
+@DirtiesContext
+public class SeekToCurrentOnErrorRecordModeTests {
+
+	@SuppressWarnings("rawtypes")
+	@Autowired
+	private Consumer consumer;
+
+	@Autowired
+	private CountDownLatch latch;
+
+	@Autowired
+	private Config config;
+
+	/*
+	 * Deliver 6 records from three partitions, fail on the second record second
+	 * partition, first attempt; verify partition 0,1 committed and a total of 7 records
+	 * handled after seek.
+	 */
+	@SuppressWarnings("unchecked")
+	@Test
+	public void discardRemainingRecordsFromPollAndSeek() throws Exception {
+		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+		InOrder inOrder = inOrder(this.consumer);
+		inOrder.verify(this.consumer).subscribe(any(Collection.class), any(ConsumerRebalanceListener.class));
+		inOrder.verify(this.consumer).poll(1000);
+		inOrder.verify(this.consumer).commitSync(
+				Collections.singletonMap(new TopicPartition("foo", 0), new OffsetAndMetadata(1L)));
+		inOrder.verify(this.consumer).commitSync(
+				Collections.singletonMap(new TopicPartition("foo", 0), new OffsetAndMetadata(2L)));
+		inOrder.verify(this.consumer).commitSync(
+				Collections.singletonMap(new TopicPartition("foo", 1), new OffsetAndMetadata(1L)));
+		inOrder.verify(this.consumer).seek(new TopicPartition("foo", 1), 1L);
+		inOrder.verify(this.consumer).seek(new TopicPartition("foo", 2), 0L);
+		inOrder.verify(this.consumer).poll(1000);
+		inOrder.verify(this.consumer).commitSync(
+				Collections.singletonMap(new TopicPartition("foo", 1), new OffsetAndMetadata(2L)));
+		inOrder.verify(this.consumer).commitSync(
+				Collections.singletonMap(new TopicPartition("foo", 2), new OffsetAndMetadata(1L)));
+		inOrder.verify(this.consumer).commitSync(
+				Collections.singletonMap(new TopicPartition("foo", 2), new OffsetAndMetadata(2L)));
+		inOrder.verify(this.consumer).poll(1000);
+		assertThat(this.config.count).isEqualTo(7);
+		assertThat(this.config.contents.toArray()).isEqualTo(new String[]
+				{ "foo", "bar", "baz", "qux", "qux", "fiz", "buz" });
+	}
+
+	@Configuration
+	@EnableKafka
+	public static class Config {
+
+		private final List<String> contents = new ArrayList<>();
+
+		private int count;
+
+		@KafkaListener(topics = "foo")
+		public void foo(String in) {
+			this.contents.add(in);
+			latch().countDown();
+			if (++this.count == 4) { // part 1, offset 1, first time
+				throw new RuntimeException("foo");
+			}
+		}
+
+		@SuppressWarnings({ "rawtypes" })
+		@Bean
+		public ConsumerFactory consumerFactory() {
+			ConsumerFactory consumerFactory = mock(ConsumerFactory.class);
+			final Consumer consumer = consumer();
+			given(consumerFactory.createConsumer(null, "-0")).willReturn(consumer);
+			return consumerFactory;
+		}
+
+		@SuppressWarnings({ "rawtypes", "unchecked" })
+		@Bean
+		public Consumer consumer() {
+			final Consumer consumer = mock(Consumer.class);
+			final TopicPartition topicPartition0 = new TopicPartition("foo", 0);
+			final TopicPartition topicPartition1 = new TopicPartition("foo", 1);
+			final TopicPartition topicPartition2 = new TopicPartition("foo", 2);
+			willAnswer(i -> {
+				((ConsumerRebalanceListener) i.getArgument(1)).onPartitionsAssigned(
+						Collections.singletonList(topicPartition1));
+				return null;
+			}).given(consumer).subscribe(any(Collection.class), any(ConsumerRebalanceListener.class));
+			Map<TopicPartition, List<ConsumerRecord>> records1 = new LinkedHashMap<>();
+			records1.put(topicPartition0, Arrays.asList(new ConsumerRecord[] {
+					new ConsumerRecord("foo", 0, 0L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "foo"),
+					new ConsumerRecord("foo", 0, 1L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "bar")
+					}));
+			records1.put(topicPartition1, Arrays.asList(new ConsumerRecord[] {
+					new ConsumerRecord("foo", 1, 0L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "baz"),
+					new ConsumerRecord("foo", 1, 1L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "qux")
+					}));
+			records1.put(topicPartition2, Arrays.asList(new ConsumerRecord[] {
+					new ConsumerRecord("foo", 2, 0L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "fiz"),
+					new ConsumerRecord("foo", 2, 1L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "buz")
+					}));
+			Map<TopicPartition, List<ConsumerRecord>> records2 = new LinkedHashMap<>(records1);
+			records2.remove(topicPartition0);
+			records2.put(topicPartition1, Arrays.asList(new ConsumerRecord[] {
+					new ConsumerRecord("foo", 1, 1L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "qux")
+					}));
+			final AtomicInteger which = new AtomicInteger();
+			willAnswer(i -> {
+					switch (which.getAndIncrement()) {
+						case 0:
+							return new ConsumerRecords(records1);
+						case 1:
+							return new ConsumerRecords(records2);
+						default:
+							try {
+								Thread.sleep(1000);
+							}
+							catch (InterruptedException e) {
+								Thread.currentThread().interrupt();
+							}
+							return new ConsumerRecords(Collections.emptyMap());
+					}
+			}).given(consumer).poll(1000);
+			return consumer;
+		}
+
+		@SuppressWarnings({ "rawtypes", "unchecked" })
+		@Bean
+		public ConcurrentKafkaListenerContainerFactory kafkaListenerContainerFactory() {
+			ConcurrentKafkaListenerContainerFactory factory = new ConcurrentKafkaListenerContainerFactory();
+			factory.setConsumerFactory(consumerFactory());
+			factory.getContainerProperties().setAckOnError(false);
+			factory.getContainerProperties().setErrorHandler(new SeekToCurrentErrorHandler());
+			factory.getContainerProperties().setAckMode(AckMode.RECORD);
+			return factory;
+		}
+
+		@Bean
+		public CountDownLatch latch() {
+			return new CountDownLatch(7);
+		}
+
+	}
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentOnErrorRecordModeTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentOnErrorRecordModeTests.java
@@ -125,7 +125,7 @@ public class SeekToCurrentOnErrorRecordModeTests {
 
 		private final CountDownLatch closeLatch = new CountDownLatch(1);
 
-		private final CountDownLatch commitLatch = new CountDownLatch(6);
+		private final CountDownLatch commitLatch = new CountDownLatch(7);
 
 		private int count;
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentOnErrorRecordModeTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentOnErrorRecordModeTests.java
@@ -85,6 +85,7 @@ public class SeekToCurrentOnErrorRecordModeTests {
 	@Test
 	public void discardRemainingRecordsFromPollAndSeek() throws Exception {
 		assertThat(this.config.deliveryLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(this.config.commitLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		this.registry.stop();
 		assertThat(this.config.closeLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		InOrder inOrder = inOrder(this.consumer);
@@ -120,6 +121,8 @@ public class SeekToCurrentOnErrorRecordModeTests {
 		private final CountDownLatch deliveryLatch = new CountDownLatch(7);
 
 		private final CountDownLatch closeLatch = new CountDownLatch(1);
+
+		private final CountDownLatch commitLatch = new CountDownLatch(6);
 
 		private int count;
 
@@ -188,6 +191,10 @@ public class SeekToCurrentOnErrorRecordModeTests {
 							return new ConsumerRecords(Collections.emptyMap());
 					}
 			}).given(consumer).poll(1000);
+			willAnswer(i -> {
+				this.commitLatch.countDown();
+				return null;
+			}).given(consumer).commitSync(any(Map.class));
 			willAnswer(i -> {
 				this.closeLatch.countDown();
 				return null;

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -1427,7 +1427,7 @@ Those records will not be passed to the listener after the handler exits.
 @FunctionalInterface
 public interface RemainingRecordsErrorHandler extends ConsumerAwareErrorHandler {
 
-	void handle(Exception thrownException, List<ConsumerRecord<?, ?>> records, Consumer<?, ?> consumer);
+    void handle(Exception thrownException, List<ConsumerRecord<?, ?>> records, Consumer<?, ?> consumer);
 
 }
 ----
@@ -1454,8 +1454,7 @@ public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerCont
 }
 ----
 
-As an example; if the `poll` returns 6 records (2 from each partition 0, 1, 2) and the listener throws an exception on the fourth record,
-the container will have acknowledged the first 3 by committing their offsets.
+As an example; if the `poll` returns 6 records (2 from each partition 0, 1, 2) and the listener throws an exception on the fourth record, the container will have acknowledged the first 3 by committing their offsets.
 The `SeekToCurrentErrorHandler` will seek to offset 1 for partition 1 and offset 0 for partition 2.
 The next `poll()` will return the 3 unprocessed records.
 

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -1419,6 +1419,48 @@ Similar to the `@KafkaListener` error handlers, you can reset the offsets as nee
 
 NOTE: Unlike the listener-level error handlers, however, you should set the container property `ackOnError` to false when making adjustments; otherwise any pending acks will be applied after your repositioning.
 
+If an `ErrorHandler` implements `RemainingRecordsErrorHandler`, the error handler is provided with the failed record and any unprocessed records retrieved by the previous `poll()`.
+Those records will not be passed to the listener after the handler exits.
+
+[source, java]
+----
+@FunctionalInterface
+public interface RemainingRecordsErrorHandler extends ConsumerAwareErrorHandler {
+
+	void handle(Exception thrownException, List<ConsumerRecord<?, ?>> records, Consumer<?, ?> consumer);
+
+}
+----
+
+This allows implementations to seek all unprocessed topic/partitions so the current record (and the others remaining) will be retrieved by the next poll.
+The `SeekToCurrentErrorHandler` does exactly this.
+
+The container will commit any pending offset commits before calling the error handler.
+
+To configure the listener container with this handler, add it to the `ContainerProperties`.
+
+For example, with the `@KafkaListener` container factory:
+
+[source, java]
+----
+@Bean
+public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+    ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory();
+    factory.setConsumerFactory(consumerFactory());
+    factory.getContainerProperties().setAckOnError(false);
+    factory.getContainerProperties().setErrorHandler(new SeekToCurrentErrorHandler());
+    factory.getContainerProperties().setAckMode(AckMode.RECORD);
+    return factory;
+}
+----
+
+As an example; if the `poll` returns 6 records (2 from each partition 0, 1, 2) and the listener throws an exception on the fourth record,
+the container will have acknowledged the first 3 by committing their offsets.
+The `SeekToCurrentErrorHandler` will seek to offset 1 for partition 1 and offset 0 for partition 2.
+The next `poll()` will return the 3 unprocessed records.
+
+If the `AckMode` was `BATCH`, the container commits the offsets for the first 2 partitions before calling the error handler.
+
 [[kerberos]]
 ==== Kerberos
 


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-kafka/issues/470

2.0 introduced the `ConsumerAwareErrorHandler`, which allows the user to
`seek()` the consumer after an exception.

However, any pending records from the previous poll are still sent to
the listener.

Add the `RemainingRecordsErrorHandler` interface and `SeekToCurrentErrorHandler`
implementation which resets the offsets of all unprocessed topic/partitions so
that the next poll will return the failed record and all of the previously
unprocessed records.

__cherry-pick to 2.0.x__