### PR TITLE
GH-485: Fix multi listener method @KafkaListener

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/DelegatingInvocableHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/DelegatingInvocableHandler.java
@@ -36,6 +36,7 @@ import org.springframework.expression.common.TemplateParserContext;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.kafka.KafkaException;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
@@ -185,11 +186,11 @@ public class DelegatingInvocableHandler {
 	protected boolean matchHandlerMethod(Class<? extends Object> payloadClass, InvocableHandlerMethod handler) {
 		Method method = handler.getMethod();
 		Annotation[][] parameterAnnotations = method.getParameterAnnotations();
-		// Single param; no annotation or @Payload
+		// Single param; no annotation or not @Header
 		if (parameterAnnotations.length == 1) {
 			MethodParameter methodParameter = new MethodParameter(method, 0);
 			if ((methodParameter.getParameterAnnotations().length == 0
-					|| methodParameter.hasParameterAnnotation(Payload.class))
+					|| !methodParameter.hasParameterAnnotation(Header.class))
 					&& methodParameter.getParameterType().isAssignableFrom(payloadClass)) {
 				return true;
 			}
@@ -199,7 +200,7 @@ public class DelegatingInvocableHandler {
 		for (int i = 0; i < parameterAnnotations.length; i++) {
 			MethodParameter methodParameter = new MethodParameter(method, i);
 			if ((methodParameter.getParameterAnnotations().length == 0
-					|| methodParameter.hasParameterAnnotation(Payload.class))
+					|| !methodParameter.hasParameterAnnotation(Header.class))
 					&& methodParameter.getParameterType().isAssignableFrom(payloadClass)) {
 				if (foundCandidate) {
 					throw new KafkaException("Ambiguous payload parameter for " + method.toGenericString());

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -82,6 +82,7 @@ import org.springframework.kafka.support.TopicPartitionInitialOffset;
 import org.springframework.kafka.support.converter.StringJsonMessageConverter;
 import org.springframework.kafka.test.rule.KafkaEmbedded;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.lang.NonNull;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.handler.annotation.Header;
@@ -280,6 +281,7 @@ public class EnableKafkaIntegrationTests {
 		template.send("annotated8", 0, 1, null);
 		template.flush();
 		assertThat(this.multiListener.latch1.await(60, TimeUnit.SECONDS)).isTrue();
+		assertThat(this.multiListener.latch2.await(60, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Test
@@ -1273,16 +1275,18 @@ public class EnableKafkaIntegrationTests {
 	@KafkaListener(id = "multi", topics = "annotated8")
 	static class MultiListenerBean {
 
-		private final CountDownLatch latch1 = new CountDownLatch(2);
+		private final CountDownLatch latch1 = new CountDownLatch(1);
+
+		private final CountDownLatch latch2 = new CountDownLatch(1);
 
 		@KafkaHandler
-		public void bar(String bar) {
+		public void bar(@NonNull String bar) {
 			latch1.countDown();
 		}
 
 		@KafkaHandler
 		public void bar(@Payload(required = false) KafkaNull nul, @Header(KafkaHeaders.RECEIVED_MESSAGE_KEY) int key) {
-			latch1.countDown();
+			latch2.countDown();
 		}
 
 		public void foo(String bar) {


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-kafka/issues/485

When looking for matching methods, we matched on no annotation or `@Payload`.

Match should have been no annotation(s) or not `@Header`.

__cherry-pick to 2.0.x, 1.3.x__