### PR TITLE
GH-501: Fix transactions with AckMode.RECORD

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -934,12 +934,16 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 					Map<TopicPartition, OffsetAndMetadata> offsetsToCommit =
 							Collections.singletonMap(new TopicPartition(record.topic(), record.partition()),
 									new OffsetAndMetadata(record.offset() + 1));
-
-					if (this.containerProperties.isSyncCommits()) {
-						this.consumer.commitSync(offsetsToCommit);
+					if (producer == null) {
+						if (this.containerProperties.isSyncCommits()) {
+							this.consumer.commitSync(offsetsToCommit);
+						}
+						else {
+							this.consumer.commitAsync(offsetsToCommit, this.commitCallback);
+						}
 					}
 					else {
-						this.consumer.commitAsync(offsetsToCommit, this.commitCallback);
+						this.acks.add(record);
 					}
 				}
 				else if (!this.isAnyManualAck && !this.autoCommit) {


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-kafka/issues/501

With `AckMode.RECORD`, the container was committing the offsets on the
consumer instead of sending them to the transaction.