### PR TITLE
Fix NPE when Jackson not present

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/converter/MessagingMessageConverter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/converter/MessagingMessageConverter.java
@@ -138,7 +138,9 @@ public class MessagingMessageConverter implements RecordMessageConverter {
 		Object payload = convertPayload(message);
 		Long timestamp = headers.get(KafkaHeaders.TIMESTAMP, Long.class);
 		Headers recordHeaders = initialRecordHeaders(message);
-		this.headerMapper.fromHeaders(headers, recordHeaders);
+		if (this.headerMapper != null) {
+			this.headerMapper.fromHeaders(headers, recordHeaders);
+		}
 		return new ProducerRecord(topic == null ? defaultTopic : topic, partition, timestamp, key, payload,
 				recordHeaders);
 	}


### PR DESCRIPTION
When using the `KafkaTemplate.send(Message<?>)` variant, an NPE was thrown
if Jackson wasn't on the classpath.

__cherry-pick to 1.3.x, 2.0.x__