### PR TITLE
Introduced support for Spring Data projection based message binding.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,7 @@ subprojects { subproject ->
 		assertjVersion = '2.6.0'
 		hamcrestVersion = '1.3'
 		jacksonVersion = '2.9.1'
+		jaywayJsonPathVersion = '2.4.0'
 		junitVersion = '4.12'
 		kafkaVersion = '1.0.0'
 		mockitoVersion = '2.11.0'
@@ -80,6 +81,7 @@ subprojects { subproject ->
 		slf4jVersion = '1.7.25'
 		springRetryVersion = '1.2.1.RELEASE'
 		springVersion = '5.0.2.RELEASE'
+		springDataCommonsVersion = '2.0.2.RELEASE'
 
 		idPrefix = 'kafka'
 
@@ -169,6 +171,10 @@ project ('spring-kafka') {
 
 		compile ("com.fasterxml.jackson.core:jackson-core:$jacksonVersion", optional)
 		compile ("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion", optional)
+
+		// Spring Data projection message binding support
+		compile ("org.springframework.data:spring-data-commons:$springDataCommonsVersion", optional)
+		compile ("com.jayway.jsonpath:json-path:$jaywayJsonPathVersion", optional)
 
 		testCompile project (":spring-kafka-test")
 		testCompile "org.assertj:assertj-core:$assertjVersion"

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/converter/ProjectingMessageConverter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/converter/ProjectingMessageConverter.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support.converter;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+import org.springframework.core.ResolvableType;
+import org.springframework.data.projection.ProjectionFactory;
+import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
+import org.springframework.data.web.JsonProjectingMethodInterceptorFactory;
+import org.springframework.kafka.support.KafkaNull;
+import org.springframework.util.Assert;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+
+/**
+ * A {@link MessageConverter} implementation that uses a Spring Data {@link ProjectionFactory} to bind incoming messages
+ * to projection interfaces.
+ *
+ * @author Oliver Gierke
+ * @since 2.2
+ */
+public class ProjectingMessageConverter extends MessagingMessageConverter {
+
+	private final ProjectionFactory projectionFactory;
+	private final MessagingMessageConverter delegate;
+
+	/**
+	 * Creates a new {@link ProjectingMessageConverter} using the given {@link ObjectMapper}.
+	 *
+	 * @param mapper must not be {@literal null}.
+	 */
+	public ProjectingMessageConverter(ObjectMapper mapper) {
+
+		Assert.notNull(mapper, "ObjectMapper must not be null!");
+
+		JacksonMappingProvider provider = new JacksonMappingProvider(mapper);
+		JsonProjectingMethodInterceptorFactory interceptorFactory = new JsonProjectingMethodInterceptorFactory(provider);
+
+		SpelAwareProxyProjectionFactory factory = new SpelAwareProxyProjectionFactory();
+		factory.registerMethodInvokerFactory(interceptorFactory);
+
+		this.projectionFactory = factory;
+		this.delegate = new StringJsonMessageConverter(mapper);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.kafka.support.converter.MessagingMessageConverter#extractAndConvertValue(org.apache.kafka.clients.consumer.ConsumerRecord, java.lang.reflect.Type)
+	 */
+	@Override
+	protected Object extractAndConvertValue(ConsumerRecord<?, ?> record, Type type) {
+
+		Object value = record.value();
+
+		if (value == null) {
+			return KafkaNull.INSTANCE;
+		}
+
+		Class<?> rawType = ResolvableType.forType(type).resolve(Object.class);
+
+		if (!rawType.isInterface()) {
+			return this.delegate.extractAndConvertValue(record, type);
+		}
+
+		InputStream inputStream = new ByteArrayInputStream(getAsByteArray(value));
+
+		return this.projectionFactory.createProjection(rawType, inputStream);
+	}
+
+	/**
+	 * Returns the given source value as byte array.
+	 *
+	 * @param source must not be {@literal null}.
+	 * @return the source instance as byte array.
+	 */
+	private static byte[] getAsByteArray(Object source) {
+
+		Assert.notNull(source, "Source must not be null!");
+
+		if (source instanceof String) {
+			return String.class.cast(source).getBytes(StandardCharsets.UTF_8);
+		}
+
+		if (source instanceof byte[]) {
+			return byte[].class.cast(source);
+		}
+
+		throw new ConversionException(String.format("Unsupported payload type %s!", source.getClass()), null);
+	}
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/converter/ProjectingMessageConverter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/converter/ProjectingMessageConverter.java
@@ -28,6 +28,7 @@ import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.data.projection.SpelAwareProxyProjectionFactory;
 import org.springframework.data.web.JsonProjectingMethodInterceptorFactory;
 import org.springframework.kafka.support.KafkaNull;
+import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -38,7 +39,7 @@ import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
  * to projection interfaces.
  *
  * @author Oliver Gierke
- * @since 2.2
+ * @since 2.1.1
  */
 public class ProjectingMessageConverter extends MessagingMessageConverter {
 
@@ -62,6 +63,15 @@ public class ProjectingMessageConverter extends MessagingMessageConverter {
 
 		this.projectionFactory = factory;
 		this.delegate = new StringJsonMessageConverter(mapper);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.kafka.support.converter.MessagingMessageConverter#convertPayload(org.springframework.messaging.Message)
+	 */
+	@Override
+	protected Object convertPayload(Message<?> message) {
+		return this.delegate.convertPayload(message);
 	}
 
 	/*

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/converter/ProjectingMessageConverterTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/converter/ProjectingMessageConverterTests.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support.converter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doReturn;
+
+import java.nio.charset.StandardCharsets;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import org.springframework.data.web.JsonPath;
+import org.springframework.kafka.support.KafkaNull;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * @author Oliver Gierke
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class ProjectingMessageConverterTests {
+
+	static final String STRING_PAYLOAD = "{ \"username\" : \"SomeUsername\", \"user\" : { \"name\" : \"SomeName\"}}";
+	static final byte[] BYTE_ARRAY_PAYLOAD = STRING_PAYLOAD.getBytes(StandardCharsets.UTF_8);
+
+	ProjectingMessageConverter converter = new ProjectingMessageConverter(new ObjectMapper());
+
+	@Mock
+	ConsumerRecord<?, ?> record;
+
+	public @Rule ExpectedException exception = ExpectedException.none();
+
+	@Test
+	public void rejectsNullObjectMapper() {
+
+		exception.expect(IllegalArgumentException.class);
+
+		new ProjectingMessageConverter(null);
+	}
+
+	@Test
+	public void returnsKafkaNullForNullPayload() {
+
+		doReturn(null).when(record).value();
+
+		assertThat(converter.extractAndConvertValue(record, Object.class)).isEqualTo(KafkaNull.INSTANCE);
+	}
+
+	@Test
+	public void createsProjectedPayloadForInterface() {
+
+		assertProjectionProxy(STRING_PAYLOAD);
+		assertProjectionProxy(BYTE_ARRAY_PAYLOAD);
+	}
+
+	@Test
+	public void usesJacksonToCreatePayloadForClass() {
+
+		assertSimpleObject(STRING_PAYLOAD);
+		assertSimpleObject(BYTE_ARRAY_PAYLOAD);
+	}
+
+	@Test
+	public void rejectsInvalidPayload() {
+
+		exception.expect(ConversionException.class);
+		exception.expectMessage(Object.class.getName());
+
+		assertProjectionProxy(new Object());
+	}
+
+	private void assertProjectionProxy(Object payload) {
+
+		doReturn(payload).when(record).value();
+
+		Object value = converter.extractAndConvertValue(record, Sample.class);
+
+		assertThat(value).isInstanceOf(Sample.class);
+
+		Sample sample = (Sample) value;
+
+		assertThat(sample.getName()).isEqualTo("SomeName");
+		assertThat(sample.getUsername()).isEqualTo("SomeUsername");
+	}
+
+	private void assertSimpleObject(Object payload) {
+
+		doReturn(payload).when(record).value();
+
+		Object value = converter.extractAndConvertValue(record, AnotherSample.class);
+
+		assertThat(value).isInstanceOf(AnotherSample.class);
+
+		AnotherSample sample = (AnotherSample) value;
+
+		assertThat(sample.user.name).isEqualTo("SomeName");
+		assertThat(sample.username).isEqualTo("SomeUsername");
+	}
+
+	interface Sample {
+
+		String getUsername();
+
+		@JsonPath("$.user.name")
+		String getName();
+	}
+
+	public static class AnotherSample {
+
+		public String username;
+		public User user;
+
+		public static class User {
+			public String name;
+		}
+	}
+}


### PR DESCRIPTION
This commit introduces a ProjectingMessageConverter that supports binding `String`- and `byte[]`-backed JSON strings to Spring Data Projection interfaces. This allows very selective, and low-coupled bindings to data including the lookup of values from multiple places inside the JSON document. E.g. the following interface can be defined as message payload type:

```java
interface SomeSample {

  @JsonPath({ "$.username", "$.user.name" })
  String getUsername();
}
```

Accessor methods will be used to lookup the property name as field in the received JSON document by default. The `@JsonPath` expression allows to customize the value lookup and even to define multiple JSONPath expression to lookup values from multiple places until an expression returns an actual value.

If the type we're supposed to unmarshal into is a plain class the `ProjectingMessageConverter` delegates to the default `StringJsonMessageConverter`.

Added Spring Data and the transitively required Jayway JSONPath library as optional build dependencies.