### PR TITLE
Fix KafkaAdminBadContextTests

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaAdmin.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaAdmin.java
@@ -236,6 +236,7 @@ public class KafkaAdmin implements ApplicationContextAware, SmartInitializingSin
 				}
 				catch (ExecutionException e) {
 					logger.error("Failed to create topics", e.getCause());
+					throw new KafkaException("Failed to create topics", e.getCause());
 				}
 			}
 			if (topicsToModify.size() > 0) {
@@ -253,7 +254,7 @@ public class KafkaAdmin implements ApplicationContextAware, SmartInitializingSin
 				catch (ExecutionException e) {
 					logger.error("Failed to create partitions", e.getCause());
 					if (!(e.getCause() instanceof UnsupportedVersionException)) {
-						throw e.getCause();
+						throw new KafkaException("Failed to create partitions", e.getCause());
 					}
 				}
 			}

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaAdminBadContextTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaAdminBadContextTests.java
@@ -45,7 +45,7 @@ public class KafkaAdminBadContextTests {
 			fail("Expected Exception");
 		}
 		catch (IllegalStateException e) {
-			assertThat(e.getMessage()).isEqualTo("Could not create admin");
+			assertThat(e.getMessage()).isIn("Could not create admin", "Could not configure topics");
 		}
 	}
 


### PR DESCRIPTION
Locally, I find the admin is sometimes created even with a bad host causing the test to fail.

Also, topic creation logged an error but did not throw an exception.

Fixed the test to expect one of two exceptions.

__cherry-pick to 2.0.x__