### PR TITLE
Apply addTargetPackageToTrusted() consistently in JsonDeserializer

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java
@@ -137,8 +137,8 @@ public class JsonDeserializer<T> implements ExtendedDeserializer<T> {
 				else {
 					throw new IllegalStateException(DEFAULT_VALUE_TYPE + " must be Class or String");
 				}
-				addTargetPackageToTrusted();
 			}
+			addTargetPackageToTrusted();
 		}
 		catch (ClassNotFoundException | LinkageError e) {
 			throw new IllegalStateException(e);


### PR DESCRIPTION
When `isKey` is `true`, `addTargetPackageToTrusted()` is not applied. So this PR applies `addTargetPackageToTrusted()` consistently.