### PR TITLE
fix Doc's description

### DIFF
--- a/src/reference/asciidoc/testing.adoc
+++ b/src/reference/asciidoc/testing.adoc
@@ -117,11 +117,11 @@ For convenience a test class level `@EmbeddedKafka` annotation is provided with 
 public class KafkaStreamsTests {
 
     @Autowired
-    private KafkaEmbedded kafkaEmbedded;
+    private KafkaEmbedded embeddedKafka;
 
     @Test
     public void someTest() {
-        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps("testGroup", "true", this.kafkaEmbedded);
+        Map<String, Object> consumerProps = KafkaTestUtils.consumerProps("testGroup", "true", this.embeddedKafka);
         consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
         ConsumerFactory<Integer, String> cf = new DefaultKafkaConsumerFactory<>(consumerProps);
         Consumer<Integer, String> consumer = cf.createConsumer();


### PR DESCRIPTION
In https://docs.spring.io/spring-kafka/docs/current/reference/htmlsingle/#__embeddedkafka_annotation

KafkaEmbedded bean's field-name is 'kafkaEmbedded'. But, a few lines below are called 'embeddedKafka'

```
this.embeddedKafka.consumeFromAnEmbeddedTopic(consumer, KafkaStreamsTests.STREAMING_TOPIC2);
```