### PR TITLE
Support local bean reference in @KafkaListener

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
@@ -178,12 +178,12 @@ public @interface KafkaListener {
 	 * A pseudo bean name used in SpEL expressions within this annotation to reference
 	 * the current bean within which this listener is defined. This allows access to
 	 * properties and methods within the enclosing bean.
-	 * Default '__listenerBean__'.
+	 * Default '__listener'.
 	 * <p>
-	 * Example: {@code topics = "#{__listenerBean__.topicList}"}.
+	 * Example: {@code topics = "#{__listener.topicList}"}.
 	 * @return the pseudo bean name.
 	 * @since 2.1.2
 	 */
-	String beanRef() default "__listenerBean__";
+	String beanRef() default "__listener";
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
@@ -174,4 +174,16 @@ public @interface KafkaListener {
 	 */
 	String clientIdPrefix() default "";
 
+	/**
+	 * A pseudo bean name used in SpEL expressions within this annotation to reference
+	 * the current bean within which this listener is defined. This allows access to
+	 * properties and methods within the enclosing bean.
+	 * Default '__listenerBean__'.
+	 * <p>
+	 * Example: {@code topics = "#{__listenerBean__.topicList}"}.
+	 * @return the pseudo bean name.
+	 * @since 2.1.2
+	 */
+	String beanRef() default "__listenerBean__";
+
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/BatchListenerConversionTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/BatchListenerConversionTests.java
@@ -70,18 +70,24 @@ public class BatchListenerConversionTests {
 	@Autowired
 	private KafkaTemplate<Integer, Foo> template;
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testBatchOfPojos() throws Exception {
+		doTest(this.config.listener1(), "blc1");
+		doTest(this.config.listener2(), "blc2");
+	}
+
+	private void doTest(Listener listener, String topic) throws InterruptedException {
 		this.template.send(new GenericMessage<>(
-				new Foo("bar"), Collections.singletonMap(KafkaHeaders.TOPIC, "blc1")));
+				new Foo("bar"), Collections.singletonMap(KafkaHeaders.TOPIC, topic)));
 		this.template.send(new GenericMessage<>(
-				new Foo("baz"), Collections.singletonMap(KafkaHeaders.TOPIC, "blc1")));
-		assertThat(config.listener().latch1.await(10, TimeUnit.SECONDS)).isTrue();
-		assertThat(config.listener().received).isInstanceOf(List.class);
-		assertThat(((List<?>) config.listener().received).size()).isGreaterThan(0);
-		assertThat(((List<?>) config.listener().received).get(0)).isInstanceOf(Foo.class);
-		assertThat(((List<Foo>) config.listener().received).get(0).bar).isEqualTo("bar");
+				new Foo("baz"), Collections.singletonMap(KafkaHeaders.TOPIC, topic)));
+		assertThat(listener.latch1.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(listener.latch2.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(listener.received.size()).isGreaterThan(0);
+		assertThat(listener.received.get(0)).isInstanceOf(Foo.class);
+		assertThat(listener.received.get(0).bar).isEqualTo("bar");
+		assertThat((listener.receivedTopics).get(0)).isEqualTo(topic);
+		assertThat((listener.receivedPartitions).get(0)).isEqualTo(0);
 	}
 
 	@Configuration
@@ -134,22 +140,53 @@ public class BatchListenerConversionTests {
 		}
 
 		@Bean
-		public Listener listener() {
-			return new Listener();
+		public Listener listener1() {
+			return new Listener("blc1");
+		}
+
+		@Bean
+		public Listener listener2() {
+			return new Listener("blc2");
 		}
 
 	}
 
 	public static class Listener {
 
+		private final String topic;
+
 		private final CountDownLatch latch1 = new CountDownLatch(1);
 
-		private Object received;
+		private final CountDownLatch latch2 = new CountDownLatch(1);
 
-		@KafkaListener(topics = "blc1")
-		public void listen(List<Foo> foos, @Header(KafkaHeaders.OFFSET) List<Long> offsets) {
-			this.received = foos;
+		private List<Foo> received;
+
+		private List<String> receivedTopics;
+
+		private List<Integer> receivedPartitions;
+
+		public Listener(String topic) {
+			this.topic = topic;
+		}
+
+		@KafkaListener(topics = "#{__listenerBean__.topic}", groupId = "#{__listenerBean__.topic}.group")
+		public void listen1(List<Foo> foos, @Header(KafkaHeaders.RECEIVED_TOPIC) List<String> topics,
+				@Header(KafkaHeaders.RECEIVED_PARTITION_ID) List<Integer> partitions) {
+			if (this.received == null) {
+				this.received = foos;
+			}
+			this.receivedTopics = topics;
+			this.receivedPartitions = partitions;
 			this.latch1.countDown();
+		}
+
+		@KafkaListener(beanRef = "__x__", topics = "#{__x__.topic}", groupId = "#{__x__.topic}.group2")
+		public void listen2(List<Foo> foos) {
+			this.latch2.countDown();
+		}
+
+		public String getTopic() {
+			return this.topic;
 		}
 
 	}

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/BatchListenerConversionTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/BatchListenerConversionTests.java
@@ -169,7 +169,7 @@ public class BatchListenerConversionTests {
 			this.topic = topic;
 		}
 
-		@KafkaListener(topics = "#{__listenerBean__.topic}", groupId = "#{__listenerBean__.topic}.group")
+		@KafkaListener(topics = "#{__listener.topic}", groupId = "#{__listener.topic}.group")
 		public void listen1(List<Foo> foos, @Header(KafkaHeaders.RECEIVED_TOPIC) List<String> topics,
 				@Header(KafkaHeaders.RECEIVED_PARTITION_ID) List<Integer> partitions) {
 			if (this.received == null) {
@@ -180,7 +180,7 @@ public class BatchListenerConversionTests {
 			this.latch1.countDown();
 		}
 
-		@KafkaListener(beanRef = "__x__", topics = "#{__x__.topic}", groupId = "#{__x__.topic}.group2")
+		@KafkaListener(beanRef = "__x", topics = "#{__x.topic}", groupId = "#{__x.topic}.group2")
 		public void listen2(List<Foo> foos) {
 			this.latch2.countDown();
 		}

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -795,8 +795,8 @@ public class Listener {
         this.topic = topic;
     }
 
-    @KafkaListener(topics = "#{__listenerBean__.topic}",
-        groupId = "#{__listenerBean__.topic}.group")
+    @KafkaListener(topics = "#{__listener.topic}",
+        groupId = "#{__listener.topic}.group")
     public void listen(...) {
         ...
     }
@@ -808,12 +808,12 @@ public class Listener {
 }
 ----
 
-If, in the unlikely event that you have an actual bean called `__kafkaListener__`, you can change the expression token using the `beanRef` attribute...
+If, in the unlikely event that you have an actual bean called `__listener`, you can change the expression token using the `beanRef` attribute...
 
 [source, java]
 ----
-@KafkaListener(beanRef = "__x__", topics = "#{__x__.topic}",
-    groupId = "#{__x__.topic}.group")
+@KafkaListener(beanRef = "__x", topics = "#{__x.topic}",
+    groupId = "#{__x.topic}.group")
 ----
 
 ===== Container Thread Naming

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -756,6 +756,66 @@ public void listen(List<ConsumerRecord<Integer, String>> list, Acknowledgment ac
 Starting with _version 2.0_, the `id` attribute (if present) is used as the Kafka `group.id` property, overriding the configured property in the consumer factory, if present.
 You can also set `groupId` explicitly, or set `idIsGroup` to false, to restore the previous behavior of using the consumer factory `group.id`.
 
+You can use property placeholders or SpEL expressions within annotation properties, for example...
+
+[source, java]
+----
+@KafkaListener(topics = "${some.property}")
+
+@KafkaListener(topics = "#{someBean.someProperty}",
+    groupId = "#{someBean.someProperty}.group")
+----
+
+Starting with _version 2.1.2_, the SpEL expressions support a special token `__kafkaListener__` which is a pseudo bean name which represents the current bean instance within which this annotation exists.
+
+For example, given...
+
+[source, java]
+----
+@Bean
+public Listener listener1() {
+    return new Listener("topic1");
+}
+
+@Bean
+public Listener listener2() {
+    return new Listener("topic2");
+}
+----
+
+...we can use...
+
+[source, java]
+----
+public class Listener {
+
+    private final String topic;
+
+    public Listener(String topic) {
+        this.topic = topic;
+    }
+
+    @KafkaListener(topics = "#{__listenerBean__.topic}",
+        groupId = "#{__listenerBean__.topic}.group")
+    public void listen(...) {
+        ...
+    }
+
+    public String getTopic() {
+        return this.topic;
+    }
+
+}
+----
+
+If, in the unlikely event that you have an actual bean called `__kafkaListener__`, you can change the expression token using the `beanRef` attribute...
+
+[source, java]
+----
+@KafkaListener(beanRef = "__x__", topics = "#{__x__.topic}",
+    groupId = "#{__x__.topic}.group")
+----
+
 ===== Container Thread Naming
 
 Listener containers currently use two task executors, one to invoke the consumer and another which will be used to invoke the listener, when the kafka consumer property `enable.auto.commit` is `false`.


### PR DESCRIPTION
In the `@KafkaListener` bean post processor, allow property SpEL expressions to
access properties and methods on the bean being post-processed.

[See Stack Overflow](https://stackoverflow.com/questions/48162588/spring-expression-language-is-it-possible-to-use-this-in-sel/48171277#48171277).