### PR TITLE
More Spring Integration Kafka Support

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/AbstractKafkaHeaderMapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/AbstractKafkaHeaderMapper.java
@@ -24,6 +24,7 @@ import java.util.List;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.messaging.MessageHeaders;
 import org.springframework.util.Assert;
 import org.springframework.util.PatternMatchUtils;
 
@@ -62,6 +63,21 @@ public abstract class AbstractKafkaHeaderMapper implements KafkaHeaderMapper {
 		for (String pattern : patterns) {
 			this.matchers.add(new SimplePatternBasedHeaderMatcher(pattern));
 		}
+	}
+
+	protected boolean matches(String header, Object value) {
+		if (matches(header)) {
+			if ((header.equals(MessageHeaders.REPLY_CHANNEL) || header.equals(MessageHeaders.ERROR_CHANNEL))
+					&& !(value instanceof String)) {
+				if (this.logger.isDebugEnabled()) {
+					this.logger.debug("Cannot map " + header + " when type is [" + value.getClass()
+							+ "]; it must be a String");
+				}
+				return false;
+			}
+			return true;
+		}
+		return false;
 	}
 
 	protected boolean matches(String header) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/DefaultKafkaHeaderMapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/DefaultKafkaHeaderMapper.java
@@ -168,7 +168,7 @@ public class DefaultKafkaHeaderMapper extends AbstractKafkaHeaderMapper {
 	public void fromHeaders(MessageHeaders headers, Headers target) {
 		final Map<String, String> jsonHeaders = new HashMap<>();
 		headers.forEach((k, v) -> {
-			if (matches(k)) {
+			if (matches(k, v)) {
 				if (v instanceof byte[]) {
 					target.add(new RecordHeader(k, (byte[]) v));
 				}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/SimpleKafkaHeaderMapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/SimpleKafkaHeaderMapper.java
@@ -65,7 +65,7 @@ public class SimpleKafkaHeaderMapper extends AbstractKafkaHeaderMapper {
 	@Override
 	public void fromHeaders(MessageHeaders headers, Headers target) {
 		headers.forEach((k, v) -> {
-			if (v instanceof byte[] && matches(k)) {
+			if (v instanceof byte[] && matches(k, v)) {
 				target.add(new RecordHeader(k, (byte[]) v));
 			}
 		});

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/converter/MessagingMessageConverter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/converter/MessagingMessageConverter.java
@@ -37,6 +37,7 @@ import org.springframework.kafka.support.KafkaNull;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.util.Assert;
 
 /**
  * A Messaging {@link MessageConverter} implementation for a message listener that
@@ -135,12 +136,15 @@ public class MessagingMessageConverter implements RecordMessageConverter {
 	public ProducerRecord<?, ?> fromMessage(Message<?> message, String defaultTopic) {
 		MessageHeaders headers = message.getHeaders();
 		Object topicHeader = headers.get(KafkaHeaders.TOPIC);
-		String topic;
+		String topic = null;
 		if (topicHeader instanceof byte[]) {
 			topic = new String(((byte[]) topicHeader), StandardCharsets.UTF_8);
 		}
 		else if (topicHeader instanceof String) {
 			topic = (String) topicHeader;
+		}
+		else if (topicHeader == null) {
+			Assert.state(defaultTopic != null, "With no topic header, a defaultTopic is required");
 		}
 		else {
 			throw new IllegalStateException(KafkaHeaders.TOPIC + " must be a String or byte[], not "


### PR DESCRIPTION
- don't map message channel headers, unless they are String
- tolerate `byte[]` in topic header.