### PR TITLE
rename constant DEFAULT_VALUE_TYPE to keep the same with DEFAULT_KEY_TYPE

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java
@@ -54,7 +54,6 @@ public class JsonDeserializer<T> implements ExtendedDeserializer<T> {
 
 	/**
 	 * Kafka config property for the default key type if no header.
-	 *
 	 * @deprecated in favor of {@link #KEY_DEFAULT_TYPE}
 	 */
 	@Deprecated
@@ -62,8 +61,9 @@ public class JsonDeserializer<T> implements ExtendedDeserializer<T> {
 
 	/**
 	 * Kafka config property for the default value type if no header.
-	 * <p>Will be removed in the future, use {@link #VALUE_DEFAULT_TYPE} instead.
+	 * @deprecated in favor of {@link #VALUE_DEFAULT_TYPE}
 	 */
+	@Deprecated
 	public static final String DEFAULT_VALUE_TYPE = "spring.json.default.value.type";
 
 	/**
@@ -162,15 +162,16 @@ public class JsonDeserializer<T> implements ExtendedDeserializer<T> {
 				}
 			}
 			// TODO don't forget to remove these code after DEFAULT_VALUE_TYPE being removed.
-			else if (!isKey && configs.containsKey(DEFAULT_VALUE_TYPE)) {
-				if (configs.get(DEFAULT_VALUE_TYPE) instanceof Class) {
-					this.targetType = (Class<T>) configs.get(DEFAULT_VALUE_TYPE);
+			else if (!isKey && configs.containsKey("spring.json.default.value.type")) {
+				if (configs.get("spring.json.default.value.type") instanceof Class) {
+					this.targetType = (Class<T>) configs.get("spring.json.default.value.type");
 				}
-				else if (configs.get(DEFAULT_VALUE_TYPE) instanceof String) {
-					this.targetType = (Class<T>) ClassUtils.forName((String) configs.get(DEFAULT_VALUE_TYPE), null);
+				else if (configs.get("spring.json.default.value.type") instanceof String) {
+					this.targetType = (Class<T>) ClassUtils
+						.forName((String) configs.get("spring.json.default.value.type"), null);
 				}
 				else {
-					throw new IllegalStateException(DEFAULT_VALUE_TYPE + " must be Class or String");
+					throw new IllegalStateException("spring.json.default.value.type must be Class or String");
 				}
 			}
 			else if (!isKey && configs.containsKey(VALUE_DEFAULT_TYPE)) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java
@@ -53,15 +53,17 @@ import com.fasterxml.jackson.databind.ObjectReader;
 public class JsonDeserializer<T> implements ExtendedDeserializer<T> {
 
 	/**
+	 * Kafka config property for the default key type if no header.
+	 *
 	 * @deprecated in favor of {@link #KEY_DEFAULT_TYPE}
 	 */
 	@Deprecated
 	public static final String DEFAULT_KEY_TYPE = "spring.json.key.default.type";
 
 	/**
-	 * @deprecated in favor of {@link #VALUE_DEFAULT_TYPE}
+	 * Kafka config property for the default value type if no header.
+	 * <p>Will be removed in the future, use {@link #VALUE_DEFAULT_TYPE} instead.
 	 */
-	@Deprecated
 	public static final String DEFAULT_VALUE_TYPE = "spring.json.default.value.type";
 
 	/**
@@ -159,6 +161,7 @@ public class JsonDeserializer<T> implements ExtendedDeserializer<T> {
 					throw new IllegalStateException(KEY_DEFAULT_TYPE + " must be Class or String");
 				}
 			}
+			// TODO don't forget to remove these code after DEFAULT_VALUE_TYPE being removed.
 			else if (!isKey && configs.containsKey(DEFAULT_VALUE_TYPE)) {
 				if (configs.get(DEFAULT_VALUE_TYPE) instanceof Class) {
 					this.targetType = (Class<T>) configs.get(DEFAULT_VALUE_TYPE);

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java
@@ -53,14 +53,26 @@ import com.fasterxml.jackson.databind.ObjectReader;
 public class JsonDeserializer<T> implements ExtendedDeserializer<T> {
 
 	/**
+	 * @deprecated in favor of {@link #KEY_DEFAULT_TYPE}
+	 */
+	@Deprecated
+	public static final String DEFAULT_KEY_TYPE = "spring.json.key.default.type";
+
+	/**
+	 * @deprecated in favor of {@link #VALUE_DEFAULT_TYPE}
+	 */
+	@Deprecated
+	public static final String DEFAULT_VALUE_TYPE = "spring.json.default.value.type";
+
+	/**
 	 * Kafka config property for the default key type if no header.
 	 */
-	public static final String DEFAULT_KEY_TYPE = "spring.json.key.default.type";
+	public static final String KEY_DEFAULT_TYPE = "spring.json.key.default.type";
 
 	/**
 	 * Kafka config property for the default value type if no header.
 	 */
-	public static final String DEFAULT_VALUE_TYPE = "spring.json.value.default.type";
+	public static final String VALUE_DEFAULT_TYPE = "spring.json.value.default.type";
 
 	/**
 	 * Kafka config property for trusted deserialization packages.
@@ -136,15 +148,15 @@ public class JsonDeserializer<T> implements ExtendedDeserializer<T> {
 	public void configure(Map<String, ?> configs, boolean isKey) {
 		setUseTypeMapperForKey(isKey);
 		try {
-			if (isKey && configs.containsKey(DEFAULT_KEY_TYPE)) {
-				if (configs.get(DEFAULT_KEY_TYPE) instanceof Class) {
-					this.targetType = (Class<T>) configs.get(DEFAULT_KEY_TYPE);
+			if (isKey && configs.containsKey(KEY_DEFAULT_TYPE)) {
+				if (configs.get(KEY_DEFAULT_TYPE) instanceof Class) {
+					this.targetType = (Class<T>) configs.get(KEY_DEFAULT_TYPE);
 				}
-				else if (configs.get(DEFAULT_KEY_TYPE) instanceof String) {
-					this.targetType = (Class<T>) ClassUtils.forName((String) configs.get(DEFAULT_KEY_TYPE), null);
+				else if (configs.get(KEY_DEFAULT_TYPE) instanceof String) {
+					this.targetType = (Class<T>) ClassUtils.forName((String) configs.get(KEY_DEFAULT_TYPE), null);
 				}
 				else {
-					throw new IllegalStateException(DEFAULT_KEY_TYPE + " must be Class or String");
+					throw new IllegalStateException(KEY_DEFAULT_TYPE + " must be Class or String");
 				}
 			}
 			else if (!isKey && configs.containsKey(DEFAULT_VALUE_TYPE)) {
@@ -156,6 +168,17 @@ public class JsonDeserializer<T> implements ExtendedDeserializer<T> {
 				}
 				else {
 					throw new IllegalStateException(DEFAULT_VALUE_TYPE + " must be Class or String");
+				}
+			}
+			else if (!isKey && configs.containsKey(VALUE_DEFAULT_TYPE)) {
+				if (configs.get(VALUE_DEFAULT_TYPE) instanceof Class) {
+					this.targetType = (Class<T>) configs.get(VALUE_DEFAULT_TYPE);
+				}
+				else if (configs.get(VALUE_DEFAULT_TYPE) instanceof String) {
+					this.targetType = (Class<T>) ClassUtils.forName((String) configs.get(VALUE_DEFAULT_TYPE), null);
+				}
+				else {
+					throw new IllegalStateException(VALUE_DEFAULT_TYPE + " must be Class or String");
 				}
 			}
 			addTargetPackageToTrusted();
@@ -226,5 +249,4 @@ public class JsonDeserializer<T> implements ExtendedDeserializer<T> {
 	public void close() {
 		// No-op
 	}
-
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java
@@ -60,7 +60,7 @@ public class JsonDeserializer<T> implements ExtendedDeserializer<T> {
 	/**
 	 * Kafka config property for the default value type if no header.
 	 */
-	public static final String DEFAULT_VALUE_TYPE = "spring.json.default.value.type";
+	public static final String DEFAULT_VALUE_TYPE = "spring.json.value.default.type";
 
 	/**
 	 * Kafka config property for trusted deserialization packages.

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
@@ -1458,7 +1458,7 @@ public class KafkaMessageListenerContainerTests {
 		this.logger.info("Start JSON1");
 		Map<String, Object> props = KafkaTestUtils.consumerProps("testJson", "false", embeddedKafka);
 		props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
-		props.put(JsonDeserializer.DEFAULT_VALUE_TYPE, Foo.class);
+		props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, Foo.class);
 		DefaultKafkaConsumerFactory<Integer, Foo> cf = new DefaultKafkaConsumerFactory<>(props);
 		ContainerProperties containerProps = new ContainerProperties(topic1);
 

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -1421,8 +1421,8 @@ Starting with _version 2.1_, type information can be conveyed in record `Headers
 In addition, the serializer/deserializer can be configured using Kafka properties.
 
 -  `JsonSerializer.ADD_TYPE_INFO_HEADERS` (default `true`); set to `false` to disable this feature.
-- `JsonDeserializer.DEFAULT_KEY_TYPE`; fallback type for deserialization of keys if no header information is present.
-- `JsonDeserializer.DEFAULT_VALUE_TYPE`; fallback type for deserialization of values if no header information is present.
+- `JsonDeserializer.KEY_DEFAULT_TYPE`; fallback type for deserialization of keys if no header information is present.
+- `JsonDeserializer.VALUE_DEFAULT_TYPE`; fallback type for deserialization of values if no header information is present.
 - `JsonDeserializer.TRUSTED_PACKAGES` (default `java.util`, `java.lang`); comma-delimited list of package patterns allowed for deserialization; `*` means deserialize all.
 
 Although the `Serializer`/`Deserializer` API is quite simple and flexible from the low-level Kafka `Consumer` and


### PR DESCRIPTION
because DEFAULT_KEY_TYPE is "spring.json.key.default.type",  but DEFAULT_VALUE_TYPE is "spring.json.default.value.type", seems like wrong word order, we should keep them the same.

from
```
public static final String DEFAULT_KEY_TYPE = "spring.json.key.default.type";
public static final String DEFAULT_VALUE_TYPE = "spring.json.default.value.type";
```
to 
```
public static final String DEFAULT_KEY_TYPE = "spring.json.key.default.type";
public static final String DEFAULT_VALUE_TYPE = "spring.json.value.default.type";
```