### PR TITLE
#561 -  Cannot use JsonSerde for both key and value serialization in a stream

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/converter/AbstractJavaTypeMapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/converter/AbstractJavaTypeMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import org.springframework.util.ClassUtils;
  * @author Sam Nelson
  * @author Andreas Asplund
  * @author Gary Russell
+ * @author Elliot Kennedy
  *
  * @since 2.1
  */
@@ -57,22 +58,70 @@ public abstract class AbstractJavaTypeMapper implements BeanClassLoaderAware {
 	 */
 	public static final String DEFAULT_KEY_CLASSID_FIELD_NAME = "__KeyTypeId__";
 
+	/**
+	 * Default header name for key type information.
+	 */
+	public static final String KEY_DEFAULT_CLASSID_FIELD_NAME = "__Key_TypeId__";
+
+	/**
+	 * Default header name for key container object contents type information.
+	 */
+	public static final String KEY_DEFAULT_CONTENT_CLASSID_FIELD_NAME = "__Key_ContentTypeId__";
+
+	/**
+	 * Default header name for key map key type information.
+	 */
+	public static final String KEY_DEFAULT_KEY_CLASSID_FIELD_NAME = "__Key_KeyTypeId__";
+
 	private final Map<String, Class<?>> idClassMapping = new HashMap<String, Class<?>>();
 
 	private final Map<Class<?>, byte[]> classIdMapping = new HashMap<Class<?>, byte[]>();
 
+	private String classIdFieldName = DEFAULT_CLASSID_FIELD_NAME;
+
+	private String contentClassIdFieldName = DEFAULT_CONTENT_CLASSID_FIELD_NAME;
+
+	private String keyClassIdFieldName = DEFAULT_KEY_CLASSID_FIELD_NAME;
+
 	private ClassLoader classLoader = ClassUtils.getDefaultClassLoader();
 
 	public String getClassIdFieldName() {
-		return DEFAULT_CLASSID_FIELD_NAME;
+		return this.classIdFieldName;
+	}
+
+	/**
+	 * Configure header name for type information.
+	 * @param classIdFieldName the header name.
+	 * @since 2.1.3
+	 */
+	public void setClassIdFieldName(String classIdFieldName) {
+		this.classIdFieldName = classIdFieldName;
 	}
 
 	public String getContentClassIdFieldName() {
-		return DEFAULT_CONTENT_CLASSID_FIELD_NAME;
+		return this.contentClassIdFieldName;
+	}
+
+	/**
+	 * Configure header name for container object contents type information.
+	 * @param contentClassIdFieldName the header name.
+	 * @since 2.1.3
+	 */
+	public void setContentClassIdFieldName(String contentClassIdFieldName) {
+		this.contentClassIdFieldName = contentClassIdFieldName;
 	}
 
 	public String getKeyClassIdFieldName() {
-		return DEFAULT_KEY_CLASSID_FIELD_NAME;
+		return this.keyClassIdFieldName;
+	}
+
+	/**
+	 * Configure header name for map key type information.
+	 * @param keyClassIdFieldName the header name.
+	 * @since 2.1.3
+	 */
+	public void setKeyClassIdFieldName(String keyClassIdFieldName) {
+		this.keyClassIdFieldName = keyClassIdFieldName;
 	}
 
 	public void setIdClassMapping(Map<String, Class<?>> idClassMapping) {
@@ -131,6 +180,19 @@ public abstract class AbstractJavaTypeMapper implements BeanClassLoaderAware {
 
 	public Map<String, Class<?>> getIdClassMapping() {
 		return Collections.unmodifiableMap(this.idClassMapping);
+	}
+
+	/**
+	 * Configure the TypeMapper to use default key type class.
+	 * @param isKey Use key type headers if true
+	 * @since 2.1.3
+	 */
+	public void setUseForKey(boolean isKey) {
+		if (isKey) {
+			setClassIdFieldName(AbstractJavaTypeMapper.KEY_DEFAULT_CLASSID_FIELD_NAME);
+			setContentClassIdFieldName(AbstractJavaTypeMapper.KEY_DEFAULT_CONTENT_CLASSID_FIELD_NAME);
+			setKeyClassIdFieldName(AbstractJavaTypeMapper.KEY_DEFAULT_KEY_CLASSID_FIELD_NAME);
+		}
 	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerde.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerde.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * @param <T> target class for serialization/deserialization
  *
  * @author Marius Bogoevici
+ * @author Elliot Kennedy
  *
  * @since 1.1.5
  */
@@ -101,6 +102,18 @@ public class JsonSerde<T> implements Serde<T> {
 	@Override
 	public Deserializer<T> deserializer() {
 		return this.jsonDeserializer;
+	}
+
+	/**
+	 * Configure the TypeMapper to use key types if the JsonSerde is used to serialize keys.
+	 * @param isKey Use key type headers if true
+	 * @return the JsonSerde
+	 * @since 2.1.3
+	 */
+	public JsonSerde<T> setUseTypeMapperForKey(boolean isKey) {
+		this.jsonSerializer.setUseTypeMapperForKey(isKey);
+		this.jsonDeserializer.setUseTypeMapperForKey(isKey);
+		return this;
 	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerializer.java
@@ -94,7 +94,7 @@ public class JsonSerializer<T> implements ExtendedSerializer<T> {
 	public void setTypeMapper(Jackson2JavaTypeMapper typeMapper) {
 		Assert.notNull(typeMapper, "'typeMapper' cannot be null");
 		this.typeMapper = typeMapper;
-		this.setTypeMapperExplicitlySet(true);
+		this.typeMapperExplicitlySet = true;
 	}
 
 	/**
@@ -103,7 +103,7 @@ public class JsonSerializer<T> implements ExtendedSerializer<T> {
 	 * @since 2.1.3
 	 */
 	public void setUseTypeMapperForKey(boolean isKey) {
-		if (!isTypeMapperExplicitlySet()) {
+		if (!this.typeMapperExplicitlySet) {
 			if (this.getTypeMapper() instanceof AbstractJavaTypeMapper) {
 				AbstractJavaTypeMapper typeMapper = (AbstractJavaTypeMapper) this.getTypeMapper();
 				typeMapper.setUseForKey(isKey);
@@ -153,13 +153,5 @@ public class JsonSerializer<T> implements ExtendedSerializer<T> {
 	@Override
 	public void close() {
 		// No-op
-	}
-
-	private boolean isTypeMapperExplicitlySet() {
-		return this.typeMapperExplicitlySet;
-	}
-
-	private void setTypeMapperExplicitlySet(boolean typeMapperExplicitlySet) {
-		this.typeMapperExplicitlySet = typeMapperExplicitlySet;
 	}
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.ExtendedSerializer;
 import org.apache.kafka.common.serialization.Serializer;
 
+import org.springframework.kafka.support.converter.AbstractJavaTypeMapper;
 import org.springframework.kafka.support.converter.DefaultJackson2JavaTypeMapper;
 import org.springframework.kafka.support.converter.Jackson2JavaTypeMapper;
 import org.springframework.util.Assert;
@@ -40,6 +41,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * @author Igor Stepanov
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Elliot Kennedy
  */
 public class JsonSerializer<T> implements ExtendedSerializer<T> {
 
@@ -53,6 +55,8 @@ public class JsonSerializer<T> implements ExtendedSerializer<T> {
 	protected boolean addTypeInfo = true;
 
 	protected Jackson2JavaTypeMapper typeMapper = new DefaultJackson2JavaTypeMapper();
+
+	private boolean typeMapperExplicitlySet = false;
 
 	public JsonSerializer() {
 		this(new ObjectMapper());
@@ -90,10 +94,26 @@ public class JsonSerializer<T> implements ExtendedSerializer<T> {
 	public void setTypeMapper(Jackson2JavaTypeMapper typeMapper) {
 		Assert.notNull(typeMapper, "'typeMapper' cannot be null");
 		this.typeMapper = typeMapper;
+		this.setTypeMapperExplicitlySet(true);
+	}
+
+	/**
+	 * Configure the default Jackson2JavaTypeMapper to use key type headers.
+	 * @param isKey Use key type headers if true
+	 * @since 2.1.3
+	 */
+	public void setUseTypeMapperForKey(boolean isKey) {
+		if (!isTypeMapperExplicitlySet()) {
+			if (this.getTypeMapper() instanceof AbstractJavaTypeMapper) {
+				AbstractJavaTypeMapper typeMapper = (AbstractJavaTypeMapper) this.getTypeMapper();
+				typeMapper.setUseForKey(isKey);
+			}
+		}
 	}
 
 	@Override
 	public void configure(Map<String, ?> configs, boolean isKey) {
+		setUseTypeMapperForKey(isKey);
 		if (configs.containsKey(ADD_TYPE_INFO_HEADERS)) {
 			Object config = configs.get(ADD_TYPE_INFO_HEADERS);
 			if (config instanceof Boolean) {
@@ -135,4 +155,11 @@ public class JsonSerializer<T> implements ExtendedSerializer<T> {
 		// No-op
 	}
 
+	private boolean isTypeMapperExplicitlySet() {
+		return this.typeMapperExplicitlySet;
+	}
+
+	private void setTypeMapperExplicitlySet(boolean typeMapperExplicitlySet) {
+		this.typeMapperExplicitlySet = typeMapperExplicitlySet;
+	}
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/kstream/KafkaStreamsJsonSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/kstream/KafkaStreamsJsonSerializationTests.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.kstream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.streams.Consumed;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.Printed;
+import org.apache.kafka.streams.kstream.Produced;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafkaStreams;
+import org.springframework.kafka.annotation.KafkaStreamsDefaultConfiguration;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerde;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.rule.KafkaEmbedded;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * @author Elliot Kennedy
+ */
+@RunWith(SpringRunner.class)
+@DirtiesContext
+@EmbeddedKafka(partitions = 1,
+		topics = {
+			KafkaStreamsJsonSerializationTests.OBJECT_INPUT_TOPIC,
+			KafkaStreamsJsonSerializationTests.OBJECT_OUTPUT_TOPIC
+		})
+public class KafkaStreamsJsonSerializationTests {
+
+	public static final String OBJECT_INPUT_TOPIC = "object-input-topic";
+	public static final String OBJECT_OUTPUT_TOPIC = "object-output-topic";
+
+	public static final JsonSerde<JsonObjectKey> jsonObjectKeySerde = new JsonSerde<>(JsonObjectKey.class).setUseTypeMapperForKey(true);
+	public static final JsonSerde<JsonObjectValue> jsonObjectValueSerde = new JsonSerde<>(JsonObjectValue.class);
+
+	@Autowired
+	private KafkaTemplate<Object, Object> template;
+
+	@Autowired
+	private KafkaEmbedded kafkaEmbedded;
+
+	private Consumer<JsonObjectKey, JsonObjectValue> objectOutputTopicConsumer;
+
+	@Before
+	public void setup() throws Exception {
+		objectOutputTopicConsumer = consumer(OBJECT_OUTPUT_TOPIC, jsonObjectKeySerde, jsonObjectValueSerde);
+	}
+
+	@Test
+	public void testJsonObjectSerialization() throws Exception {
+		template.send(OBJECT_INPUT_TOPIC, new JsonObjectKey(25), new JsonObjectValue("twenty-five"));
+
+		ConsumerRecords<JsonObjectKey, JsonObjectValue> outputTopicRecords = KafkaTestUtils.getRecords(objectOutputTopicConsumer);
+
+		assertThat(outputTopicRecords.count()).isEqualTo(1);
+		ConsumerRecord<JsonObjectKey, JsonObjectValue> output = outputTopicRecords.iterator().next();
+		assertThat(output.key()).isInstanceOf(JsonObjectKey.class);
+		assertThat(output.key().getKey()).isEqualTo(25);
+		assertThat(output.value()).isInstanceOf(JsonObjectValue.class);
+		assertThat(output.value().getValue()).isEqualTo("twenty-five");
+	}
+
+	private <K, V> Consumer<K, V> consumer(String topic, Serde<K> keySerde, Serde<V> valueSerde) throws Exception {
+		Map<String, Object> consumerProps =
+				KafkaTestUtils.consumerProps(UUID.randomUUID().toString(), "false", this.kafkaEmbedded);
+		consumerProps.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 10000);
+
+		DefaultKafkaConsumerFactory<K, V> kafkaConsumerFactory =
+				new DefaultKafkaConsumerFactory<>(consumerProps, keySerde.deserializer(), valueSerde.deserializer());
+		Consumer<K, V> consumer = kafkaConsumerFactory.createConsumer();
+		kafkaEmbedded.consumeFromAnEmbeddedTopic(consumer, topic);
+		return consumer;
+	}
+
+	public static class JsonObjectKey {
+
+		private final Integer key;
+
+		@JsonCreator
+		public JsonObjectKey(@JsonProperty(value = "key", required = true) Integer key) {
+			this.key = key;
+		}
+
+		public Integer getKey() {
+			return key;
+		}
+
+		@Override
+		public String toString() {
+			return "JsonObjectKey{" +
+					"key=" + key +
+					'}';
+		}
+	}
+
+	public static class JsonObjectValue {
+
+		private final String value;
+
+		@JsonCreator
+		public JsonObjectValue(@JsonProperty(value = "value", required = true) String value) {
+			this.value = value;
+		}
+
+		public String getValue() {
+			return value;
+		}
+
+		public static Serde<JsonObjectValue> jsonObjectValueSerde() {
+			return new JsonSerde<>(JsonObjectValue.class);
+		}
+
+		@Override
+		public String toString() {
+			return "JsonObjectValue{" +
+					"value='" + value + '\'' +
+					'}';
+		}
+	}
+
+	@Configuration
+	@EnableKafkaStreams
+	public static class Config {
+
+		@Value("${" + KafkaEmbedded.SPRING_EMBEDDED_KAFKA_BROKERS + "}")
+		private String brokerAddresses;
+
+		@Bean
+		public ProducerFactory<?, ?> producerFactory() {
+			return new DefaultKafkaProducerFactory<>(producerConfigs());
+		}
+
+		@Bean
+		public Map<String, Object> producerConfigs() {
+			Map<String, Object> senderProps = KafkaTestUtils.senderProps(this.brokerAddresses);
+			senderProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+			senderProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+			return senderProps;
+		}
+
+		@Bean
+		public KafkaTemplate<?, ?> kafkaTemplate() {
+			return new KafkaTemplate<>(producerFactory());
+		}
+
+		@Bean(name = KafkaStreamsDefaultConfiguration.DEFAULT_STREAMS_CONFIG_BEAN_NAME)
+		public StreamsConfig kStreamsConfigs() {
+			Map<String, Object> props = new HashMap<>();
+			props.put(StreamsConfig.APPLICATION_ID_CONFIG, "testStreams");
+			props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, this.brokerAddresses);
+			return new StreamsConfig(props);
+		}
+
+		@Bean
+		public KStream<JsonObjectKey, JsonObjectValue> jsonObjectSerializationStream(StreamsBuilder streamsBuilder) {
+			KStream<JsonObjectKey, JsonObjectValue> testStream = streamsBuilder
+					.stream(OBJECT_INPUT_TOPIC, Consumed.with(jsonObjectKeySerde, jsonObjectValueSerde));
+
+			testStream.print(Printed.toSysOut());
+			testStream.to(OBJECT_OUTPUT_TOPIC, Produced.with(jsonObjectKeySerde, jsonObjectValueSerde));
+
+			return testStream;
+		}
+	}
+
+}


### PR DESCRIPTION
GH-561 Add a test to json serialize both a key and value in a stream.

GH-561 - Configure Jackson2JavaKeyTypeMapper in JsonDeserializer and JsonSerializer when the isKey flag is present.

GH-561 - Add collection json serialization tests.

GH-561 - Use isKey to set json headers.
