### PR TITLE
More tracing and debug logging

### DIFF
--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/utils/KafkaTestUtils.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/utils/KafkaTestUtils.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -163,7 +164,12 @@ public final class KafkaTestUtils {
 		logger.debug("Polling...");
 		ConsumerRecords<K, V> received = consumer.poll(timeout);
 		if (logger.isDebugEnabled()) {
-			logger.debug("Received: " + received.count());
+			logger.debug("Received: " + received.count() + ", "
+					+ received.partitions().stream()
+							.flatMap(p -> received.records(p).stream())
+							// map to same format as send metadata toString()
+							.map(r -> r.topic() + "-" + r.partition() + "@" + r.offset())
+							.collect(Collectors.toList()));
 		}
 		assertThat(received).as("null received from consumer.poll()").isNotNull();
 		return received;

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
@@ -346,6 +346,9 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V> {
 							KafkaTemplate.this.producerListener.onSuccess(producerRecord.topic(),
 									producerRecord.partition(), producerRecord.key(), producerRecord.value(), metadata);
 						}
+						if (KafkaTemplate.this.logger.isTraceEnabled()) {
+							KafkaTemplate.this.logger.trace("Sent ok: " + producerRecord + ", metadata: " + metadata);
+						}
 					}
 					else {
 						future.setException(new KafkaProducerException(producerRecord, "Failed to send", exception));
@@ -355,6 +358,9 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V> {
 									producerRecord.key(),
 									producerRecord.value(),
 									exception);
+						}
+						if (KafkaTemplate.this.logger.isDebugEnabled()) {
+							KafkaTemplate.this.logger.debug("Failed to send: " + producerRecord, exception);
 						}
 					}
 				}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledFuture;
+import java.util.stream.Collectors;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -657,6 +658,13 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 					ConsumerRecords<K, V> records = this.consumer.poll(this.containerProperties.getPollTimeout());
 					if (records != null && this.logger.isDebugEnabled()) {
 						this.logger.debug("Received: " + records.count() + " records");
+						if (records.count() > 0 && this.logger.isTraceEnabled()) {
+							this.logger.trace(records.partitions().stream()
+								.flatMap(p -> records.records(p).stream())
+								// map to same format as send metadata toString()
+								.map(r -> r.topic() + "-" + r.partition() + "@" + r.offset())
+								.collect(Collectors.toList()));
+						}
 					}
 					if (records != null && records.count() > 0) {
 						if (this.containerProperties.getIdleEventInterval() != null) {


### PR DESCRIPTION
- Add trace log for successfull send
- Add debug log for failed send (debug because the user code should react to the future)
- Add trace logging for records received (topic-partition@offset) (container)
- Add debug logging for records received (topic-partition@offset) (test utils)