### PR TITLE
Add a missing InterruptedException handling

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
@@ -242,6 +242,7 @@ public abstract class AbstractMessageListenerContainer<K, V>
 					latch.await(this.containerProperties.getShutdownTimeout(), TimeUnit.MILLISECONDS);
 				}
 				catch (InterruptedException e) {
+					Thread.currentThread().interrupt();
 				}
 			}
 		}


### PR DESCRIPTION
This PR adds a missing `InterruptedException` handling.