### PR TITLE
Transaction Tests Polishing

### DIFF
--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/rule/KafkaEmbedded.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/rule/KafkaEmbedded.java
@@ -95,13 +95,13 @@ public class KafkaEmbedded extends ExternalResource implements KafkaRule, Initia
 
 	private final List<KafkaServer> kafkaServers = new ArrayList<>();
 
+	private final Map<String, Object> brokerProperties = new HashMap<>();
+
 	private EmbeddedZookeeper zookeeper;
 
 	private ZkClient zookeeperClient;
 
 	private String zkConnect;
-
-	private Map<String, String> brokerProperties;
 
 	private int[] kafkaPorts;
 
@@ -147,7 +147,19 @@ public class KafkaEmbedded extends ExternalResource implements KafkaRule, Initia
 	 * @see KafkaConfig
 	 */
 	public KafkaEmbedded brokerProperties(Map<String, String> brokerProperties) {
-		this.brokerProperties = brokerProperties;
+		this.brokerProperties.putAll(brokerProperties);
+		return this;
+	}
+
+	/**
+	 * Specify a broker property.
+	 * @param property the property name.
+	 * @param value the value.
+	 * @return the {@link KafkaEmbedded}.
+	 * @since 2.1.4
+	 */
+	public KafkaEmbedded brokerProperty(String property, Object value) {
+		this.brokerProperties.put(property, value);
 		return this;
 	}
 
@@ -185,11 +197,11 @@ public class KafkaEmbedded extends ExternalResource implements KafkaRule, Initia
 					scala.Option.apply(null),
 					scala.Option.apply(null),
 					true, false, 0, false, 0, false, 0, scala.Option.apply(null), 1);
-			brokerConfigProperties.setProperty("replica.socket.timeout.ms", "1000");
-			brokerConfigProperties.setProperty("controller.socket.timeout.ms", "1000");
-			brokerConfigProperties.setProperty("offsets.topic.replication.factor", "1");
+			brokerConfigProperties.setProperty(KafkaConfig.ReplicaSocketTimeoutMsProp(), "1000");
+			brokerConfigProperties.setProperty(KafkaConfig.ControllerSocketTimeoutMsProp(), "1000");
+			brokerConfigProperties.setProperty(KafkaConfig.OffsetsTopicReplicationFactorProp(), "1");
 			if (this.brokerProperties != null) {
-				this.brokerProperties.forEach(brokerConfigProperties::setProperty);
+				this.brokerProperties.forEach(brokerConfigProperties::put);
 			}
 			KafkaServer server = TestUtils.createServer(new KafkaConfig(brokerConfigProperties), Time.SYSTEM);
 			this.kafkaServers.add(server);

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTransactionTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTransactionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -58,6 +58,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.AbstractPlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
+import kafka.server.KafkaConfig;
+
 /**
  * @author Gary Russell
  * @author Nakul Mishra
@@ -70,7 +72,9 @@ public class KafkaTemplateTransactionTests {
 	private static final String STRING_KEY_TOPIC = "stringKeyTopic";
 
 	@ClassRule
-	public static KafkaEmbedded embeddedKafka = new KafkaEmbedded(3, true, STRING_KEY_TOPIC);
+	public static KafkaEmbedded embeddedKafka = new KafkaEmbedded(1, true, STRING_KEY_TOPIC)
+		.brokerProperty(KafkaConfig.TransactionsTopicReplicationFactorProp(), "1")
+		.brokerProperty(KafkaConfig.TransactionsTopicMinISRProp(), "1");
 
 	@Test
 	public void testLocalTransaction() throws Exception {

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/TransactionalContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/TransactionalContainerTests.java
@@ -72,6 +72,8 @@ import org.springframework.transaction.TransactionException;
 import org.springframework.transaction.support.AbstractPlatformTransactionManager;
 import org.springframework.transaction.support.DefaultTransactionStatus;
 
+import kafka.server.KafkaConfig;
+
 /**
  * @author Gary Russell
  * @author Artem Bilan
@@ -88,7 +90,9 @@ public class TransactionalContainerTests {
 	private static String topic2 = "txTopic2";
 
 	@ClassRule
-	public static KafkaEmbedded embeddedKafka = new KafkaEmbedded(3, true, topic1, topic2);
+	public static KafkaEmbedded embeddedKafka = new KafkaEmbedded(1, true, topic1, topic2)
+			.brokerProperty(KafkaConfig.TransactionsTopicReplicationFactorProp(), "1")
+			.brokerProperty(KafkaConfig.TransactionsTopicMinISRProp(), "1");
 
 	@Test
 	public void testConsumeAndProduceTransactionKTM() throws Exception {


### PR DESCRIPTION
The default broker configuration requires 3 broker instances for transactions.

Instead of running 3 embedded brokers, change the configuration to allow
transactions with just one.

Use broker config constants.

Add a builder method for individual properties.