### PR TITLE
GH-614: Fix general consumer error handling

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/BatchErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/BatchErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.kafka.listener;
 
+import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 
 /**
@@ -28,5 +29,17 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
  * @since 1.1
  */
 public interface BatchErrorHandler extends GenericErrorHandler<ConsumerRecords<?, ?>> {
+
+	/**
+	 * Handle the exception.
+	 * @param thrownException the exception.
+	 * @param data the consumer records.
+	 * @param consumer the consumer.
+	 * @param container the container.
+	 */
+	default void handle(Exception thrownException, ConsumerRecords<?, ?> data, Consumer<?, ?> consumer,
+			MessageListenerContainer container) {
+		handle(thrownException, data);
+	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerAwareBatchErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerAwareBatchErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,5 +37,11 @@ public interface ConsumerAwareBatchErrorHandler extends BatchErrorHandler {
 
 	@Override
 	void handle(Exception thrownException, ConsumerRecords<?, ?> data, Consumer<?, ?> consumer);
+
+	@Override
+	default void handle(Exception thrownException, ConsumerRecords<?, ?> data, Consumer<?, ?> consumer,
+			MessageListenerContainer container) {
+		handle(thrownException, data, consumer);
+	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerAwareErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerAwareErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@
  */
 
 package org.springframework.kafka.listener;
+
+import java.util.List;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -37,5 +39,11 @@ public interface ConsumerAwareErrorHandler extends ErrorHandler {
 
 	@Override
 	void handle(Exception thrownException, ConsumerRecord<?, ?> data, Consumer<?, ?> consumer);
+
+	@Override
+	default void handle(Exception thrownException, List<ConsumerRecord<?, ?>> data, Consumer<?, ?> consumer,
+			MessageListenerContainer container) {
+		handle(thrownException, null, consumer);
+	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerAwareBatchErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerAwareBatchErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,13 +35,7 @@ public interface ContainerAwareBatchErrorHandler extends ConsumerAwareBatchError
 		throw new UnsupportedOperationException("Container should never call this");
 	}
 
-	/**
-	 * Handle the exception.
-	 * @param thrownException the exception.
-	 * @param data the consumer records.
-	 * @param consumer the consumer.
-	 * @param container the container.
-	 */
+	@Override
 	void handle(Exception thrownException, ConsumerRecords<?, ?> data, Consumer<?, ?> consumer,
 			MessageListenerContainer container);
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerAwareErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerAwareErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,13 +39,7 @@ public interface ContainerAwareErrorHandler extends RemainingRecordsErrorHandler
 		throw new UnsupportedOperationException("Container should never call this");
 	}
 
-	/**
-	 * Handle the exception.
-	 * @param thrownException the exception.
-	 * @param records the remaining records including the one that failed.
-	 * @param consumer the consumer.
-	 * @param container the container.
-	 */
+	@Override
 	void handle(Exception thrownException, List<ConsumerRecord<?, ?>> records, Consumer<?, ?> consumer,
 			MessageListenerContainer container);
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2016 the original author or authors.
+ * Copyright 2015-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,9 @@
 
 package org.springframework.kafka.listener;
 
+import java.util.List;
+
+import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
 /**
@@ -25,5 +28,17 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
  * @author Gary Russell
  */
 public interface ErrorHandler extends GenericErrorHandler<ConsumerRecord<?, ?>> {
+
+	/**
+	 * Handle the exception.
+	 * @param thrownException the exception.
+	 * @param records the remaining records including the one that failed.
+	 * @param consumer the consumer.
+	 * @param container the container.
+	 */
+	default void handle(Exception thrownException, List<ConsumerRecord<?, ?>> records, Consumer<?, ?> consumer,
+			MessageListenerContainer container) {
+		handle(thrownException, null);
+	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/RemainingRecordsErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/RemainingRecordsErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,5 +46,11 @@ public interface RemainingRecordsErrorHandler extends ConsumerAwareErrorHandler 
 	 * @param consumer the consumer.
 	 */
 	void handle(Exception thrownException, List<ConsumerRecord<?, ?>> records, Consumer<?, ?> consumer);
+
+	@Override
+	default void handle(Exception thrownException, List<ConsumerRecord<?, ?>> records, Consumer<?, ?> consumer,
+			MessageListenerContainer container) {
+		handle(thrownException, records, consumer);
+	}
 
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
@@ -1747,7 +1747,7 @@ public class KafkaMessageListenerContainerTests {
 				Thread.sleep(3000);
 			}
 			catch (InterruptedException e) {
-				e.printStackTrace();
+				Thread.currentThread().interrupt();
 			}
 		});
 		containerProps.setSyncCommits(true);


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-kafka/issues/614

PR #595 added support for calling error handlers for general errors not related
to listener invocation.

However, the wrong `handle()` method was called.

Add a default implementation of the lowest interface method in the hierarchies to
`ErrorHandler` and `BatchErrorHandler` respectively and invoke that so the
right method will always be invoked, regardless of the error handler type.

Also see #615