### PR TITLE
GH-618: Add StreamsBuilderFactoryBean#getStreamsConfig

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/StreamsBuilderFactoryBean.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/StreamsBuilderFactoryBean.java
@@ -28,6 +28,7 @@ import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
 import org.springframework.beans.factory.config.AbstractFactoryBean;
 import org.springframework.context.SmartLifecycle;
 import org.springframework.kafka.KafkaException;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
@@ -37,6 +38,7 @@ import org.springframework.util.Assert;
  * @author Artem Bilan
  * @author Ivan Ursul
  * @author Soby Chacko
+ * @author Zach Olauson
  *
  * @since 1.1.4
  */
@@ -126,6 +128,11 @@ public class StreamsBuilderFactoryBean extends AbstractFactoryBean<StreamsBuilde
 	public void setStreamsConfig(StreamsConfig streamsConfig) {
 		Assert.notNull(streamsConfig, "'streamsConfig' must not be null");
 		this.streamsConfig = streamsConfig;
+	}
+
+	@Nullable
+	public StreamsConfig getStreamsConfig() {
+		return this.streamsConfig;
 	}
 
 	public void setClientSupplier(KafkaClientSupplier clientSupplier) {

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/StreamsBuilderFactoryLateConfigTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/StreamsBuilderFactoryLateConfigTests.java
@@ -55,7 +55,7 @@ public class StreamsBuilderFactoryLateConfigTests {
 	private StreamsBuilderFactoryBean streamsBuilderFactoryBean;
 
 	@Test(expected = KafkaException.class)
-	public void testStreamBuilderFactoryCannotBeStartedWithoutStreamconfig() {
+	public void testStreamBuilderFactoryCannotBeStartedWithoutStreamsConfig() {
 		StreamsBuilderFactoryBean streamsBuilderFactoryBean = new StreamsBuilderFactoryBean();
 		streamsBuilderFactoryBean.start();
 	}


### PR DESCRIPTION
@garyrussell mentioned returning an `UnmodifiableMap` for the `StreamsConfig` in #618 , but after looking through the `StreamsConfig` code it doesn't look like it's mutable anyways (unless I'm missing something), as it makes a copy of the original configs when querying a `StreamsConfig` instance. With that said, let me know if you would still prefer an `UnmodifiableMap`, I'm happy to change it. As it stands right now, `StreamsConfig` has the benefit of knowing which keys are valid, the expected types of each value which helps for validation when retrieving configs. 

I also marked the return value as `Nullable`, as the `StreamsBuilderFactoryBean` allows configuration after instantiation. I also considering wrapping this in an `Optional`, but I didn't see any usage of `Optionals` in this project, so I wasn't sure if there was a project convention around them.