### PR TITLE
GH-634: 1.1.0 Client compatibility

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.1.5.BUILD-SNAPSHOT
+version=2.2.0.BUILD-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=2.2.0.BUILD-SNAPSHOT
+version=2.1.5.BUILD-SNAPSHOT

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/rule/KafkaEmbedded.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/rule/KafkaEmbedded.java
@@ -225,7 +225,7 @@ public class KafkaEmbedded extends ExternalResource implements KafkaRule, Initia
 	}
 
 	public Properties createBrokerProperties(int i) {
-		if (this.clientVersion.startsWith("1.0.0")) {
+		if (this.clientVersion.startsWith("1.0.")) {
 			return TestUtils.createBrokerConfig(i, this.zkConnect, this.controlledShutdown,
 					true, this.kafkaPorts[i],
 					scala.Option.apply(null),

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/rule/KafkaEmbedded.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/rule/KafkaEmbedded.java
@@ -95,17 +95,21 @@ public class KafkaEmbedded extends ExternalResource implements KafkaRule, Initia
 
 	static {
 		clientVersion = AppInfoParser.getVersion();
-		try {
-			testUtilsCreateBrokerConfigMethod = TestUtils.class.getDeclaredMethod("createBrokerConfig",
-					int.class, String.class, boolean.class, boolean.class, int.class,
-					scala.Option.class, scala.Option.class, scala.Option.class,
-					boolean.class, boolean.class, int.class, boolean.class, int.class, boolean.class,
-					int.class, scala.Option.class, int.class, boolean.class);
+		if (clientVersion.startsWith("1.1.")) {
+			try {
+				testUtilsCreateBrokerConfigMethod = TestUtils.class.getDeclaredMethod("createBrokerConfig",
+						int.class, String.class, boolean.class, boolean.class, int.class,
+						scala.Option.class, scala.Option.class, scala.Option.class,
+						boolean.class, boolean.class, int.class, boolean.class, int.class, boolean.class,
+						int.class, scala.Option.class, int.class, boolean.class);
+			}
+			catch (NoSuchMethodException | SecurityException e) {
+				throw new RuntimeException("Failed to determine TestUtils.createBrokerConfig() method");
+			}
 		}
-		catch (NoSuchMethodException | SecurityException e) {
-			throw new RuntimeException("Failed to determine TestUtils.createBrokerConfig() method");
+		else {
+			testUtilsCreateBrokerConfigMethod = null;
 		}
-
 	}
 
 	private final int count;
@@ -241,7 +245,7 @@ public class KafkaEmbedded extends ExternalResource implements KafkaRule, Initia
 	}
 
 	public Properties createBrokerProperties(int i) {
-		if (clientVersion.startsWith("1.0.")) {
+		if (testUtilsCreateBrokerConfigMethod == null) {
 			return TestUtils.createBrokerConfig(i, this.zkConnect, this.controlledShutdown,
 					true, this.kafkaPorts[i],
 					scala.Option.apply(null),

--- a/src/reference/asciidoc/appendix.adoc
+++ b/src/reference/asciidoc/appendix.adoc
@@ -1,3 +1,56 @@
+[[deps-for-11x]]
+== Override Dependencies to use the 1.1.x kafka-clients
+
+When using `spring-kafka-test` (_version 2.1.x_, starting with _version 2.1.5_) with the 1.1.x `kafka-clients` jar, you will need to override certain transitive dependencies as follows:
+
+[source, xml]
+----
+<dependency>
+    <groupId>org.springframework.kafka</groupId>
+    <artifactId>spring-kafka</artifactId>
+    <version>${spring.kafka.version}</version>
+</dependency>
+
+<dependency>
+    <groupId>org.springframework.kafka</groupId>
+    <artifactId>spring-kafka-test</artifactId>
+    <version>${spring.kafka.version}</version>
+    <scope>test</scope>
+    <exclusions>
+        <exclusion>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+        </exclusion>
+    </exclusions>
+</dependency>
+
+<dependency>
+    <groupId>org.apache.kafka</groupId>
+    <artifactId>kafka-clients</artifactId>
+    <version>1.1.0</version>
+</dependency>
+
+<dependency>
+    <groupId>org.apache.kafka</groupId>
+    <artifactId>kafka-clients</artifactId>
+    <version>1.1.0</version>
+    <classifier>test</classifier>
+</dependency>
+
+<dependency>
+    <groupId>org.apache.kafka</groupId>
+    <artifactId>kafka_2.11</artifactId>
+    <version>1.1.0</version>
+</dependency>
+
+<dependency>
+    <groupId>org.apache.kafka</groupId>
+    <artifactId>kafka_2.11</artifactId>
+    <version>1.1.0</version>
+    <classifier>test</classifier>
+</dependency>
+----
+
 [[history]]
 == Change History
 

--- a/src/reference/asciidoc/testing.adoc
+++ b/src/reference/asciidoc/testing.adoc
@@ -5,6 +5,8 @@
 
 The `spring-kafka-test` jar contains some useful utilities to assist with testing your applications.
 
+NOTE: See <<deps-for-11x>> if you wish to use the 1.1.x `kafka-clients` jar with _version 2.1.x_.
+
 ==== JUnit
 
 `o.s.kafka.test.utils.KafkaTestUtils` provides some static methods to set up producer and consumer properties:

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -4,6 +4,9 @@
 
 This version requires the 1.0.0 `kafka-clients` or higher.
 
+NOTE: The 1.1.x client is supported, with _version 2.1.5_, but you will need to override dependencies as described in <<deps-for-11x>>.
+The 1.1.x client will be supported natively in _version 2.2_.
+
 ==== JSON Improvements
 
 The `StringJsonMessageConverter` and `JsonSerializer` now add type information in `Headers`, allowing the converter and `JsonDeserializer` to create specific types on reception, based on the message itself rather than a fixed configured type.


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-kafka/issues/634

Tested with

```xml
	<dependencies>
		<dependency>
			<groupId>org.springframework.boot</groupId>
			<artifactId>spring-boot-starter</artifactId>
		</dependency>
		<dependency>
			<groupId>org.springframework.kafka</groupId>
			<artifactId>spring-kafka</artifactId>
			<version>2.1.5.BUILD-SNAPSHOT</version>
		</dependency>

		<dependency>
			<groupId>org.springframework.kafka</groupId>
			<artifactId>spring-kafka-test</artifactId>
			<version>2.1.5.BUILD-SNAPSHOT</version>
			<scope>test</scope>
			<exclusions>
				<exclusion>
					<groupId>org.apache.kafka</groupId>
					<artifactId>kafka-clients</artifactId>
				</exclusion>
			</exclusions>
		</dependency>

		<dependency>
			<groupId>org.apache.kafka</groupId>
			<artifactId>kafka-clients</artifactId>
			<version>1.1.0</version>
		</dependency>

		<dependency>
			<groupId>org.apache.kafka</groupId>
			<artifactId>kafka-clients</artifactId>
			<version>1.1.0</version>
			<classifier>test</classifier>
		</dependency>

		<dependency>
			<groupId>org.apache.kafka</groupId>
			<artifactId>kafka_2.11</artifactId>
			<version>1.1.0</version>
		</dependency>

		<dependency>
			<groupId>org.apache.kafka</groupId>
			<artifactId>kafka_2.11</artifactId>
			<version>1.1.0</version>
			<classifier>test</classifier>
		</dependency>

		<dependency>
			<groupId>org.springframework.boot</groupId>
			<artifactId>spring-boot-starter-test</artifactId>
			<scope>test</scope>
		</dependency>
	</dependencies>
```