### PR TITLE
GH-646: Avoid sync when no transaction

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
@@ -302,9 +302,13 @@ public class DefaultKafkaProducerFactory<K, V> implements ProducerFactory<K, V>,
 		}
 
 		@Override
-		public synchronized void close() {
-			if (this.cache != null && !this.cache.contains(this)) {
-				this.cache.offer(this);
+		public void close() {
+			if (this.cache != null) {
+				synchronized (this) {
+					if (!this.cache.contains(this)) {
+						this.cache.offer(this);
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
Unfortunately, I had this local change that I failed to push to the PR #647 - it avoids synchronization when there transactions are not being used.

@artembilan I will do the merge/cherry-picking if you like, after your review.