### PR TITLE
KBGH-356: Fix thread naming with no bean name

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
@@ -153,9 +153,8 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 					container = new KafkaMessageListenerContainer<>(this, this.consumerFactory,
 							containerProperties, partitionSubset(containerProperties, i));
 				}
-				if (getBeanName() != null) {
-					container.setBeanName(getBeanName() + "-" + i);
-				}
+				String beanName = getBeanName();
+				container.setBeanName((beanName != null ? beanName : "consumer") + "-" + i);
 				if (getApplicationEventPublisher() != null) {
 					container.setApplicationEventPublisher(getApplicationEventPublisher());
 				}


### PR DESCRIPTION
See https://github.com/spring-cloud/spring-cloud-stream-binder-kafka/issues/356

Use token 'consumer' for thread prefix when no bean name.

**cherry-pick to 2.0.x, 1.3.x**