### PR TITLE
GH-667: Fix BatchErrorHandler for generic errors

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -781,11 +781,11 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 		 */
 		protected void handleConsumerException(Exception e) {
 			try {
-				if (this.errorHandler != null) {
+				if (!this.isBatchListener && this.errorHandler != null) {
 					this.errorHandler.handle(e, Collections.emptyList(), this.consumer,
 							KafkaMessageListenerContainer.this);
 				}
-				else if (this.batchErrorHandler != null) {
+				else if (this.isBatchListener && this.batchErrorHandler != null) {
 					this.batchErrorHandler.handle(e, new ConsumerRecords<K, V>(Collections.emptyMap()), this.consumer,
 							KafkaMessageListenerContainer.this);
 				}


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-kafka/issues/667

When catching exceptions outside of the listener (e.g. commit errors), the
`BatchErrorHandler` was never called since the record error handler gets a
logging handler.

Check listener type before invoking the error handler for consumer errors.