### PR TITLE
GH-683: Fix Transactions with ErrorHandler [2.1.x]

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -1112,12 +1112,7 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 						this.errorHandler.handle(e, record, this.consumer);
 					}
 					if (producer != null) {
-						try {
-							sendOffsetsToTransaction(producer);
-						}
-						catch (Exception e1) {
-							this.logger.error("Send offsets to transaction failed", e1);
-						}
+						ackCurrent(record, producer);
 					}
 				}
 				catch (RuntimeException ee) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/config/ContainerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/config/ContainerProperties.java
@@ -326,6 +326,13 @@ public class ContainerProperties {
 	 * offset of the failed message anyway, so this option has limited applicability.
 	 * Perhaps useful for a component that starts throwing exceptions consistently;
 	 * allowing it to resume when restarted from the last successfully processed message.
+	 * <p>
+	 * Does not apply when transactions are used - in that case, whether or not the
+	 * offsets are sent to the transaction depends on whether the transaction is committed
+	 * or rolled back. If a listener throws an exception, the transaction will normally
+	 * be rolled back unless an error handler is provided that handles the error and
+	 * exits normally; in which case the offsets are sent to the transaction and the
+	 * transaction is committed.
 	 * @param ackOnError whether the container should acknowledge messages that throw
 	 * exceptions.
 	 */


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-kafka/issues/683

If the error handler handles the error, the offset should be sent to the tx.

**cherry-pick to 2.0.x, 1.3.x**