### PR TITLE
GH-701: Support ConsumerRecords<?, ?> (@Klistener)

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/BatchMessageListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/BatchMessageListener.java
@@ -18,7 +18,12 @@ package org.springframework.kafka.listener;
 
 import java.util.List;
 
+import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.lang.Nullable;
 
 /**
  * Listener for handling a batch of incoming Kafka messages; the list
@@ -34,5 +39,29 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
  */
 @FunctionalInterface
 public interface BatchMessageListener<K, V> extends GenericMessageListener<List<ConsumerRecord<K, V>>> {
+
+
+	/**
+	 * Listener receives the original {@link ConsumerRecords} object instead of a
+	 * list of {@link ConsumerRecord}.
+	 * @param records the records.
+	 * @param acknowledgment the acknowledgment (null if not manual acks)
+	 * @param consumer the consumer.
+	 * @since 2.2
+	 */
+	default void onMessage(ConsumerRecords<K, V> records, @Nullable Acknowledgment acknowledgment,
+			Consumer<K, V> consumer) {
+		throw new UnsupportedOperationException("This batch listener doesn't support ConsumerRecords");
+	}
+
+	/**
+	 * Return true if this listener wishes to receive the original {@link ConsumerRecords}
+	 * object instead of a list of {@link ConsumerRecord}.
+	 * @return true for consumer records.
+	 * @since 2.2
+	 */
+	default boolean wantsPollResult() {
+		return false;
+	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -1366,9 +1366,8 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 		private Collection<ConsumerRecord<K, V>> getHighestOffsetRecords(ConsumerRecords<K, V> records) {
 			final Map<TopicPartition, ConsumerRecord<K, V>> highestOffsetMap = new HashMap<>();
 			records.partitions().forEach(tp -> {
-				records.records(tp).forEach(r ->
-					highestOffsetMap.compute(tp,
-						(k, v) -> v == null ? r : r.offset() > v.offset() ? r : v));
+					List<ConsumerRecord<K, V>> recordList = records.records(tp);
+					highestOffsetMap.put(tp, recordList.get(recordList.size() - 1));
 			});
 			return highestOffsetMap.values();
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/SeekToCurrentBatchErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/SeekToCurrentBatchErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,8 @@ public class SeekToCurrentBatchErrorHandler implements ContainerAwareBatchErrorH
 	public void handle(Exception thrownException, ConsumerRecords<?, ?> data, Consumer<?, ?> consumer,
 			MessageListenerContainer container) {
 		Map<TopicPartition, Long> offsets = new LinkedHashMap<>();
-		data.forEach(r -> offsets.computeIfAbsent(new TopicPartition(r.topic(), r.partition()), k -> r.offset()));
+		data.partitions()
+			.forEach(tp -> offsets.put(tp, data.records(tp).get(0).offset()));
 		offsets.forEach(consumer::seek);
 		throw new KafkaException("Seek to current after exception", thrownException);
 	}

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -707,6 +707,9 @@ The `- 100` leaves room for later phases to enable components to be auto-started
 [[kafka-listener-annotation]]
 ===== @KafkaListener Annotation
 
+[[record-listener]]
+====== Record Listeners
+
 The `@KafkaListener` annotation provides a mechanism for simple POJO listeners:
 
 [source, java]
@@ -813,6 +816,9 @@ public void listen(@Payload String foo,
 }
 ----
 
+[[batch-listeners]]
+====== Batch listeners
+
 Starting with _version 1.1_, `@KafkaListener` methods can be configured to receive the entire batch of consumer records received from the consumer poll.
 To configure the listener container factory to create batch listeners, set the `batchListener` property:
 
@@ -852,7 +858,7 @@ public void listen(List<String> list,
 }
 ----
 
-Alternatively you can receive a List of `Message<?>` objects with each offset, etc in each message, but it must be the only parameter (aside from an optional `Acknowledgment` when using manual commits) defined on the method:
+Alternatively you can receive a List of `Message<?>` objects with each offset, etc in each message, but it must be the only parameter (aside from optional `Acknowledgment`, when using manual commits, and/or `Consumer<?, ?>` parameters) defined on the method:
 
 [source, java]
 ----
@@ -865,6 +871,11 @@ public void listen14(List<Message<?>> list) {
 public void listen15(List<Message<?>> list, Acknowledgment ack) {
     ...
 }
+
+@KafkaListener(id = "listMsgAckConsumer", topics = "myTopic", containerFactory = "batchFactory")
+public void listen16(List<Message<?>> list, Acknowledgment ack, Consumer<?, ?> consumer) {
+    ...
+}
 ----
 
 No conversion is performed on the payloads in this case.
@@ -872,7 +883,7 @@ No conversion is performed on the payloads in this case.
 If the `BatchMessagingMessageConverter` is configured with a `RecordMessageConverter`, you can also add a generic type to the `Message` parameter and the payloads will be converted.
 See <<payload-conversion-with-batch>> for more information.
 
-You can also receive a list of `ConsumerRecord<?, ?>` objects but it must be the only parameter (aside from an optional `Acknowledgment` when using manual commits) defined on the method:
+You can also receive a list of `ConsumerRecord<?, ?>` objects but it must be the only parameter (aside from optional `Acknowledgment`, when using manual commits, and/or `Consumer<?, ?>` parameters) defined on the method:
 
 [source, java]
 ----
@@ -886,6 +897,20 @@ public void listen(List<ConsumerRecord<Integer, String>> list, Acknowledgment ac
     ...
 }
 ----
+
+Starting with _version 2.2_, the listener can receive the complete `ConsumerRecords<?, ?>` object returned by the `poll()` method, allowing the listener to access additional methods such as `partitions()` which returns the `TopicPartition` s in the list and `records(TopicPartition)` to get selective records.
+Again, this must be the only parameter (aside from optional `Acknowledgment`, when using manual commits, and/or `Consumer<?, ?>` parameters) on the method:
+
+[source, java]
+----
+@KafkaListener(id = "pollResults", topics = "myTopic", containerFactory = "batchFactory")
+public void pollResults(ConsumerRecords<?, ?> records) {
+    ...
+}
+----
+
+IMPORTANT: If the container factory has a `RecordFilterStrategy` configured, it will be ignored for `ConsumerRecords<?, ?>` listeners, with a WARNing log emitted.
+Records can only be filtered with a batch listener if the `<List<?>>` form of listener is used.
 
 Starting with _version 2.0_, the `id` attribute (if present) is used as the Kafka `group.id` property, overriding the configured property in the consumer factory, if present.
 You can also set `groupId` explicitly, or set `idIsGroup` to false, to restore the previous behavior of using the consumer factory `group.id`.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -26,3 +26,7 @@ See <<container-factory>> for more information.
 A new container property `missingTopicsFatal` has been added.
 
 See <<kafka-container>> for more information.
+
+Batch listeners can optionally receive the complete `ConsumerRecords<?, ?>` object instead of a `List<ConsumerRecord<?, ?>`.
+
+See <<batch-listeners>> for more information.


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/701

Support passing the entire `ConsumerRecords<?, ?>` object to the listener.
Record filtering is not applied in this case.