### PR TITLE
Exclude Spring 4.X dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -190,7 +190,7 @@ project ('spring-kafka') {
 		compile "org.springframework:spring-messaging:$springVersion"
 		compile "org.springframework:spring-tx:$springVersion"
 		compile ("org.springframework.retry:spring-retry:$springRetryVersion") {
-			exclude group: 'org.springframework'
+			exclude group: 'org.springframework', module: 'spring-core'
 		}
 		compile "org.apache.kafka:kafka-clients:$kafkaVersion"
 		compile ("org.apache.kafka:kafka-streams:$kafkaVersion", optional)

--- a/build.gradle
+++ b/build.gradle
@@ -189,7 +189,9 @@ project ('spring-kafka') {
 		compile "org.springframework:spring-context:$springVersion"
 		compile "org.springframework:spring-messaging:$springVersion"
 		compile "org.springframework:spring-tx:$springVersion"
-		compile "org.springframework.retry:spring-retry:$springRetryVersion"
+		compile ("org.springframework.retry:spring-retry:$springRetryVersion") {
+			exclude group: 'org.springframework'
+		}
 		compile "org.apache.kafka:kafka-clients:$kafkaVersion"
 		compile ("org.apache.kafka:kafka-streams:$kafkaVersion", optional)
 


### PR DESCRIPTION
Exclusion of Spring 4.X transitive dependencies from Spring-Retry
#719 