### PR TITLE
Add ErrorHandlingDeserializer

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -65,6 +65,7 @@ import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.kafka.support.LogIfLevelEnabled;
 import org.springframework.kafka.support.TopicPartitionInitialOffset;
 import org.springframework.kafka.support.TopicPartitionInitialOffset.SeekPosition;
+import org.springframework.kafka.support.serializer.DeserializationException;
 import org.springframework.kafka.transaction.KafkaAwareTransactionManager;
 import org.springframework.scheduling.SchedulingAwareRunnable;
 import org.springframework.scheduling.TaskScheduler;
@@ -1095,6 +1096,12 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 				@SuppressWarnings("rawtypes") Producer producer,
 				Iterator<ConsumerRecord<K, V>> iterator) throws Error {
 			try {
+				if (record.value() instanceof DeserializationException) {
+					throw (DeserializationException) record.value();
+				}
+				if (record.key() instanceof DeserializationException) {
+					throw (DeserializationException) record.key();
+				}
 				switch (this.listenerType) {
 					case ACKNOWLEDGING_CONSUMER_AWARE:
 						this.listener.onMessage(record,

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DeserializationException.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DeserializationException.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support.serializer;
+
+import org.springframework.kafka.KafkaException;
+
+/**
+ * Exception returned in the consumer record value or key when a deserialization failure
+ * occurs.
+ *
+ * @author Gary Russell
+ * @since 2.2
+ *
+ */
+@SuppressWarnings("serial")
+public class DeserializationException extends KafkaException {
+
+	private final byte[] data;
+
+	private final boolean isKey;
+
+	public DeserializationException(String message, byte[] data, boolean isKey, Throwable cause) {
+		super(message, cause);
+		this.data = data;
+		this.isKey = isKey;
+	}
+
+	public byte[] getData() {
+		return this.data;
+	}
+
+	public boolean isKey() {
+		return this.isKey;
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ErrorHandlingDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ErrorHandlingDeserializer.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support.serializer;
+
+import java.util.Map;
+
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.serialization.ExtendedDeserializer;
+
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
+
+/**
+ * Delegating key/value deserializer that catches exceptions, returning them
+ * in the consumer record.
+ *
+ * @author Gary Russell
+ * @since 2.2
+ *
+ */
+public class ErrorHandlingDeserializer implements ExtendedDeserializer<Object> {
+
+	public static final String KEY_DESERIALIZER_CLASS = "spring.deserializer.key.delegate.class";
+
+	public static final String VALUE_DESERIALIZER_CLASS = "spring.deserializer.value.delegate.class";
+
+	private ExtendedDeserializer<Object> delegate;
+
+	private boolean isKey;
+
+	public ErrorHandlingDeserializer() {
+		super();
+	}
+
+	public ErrorHandlingDeserializer(ExtendedDeserializer<Object> delegate) {
+		this.delegate = delegate;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public void configure(Map<String, ?> configs, boolean isKey) {
+		if (isKey && configs.containsKey(KEY_DESERIALIZER_CLASS)) {
+				try {
+					Object value = configs.get(KEY_DESERIALIZER_CLASS);
+					Class<?> clazz = value instanceof Class ? (Class<?>) value : ClassUtils.forName((String) value, null);
+					this.delegate = (ExtendedDeserializer<Object>) clazz.newInstance();
+				}
+				catch (ClassNotFoundException | LinkageError | InstantiationException | IllegalAccessException e) {
+					throw new IllegalStateException(e);
+				}
+		}
+		else if (!isKey && configs.containsKey(VALUE_DESERIALIZER_CLASS)) {
+			try {
+				Object value = configs.get(VALUE_DESERIALIZER_CLASS);
+				Class<?> clazz = value instanceof Class ? (Class<?>) value : ClassUtils.forName((String) value, null);
+				this.delegate = (ExtendedDeserializer<Object>) clazz.newInstance();
+			}
+			catch (ClassNotFoundException | LinkageError | InstantiationException | IllegalAccessException e) {
+				throw new IllegalStateException(e);
+			}
+		}
+		Assert.state(this.delegate != null, "No delegate deserializer configured");
+		this.delegate.configure(configs, isKey);
+		this.isKey = isKey;
+	}
+
+	@Override
+	public Object deserialize(String topic, byte[] data) {
+		try {
+			return this.delegate.deserialize(topic, data);
+		}
+		catch (Exception e) {
+			return new DeserializationException("Failed to deserialize", data, this.isKey, e);
+		}
+	}
+
+	@Override
+	public void close() {
+		this.delegate.close();
+	}
+
+	@Override
+	public Object deserialize(String topic, Headers headers, byte[] data) {
+		try {
+			return this.delegate.deserialize(topic, headers, data);
+		}
+		catch (Exception e) {
+			return new DeserializationException("Failed to deserialize", data, this.isKey, e);
+		}
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ErrorHandlingDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ErrorHandlingDeserializer.java
@@ -34,8 +34,14 @@ import org.springframework.util.ClassUtils;
  */
 public class ErrorHandlingDeserializer implements ExtendedDeserializer<Object> {
 
+	/**
+	 * Property name for the delegate key deserializer.
+	 */
 	public static final String KEY_DESERIALIZER_CLASS = "spring.deserializer.key.delegate.class";
 
+	/**
+	 * Property name for the delegate value deserializer.
+	 */
 	public static final String VALUE_DESERIALIZER_CLASS = "spring.deserializer.value.delegate.class";
 
 	private ExtendedDeserializer<Object> delegate;

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ErrorHandlingDeserializerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ErrorHandlingDeserializerTests.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.serialization.ExtendedDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.DeserializationException;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
+import org.springframework.kafka.test.rule.KafkaEmbedded;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+/**
+ * @author Gary Russell
+ * @since 2.2
+ *
+ */
+@SpringJUnitConfig
+@DirtiesContext
+public class ErrorHandlingDeserializerTests {
+
+	private static final String TOPIC = "ehdt";
+
+	@Autowired
+	public Config config;
+
+	@Test
+	public void testBadDeser() throws Exception {
+		this.config.template().send(TOPIC, "foo", "bar");
+		this.config.template().send(TOPIC, "fail", "bar");
+		this.config.template().send(TOPIC, "foo", "fail");
+		assertThat(this.config.latch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(this.config.goodCount).isEqualTo(1);
+		assertThat(this.config.keyErrorCount).isEqualTo(1);
+		assertThat(this.config.valueErrorCount).isEqualTo(1);
+	}
+
+	@Configuration
+	@EnableKafka
+	public static class Config {
+
+		private final CountDownLatch latch = new CountDownLatch(3);
+
+		private int goodCount;
+
+		private int keyErrorCount;
+
+		private int valueErrorCount;
+
+		@KafkaListener(topics = TOPIC)
+		public void listen(ConsumerRecord<String, String> record) {
+			this.goodCount++;
+			this.latch.countDown();
+		}
+
+
+		@Bean
+		public KafkaEmbedded embeddedKafka() {
+			return new KafkaEmbedded(1, true, 1, TOPIC);
+		}
+
+		@Bean
+		public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+			ConcurrentKafkaListenerContainerFactory<String, String> factory =
+					new ConcurrentKafkaListenerContainerFactory<>();
+			factory.setConsumerFactory(cf());
+			factory.setErrorHandler((t, r) -> {
+				if (r.value() instanceof DeserializationException) {
+					this.valueErrorCount++;
+				}
+				else if (r.key() instanceof DeserializationException) {
+					this.keyErrorCount++;
+				}
+				this.latch.countDown();
+			});
+			return factory;
+		}
+
+		@Bean
+		public ConsumerFactory<String, String> cf() {
+			Map<String, Object> props = KafkaTestUtils.consumerProps(TOPIC, "false", embeddedKafka());
+			props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+			props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+			props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+			props.put(ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS, FailSometimesDeserializer.class);
+			props.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, FailSometimesDeserializer.class.getName());
+			return new DefaultKafkaConsumerFactory<>(props);
+		}
+
+		@Bean
+		public ProducerFactory<String, String> pf() {
+			Map<String, Object> props = KafkaTestUtils.producerProps(embeddedKafka());
+			props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+			return new DefaultKafkaProducerFactory<>(props);
+		}
+
+		@Bean
+		public KafkaTemplate<String, String> template() {
+			return new KafkaTemplate<>(pf());
+		}
+
+	}
+
+	public static class FailSometimesDeserializer implements ExtendedDeserializer<String> {
+
+		@Override
+		public void configure(Map<String, ?> configs, boolean isKey) {
+		}
+
+		@Override
+		public String deserialize(String topic, byte[] data) {
+			return new String(data);
+		}
+
+		@Override
+		public void close() {
+		}
+
+		@Override
+		public String deserialize(String topic, Headers headers, byte[] data) {
+			String string = new String(data);
+			if ("fail".equals(string)) {
+				throw new RuntimeException("fail");
+			}
+			return string;
+		}
+
+	}
+
+}

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -1546,6 +1546,34 @@ NOTE: When using the `StringJsonMessageConverter`, you should use a `StringDeser
 When using the `BytesJsonMessageConverter`, you should use a `BytesDeserializer` in the kafka consumer configuration and `BytesSerializer` in the kafka producer configuration, when using Spring Integration or the `KafkaTemplate.send(Message<?> message)` method.
 Generally, the `BytesJsonMessageConverter` is more efficient because it avoids a `String` to/from `byte[]` conversion.
 
+[[error-handling-deserializer]]
+===== ErrorHandlingDeserializer
+
+When a deserializer fails to deserialize a message, Spring has no way to handle the problem because it occurs before the `poll()` returns.
+To solve this problem, version 2.2 introduced the `ErrorHandlingDeserializer`.
+This deserializer delegates to a real deserializer (key or value).
+If the delegate fails to deserialize the record content, the `ErrorHandlingDeserializer` returns a `DeserializationException` instead, containing the cause and raw bytes.
+When using a record-level `MessageListener`, if either the key or value contains a `DeserializationException`, the container's `ErrorHandler` is called with the failed `ConsumerRecord`.
+When using a `BatchMessageListener`, the failed record is passed to the application along with the remaining records in the batch, so it is the responsibility of the application listener to check whether the key or value in a particular record is a `DeserializationException`.
+
+You can use the `DefaultKafkaConsumerFactory` constructor that takes key and value `Deserializer` objects and wire in appropriate `ErrorHandlingDeserializer` configured with the proper delegates.
+Alternatively, you can use consumer configuration properties which are used by the `ErrorHandlingDeserializer` to instantiate the delegates.
+The property names are `ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS` and `ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS`; the property value can be a class or class name.
+For example:
+
+[source, java]
+----
+... // other props
+props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+props.put(ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS, JsonDeserializer.class);
+props.put(JsonDeserializer.KEY_DEFAULT_TYPE, "com.example.MyKey")
+props.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, JsonDeserializer.class.getName());
+props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, "com.example.MyValue")
+props.put(JsonDeserializer.TRUSTED_PACKAGES, "com.example")
+return new DefaultKafkaConsumerFactory<>(props);
+----
+
 [[payload-conversion-with-batch]]
 ===== Payload Conversion with Batch Listeners
 


### PR DESCRIPTION
A delegating deserializer that populates the key or value with a
`DeserializationException` containing the raw data when deserialization
fails.