### PR TITLE
GH-725: Fix return Collection<Message<?>>

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/InvocationResult.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/InvocationResult.java
@@ -30,9 +30,12 @@ public final class InvocationResult {
 
 	private final Expression sendTo;
 
-	public InvocationResult(Object result, Expression sendTo) {
+	private final boolean messageReturnType;
+
+	public InvocationResult(Object result, Expression sendTo, boolean messageReturnType) {
 		this.result = result;
 		this.sendTo = sendTo;
+		this.messageReturnType = messageReturnType;
 	}
 
 	public Object getResult() {
@@ -41,6 +44,10 @@ public final class InvocationResult {
 
 	public Expression getSendTo() {
 		return this.sendTo;
+	}
+
+	public boolean isMessageReturnType() {
+		return this.messageReturnType;
 	}
 
 	@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/KafkaUtils.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/KafkaUtils.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collection;
+
+import org.springframework.messaging.Message;
+
+/**
+ * Utility methods.
+ *
+ * @author Gary Russell
+ *
+ * @since 2.2
+ *
+ */
+public final class KafkaUtils {
+
+	/**
+	 * Return true if the method return type is {@link Message} or
+	 * {@code Collection<Message<?>>}.
+	 * @param method the method.
+	 * @return true if it returns message(s).
+	 */
+	public static boolean returnTypeMessageOrCollectionOf(Method method) {
+		Type returnType = method.getGenericReturnType();
+		if (returnType.equals(Message.class)) {
+			return true;
+		}
+		if (returnType instanceof ParameterizedType) {
+			ParameterizedType prt = (ParameterizedType) returnType;
+			Type rawType = prt.getRawType();
+			if (rawType.equals(Message.class)) {
+				return true;
+			}
+			if (rawType.equals(Collection.class)) {
+				Type collectionType = prt.getActualTypeArguments()[0];
+				if (collectionType.equals(Message.class)) {
+					return true;
+				}
+				return collectionType instanceof ParameterizedType
+						&& ((ParameterizedType) collectionType).getRawType().equals(Message.class);
+			}
+		}
+		return false;
+
+	}
+
+	private KafkaUtils() {
+		super();
+	}
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/BatchListenerConversionTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/BatchListenerConversionTests.java
@@ -18,11 +18,13 @@ package org.springframework.kafka.annotation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -48,7 +50,9 @@ import org.springframework.kafka.test.rule.KafkaEmbedded;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.support.GenericMessage;
+import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -66,7 +70,8 @@ public class BatchListenerConversionTests {
 	private static final String DEFAULT_TEST_GROUP_ID = "blc";
 
 	@ClassRule // one topic to preserve order
-	public static KafkaEmbedded embeddedKafka = new KafkaEmbedded(1, true, 1, "blc1", "blc2", "blc3");
+	public static KafkaEmbedded embeddedKafka = new KafkaEmbedded(1, true, 1, "blc1", "blc2", "blc3",
+			"blc4", "blc5");
 
 	@Autowired
 	private Config config;
@@ -108,22 +113,40 @@ public class BatchListenerConversionTests {
 		assertThat(listener.received.get(0).getPayload().getBar()).isEqualTo("bar");
 	}
 
+	@Test
+	public void testBatchReplies() throws Exception {
+		Listener4 listener = this.config.listener4();
+		String topic = "blc4";
+		this.template.send(new GenericMessage<>(
+				new Foo("bar"), Collections.singletonMap(KafkaHeaders.TOPIC, topic)));
+		this.template.send(new GenericMessage<>(
+				new Foo("baz"), Collections.singletonMap(KafkaHeaders.TOPIC, topic)));
+		assertThat(listener.latch1.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(listener.received.size()).isGreaterThan(0);
+		assertThat(listener.received.get(0)).isInstanceOf(Foo.class);
+		assertThat(listener.received.get(0).bar).isEqualTo("bar");
+		assertThat(listener.replies.size()).isGreaterThan(0);
+		assertThat(listener.replies.get(0)).isInstanceOf(Foo.class);
+		assertThat(listener.replies.get(0).bar).isEqualTo("BAR");
+	}
+
 	@Configuration
 	@EnableKafka
 	public static class Config {
 
 		@Bean
 		public KafkaListenerContainerFactory<?> kafkaListenerContainerFactory() {
-			ConcurrentKafkaListenerContainerFactory<Integer, String> factory =
+			ConcurrentKafkaListenerContainerFactory<Integer, Foo> factory =
 					new ConcurrentKafkaListenerContainerFactory<>();
 			factory.setConsumerFactory(consumerFactory());
 			factory.setBatchListener(true);
 			factory.setMessageConverter(new BatchMessagingMessageConverter(converter()));
+			factory.setReplyTemplate(template());
 			return factory;
 		}
 
 		@Bean
-		public DefaultKafkaConsumerFactory<Integer, String> consumerFactory() {
+		public DefaultKafkaConsumerFactory<Integer, Foo> consumerFactory() {
 			return new DefaultKafkaConsumerFactory<>(consumerConfigs());
 		}
 
@@ -173,6 +196,11 @@ public class BatchListenerConversionTests {
 		@Bean
 		public Listener3 listener3() {
 			return new Listener3();
+		}
+
+		@Bean
+		public Listener4 listener4() {
+			return new Listener4();
 		}
 
 	}
@@ -229,6 +257,35 @@ public class BatchListenerConversionTests {
 			if (this.received == null) {
 				this.received = foos;
 			}
+			this.latch1.countDown();
+		}
+
+	}
+
+	public static class Listener4 {
+
+		private final CountDownLatch latch1 = new CountDownLatch(1);
+
+		private List<Foo> received;
+
+		private List<Foo> replies;
+
+		@KafkaListener(topics = "blc4", groupId = "blc4")
+		@SendTo
+		public Collection<Message<?>> listen1(List<Foo> foos) {
+			if (this.received == null) {
+				this.received = foos;
+			}
+			return foos.stream().map(f -> MessageBuilder.withPayload(new Foo(f.getBar().toUpperCase()))
+					.setHeader(KafkaHeaders.TOPIC, "blc5")
+					.setHeader(KafkaHeaders.MESSAGE_KEY, 42)
+					.build())
+				.collect(Collectors.toList());
+		}
+
+		@KafkaListener(topics = "blc5", groupId = "blc5")
+		public void listen2(List<Foo> foos) {
+			this.replies = foos;
 			this.latch1.countDown();
 		}
 

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -1171,6 +1171,22 @@ public KafkaTemplate<String, String> myReplyingTemplate() {
 }
 ----
 
+IMPORTANT: If the listener method returns `Message<?>` or `Collection<Messge<?>>` the listener method is responsible for setting up the message headers for the reply; for example, when handling a request from a `ReplyingKafkaTemplate`, you might do the following:
+
+[source, java]
+----
+@KafkaListener(id = "messageReturned", topics = "someTopic")
+public Message<?> listen(String in, @Header(KafkaHeaders.REPLY_TOPIC) byte[] replyTo,
+        @Header(KafkaHeaders.CORRELATION_ID) byte[] correlation) {
+    return MessageBuilder.withPayload(in.toUpperCase())
+            .setHeader(KafkaHeaders.TOPIC, replyTo)
+            .setHeader(KafkaHeaders.MESSAGE_KEY, 42)
+            .setHeader(KafkaHeaders.CORRELATION_ID, correlation)
+            .setHeader("someOtherHeader", "someValue")
+            .build();
+}
+----
+
 When using request/reply semantics, the target partition can be requested by the sender.
 
 NOTE: You can annotate a `@KafkaListener` method with `@SendTo` even if no result is returned.


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-kafka/issues/725
Fixes https://github.com/spring-projects/spring-kafka/issues/726

Handle return type `Collection<Message<?>>`.
Allow empty `@SendTo` when the return type is `Message<?>` (or a collection thereof).