### PR TITLE
GH-732: Refactor KafkaEmbedded for JUnit 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -219,14 +219,12 @@ project ('spring-kafka-test') {
 		compile "org.apache.kafka:kafka_$scalaVersion:$kafkaVersion"
 		compile "org.apache.kafka:kafka_$scalaVersion:$kafkaVersion:test"
 
-		compile ("junit:junit:$junit4Version") {
-			exclude group: 'org.hamcrest', module: 'hamcrest-core'
-		}
-		compile ("org.mockito:mockito-core:$mockitoVersion") {
-			exclude group: 'org.hamcrest', module: 'hamcrest-core'
-		}
-
 		compile ("org.hamcrest:hamcrest-all:$hamcrestVersion", optional)
+
+		compile ("org.mockito:mockito-core:$mockitoVersion", optional)
+
+		compile ("junit:junit:$junit4Version", optional)
+
 		compile ("org.assertj:assertj-core:$assertjVersion", optional)
 		compile ("org.apache.logging.log4j:log4j-core:$log4jVersion", optional)
 	}

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaBroker.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaBroker.java
@@ -1,0 +1,442 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.I0Itec.zkclient.ZkClient;
+import org.I0Itec.zkclient.exception.ZkInterruptedException;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.CreateTopicsResult;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.security.auth.SecurityProtocol;
+import org.apache.kafka.common.utils.Time;
+
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.kafka.test.core.BrokerAddress;
+import org.springframework.kafka.test.rule.EmbeddedKafkaRule;
+import org.springframework.retry.backoff.ExponentialBackOffPolicy;
+import org.springframework.retry.policy.SimpleRetryPolicy;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.util.Assert;
+
+import kafka.common.KafkaException;
+import kafka.server.KafkaConfig;
+import kafka.server.KafkaServer;
+import kafka.server.NotRunning;
+import kafka.utils.CoreUtils;
+import kafka.utils.TestUtils;
+import kafka.utils.ZKStringSerializer$;
+import kafka.zk.EmbeddedZookeeper;
+
+/**
+ * An embedded Kafka Broker(s) and Zookeeper manager.
+ * This class is intended to be used in the unit tests.
+ *
+ * @author Marius Bogoevici
+ * @author Artem Bilan
+ * @author Gary Russell
+ * @author Kamill Sokol
+ * @author Elliot Kennedy
+ * @author Nakul Mishra
+ *
+ * @since 2.2
+ */
+public class EmbeddedKafkaBroker implements InitializingBean, DisposableBean {
+
+	private static final Log logger = LogFactory.getLog(EmbeddedKafkaRule.class);
+
+	public static final String BEAN_NAME = "embeddedKafka";
+
+	public static final String SPRING_EMBEDDED_KAFKA_BROKERS = "spring.embedded.kafka.brokers";
+
+	public static final String SPRING_EMBEDDED_ZOOKEEPER_CONNECT = "spring.embedded.zookeeper.connect";
+
+	private final int count;
+
+	private final boolean controlledShutdown;
+
+	private final Set<String> topics;
+
+	private final int partitionsPerTopic;
+
+	private final List<KafkaServer> kafkaServers = new ArrayList<>();
+
+	private final Map<String, Object> brokerProperties = new HashMap<>();
+
+	private EmbeddedZookeeper zookeeper;
+
+	private ZkClient zookeeperClient;
+
+	private String zkConnect;
+
+	private int[] kafkaPorts;
+
+	public EmbeddedKafkaBroker(int count) {
+		this(count, false);
+	}
+
+	/**
+	 * Create embedded Kafka brokers.
+	 * @param count the number of brokers.
+	 * @param controlledShutdown passed into TestUtils.createBrokerConfig.
+	 * @param topics the topics to create (2 partitions per).
+	 */
+	public EmbeddedKafkaBroker(int count, boolean controlledShutdown, String... topics) {
+		this(count, controlledShutdown, 2, topics);
+	}
+
+	/**
+	 * Create embedded Kafka brokers listening on random ports.
+	 * @param count the number of brokers.
+	 * @param controlledShutdown passed into TestUtils.createBrokerConfig.
+	 * @param partitions partitions per topic.
+	 * @param topics the topics to create.
+	 */
+	public EmbeddedKafkaBroker(int count, boolean controlledShutdown, int partitions, String... topics) {
+		this.count = count;
+		this.kafkaPorts = new int[this.count]; // random ports by default.
+		this.controlledShutdown = controlledShutdown;
+		if (topics != null) {
+			this.topics = new HashSet<>(Arrays.asList(topics));
+		}
+		else {
+			this.topics = new HashSet<>();
+		}
+		this.partitionsPerTopic = partitions;
+	}
+
+	/**
+	 * Specify the properties to configure Kafka Broker before start, e.g.
+	 * {@code auto.create.topics.enable}, {@code transaction.state.log.replication.factor} etc.
+	 * @param brokerProperties the properties to use for configuring Kafka Broker(s).
+	 * @return this for chaining configuration
+	 * @see KafkaConfig
+	 */
+	public EmbeddedKafkaBroker brokerProperties(Map<String, String> brokerProperties) {
+		this.brokerProperties.putAll(brokerProperties);
+		return this;
+	}
+
+	/**
+	 * Specify a broker property.
+	 * @param property the property name.
+	 * @param value the value.
+	 * @return the {@link EmbeddedKafkaRule}.
+	 */
+	public EmbeddedKafkaBroker brokerProperty(String property, Object value) {
+		this.brokerProperties.put(property, value);
+		return this;
+	}
+
+	/**
+	 * Set explicit ports on which the kafka brokers will listen. Useful when running an
+	 * embedded broker that you want to access from other processes.
+	 * @param kafkaPorts the ports.
+	 */
+	public EmbeddedKafkaBroker kafkaPorts(int... kafkaPorts) {
+		Assert.isTrue(kafkaPorts.length == this.count, "A port must be provided for each instance ["
+				+ this.count + "], provided: " + Arrays.toString(kafkaPorts) + ", use 0 for a random port");
+		this.kafkaPorts = kafkaPorts;
+		return this;
+	}
+
+	@Override
+	public void afterPropertiesSet() {
+		this.zookeeper = new EmbeddedZookeeper();
+		int zkConnectionTimeout = 6000;
+		int zkSessionTimeout = 6000;
+
+		this.zkConnect = "127.0.0.1:" + this.zookeeper.port();
+		this.zookeeperClient = new ZkClient(this.zkConnect, zkSessionTimeout, zkConnectionTimeout,
+				ZKStringSerializer$.MODULE$);
+		this.kafkaServers.clear();
+		for (int i = 0; i < this.count; i++) {
+			Properties brokerConfigProperties = createBrokerProperties(i);
+			brokerConfigProperties.setProperty(KafkaConfig.ReplicaSocketTimeoutMsProp(), "1000");
+			brokerConfigProperties.setProperty(KafkaConfig.ControllerSocketTimeoutMsProp(), "1000");
+			brokerConfigProperties.setProperty(KafkaConfig.OffsetsTopicReplicationFactorProp(), "1");
+			brokerConfigProperties.setProperty(KafkaConfig.ReplicaHighWatermarkCheckpointIntervalMsProp(),
+					String.valueOf(Long.MAX_VALUE));
+			if (this.brokerProperties != null) {
+				this.brokerProperties.forEach(brokerConfigProperties::put);
+			}
+			KafkaServer server = TestUtils.createServer(new KafkaConfig(brokerConfigProperties), Time.SYSTEM);
+			this.kafkaServers.add(server);
+			if (this.kafkaPorts[i] == 0) {
+				this.kafkaPorts[i] = TestUtils.boundPort(server, SecurityProtocol.PLAINTEXT);
+			}
+		}
+		createKafkaTopics(this.topics);
+		System.setProperty(SPRING_EMBEDDED_KAFKA_BROKERS, getBrokersAsString());
+		System.setProperty(SPRING_EMBEDDED_ZOOKEEPER_CONNECT, getZookeeperConnectionString());
+	}
+
+	private Properties createBrokerProperties(int i) {
+		return TestUtils.createBrokerConfig(i, this.zkConnect, this.controlledShutdown,
+				true, this.kafkaPorts[i],
+				scala.Option.apply(null),
+				scala.Option.apply(null),
+				scala.Option.apply(null),
+				true, false, 0, false, 0, false, 0, scala.Option.apply(null), 1, false);
+	}
+
+	/**
+	 * Create topics in the existing broker(s) using the configured number of partitions.
+	 * @param topics the topics.
+	 */
+	private void createKafkaTopics(Set<String> topics) {
+		doWithAdmin(admin -> {
+			List<NewTopic> newTopics = topics.stream()
+					.map(t -> new NewTopic(t, this.partitionsPerTopic, (short) this.count))
+					.collect(Collectors.toList());
+			CreateTopicsResult createTopics = admin.createTopics(newTopics);
+			try {
+				createTopics.all().get();
+			}
+			catch (Exception e) {
+				throw new KafkaException(e);
+			}
+		});
+	}
+
+
+	/**
+	 * Add topics to the existing broker(s) using the configured number of partitions.
+	 * @param topics the topics.
+	 */
+	public void addTopics(String... topics) {
+		HashSet<String> set = new HashSet<>(Arrays.asList(topics));
+		createKafkaTopics(set);
+		this.topics.addAll(set);
+	}
+
+	/**
+	 * Create an {@link AdminClient}; invoke the callback and reliably close the admin.
+	 * @param callback the callback.
+	 */
+	public void doWithAdmin(java.util.function.Consumer<AdminClient> callback) {
+		Map<String, Object> adminConfigs = new HashMap<>();
+		adminConfigs.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, getBrokersAsString());
+		try (AdminClient admin = AdminClient.create(adminConfigs)) {
+			callback.accept(admin);
+		}
+	}
+
+	@Override
+	public void destroy() {
+		System.getProperties().remove(SPRING_EMBEDDED_KAFKA_BROKERS);
+		System.getProperties().remove(SPRING_EMBEDDED_ZOOKEEPER_CONNECT);
+		for (KafkaServer kafkaServer : this.kafkaServers) {
+			try {
+				if (kafkaServer.brokerState().currentState() != (NotRunning.state())) {
+					kafkaServer.shutdown();
+					kafkaServer.awaitShutdown();
+				}
+			}
+			catch (Exception e) {
+				// do nothing
+			}
+			try {
+				CoreUtils.delete(kafkaServer.config().logDirs());
+			}
+			catch (Exception e) {
+				// do nothing
+			}
+		}
+		try {
+			this.zookeeperClient.close();
+		}
+		catch (ZkInterruptedException e) {
+			// do nothing
+		}
+		try {
+			this.zookeeper.shutdown();
+		}
+		catch (Exception e) {
+			// do nothing
+		}
+	}
+
+	public Set<String> getTopics() {
+		return new HashSet<>(this.topics);
+	}
+
+	public List<KafkaServer> getKafkaServers() {
+		return this.kafkaServers;
+	}
+
+	public KafkaServer getKafkaServer(int id) {
+		return this.kafkaServers.get(id);
+	}
+
+	public EmbeddedZookeeper getZookeeper() {
+		return this.zookeeper;
+	}
+
+	public ZkClient getZkClient() {
+		return this.zookeeperClient;
+	}
+
+	public String getZookeeperConnectionString() {
+		return this.zkConnect;
+	}
+
+	public BrokerAddress getBrokerAddress(int i) {
+		KafkaServer kafkaServer = this.kafkaServers.get(i);
+		return new BrokerAddress("127.0.0.1", kafkaServer.config().port());
+	}
+
+	public BrokerAddress[] getBrokerAddresses() {
+		List<BrokerAddress> addresses = new ArrayList<BrokerAddress>();
+		for (int i = 0; i < this.kafkaPorts.length; i++) {
+			addresses.add(new BrokerAddress("127.0.0.1", this.kafkaPorts[i]));
+		}
+		return addresses.toArray(new BrokerAddress[addresses.size()]);
+	}
+
+	public int getPartitionsPerTopic() {
+		return this.partitionsPerTopic;
+	}
+
+	public void bounce(BrokerAddress brokerAddress) {
+		for (KafkaServer kafkaServer : getKafkaServers()) {
+			if (brokerAddress.equals(new BrokerAddress(kafkaServer.config().hostName(), kafkaServer.config().port()))) {
+				kafkaServer.shutdown();
+				kafkaServer.awaitShutdown();
+			}
+		}
+	}
+
+	public void restart(final int index) throws Exception { //NOSONAR
+
+		// retry restarting repeatedly, first attempts may fail
+
+		SimpleRetryPolicy retryPolicy = new SimpleRetryPolicy(10, Collections.singletonMap(Exception.class, true));
+
+		ExponentialBackOffPolicy backOffPolicy = new ExponentialBackOffPolicy();
+		backOffPolicy.setInitialInterval(100);
+		backOffPolicy.setMaxInterval(1000);
+		backOffPolicy.setMultiplier(2);
+
+		RetryTemplate retryTemplate = new RetryTemplate();
+		retryTemplate.setRetryPolicy(retryPolicy);
+		retryTemplate.setBackOffPolicy(backOffPolicy);
+
+
+		retryTemplate.execute(context -> {
+			this.kafkaServers.get(index).startup();
+			return null;
+		});
+	}
+
+	public String getBrokersAsString() {
+		StringBuilder builder = new StringBuilder();
+		for (BrokerAddress brokerAddress : getBrokerAddresses()) {
+			builder.append(brokerAddress.toString()).append(',');
+		}
+		return builder.substring(0, builder.length() - 1);
+	}
+
+	/**
+	 * Subscribe a consumer to all the embedded topics.
+	 * @param consumer the consumer.
+	 * @throws Exception an exception.
+	 */
+	public void consumeFromAllEmbeddedTopics(Consumer<?, ?> consumer) throws Exception {
+		consumeFromEmbeddedTopics(consumer, this.topics.toArray(new String[0]));
+	}
+
+	/**
+	 * Subscribe a consumer to one of the embedded topics.
+	 * @param consumer the consumer.
+	 * @param topic the topic.
+	 * @throws Exception an exception.
+	 */
+	public void consumeFromAnEmbeddedTopic(Consumer<?, ?> consumer, String topic) throws Exception {
+		consumeFromEmbeddedTopics(consumer, topic);
+	}
+
+	/**
+	 * Subscribe a consumer to one or more of the embedded topics.
+	 * @param consumer the consumer.
+	 * @param topics the topics.
+	 * @throws Exception an exception.
+	 */
+	public void consumeFromEmbeddedTopics(Consumer<?, ?> consumer, String... topics) throws Exception {
+		HashSet<String> diff = new HashSet<>(Arrays.asList(topics));
+		diff.removeAll(new HashSet<>(this.topics));
+		assertThat(this.topics)
+				.as("topic(s):'" + diff + "' are not in embedded topic list")
+				.containsAll(new HashSet<>(Arrays.asList(topics)));
+		final CountDownLatch consumerLatch = new CountDownLatch(1);
+		consumer.subscribe(Arrays.asList(topics), new ConsumerRebalanceListener() {
+
+			@Override
+			public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
+			}
+
+			@Override
+			public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
+				consumerLatch.countDown();
+				if (logger.isDebugEnabled()) {
+					logger.debug("partitions assigned: " + partitions);
+				}
+			}
+
+		});
+		ConsumerRecords<?, ?> records = consumer.poll(0); // force assignment
+		if (records.count() > 0) {
+			if (logger.isDebugEnabled()) {
+				logger.debug("Records received on initial poll for assignment; re-seeking to beginning; "
+						+ records.partitions().stream()
+						.flatMap(p -> records.records(p).stream())
+						// map to same format as send metadata toString()
+						.map(r -> r.topic() + "-" + r.partition() + "@" + r.offset())
+						.collect(Collectors.toList()));
+			}
+			consumer.seekToBeginning(records.partitions());
+		}
+		assertThat(consumerLatch.await(30, TimeUnit.SECONDS))
+				.as("Failed to be assigned partitions from the embedded topics")
+				.isTrue();
+		logger.debug("Subscription Initiated");
+	}
+
+}

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafka.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafka.java
@@ -24,14 +24,15 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.springframework.core.annotation.AliasFor;
-import org.springframework.kafka.test.rule.KafkaEmbedded;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
 
 /**
  * Annotation that can be specified on a test class that runs Spring Kafka based tests.
  * Provides the following features over and above the regular <em>Spring TestContext
  * Framework</em>:
  * <ul>
- * <li>Registers a {@link KafkaEmbedded} bean with the {@link KafkaEmbedded#BEAN_NAME} bean name.
+ * <li>Registers a {@link EmbeddedKafkaBroker} bean with the
+ * {@link EmbeddedKafkaBroker#BEAN_NAME} bean name.
  * </li>
  * </ul>
  * <p>
@@ -42,7 +43,7 @@ import org.springframework.kafka.test.rule.KafkaEmbedded;
  * public class MyKafkaTests {
  *
  *    &#064;Autowired
- *    private KafkaEmbedded kafkaEmbedded;
+ *    private EmbeddedKafkaBroker kafkaEmbedded;
  *
  *    &#064;Value("${spring.embedded.kafka.brokers}")
  *    private String brokerAddresses;
@@ -55,7 +56,7 @@ import org.springframework.kafka.test.rule.KafkaEmbedded;
  *
  * @since 1.3
  *
- * @see KafkaEmbedded
+ * @see EmbeddedKafkaBroker
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
@@ -98,7 +99,7 @@ public @interface EmbeddedKafka {
 	 * Properties may contain property placeholders, e.g. {@code delete.topic.enable=${topic.delete:true}}.
 	 * @return the properties to add
 	 * @see #brokerPropertiesLocation()
-	 * @see KafkaEmbedded#brokerProperties(java.util.Map)
+	 * @see EmbeddedKafkaBroker#brokerProperties(java.util.Map)
 	 */
 	String[] brokerProperties() default { };
 
@@ -111,7 +112,7 @@ public @interface EmbeddedKafka {
 	 * in {@code brokerPropertiesLocation}.
 	 * @return a {@code Resource} url specifying the location of properties to add
 	 * @see #brokerProperties()
-	 * @see KafkaEmbedded#brokerProperties(java.util.Map)
+	 * @see EmbeddedKafkaBroker#brokerProperties(java.util.Map)
 	 */
 	String brokerPropertiesLocation() default "";
 

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizer.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizer.java
@@ -28,16 +28,14 @@ import org.springframework.beans.factory.support.DefaultSingletonBeanRegistry;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.io.Resource;
-import org.springframework.kafka.test.rule.KafkaEmbedded;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.test.context.ContextCustomizer;
 import org.springframework.test.context.MergedContextConfiguration;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 /**
- * The {@link ContextCustomizer} implementation for Spring Integration specific environment.
- * <p>
- * Registers {@link KafkaEmbedded} bean.
+ * The {@link ContextCustomizer} implementation for the {@link EmbeddedKafkaBroker} bean registration.
  *
  * @author Artem Bilan
  * @author Elliot Metsger
@@ -66,7 +64,7 @@ class EmbeddedKafkaContextCustomizer implements ContextCustomizer {
 						.map(environment::resolvePlaceholders)
 						.toArray(String[]::new);
 
-		KafkaEmbedded kafkaEmbedded = new KafkaEmbedded(this.embeddedKafka.count(),
+		EmbeddedKafkaBroker embeddedKafka = new EmbeddedKafkaBroker(this.embeddedKafka.count(),
 				this.embeddedKafka.controlledShutdown(),
 				this.embeddedKafka.partitions(),
 				topics);
@@ -102,11 +100,11 @@ class EmbeddedKafkaContextCustomizer implements ContextCustomizer {
 			}
 		}
 
-		kafkaEmbedded.brokerProperties((Map<String, String>) (Map<?, ?>) properties);
+		embeddedKafka.brokerProperties((Map<String, String>) (Map<?, ?>) properties);
 
-		beanFactory.initializeBean(kafkaEmbedded, KafkaEmbedded.BEAN_NAME);
-		beanFactory.registerSingleton(KafkaEmbedded.BEAN_NAME, kafkaEmbedded);
-		((DefaultSingletonBeanRegistry) beanFactory).registerDisposableBean(KafkaEmbedded.BEAN_NAME, kafkaEmbedded);
+		beanFactory.initializeBean(embeddedKafka, EmbeddedKafkaBroker.BEAN_NAME);
+		beanFactory.registerSingleton(EmbeddedKafkaBroker.BEAN_NAME, embeddedKafka);
+		((DefaultSingletonBeanRegistry) beanFactory).registerDisposableBean(EmbeddedKafkaBroker.BEAN_NAME, embeddedKafka);
 	}
 
 }

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/rule/EmbeddedKafkaRule.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/rule/EmbeddedKafkaRule.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2015-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.test.rule;
+
+import java.util.Map;
+
+import org.junit.rules.ExternalResource;
+import org.junit.rules.TestRule;
+
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+
+import kafka.server.KafkaConfig;
+
+/**
+ * A {@link TestRule} wrapper around an {@link EmbeddedKafkaBroker}.
+ *
+ * @author Artem Bilan
+ *
+ * @since 2.2
+ *
+ * @see EmbeddedKafkaBroker
+ */
+public class EmbeddedKafkaRule extends ExternalResource implements TestRule {
+
+	private final EmbeddedKafkaBroker embeddedKafka;
+
+	public EmbeddedKafkaRule(int count) {
+		this(count, false);
+	}
+
+	/**
+	 * Create embedded Kafka brokers.
+	 * @param count the number of brokers.
+	 * @param controlledShutdown passed into TestUtils.createBrokerConfig.
+	 * @param topics the topics to create (2 partitions per).
+	 */
+	public EmbeddedKafkaRule(int count, boolean controlledShutdown, String... topics) {
+		this(count, controlledShutdown, 2, topics);
+	}
+
+	/**
+	 * Create embedded Kafka brokers listening on random ports.
+	 * @param count the number of brokers.
+	 * @param controlledShutdown passed into TestUtils.createBrokerConfig.
+	 * @param partitions partitions per topic.
+	 * @param topics the topics to create.
+	 */
+	public EmbeddedKafkaRule(int count, boolean controlledShutdown, int partitions, String... topics) {
+		this.embeddedKafka = new EmbeddedKafkaBroker(count, controlledShutdown, partitions, topics);
+	}
+
+	/**
+	 * Specify the properties to configure Kafka Broker before start, e.g.
+	 * {@code auto.create.topics.enable}, {@code transaction.state.log.replication.factor} etc.
+	 * @param brokerProperties the properties to use for configuring Kafka Broker(s).
+	 * @return this for chaining configuration
+	 * @see KafkaConfig
+	 */
+	public EmbeddedKafkaRule brokerProperties(Map<String, String> brokerProperties) {
+		this.embeddedKafka.brokerProperties(brokerProperties);
+		return this;
+	}
+
+	/**
+	 * Specify a broker property.
+	 * @param property the property name.
+	 * @param value the value.
+	 * @return the {@link EmbeddedKafkaRule}.
+	 * @since 2.1.4
+	 */
+	public EmbeddedKafkaRule brokerProperty(String property, Object value) {
+		this.embeddedKafka.brokerProperty(property, value);
+		return this;
+	}
+
+	/**
+	 * Set explicit ports on which the kafka brokers will listen. Useful when running an
+	 * embedded broker that you want to access from other processes.
+	 * @param kafkaPorts the ports.
+	 */
+	public EmbeddedKafkaRule kafkaPorts(int... kafkaPorts) {
+		this.embeddedKafka.kafkaPorts(kafkaPorts);
+		return this;
+	}
+
+	/**
+	 * Return an underlying delegator {@link EmbeddedKafkaBroker} instance.
+	 * @return the {@link EmbeddedKafkaBroker} instance.
+	 */
+	public EmbeddedKafkaBroker getEmbeddedKafka() {
+		return this.embeddedKafka;
+	}
+
+	@Override
+	public void before() {
+		this.embeddedKafka.afterPropertiesSet();
+	}
+
+	@Override
+	public void after() {
+		this.embeddedKafka.destroy();
+	}
+
+}

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/rule/KafkaRule.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/rule/KafkaRule.java
@@ -30,7 +30,10 @@ import kafka.server.KafkaServer;
  *
  * @author Marius Bogoevici
  * @author Gary Russell
+ *
+ * @deprecated since 2.2 in favor of {@link EmbeddedKafkaRule}
  */
+@Deprecated
 public interface KafkaRule extends TestRule {
 
 	ZkClient getZkClient();

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/utils/KafkaTestUtils.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/utils/KafkaTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 
 import org.springframework.beans.DirectFieldAccessor;
-import org.springframework.kafka.test.rule.KafkaEmbedded;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.util.Assert;
 
 /**
@@ -43,6 +43,7 @@ import org.springframework.util.Assert;
  *
  * @author Gary Russell
  * @author Hugo Wood
+ * @author Artem Bilan
  */
 public final class KafkaTestUtils {
 
@@ -56,21 +57,49 @@ public final class KafkaTestUtils {
 	 * Set up test properties for an {@code <Integer, String>} consumer.
 	 * @param group the group id.
 	 * @param autoCommit the auto commit.
-	 * @param embeddedKafka a {@link KafkaEmbedded} instance.
+	 * @param embeddedKafka a {@link org.springframework.kafka.test.rule.KafkaEmbedded} instance.
 	 * @return the properties.
+	 * @deprecated since 2.2 in favor of {@link #consumerProps(String, String, EmbeddedKafkaBroker)}
 	 */
-	public static Map<String, Object> consumerProps(String group, String autoCommit, KafkaEmbedded embeddedKafka) {
+	@SuppressWarnings("deprecation")
+	@Deprecated
+	public static Map<String, Object> consumerProps(String group, String autoCommit,
+			org.springframework.kafka.test.rule.KafkaEmbedded embeddedKafka) {
 		return consumerProps(embeddedKafka.getBrokersAsString(), group, autoCommit);
 	}
 
 	/**
 	 * Set up test properties for an {@code <Integer, String>} producer.
-	 * @param embeddedKafka a {@link KafkaEmbedded} instance.
+	 * @param embeddedKafka a {@link org.springframework.kafka.test.rule.KafkaEmbedded} instance.
 	 * @return the properties.
+	 * @deprecated since 2.2 in favor of {@link #producerProps(EmbeddedKafkaBroker)}
 	 */
-	public static Map<String, Object> producerProps(KafkaEmbedded embeddedKafka) {
+	@SuppressWarnings("deprecation")
+	@Deprecated
+	public static Map<String, Object> producerProps(org.springframework.kafka.test.rule.KafkaEmbedded embeddedKafka) {
 		return senderProps(embeddedKafka.getBrokersAsString());
 	}
+
+	/**
+	 * Set up test properties for an {@code <Integer, String>} consumer.
+	 * @param group the group id.
+	 * @param autoCommit the auto commit.
+	 * @param embeddedKafka a {@link EmbeddedKafkaBroker} instance.
+	 * @return the properties.
+	 */
+	public static Map<String, Object> consumerProps(String group, String autoCommit, EmbeddedKafkaBroker embeddedKafka) {
+		return consumerProps(embeddedKafka.getBrokersAsString(), group, autoCommit);
+	}
+
+	/**
+	 * Set up test properties for an {@code <Integer, String>} producer.
+	 * @param embeddedKafka a {@link EmbeddedKafkaBroker} instance.
+	 * @return the properties.
+	 */
+	public static Map<String, Object> producerProps(EmbeddedKafkaBroker embeddedKafka) {
+		return senderProps(embeddedKafka.getBrokersAsString());
+	}
+
 
 	/**
 	 * Set up test properties for an {@code <Integer, String>} consumer.
@@ -166,10 +195,10 @@ public final class KafkaTestUtils {
 		if (logger.isDebugEnabled()) {
 			logger.debug("Received: " + received.count() + ", "
 					+ received.partitions().stream()
-							.flatMap(p -> received.records(p).stream())
-							// map to same format as send metadata toString()
-							.map(r -> r.topic() + "-" + r.partition() + "@" + r.offset())
-							.collect(Collectors.toList()));
+					.flatMap(p -> received.records(p).stream())
+					// map to same format as send metadata toString()
+					.map(r -> r.topic() + "-" + r.partition() + "@" + r.offset())
+					.collect(Collectors.toList()));
 		}
 		assertThat(received).as("null received from consumer.poll()").isNotNull();
 		return received;

--- a/spring-kafka-test/src/test/java/org/springframework/kafka/test/rule/AddressableEmbeddedBrokerTests.java
+++ b/spring-kafka-test/src/test/java/org/springframework/kafka/test/rule/AddressableEmbeddedBrokerTests.java
@@ -36,6 +36,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.test.context.junit4.SpringRunner;
 
@@ -43,6 +44,8 @@ import org.springframework.test.context.junit4.SpringRunner;
  * @author Gary Russell
  * @author Kamill Sokol
  * @author Elliot Kennedy
+ * @author Artem Bilan
+ *
  * @since 1.3
  *
  */
@@ -55,15 +58,15 @@ public class AddressableEmbeddedBrokerTests {
 	private Config config;
 
 	@Autowired
-	private KafkaEmbedded broker;
+	private EmbeddedKafkaBroker broker;
 
 	@Test
 	public void testKafkaEmbedded() {
 		assertThat(broker.getBrokersAsString()).isEqualTo("127.0.0.1:" + this.config.port);
 		assertThat(broker.getBrokersAsString())
-				.isEqualTo(System.getProperty(KafkaEmbedded.SPRING_EMBEDDED_KAFKA_BROKERS));
+				.isEqualTo(System.getProperty(EmbeddedKafkaBroker.SPRING_EMBEDDED_KAFKA_BROKERS));
 		assertThat(broker.getZookeeperConnectionString())
-				.isEqualTo(System.getProperty(KafkaEmbedded.SPRING_EMBEDDED_ZOOKEEPER_CONNECT));
+				.isEqualTo(System.getProperty(EmbeddedKafkaBroker.SPRING_EMBEDDED_ZOOKEEPER_CONNECT));
 	}
 
 	@Test
@@ -74,7 +77,7 @@ public class AddressableEmbeddedBrokerTests {
 		this.broker.consumeFromAnEmbeddedTopic(consumer, TEST_EMBEDDED);
 
 		Producer<String, Object> producer = new KafkaProducer<>(KafkaTestUtils.producerProps(this.broker));
-		producer.send(new ProducerRecord<String, Object>(TEST_EMBEDDED, "foo"));
+		producer.send(new ProducerRecord<>(TEST_EMBEDDED, "foo"));
 		producer.close();
 		KafkaTestUtils.getSingleRecord(consumer, TEST_EMBEDDED);
 
@@ -94,13 +97,13 @@ public class AddressableEmbeddedBrokerTests {
 		private int port;
 
 		@Bean
-		public KafkaEmbedded broker() throws IOException {
-			KafkaEmbedded broker = new KafkaEmbedded(1, true, TEST_EMBEDDED);
+		public EmbeddedKafkaBroker broker() throws IOException {
 			ServerSocket ss = ServerSocketFactory.getDefault().createServerSocket(0);
 			this.port = ss.getLocalPort();
 			ss.close();
-			broker.setKafkaPorts(this.port);
-			return broker;
+
+			return new EmbeddedKafkaBroker(1, true, TEST_EMBEDDED)
+					.kafkaPorts(this.port);
 		}
 
 	}

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/BatchListenerConversionTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/BatchListenerConversionTests.java
@@ -46,7 +46,7 @@ import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.support.converter.BatchMessagingMessageConverter;
 import org.springframework.kafka.support.converter.BytesJsonMessageConverter;
-import org.springframework.kafka.test.rule.KafkaEmbedded;
+import org.springframework.kafka.test.rule.EmbeddedKafkaRule;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.annotation.Header;
@@ -59,6 +59,8 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 1.3.2
  *
  */
@@ -70,7 +72,7 @@ public class BatchListenerConversionTests {
 	private static final String DEFAULT_TEST_GROUP_ID = "blc";
 
 	@ClassRule // one topic to preserve order
-	public static KafkaEmbedded embeddedKafka = new KafkaEmbedded(1, true, 1, "blc1", "blc2", "blc3",
+	public static EmbeddedKafkaRule embeddedKafka = new EmbeddedKafkaRule(1, true, 1, "blc1", "blc2", "blc3",
 			"blc4", "blc5");
 
 	@Autowired
@@ -153,7 +155,7 @@ public class BatchListenerConversionTests {
 		@Bean
 		public Map<String, Object> consumerConfigs() {
 			Map<String, Object> consumerProps =
-					KafkaTestUtils.consumerProps(DEFAULT_TEST_GROUP_ID, "false", embeddedKafka);
+					KafkaTestUtils.consumerProps(DEFAULT_TEST_GROUP_ID, "false", embeddedKafka.getEmbeddedKafka());
 			consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class);
 			consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 			return consumerProps;
@@ -178,7 +180,7 @@ public class BatchListenerConversionTests {
 
 		@Bean
 		public Map<String, Object> producerConfigs() {
-			Map<String, Object> props = KafkaTestUtils.producerProps(embeddedKafka);
+			Map<String, Object> props = KafkaTestUtils.producerProps(embeddedKafka.getEmbeddedKafka());
 			props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, BytesSerializer.class);
 			return props;
 		}
@@ -280,7 +282,7 @@ public class BatchListenerConversionTests {
 					.setHeader(KafkaHeaders.TOPIC, "blc5")
 					.setHeader(KafkaHeaders.MESSAGE_KEY, 42)
 					.build())
-				.collect(Collectors.toList());
+					.collect(Collectors.toList());
 		}
 
 		@KafkaListener(topics = "blc5", groupId = "blc5")

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -85,7 +85,8 @@ import org.springframework.kafka.support.converter.DefaultJackson2JavaTypeMapper
 import org.springframework.kafka.support.converter.Jackson2JavaTypeMapper;
 import org.springframework.kafka.support.converter.Jackson2JavaTypeMapper.TypePrecedence;
 import org.springframework.kafka.support.converter.StringJsonMessageConverter;
-import org.springframework.kafka.test.rule.KafkaEmbedded;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.rule.EmbeddedKafkaRule;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.lang.NonNull;
 import org.springframework.messaging.Message;
@@ -120,7 +121,7 @@ public class EnableKafkaIntegrationTests {
 	private static final String DEFAULT_TEST_GROUP_ID = "testAnnot";
 
 	@ClassRule
-	public static KafkaEmbedded embeddedKafka = new KafkaEmbedded(1, true,
+	public static EmbeddedKafkaRule embeddedKafkaRule = new EmbeddedKafkaRule(1, true,
 			"annotated1", "annotated2", "annotated3",
 			"annotated4", "annotated5", "annotated6", "annotated7", "annotated8", "annotated9", "annotated10",
 			"annotated11", "annotated12", "annotated13", "annotated14", "annotated15", "annotated16", "annotated17",
@@ -130,9 +131,7 @@ public class EnableKafkaIntegrationTests {
 			"annotated29", "annotated30", "annotated30reply", "annotated31", "annotated32", "annotated33",
 			"annotated34");
 
-//	@Rule
-//	public Log4jLevelAdjuster adjuster = new Log4jLevelAdjuster(Level.TRACE,
-//			"org.springframework.kafka", "org.apache.kafka.clients.consumer");
+	private static EmbeddedKafkaBroker embeddedKafka = embeddedKafkaRule.getEmbeddedKafka();
 
 	@Autowired
 	private Config config;
@@ -274,7 +273,7 @@ public class EnableKafkaIntegrationTests {
 		assertThat(KafkaTestUtils.getPropertyValue(rebalanceContainer, "listenerConsumer.consumer.coordinator.groupId"))
 				.isNotEqualTo("rebalanceListener");
 		String clientId = KafkaTestUtils.getPropertyValue(rebalanceContainer, "listenerConsumer.consumer.clientId",
-			String.class);
+				String.class);
 		assertThat(
 				clientId)
 				.startsWith("consumer-");
@@ -685,7 +684,7 @@ public class EnableKafkaIntegrationTests {
 
 		@Bean
 		public KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<Integer, String>>
-				kafkaListenerContainerFactory() {
+		kafkaListenerContainerFactory() {
 			ConcurrentKafkaListenerContainerFactory<Integer, String> factory =
 					new ConcurrentKafkaListenerContainerFactory<>();
 			factory.setConsumerFactory(consumerFactory());
@@ -700,7 +699,7 @@ public class EnableKafkaIntegrationTests {
 
 		@Bean
 		public KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<Integer, String>>
-				withNoReplyTemplateContainerFactory() {
+		withNoReplyTemplateContainerFactory() {
 			ConcurrentKafkaListenerContainerFactory<Integer, String> factory =
 					new ConcurrentKafkaListenerContainerFactory<>();
 			factory.setConsumerFactory(consumerFactory());
@@ -813,7 +812,7 @@ public class EnableKafkaIntegrationTests {
 
 		@Bean
 		public KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<Integer, String>>
-				kafkaManualAckListenerContainerFactory() {
+		kafkaManualAckListenerContainerFactory() {
 			ConcurrentKafkaListenerContainerFactory<Integer, String> factory =
 					new ConcurrentKafkaListenerContainerFactory<>();
 			factory.setConsumerFactory(manualConsumerFactory("clientIdViaProps3"));
@@ -829,7 +828,7 @@ public class EnableKafkaIntegrationTests {
 
 		@Bean
 		public KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<Integer, String>>
-				kafkaAutoStartFalseListenerContainerFactory() {
+		kafkaAutoStartFalseListenerContainerFactory() {
 			ConcurrentKafkaListenerContainerFactory<Integer, String> factory =
 					new ConcurrentKafkaListenerContainerFactory<>();
 			ContainerProperties props = factory.getContainerProperties();
@@ -843,7 +842,7 @@ public class EnableKafkaIntegrationTests {
 
 		@Bean
 		public KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<Integer, String>>
-				kafkaRebalanceListenerContainerFactory() {
+		kafkaRebalanceListenerContainerFactory() {
 			ConcurrentKafkaListenerContainerFactory<Integer, String> factory =
 					new ConcurrentKafkaListenerContainerFactory<>();
 			ContainerProperties props = factory.getContainerProperties();
@@ -854,7 +853,7 @@ public class EnableKafkaIntegrationTests {
 
 		@Bean
 		public KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<Integer, String>>
-				recordAckListenerContainerFactory() {
+		recordAckListenerContainerFactory() {
 
 			ConcurrentKafkaListenerContainerFactory<Integer, String> factory =
 					new ConcurrentKafkaListenerContainerFactory<>();
@@ -1010,8 +1009,8 @@ public class EnableKafkaIntegrationTests {
 				this.listen3Exception = e;
 				MessageHeaders headers = m.getHeaders();
 				c.seek(new org.apache.kafka.common.TopicPartition(
-						headers.get(KafkaHeaders.RECEIVED_TOPIC, String.class),
-						headers.get(KafkaHeaders.RECEIVED_PARTITION_ID, Integer.class)),
+								headers.get(KafkaHeaders.RECEIVED_TOPIC, String.class),
+								headers.get(KafkaHeaders.RECEIVED_PARTITION_ID, Integer.class)),
 						headers.get(KafkaHeaders.OFFSET, Long.class));
 				return null;
 			};

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/StatefulRetryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/StatefulRetryTests.java
@@ -41,7 +41,7 @@ import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.listener.MessageListenerContainer;
 import org.springframework.kafka.listener.SeekToCurrentErrorHandler;
-import org.springframework.kafka.test.rule.KafkaEmbedded;
+import org.springframework.kafka.test.rule.EmbeddedKafkaRule;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.test.annotation.DirtiesContext;
@@ -49,6 +49,8 @@ import org.springframework.test.context.junit4.SpringRunner;
 
 /**
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 2.1.3
  *
  */
@@ -59,7 +61,7 @@ public class StatefulRetryTests {
 	private static final String DEFAULT_TEST_GROUP_ID = "statefulRetry";
 
 	@ClassRule
-	public static KafkaEmbedded embeddedKafka = new KafkaEmbedded(1, true, 1, "sr1");
+	public static EmbeddedKafkaRule embeddedKafka = new EmbeddedKafkaRule(1, true, 1, "sr1");
 
 	@Autowired
 	private Config config;
@@ -117,15 +119,14 @@ public class StatefulRetryTests {
 		@Bean
 		public Map<String, Object> consumerConfigs() {
 			Map<String, Object> consumerProps =
-					KafkaTestUtils.consumerProps(DEFAULT_TEST_GROUP_ID, "false", embeddedKafka);
+					KafkaTestUtils.consumerProps(DEFAULT_TEST_GROUP_ID, "false", embeddedKafka.getEmbeddedKafka());
 			consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 			return consumerProps;
 		}
 
 		@Bean
 		public KafkaTemplate<Integer, String> template() {
-			KafkaTemplate<Integer, String> kafkaTemplate = new KafkaTemplate<>(producerFactory());
-			return kafkaTemplate;
+			return new KafkaTemplate<>(producerFactory());
 		}
 
 		@Bean
@@ -135,7 +136,7 @@ public class StatefulRetryTests {
 
 		@Bean
 		public Map<String, Object> producerConfigs() {
-			return KafkaTestUtils.producerProps(embeddedKafka);
+			return KafkaTestUtils.producerProps(embeddedKafka.getEmbeddedKafka());
 		}
 
 		@KafkaListener(id = "retry", topics = "sr1", groupId = "sr1")

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaAdminBadContextTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaAdminBadContextTests.java
@@ -29,7 +29,7 @@ import org.junit.Test;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.kafka.test.rule.KafkaEmbedded;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
 
 /**
  * @author Gary Russell
@@ -53,8 +53,8 @@ public class KafkaAdminBadContextTests {
 	public static class BadConfig {
 
 		@Bean
-		public KafkaEmbedded kafkaEmbedded() {
-			return new KafkaEmbedded(1);
+		public EmbeddedKafkaBroker kafkaEmbedded() {
+			return new EmbeddedKafkaBroker(1);
 		}
 
 		@Bean

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaAdminTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaAdminTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ import org.springframework.beans.DirectFieldAccessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.kafka.test.rule.KafkaEmbedded;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.StringUtils;
@@ -76,8 +76,8 @@ public class KafkaAdminTests {
 	public static class Config {
 
 		@Bean
-		public KafkaEmbedded kafkaEmbedded() {
-			return new KafkaEmbedded(1);
+		public EmbeddedKafkaBroker kafkaEmbedded() {
+			return new EmbeddedKafkaBroker(1);
 		}
 
 		@Bean

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaStreamsCustomizerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaStreamsCustomizerTests.java
@@ -32,14 +32,15 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.annotation.EnableKafkaStreams;
 import org.springframework.kafka.annotation.KafkaStreamsDefaultConfiguration;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.context.EmbeddedKafka;
-import org.springframework.kafka.test.rule.KafkaEmbedded;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 
 /**
  * @author Nurettin Yilmaz
+ * @author Artem Bilan
  *
  * @since 2.1.5
  */
@@ -66,7 +67,7 @@ public class KafkaStreamsCustomizerTests {
 	@EnableKafkaStreams
 	public static class KafkaStreamsConfiguration {
 
-		@Value("${" + KafkaEmbedded.SPRING_EMBEDDED_KAFKA_BROKERS + "}")
+		@Value("${" + EmbeddedKafkaBroker.SPRING_EMBEDDED_KAFKA_BROKERS + "}")
 		private String brokerAddresses;
 
 		@Bean(name = KafkaStreamsDefaultConfiguration.DEFAULT_STREAMS_BUILDER_BEAN_NAME)

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTests.java
@@ -57,7 +57,8 @@ import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.support.ProducerListener;
 import org.springframework.kafka.support.SendResult;
 import org.springframework.kafka.support.converter.MessagingMessageConverter;
-import org.springframework.kafka.test.rule.KafkaEmbedded;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.rule.EmbeddedKafkaRule;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
@@ -78,7 +79,9 @@ public class KafkaTemplateTests {
 	private static final String STRING_KEY_TOPIC = "stringKeyTopic";
 
 	@ClassRule
-	public static KafkaEmbedded embeddedKafka = new KafkaEmbedded(1, true, INT_KEY_TOPIC, STRING_KEY_TOPIC);
+	public static EmbeddedKafkaRule embeddedKafkaRule = new EmbeddedKafkaRule(1, true, INT_KEY_TOPIC, STRING_KEY_TOPIC);
+
+	private static EmbeddedKafkaBroker embeddedKafka = embeddedKafkaRule.getEmbeddedKafka();
 
 	private static Consumer<Integer, String> consumer;
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTransactionTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTransactionTests.java
@@ -50,7 +50,8 @@ import org.mockito.InOrder;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.kafka.test.rule.KafkaEmbedded;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.rule.EmbeddedKafkaRule;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.kafka.transaction.KafkaTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
@@ -73,9 +74,11 @@ public class KafkaTemplateTransactionTests {
 	private static final String STRING_KEY_TOPIC = "stringKeyTopic";
 
 	@ClassRule
-	public static KafkaEmbedded embeddedKafka = new KafkaEmbedded(1, true, STRING_KEY_TOPIC)
-		.brokerProperty(KafkaConfig.TransactionsTopicReplicationFactorProp(), "1")
-		.brokerProperty(KafkaConfig.TransactionsTopicMinISRProp(), "1");
+	public static EmbeddedKafkaRule embeddedKafkaRule = new EmbeddedKafkaRule(1, true, STRING_KEY_TOPIC)
+			.brokerProperty(KafkaConfig.TransactionsTopicReplicationFactorProp(), "1")
+			.brokerProperty(KafkaConfig.TransactionsTopicMinISRProp(), "1");
+
+	private static EmbeddedKafkaBroker embeddedKafka = embeddedKafkaRule.getEmbeddedKafka();
 
 	@Test
 	public void testLocalTransaction() throws Exception {
@@ -205,8 +208,8 @@ public class KafkaTemplateTransactionTests {
 		KafkaTemplate<String, String> template = new KafkaTemplate<>(pf);
 		template.setDefaultTopic(STRING_KEY_TOPIC);
 		assertThatThrownBy(() -> template.send("foo", "bar"))
-			.isInstanceOf(IllegalStateException.class)
-			.hasMessageContaining("No transaction is in process;");
+				.isInstanceOf(IllegalStateException.class)
+				.hasMessageContaining("No transaction is in process;");
 	}
 
 	@Configuration

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/StreamsBuilderFactoryBeanTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/StreamsBuilderFactoryBeanTests.java
@@ -37,8 +37,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafkaStreams;
 import org.springframework.kafka.annotation.KafkaStreamsDefaultConfiguration;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.context.EmbeddedKafka;
-import org.springframework.kafka.test.rule.KafkaEmbedded;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
@@ -82,7 +82,7 @@ public class StreamsBuilderFactoryBeanTests {
 	@EnableKafkaStreams
 	public static class KafkaStreamsConfiguration {
 
-		@Value("${" + KafkaEmbedded.SPRING_EMBEDDED_KAFKA_BROKERS + "}")
+		@Value("${" + EmbeddedKafkaBroker.SPRING_EMBEDDED_KAFKA_BROKERS + "}")
 		private String brokerAddresses;
 
 		@Bean(name = KafkaStreamsDefaultConfiguration.DEFAULT_STREAMS_BUILDER_BEAN_NAME)

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/StreamsBuilderFactoryLateConfigTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/StreamsBuilderFactoryLateConfigTests.java
@@ -33,13 +33,14 @@ import org.springframework.kafka.KafkaException;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.annotation.EnableKafkaStreams;
 import org.springframework.kafka.annotation.KafkaStreamsDefaultConfiguration;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.context.EmbeddedKafka;
-import org.springframework.kafka.test.rule.KafkaEmbedded;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 
 /**
  * @author Soby Chacko
+ * @author Artem Bilan
  */
 @RunWith(SpringRunner.class)
 @DirtiesContext
@@ -48,7 +49,7 @@ public class StreamsBuilderFactoryLateConfigTests {
 
 	private static final String APPLICATION_ID = "streamsBuilderFactoryLateConfigTests";
 
-	@Value("${" + KafkaEmbedded.SPRING_EMBEDDED_KAFKA_BROKERS + "}")
+	@Value("${" + EmbeddedKafkaBroker.SPRING_EMBEDDED_KAFKA_BROKERS + "}")
 	private String brokerAddresses;
 
 	@Autowired
@@ -91,5 +92,7 @@ public class StreamsBuilderFactoryLateConfigTests {
 			streamsBuilderFactoryBean.setAutoStartup(false);
 			return streamsBuilderFactoryBean;
 		}
+
 	}
+
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/kstream/KafkaStreamsBranchTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/kstream/KafkaStreamsBranchTests.java
@@ -47,8 +47,8 @@ import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.context.EmbeddedKafka;
-import org.springframework.kafka.test.rule.KafkaEmbedded;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -78,15 +78,15 @@ public class KafkaStreamsBranchTests {
 	private KafkaTemplate<String, String> kafkaTemplate;
 
 	@Autowired
-	private KafkaEmbedded kafkaEmbedded;
+	private EmbeddedKafkaBroker embeddedKafka;
 
 	@Test
 	public void testBranchingStream() throws Exception {
 		Consumer<String, String> falseConsumer = createConsumer();
-		this.kafkaEmbedded.consumeFromAnEmbeddedTopic(falseConsumer, FALSE_TOPIC);
+		this.embeddedKafka.consumeFromAnEmbeddedTopic(falseConsumer, FALSE_TOPIC);
 
 		Consumer<String, String> trueConsumer = createConsumer();
-		this.kafkaEmbedded.consumeFromAnEmbeddedTopic(trueConsumer, TRUE_TOPIC);
+		this.embeddedKafka.consumeFromAnEmbeddedTopic(trueConsumer, TRUE_TOPIC);
 
 		this.kafkaTemplate.sendDefault(String.valueOf(true));
 		this.kafkaTemplate.sendDefault(String.valueOf(true));
@@ -110,7 +110,7 @@ public class KafkaStreamsBranchTests {
 
 	private Consumer<String, String> createConsumer() {
 		Map<String, Object> consumerProps =
-				KafkaTestUtils.consumerProps(UUID.randomUUID().toString(), "false", this.kafkaEmbedded);
+				KafkaTestUtils.consumerProps(UUID.randomUUID().toString(), "false", this.embeddedKafka);
 		consumerProps.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 10000);
 
 		DefaultKafkaConsumerFactory<String, String> kafkaConsumerFactory =
@@ -122,7 +122,7 @@ public class KafkaStreamsBranchTests {
 	@EnableKafkaStreams
 	public static class Config {
 
-		@Value("${" + KafkaEmbedded.SPRING_EMBEDDED_KAFKA_BROKERS + "}")
+		@Value("${" + EmbeddedKafkaBroker.SPRING_EMBEDDED_KAFKA_BROKERS + "}")
 		private String brokerAddresses;
 
 		@Bean

--- a/spring-kafka/src/test/java/org/springframework/kafka/kstream/KafkaStreamsJsonSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/kstream/KafkaStreamsJsonSerializationTests.java
@@ -51,8 +51,8 @@ import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.support.serializer.JsonSerde;
 import org.springframework.kafka.support.serializer.JsonSerializer;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.context.EmbeddedKafka;
-import org.springframework.kafka.test.rule.KafkaEmbedded;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -86,7 +86,7 @@ public class KafkaStreamsJsonSerializationTests {
 	private KafkaTemplate<Object, Object> template;
 
 	@Autowired
-	private KafkaEmbedded kafkaEmbedded;
+	private EmbeddedKafkaBroker embeddedKafka;
 
 	private Consumer<JsonObjectKey, JsonObjectValue> objectOutputTopicConsumer;
 
@@ -119,13 +119,13 @@ public class KafkaStreamsJsonSerializationTests {
 
 	private <K, V> Consumer<K, V> consumer(String topic, Serde<K> keySerde, Serde<V> valueSerde) throws Exception {
 		Map<String, Object> consumerProps =
-				KafkaTestUtils.consumerProps(UUID.randomUUID().toString(), "false", this.kafkaEmbedded);
+				KafkaTestUtils.consumerProps(UUID.randomUUID().toString(), "false", this.embeddedKafka);
 		consumerProps.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 10000);
 
 		DefaultKafkaConsumerFactory<K, V> kafkaConsumerFactory =
 				new DefaultKafkaConsumerFactory<>(consumerProps, keySerde.deserializer(), valueSerde.deserializer());
 		Consumer<K, V> consumer = kafkaConsumerFactory.createConsumer();
-		this.kafkaEmbedded.consumeFromAnEmbeddedTopic(consumer, topic);
+		this.embeddedKafka.consumeFromAnEmbeddedTopic(consumer, topic);
 		return consumer;
 	}
 
@@ -181,7 +181,7 @@ public class KafkaStreamsJsonSerializationTests {
 	@EnableKafkaStreams
 	public static class Config {
 
-		@Value("${" + KafkaEmbedded.SPRING_EMBEDDED_KAFKA_BROKERS + "}")
+		@Value("${" + EmbeddedKafkaBroker.SPRING_EMBEDDED_KAFKA_BROKERS + "}")
 		private String brokerAddresses;
 
 		@Bean

--- a/spring-kafka/src/test/java/org/springframework/kafka/kstream/KafkaStreamsTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/kstream/KafkaStreamsTests.java
@@ -61,8 +61,8 @@ import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.core.StreamsBuilderFactoryBean;
 import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
 import org.springframework.kafka.support.serializer.JsonSerde;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.context.EmbeddedKafka;
-import org.springframework.kafka.test.rule.KafkaEmbedded;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
@@ -106,16 +106,16 @@ public class KafkaStreamsTests {
 	private StreamsBuilderFactoryBean streamsBuilderFactoryBean;
 
 	@Autowired
-	private KafkaEmbedded kafkaEmbedded;
+	private EmbeddedKafkaBroker embeddedKafka;
 
 	@Value("${streaming.topic.two}")
 	private String streamingTopic2;
 
 	@Test
 	public void testKStreams() throws Exception {
-		assertThat(this.kafkaEmbedded.getKafkaServer(0).config().autoCreateTopicsEnable()).isFalse();
-		assertThat(this.kafkaEmbedded.getKafkaServer(0).config().deleteTopicEnable()).isTrue();
-		assertThat(this.kafkaEmbedded.getKafkaServer(0).config().brokerId()).isEqualTo(2);
+		assertThat(this.embeddedKafka.getKafkaServer(0).config().autoCreateTopicsEnable()).isFalse();
+		assertThat(this.embeddedKafka.getKafkaServer(0).config().deleteTopicEnable()).isTrue();
+		assertThat(this.embeddedKafka.getKafkaServer(0).config().brokerId()).isEqualTo(2);
 
 		this.streamsBuilderFactoryBean.stop();
 
@@ -155,7 +155,7 @@ public class KafkaStreamsTests {
 	@EnableKafkaStreams
 	public static class KafkaStreamsConfiguration {
 
-		@Value("${" + KafkaEmbedded.SPRING_EMBEDDED_KAFKA_BROKERS + "}")
+		@Value("${" + EmbeddedKafkaBroker.SPRING_EMBEDDED_KAFKA_BROKERS + "}")
 		private String brokerAddresses;
 
 		@Value("${streaming.topic.two}")
@@ -195,7 +195,7 @@ public class KafkaStreamsTests {
 		public KStream<Integer, String> kStream(StreamsBuilder kStreamBuilder) {
 			KStream<Integer, String> stream = kStreamBuilder.stream(STREAMING_TOPIC1);
 			stream.mapValues((ValueMapper<String, String>) String::toUpperCase)
-					.mapValues((ValueMapper<String, Foo>) Foo::new)
+					.mapValues(Foo::new)
 					.through(FOOS, Produced.with(Serdes.Integer(), new JsonSerde<Foo>() {
 
 					}))

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
@@ -53,7 +53,8 @@ import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.support.TopicPartitionInitialOffset;
-import org.springframework.kafka.test.rule.KafkaEmbedded;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.rule.EmbeddedKafkaRule;
 import org.springframework.kafka.test.utils.ContainerTestUtils;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 
@@ -90,8 +91,10 @@ public class ConcurrentMessageListenerContainerTests {
 	private static String topic11 = "testTopic11";
 
 	@ClassRule
-	public static KafkaEmbedded embeddedKafka = new KafkaEmbedded(1, true, topic1, topic2, topic4, topic5,
+	public static EmbeddedKafkaRule embeddedKafkaRule = new EmbeddedKafkaRule(1, true, topic1, topic2, topic4, topic5,
 			topic6, topic7, topic8, topic9, topic10, topic11);
+
+	private static EmbeddedKafkaBroker embeddedKafka = embeddedKafkaRule.getEmbeddedKafka();
 
 	@Test
 	public void testAutoCommit() throws Exception {

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ErrorHandlingDeserializerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ErrorHandlingDeserializerTests.java
@@ -43,7 +43,7 @@ import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.support.serializer.DeserializationException;
 import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
-import org.springframework.kafka.test.rule.KafkaEmbedded;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
@@ -63,7 +63,7 @@ public class ErrorHandlingDeserializerTests {
 	public Config config;
 
 	@Test
-	public void testBadDeser() throws Exception {
+	public void testBadDeserializer() throws Exception {
 		this.config.template().send(TOPIC, "foo", "bar");
 		this.config.template().send(TOPIC, "fail", "bar");
 		this.config.template().send(TOPIC, "foo", "fail");
@@ -93,8 +93,8 @@ public class ErrorHandlingDeserializerTests {
 
 
 		@Bean
-		public KafkaEmbedded embeddedKafka() {
-			return new KafkaEmbedded(1, true, 1, TOPIC);
+		public EmbeddedKafkaBroker embeddedKafka() {
+			return new EmbeddedKafkaBroker(1, true, 1, TOPIC);
 		}
 
 		@Bean

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
@@ -83,7 +83,8 @@ import org.springframework.kafka.support.TopicPartitionInitialOffset;
 import org.springframework.kafka.support.TopicPartitionInitialOffset.SeekPosition;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 import org.springframework.kafka.support.serializer.JsonSerializer;
-import org.springframework.kafka.test.rule.KafkaEmbedded;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.rule.EmbeddedKafkaRule;
 import org.springframework.kafka.test.utils.ContainerTestUtils;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 
@@ -139,9 +140,11 @@ public class KafkaMessageListenerContainerTests {
 
 
 	@ClassRule
-	public static KafkaEmbedded embeddedKafka = new KafkaEmbedded(1, true, topic1, topic2, topic3, topic4, topic5,
-			topic6, topic7, topic8, topic9, topic10, topic11, topic12, topic13, topic14, topic15, topic16, topic17,
-			topic18, topic19);
+	public static EmbeddedKafkaRule embeddedKafkaRule = new EmbeddedKafkaRule(1, true, topic1, topic2, topic3, topic4,
+			topic5, topic6, topic7, topic8, topic9, topic10, topic11, topic12, topic13, topic14, topic15, topic16,
+			topic17, topic18, topic19);
+
+	private static EmbeddedKafkaBroker embeddedKafka = embeddedKafkaRule.getEmbeddedKafka();
 
 	@Rule
 	public TestName testName = new TestName();

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/MissingGroupIdTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/MissingGroupIdTests.java
@@ -35,7 +35,8 @@ import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.support.TopicPartitionInitialOffset;
-import org.springframework.kafka.test.rule.KafkaEmbedded;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.rule.EmbeddedKafkaRule;
 
 /**
  * @author Gary Russell
@@ -45,7 +46,9 @@ import org.springframework.kafka.test.rule.KafkaEmbedded;
 public class MissingGroupIdTests {
 
 	@ClassRule
-	public static KafkaEmbedded kafkaEmbedded = new KafkaEmbedded(1, true, "missing.group");
+	public static EmbeddedKafkaRule embeddedKafkaRule = new EmbeddedKafkaRule(1, true, "missing.group");
+
+	private static EmbeddedKafkaBroker embeddedKafka = embeddedKafkaRule.getEmbeddedKafka();
 
 	@Test
 	public void testContextFailsWithKafkaListener() {
@@ -78,7 +81,7 @@ public class MissingGroupIdTests {
 		public ConsumerFactory<String, String> cf() {
 			return new DefaultKafkaConsumerFactory<>(
 					Collections.singletonMap(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
-							kafkaEmbedded.getBrokersAsString()),
+							embeddedKafka.getBrokersAsString()),
 					new StringDeserializer(), new StringDeserializer());
 		}
 
@@ -105,7 +108,7 @@ public class MissingGroupIdTests {
 		public ConsumerFactory<String, String> cf() {
 			return new DefaultKafkaConsumerFactory<>(
 					Collections.singletonMap(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
-							kafkaEmbedded.getBrokersAsString()),
+							embeddedKafka.getBrokersAsString()),
 					new StringDeserializer(), new StringDeserializer());
 		}
 
@@ -125,7 +128,7 @@ public class MissingGroupIdTests {
 		public ConsumerFactory<String, String> cf() {
 			return new DefaultKafkaConsumerFactory<>(
 					Collections.singletonMap(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
-							kafkaEmbedded.getBrokersAsString()),
+							embeddedKafka.getBrokersAsString()),
 					new StringDeserializer(), new StringDeserializer());
 		}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/MissingTopicsTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/MissingTopicsTests.java
@@ -25,7 +25,8 @@ import org.junit.ClassRule;
 import org.junit.Test;
 
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
-import org.springframework.kafka.test.rule.KafkaEmbedded;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.rule.EmbeddedKafkaRule;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 /**
@@ -36,8 +37,10 @@ import org.springframework.kafka.test.utils.KafkaTestUtils;
 public class MissingTopicsTests {
 
 	@ClassRule
-	public static KafkaEmbedded embeddedKafka = new KafkaEmbedded(1, true)
+	public static EmbeddedKafkaRule embeddedKafkaRule = new EmbeddedKafkaRule(1, true)
 		.brokerProperty("auto.create.topics.enable", false);
+
+	private static EmbeddedKafkaBroker embeddedKafka = embeddedKafkaRule.getEmbeddedKafka();
 
 	@Test
 	public void testMissingTopicCMLC() throws Exception {
@@ -77,6 +80,5 @@ public class MissingTopicsTests {
 		container.start();
 		container.stop();
 	}
-
 
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/TransactionalContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/TransactionalContainerTests.java
@@ -64,7 +64,8 @@ import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.support.TopicPartitionInitialOffset;
-import org.springframework.kafka.test.rule.KafkaEmbedded;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.rule.EmbeddedKafkaRule;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.kafka.transaction.ChainedKafkaTransactionManager;
 import org.springframework.kafka.transaction.KafkaTransactionManager;
@@ -92,9 +93,11 @@ public class TransactionalContainerTests {
 	private static String topic2 = "txTopic2";
 
 	@ClassRule
-	public static KafkaEmbedded embeddedKafka = new KafkaEmbedded(1, true, topic1, topic2)
+	public static EmbeddedKafkaRule embeddedKafkaRule = new EmbeddedKafkaRule(1, true, topic1, topic2)
 			.brokerProperty(KafkaConfig.TransactionsTopicReplicationFactorProp(), "1")
 			.brokerProperty(KafkaConfig.TransactionsTopicMinISRProp(), "1");
+
+	private static EmbeddedKafkaBroker embeddedKafka = embeddedKafkaRule.getEmbeddedKafka();
 
 	@Test
 	public void testConsumeAndProduceTransactionKTM() throws Exception {

--- a/spring-kafka/src/test/java/org/springframework/kafka/requestreply/ReplyingKafkaTemplateTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/requestreply/ReplyingKafkaTemplateTests.java
@@ -54,7 +54,8 @@ import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.support.SimpleKafkaHeaderMapper;
 import org.springframework.kafka.support.TopicPartitionInitialOffset;
 import org.springframework.kafka.support.converter.MessagingMessageConverter;
-import org.springframework.kafka.test.rule.KafkaEmbedded;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.rule.EmbeddedKafkaRule;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.annotation.Header;
@@ -85,8 +86,10 @@ public class ReplyingKafkaTemplateTests {
 	private static final String C_REQUEST = "cRequest";
 
 	@ClassRule
-	public static KafkaEmbedded embeddedKafka = new KafkaEmbedded(1, true, 5, A_REQUEST, A_REPLY,
+	public static EmbeddedKafkaRule embeddedKafkaRule = new EmbeddedKafkaRule(1, true, 5, A_REQUEST, A_REPLY,
 			B_REQUEST, B_REPLY, C_REQUEST, C_REPLY);
+
+	private static EmbeddedKafkaBroker embeddedKafka = embeddedKafkaRule.getEmbeddedKafka();
 
 	@Rule
 	public TestName testName = new TestName();

--- a/spring-kafka/src/test/kotlin/org/springframework/kafka/listener/EnableKafkaKotlinTests.kt
+++ b/spring-kafka/src/test/kotlin/org/springframework/kafka/listener/EnableKafkaKotlinTests.kt
@@ -28,9 +28,13 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.kafka.annotation.EnableKafka
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
-import org.springframework.kafka.core.*
+import org.springframework.kafka.core.ConsumerFactory
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory
+import org.springframework.kafka.core.DefaultKafkaProducerFactory
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.core.ProducerFactory
+import org.springframework.kafka.test.EmbeddedKafkaBroker
 import org.springframework.kafka.test.context.EmbeddedKafka
-import org.springframework.kafka.test.rule.KafkaEmbedded
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig
 import java.util.concurrent.CountDownLatch
@@ -76,7 +80,7 @@ class EnableKafkaKotlinTests {
 
 		val latch = CountDownLatch(2)
 
-		@Value("\${" + KafkaEmbedded.SPRING_EMBEDDED_KAFKA_BROKERS + "}")
+		@Value("\${" + EmbeddedKafkaBroker.SPRING_EMBEDDED_KAFKA_BROKERS + "}")
 		private lateinit var brokerAddresses: String
 
 		@Bean

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -12,7 +12,7 @@ Simply add a `NewTopic` `@Bean` for each topic to the application context.
 public KafkaAdmin admin() {
     Map<String, Object> configs = new HashMap<>();
     configs.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG,
-            StringUtils.arrayToCommaDelimitedString(kafkaEmbedded().getBrokerAddresses()));
+            StringUtils.arrayToCommaDelimitedString(embeddedKafka().getBrokerAddresses()));
     return new KafkaAdmin(configs);
 }
 

--- a/src/reference/asciidoc/testing.adoc
+++ b/src/reference/asciidoc/testing.adoc
@@ -17,21 +17,21 @@ NOTE: See <<deps-for-11x>> if you wish to use the 1.1.x `kafka-clients` jar with
  * Set up test properties for an {@code <Integer, String>} consumer.
  * @param group the group id.
  * @param autoCommit the auto commit.
- * @param embeddedKafka a {@link KafkaEmbedded} instance.
+ * @param embeddedKafka a {@link EmbeddedKafkaBroker} instance.
  * @return the properties.
  */
 public static Map<String, Object> consumerProps(String group, String autoCommit,
-                                       KafkaEmbedded embeddedKafka) { ... }
+                                       EmbeddedKafkaBroker embeddedKafka) { ... }
 
 /**
  * Set up test properties for an {@code <Integer, String>} producer.
- * @param embeddedKafka a {@link KafkaEmbedded} instance.
+ * @param embeddedKafka a {@link EmbeddedKafkaBroker} instance.
  * @return the properties.
  */
-public static Map<String, Object> senderProps(KafkaEmbedded embeddedKafka) { ... }
+public static Map<String, Object> senderProps(EmbeddedKafkaBroker embeddedKafka) { ... }
 ----
 
-A JUnit `@Rule` is provided that creates an embedded Kafka and an embedded Zookeeper server.
+A JUnit `@Rule` wrapper for the `EmbeddedKafkaBroker` is provided that creates an embedded Kafka and an embedded Zookeeper server.
 
 [source, java]
 ----
@@ -41,7 +41,7 @@ A JUnit `@Rule` is provided that creates an embedded Kafka and an embedded Zooke
  * @param controlledShutdown passed into TestUtils.createBrokerConfig.
  * @param topics the topics to create (2 partitions per).
  */
-public KafkaEmbedded(int count, boolean controlledShutdown, String... topics) { ... }
+public EmbeddedKafkaRule(int count, boolean controlledShutdown, String... topics) { ... }
 
 /**
  *
@@ -51,10 +51,10 @@ public KafkaEmbedded(int count, boolean controlledShutdown, String... topics) { 
  * @param partitions partitions per topic.
  * @param topics the topics to create.
  */
-public KafkaEmbedded(int count, boolean controlledShutdown, int partitions, String... topics) { ... }
+public EmbeddedKafkaRule(int count, boolean controlledShutdown, int partitions, String... topics) { ... }
 ----
 
-The embedded kafka class has a utility method allowing you to consume for all the topics it created:
+The `EmbeddedKafkaBroker` class has a utility method allowing you to consume for all the topics it created:
 
 [source, java]
 ----
@@ -96,10 +96,10 @@ ConsumerRecord<Integer, String> received = KafkaTestUtils.getSingleRecord(consum
 ...
 ----
 
-When the embedded Kafka and embedded Zookeeper server are started by JUnit, a system property `spring.embedded.kafka.brokers` is set to the address of the Kafka broker(s) and a system property `spring.embedded.zookeeper.connect` is set to the address of Zookeeper.
-Convenient constants `KafkaEmbedded.SPRING_EMBEDDED_KAFKA_BROKERS` and `KafkaEmbedded.SPRING_EMBEDDED_ZOOKEEPER_CONNECT` are provided for this property.
+When the embedded Kafka and embedded Zookeeper server are started by by the `EmbeddedKafkaBroker`, a system property `spring.embedded.kafka.brokers` is set to the address of the Kafka broker(s) and a system property `spring.embedded.zookeeper.connect` is set to the address of Zookeeper.
+Convenient constants `EmbeddedKafkaBroker.SPRING_EMBEDDED_KAFKA_BROKERS` and `EmbeddedKafkaBroker.SPRING_EMBEDDED_ZOOKEEPER_CONNECT` are provided for this property.
 
-With the `KafkaEmbedded.brokerProperties(Map<String, String>)` you can provide additional properties for the Kafka server(s).
+With the `EmbeddedKafkaBroker.brokerProperties(Map<String, String>)` you can provide additional properties for the Kafka server(s).
 See https://kafka.apache.org/documentation/#brokerconfigs[Kafka Config] for more information about possible broker properties.
 
 
@@ -109,13 +109,13 @@ There is no built-in support for this, but it can be achieved with something sim
 
 [source, java]
 ----
-public final class KafkaEmbeddedHolder {
+public final class EmbeddedKafkaHolder {
 
-	private static KafkaEmbedded embeddedKafka = new KafkaEmbedded(1, false);
+	private static EmbeddedKafkaRule embeddedKafka = new EmbeddedKafkaRule(1, false);
 
 	private static boolean started;
 
-	public static KafkaEmbedded getKafkaEmbedded() {
+	public static EmbeddedKafkaRule getEmbeddedKafka() {
 		if (!started) {
 			try {
 				embeddedKafka.before();
@@ -128,7 +128,7 @@ public final class KafkaEmbeddedHolder {
 		return embeddedKafka;
 	}
 
-	private KafkaEmbeddedHolder() {
+	private EmbeddedKafkaHolder() {
 		super();
 	}
 
@@ -140,21 +140,20 @@ And then, in each test class:
 [source, java]
 ----
 static {
-    KafkaEmbeddedHolder.getKafkaEmbedded().addTopics(topic1, topic2);
+    EmbeddedKafkaHolder.getEmbeddedKafka().addTopics(topic1, topic2);
 }
 
-private static KafkaEmbedded embeddedKafka = KafkaEmbeddedHolder.getKafkaEmbedded();
+private static EmbeddedKafkaRule embeddedKafka = EmbeddedKafkaHolder.getEmbeddedKafka();
 ----
 
 IMPORTANT: This example provides no mechanism for shutting down the broker(s) when all tests are complete.
-This could be a problem if, say, you run your tests in a gradle daemon.
-You should not use this technique in such a situation, or use something to call `destroy()` on the `KafkaEmbedded` when your tests are complete.
+This could be a problem if, say, you run your tests in a Gradle daemon.
+You should not use this technique in such a situation, or use something to call `destroy()` on the `EmbeddedKafkaBroker` when your tests are complete.
 
 ==== @EmbeddedKafka Annotation
 It is generally recommended to use the rule as a `@ClassRule` to avoid starting/stopping the broker between tests (and use a different topic for each test).
-Starting with _version 2.0_, if you are using Spring's test application context caching, you can also declare a `KafkaEmbedded` bean, so a single broker can be used across multiple test classes.
-The JUnit `ExternalResource` `before()/after()` lifecycle is wrapped to the `afterPropertiesSet()` and `destroy()` Spring infrastructure hooks.
-For convenience a test class level `@EmbeddedKafka` annotation is provided with the purpose to register `KafkaEmbedded` bean:
+Starting with _version 2.0_, if you are using Spring's test application context caching, you can also declare a `EmbeddedKafkaBroker` bean, so a single broker can be used across multiple test classes.
+For convenience a test class level `@EmbeddedKafka` annotation is provided with the purpose to register `EmbeddedKafkaBroker` bean:
 
 [source, java]
 ----
@@ -167,7 +166,7 @@ For convenience a test class level `@EmbeddedKafka` annotation is provided with 
 public class KafkaStreamsTests {
 
     @Autowired
-    private KafkaEmbedded embeddedKafka;
+    private EmbeddedKafkaBroker embeddedKafka;
 
     @Test
     public void someTest() {
@@ -184,7 +183,7 @@ public class KafkaStreamsTests {
     @EnableKafkaStreams
     public static class KafkaStreamsConfiguration {
 
-        @Value("${" + KafkaEmbedded.SPRING_EMBEDDED_KAFKA_BROKERS + "}")
+        @Value("${" + EmbeddedKafkaBroker.SPRING_EMBEDDED_KAFKA_BROKERS + "}")
         private String brokerAddresses;
 
         @Bean(name = KafkaStreamsDefaultConfiguration.DEFAULT_STREAMS_CONFIG_BEAN_NAME)
@@ -316,7 +315,7 @@ public class KafkaTemplateTests {
     private static final String TEMPLATE_TOPIC = "templateTopic";
 
     @ClassRule
-    public static KafkaEmbedded embeddedKafka = new KafkaEmbedded(1, true, TEMPLATE_TOPIC);
+    public static EmbeddedKafkaRule embeddedKafka = new EmbeddedKafkaRule(1, true, TEMPLATE_TOPIC);
 
     @Test
     public void testTemplate() throws Exception {
@@ -339,9 +338,9 @@ public class KafkaTemplateTests {
         });
         container.setBeanName("templateTests");
         container.start();
-        ContainerTestUtils.waitForAssignment(container, embeddedKafka.getPartitionsPerTopic());
+        ContainerTestUtils.waitForAssignment(container, embeddedKafka.getEmbeddedKafka().getPartitionsPerTopic());
         Map<String, Object> senderProps =
-                            KafkaTestUtils.senderProps(embeddedKafka.getBrokersAsString());
+                            KafkaTestUtils.senderProps(embeddedKafka.getEmbeddedKafka().getBrokersAsString());
         ProducerFactory<Integer, String> pf =
                             new DefaultKafkaProducerFactory<Integer, String>(senderProps);
         KafkaTemplate<Integer, String> template = new KafkaTemplate<>(pf);

--- a/src/reference/asciidoc/testing.adoc
+++ b/src/reference/asciidoc/testing.adoc
@@ -111,21 +111,21 @@ There is no built-in support for this, but it can be achieved with something sim
 ----
 public final class KafkaEmbeddedHolder {
 
-	private static KafkaEmbedded kafkaEmbedded = new KafkaEmbedded(1, false);
+	private static KafkaEmbedded embeddedKafka = new KafkaEmbedded(1, false);
 
 	private static boolean started;
 
 	public static KafkaEmbedded getKafkaEmbedded() {
 		if (!started) {
 			try {
-				kafkaEmbedded.before();
+				embeddedKafka.before();
 			}
 			catch (Exception e) {
 				throw new KafkaException(e);
 			}
 			started = true;
 		}
-		return kafkaEmbedded;
+		return embeddedKafka;
 	}
 
 	private KafkaEmbeddedHolder() {

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -40,3 +40,11 @@ They are now simple strings for interoperability.
 Also, the `DefaultKafkaHeaderMapper` has a new method `addToStringClasses` allowing the specification of types that should be mapped using `toString()` instead of JSON.
 
 See <<headers>> for more information.
+
+==== Embedded Kafka Changes
+
+The `KafkaEmbedded` class and its `KafkaRule` interface have need deprecated in favor of the `EmbeddedKafkaBroker` and its JUnit 4 `EmbeddedKafkaRule` wrapper.
+The `@EmbeddedKafka` now populates an `EmbeddedKafkaBroker` bean instead of deprecated `KafkaEmbedded`.
+Such a responsibility distribution allows to use an `@EmbeddedKafka` in the JUnit 5 tests.
+
+See <<testing>> for more information.


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-kafka/issues/732

The current `KafkaEmbedded` is fully tied with the JUnit 4 and can't be
used with just plain JUnit 5.

* Extract `EmbeddedKafkaBroker.java` class to the core level and add
an `EmbeddedKafkaRule` wrapper
* The `@EmbeddedKafka` now creates a `EmbeddedKafkaBroker` bean which is
still good for JUnit 5 support with Spring