### PR TITLE
GH-780: Allow using kafka-client 2.0.x with KafkaEmbedded

### DIFF
--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/rule/KafkaEmbedded.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/rule/KafkaEmbedded.java
@@ -99,7 +99,7 @@ public class KafkaEmbedded extends ExternalResource implements KafkaRule, Initia
 
 	static {
 		clientVersion = AppInfoParser.getVersion();
-		if (clientVersion.startsWith("1.1.")) {
+		if (clientVersion.startsWith("1.1.") || clientVersion.startsWith("2.0.")) {
 			try {
 				testUtilsCreateBrokerConfigMethod = TestUtils.class.getDeclaredMethod("createBrokerConfig",
 						int.class, String.class, boolean.class, boolean.class, int.class,


### PR DESCRIPTION
With this change, it becomes possible to override the kafka-clients dependencies and use version 2.0.0 with spring-kafka 2.1.x.

Note that I don't mind if this change is declined as it's possible work around this issue using a reflection hack.

Fixes #780 