### PR TITLE
Add ISSUE_TEMPLATE.md

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,19 @@
+<!--
+Thanks for raising a Spring Kafka issue. Please take the time to review the following
+categories as some of them do not apply here.
+
+🙅 "Please DO NOT Raise an Issue" Cases
+- Question
+STOP!! Please ask questions about how to use something, or to understand why something isn't
+working as you expect it to, on Stack Overflow using the spring-kafka tag.
+
+🐞 Bug report
+Please provide details of the problem, including the version of Spring Kafka that you
+are using. If possible, please provide a test case or sample application that reproduces
+the problem. This makes it much easier for us to diagnose the problem and to verify that
+we have fixed it.
+
+🎁 Enhancement
+Please start by describing the problem that you are trying to solve. There may already
+be a solution, or there may be a way to solve it that you hadn't considered.
+-->


### PR DESCRIPTION
Based on #779 , Spring Kafka's GitHub repo has a similar policy for questions with Spring Boot's, so this PR adds `ISSUE_TEMPLATE.md` file which are copied from Spring Boot and changed a bit to fit into Spring Kafka. Hope this reduces inappropriate issues.