### PR TITLE
Refactor KafkaAwareTransactionManager

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/transaction/ChainedKafkaTransactionManager.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/transaction/ChainedKafkaTransactionManager.java
@@ -55,4 +55,18 @@ public class ChainedKafkaTransactionManager<K, V> extends ChainedTransactionMana
 		return this.kafkaTransactionManager.getProducerFactory();
 	}
 
+	/**
+	 * Return the producer factory.
+	 * @return the producer factory.
+	 * @deprecated - in a future release {@link KafkaAwareTransactionManager} will not be
+	 * a sub interface of
+	 * {@link org.springframework.transaction.support.ResourceTransactionManager}.
+	 * TODO: Remove in 3.0
+	 */
+	@Deprecated
+	@Override
+	public Object getResourceFactory() {
+		return getProducerFactory();
+	}
+
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/transaction/KafkaAwareTransactionManager.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/transaction/KafkaAwareTransactionManager.java
@@ -17,9 +17,12 @@
 package org.springframework.kafka.transaction;
 
 import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.transaction.support.ResourceTransactionManager;
 
 /**
  * A transaction manager that can provide a {@link ProducerFactory}.
+ * Currently a sub-interface of {@link ResourceTransactionManager}
+ * for backwards compatibility.
  *
  * @param <K> the key type.
  * @param <V> the value type.
@@ -28,7 +31,7 @@ import org.springframework.kafka.core.ProducerFactory;
  * @since 2.1.3
  *
  */
-public interface KafkaAwareTransactionManager<K, V> {
+public interface KafkaAwareTransactionManager<K, V> extends ResourceTransactionManager {
 
 	/**
 	 * Get the producer factory.

--- a/spring-kafka/src/main/java/org/springframework/kafka/transaction/KafkaTransactionManager.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/transaction/KafkaTransactionManager.java
@@ -66,7 +66,7 @@ import org.springframework.util.Assert;
  */
 @SuppressWarnings("serial")
 public class KafkaTransactionManager<K, V> extends AbstractPlatformTransactionManager
-		implements ResourceTransactionManager, KafkaAwareTransactionManager<K, V> {
+		implements KafkaAwareTransactionManager<K, V> {
 
 	private final ProducerFactory<K, V> producerFactory;
 
@@ -93,6 +93,14 @@ public class KafkaTransactionManager<K, V> extends AbstractPlatformTransactionMa
 		return this.producerFactory;
 	}
 
+	/**
+	 * Return the producer factory.
+	 * @return the producer factory.
+	 * @deprecated - in a future release {@link KafkaAwareTransactionManager} will
+	 * not be a sub interface of {@link ResourceTransactionManager}.
+	 * TODO: Remove in 3.0
+	 */
+	@Deprecated
 	@Override
 	public Object getResourceFactory() {
 		return getProducerFactory();


### PR DESCRIPTION
Sub-interface of `PlatformTransactionManager` to facilitate Boot auto-configuration.

Deprecate `ResourceTransactionManager` inheritance.