### PR TITLE
SeekToCurrentErrorHandler and Recovery

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/SeekToCurrentErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/SeekToCurrentErrorHandler.java
@@ -78,8 +78,9 @@ public class SeekToCurrentErrorHandler implements ContainerAwareErrorHandler {
 	@Override
 	public void handle(Exception thrownException, List<ConsumerRecord<?, ?>> records,
 			Consumer<?, ?> consumer, MessageListenerContainer container) {
-		SeekUtils.doSeeks(records, consumer, thrownException, true, this.failureTracker::skip, logger);
-		throw new KafkaException("Seek to current after exception", thrownException);
+		if (!SeekUtils.doSeeks(records, consumer, thrownException, true, this.failureTracker::skip, logger)) {
+			throw new KafkaException("Seek to current after exception", thrownException);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
Don't throw an exception if the record was skipped by invoking the recoverer.

- Adds noise to the log since the record was recovered in some way.