### PR TITLE
Fix @since tag for setRemoveTypeHeaders()

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java
@@ -214,7 +214,7 @@ public class JsonDeserializer<T> implements ExtendedDeserializer<T> {
 	 * Set to false to retain type information headers after deserialization.
 	 * Default true.
 	 * @param removeTypeHeaders true to remove headers.
-	 * @since 2.1
+	 * @since 2.2
 	 */
 	public void setRemoveTypeHeaders(boolean removeTypeHeaders) {
 		this.removeTypeHeaders = removeTypeHeaders;


### PR DESCRIPTION
It was added in 7beaa606e28ef54d92e0b1831df6c229c560ea96 and looking at the commit, it looks intended to be in 2.2, so this PR changes the `@since` tag to 2.2.