### PR TITLE
InvocationResult: possible NPE fix

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/InvocationResult.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/InvocationResult.java
@@ -52,7 +52,7 @@ public final class InvocationResult {
 
 	@Override
 	public String toString() {
-		return this.result.toString();
+		return "result=" + (this.result == null ? null : this.result.toString());
 	}
 
 }


### PR DESCRIPTION
e.g. NPE can occur in case of logging lvl=debug & invocation result wrapped object is null: https://github.com/spring-projects/spring-kafka/blob/f68d2bd456a1786699e857e182d72114e0cc2316/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java#L292