### PR TITLE
GH-813: Re-pause a paused consumer after rebalance

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -566,6 +566,12 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 
 				@Override
 				public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
+					if (ListenerConsumer.this.consumerPaused) {
+						ListenerConsumer.this.consumerPaused = false;
+						ListenerConsumer.this.logger.warn("Paused consumer resumed by Kafka due to rebalance; "
+								+ "the container will pause again before polling, unless the container's "
+								+ "'paused' property is reset by a custom rebalance listener");
+					}
 					ListenerConsumer.this.assignedPartitions = partitions;
 					if (!ListenerConsumer.this.autoCommit) {
 						// Commit initial positions - this is generally redundant but


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-kafka/issues/813

Kafka resumes the consumer(s) after a rebalance, but since the
`ListenerConsumer.consumerPaused` is still true, the container starts
consuming again and can't be paused without first issuing a resume.

On a rebalance, reset the boolean; the consumer will re-pause  before
the next poll, if the container's `isPaused()` is still true after
the rebalance listeners exit.

Tested with a stand-alone Boot app (see the referenced issue).

**cherry-pick to 2.1.x**