### PR TITLE
GH-811: Configurable Reply Headers

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
@@ -172,7 +172,7 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 
 	/**
 	 * Set the name of the {@link KafkaListenerContainerFactory} to use by default.
-	 * <p>If none is specified, "KafkaListenerContainerFactory" is assumed to be defined.
+	 * <p>If none is specified, "kafkaListenerContainerFactory" is assumed to be defined.
 	 * @param containerFactoryBeanName the {@link KafkaListenerContainerFactory} bean name.
 	 */
 	public void setContainerFactoryBeanName(String containerFactoryBeanName) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
@@ -33,6 +33,7 @@ import org.springframework.kafka.listener.ContainerProperties;
 import org.springframework.kafka.listener.ErrorHandler;
 import org.springframework.kafka.listener.GenericErrorHandler;
 import org.springframework.kafka.listener.adapter.RecordFilterStrategy;
+import org.springframework.kafka.listener.adapter.ReplyHeadersConfigurer;
 import org.springframework.kafka.support.TopicPartitionInitialOffset;
 import org.springframework.kafka.support.converter.MessageConverter;
 import org.springframework.retry.RecoveryCallback;
@@ -83,6 +84,8 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 	private KafkaTemplate<?, ?> replyTemplate;
 
 	private AfterRollbackProcessor<K, V> afterRollbackProcessor;
+
+	private ReplyHeadersConfigurer replyHeadersConfigurer;
 
 	/**
 	 * Specify a {@link ConsumerFactory} to use.
@@ -231,6 +234,15 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 	}
 
 	/**
+	 * Set a configurer which will be invoked when creating a reply message.
+	 * @param replyHeadersConfigurer the configurer.
+	 * @since 2.2
+	 */
+	public void setReplyHeadersConfigurer(ReplyHeadersConfigurer replyHeadersConfigurer) {
+		this.replyHeadersConfigurer = replyHeadersConfigurer;
+	}
+
+	/**
 	 * Obtain the properties template for this factory - set properties as needed
 	 * and they will be copied to a final properties instance for the endpoint.
 	 * @return the properties.
@@ -269,6 +281,9 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 			}
 			if (this.replyTemplate != null) {
 				aklEndpoint.setReplyTemplate(this.replyTemplate);
+			}
+			if (this.replyHeadersConfigurer != null) {
+				aklEndpoint.setReplyHeadersConfigurer(this.replyHeadersConfigurer);
 			}
 		}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/ReplyHeadersConfigurer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/ReplyHeadersConfigurer.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener.adapter;
+
+import java.util.Map;
+
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.lang.Nullable;
+import org.springframework.messaging.MessageHeaders;
+
+/**
+ * A strategy for configuring which headers, if any, should be set in a reply message.
+ *
+ * @author Gary Russell
+ * @since 2.2
+ *
+ */
+@FunctionalInterface
+public interface ReplyHeadersConfigurer {
+
+	/**
+	 * Return true if the header should be copied to the reply message.
+	 * {@link KafkaHeaders#CORRELATION_ID} will not be offered; it is always copied.
+	 * {@link MessageHeaders#ID} and {@link MessageHeaders#TIMESTAMP} are never copied.
+	 * {@code KafkaHeaders.RECEIVED_*} headers are never copied.
+	 * @param headerName the header name.
+	 * @param headerValue the header value.
+	 * @return true to copy.
+	 */
+	boolean shouldCopy(String headerName, Object headerValue);
+
+	/**
+	 * A map of additional headers to add to the reply message.
+	 * @return the headers.
+	 */
+	@Nullable
+	default Map<String, Object> additionalHeaders() {
+		return null;
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/KafkaHeaders.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/KafkaHeaders.java
@@ -26,7 +26,15 @@ package org.springframework.kafka.support;
  */
 public abstract class KafkaHeaders {
 
-	private static final String PREFIX = "kafka_";
+	/**
+	 * The prefix for Kafka headers.
+	 */
+	public static final String PREFIX = "kafka_";
+
+	/**
+	 * The prefix for Kafka headers containing 'received' values.
+	 */
+	public static final String RECEIVED = PREFIX + "received";
 
 	/**
 	 * The header containing the topic when sending data to Kafka.
@@ -72,17 +80,17 @@ public abstract class KafkaHeaders {
 	/**
 	 * The header containing the topic from which the message was received.
 	 */
-	public static final String RECEIVED_TOPIC = PREFIX + "receivedTopic";
+	public static final String RECEIVED_TOPIC = RECEIVED + "Topic";
 
 	/**
 	 * The header containing the message key for the received message.
 	 */
-	public static final String RECEIVED_MESSAGE_KEY = PREFIX + "receivedMessageKey";
+	public static final String RECEIVED_MESSAGE_KEY = RECEIVED + "MessageKey";
 
 	/**
 	 * The header containing the topic partition for the received message.
 	 */
-	public static final String RECEIVED_PARTITION_ID = PREFIX + "receivedPartitionId";
+	public static final String RECEIVED_PARTITION_ID = RECEIVED + "PartitionId";
 
 	/**
 	 * The header for holding the {@link org.apache.kafka.common.record.TimestampType type} of timestamp.

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -1333,6 +1333,53 @@ public class MultiListenerSendTo {
 }
 ----
 
+Starting with version 2.2, you can add a `ReplyHeadersConfigurer` to the listener container factory.
+This is consulted to determine which headers you want to set in the reply message.
+
+====
+[source, java]
+----
+@Bean
+public ConcurrentKafkaListenerContainerFactory<Integer, String> kafkaListenerContainerFactory() {
+    ConcurrentKafkaListenerContainerFactory<Integer, String> factory =
+        new ConcurrentKafkaListenerContainerFactory<>();
+    factory.setConsumerFactory(cf());
+    factory.setReplyTemplate(template());
+    factory.setReplyHeadersConfigurer((k, v) -> k.equals("baz"));
+    return factory;
+}
+----
+====
+
+You can also add more headers if you wish
+
+====
+[source, java]
+----
+@Bean
+public ConcurrentKafkaListenerContainerFactory<Integer, String> kafkaListenerContainerFactory() {
+    ConcurrentKafkaListenerContainerFactory<Integer, String> factory =
+        new ConcurrentKafkaListenerContainerFactory<>();
+    factory.setConsumerFactory(cf());
+    factory.setReplyTemplate(template());
+    factory.setReplyHeadersConfigurer(new ReplyHeadersConfigurer() {
+
+      @Override
+      public boolean shouldCopy(String headerName, Object headerValue) {
+        return false;
+      }
+
+      @Override
+      public Map<String, Object> additionalHeaders() {
+        return Collections.singletonMap("qux", "fiz");
+      }
+
+    });
+    return factory;
+}
+----
+====
+
 When using `@SendTo`, the `ConcurrentKafkaListenerContainerFactory` must be configured with a `KafkaTemplate` in its `replyTemplate` property, to perform the send.
 NOTE: unless you are using <<replying-template,request/reply semantics>> only the simple `send(topic, value)` method is used, so you may wish to create a subclass to generate the partition and/or key:
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -43,6 +43,7 @@ See <<after-rollback>>, <<seek-to-current>> and <<dead-letters>> for more inform
 ==== @KafkaListener Changes
 
 You can now override the `concurrency` and `autoStartup` properties of the listener container factory by setting properties on the annotation.
+You can now add configuration to determine which headers (if any) are copied to a reply message.
 
 See <<kafka-listener-annotation>> for more information.
 


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/811

Support copying and/or modifying reply headers.