### PR TITLE
Embedded broker support different partition counts

### DIFF
--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaBroker.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaBroker.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
@@ -87,6 +88,8 @@ public class EmbeddedKafkaBroker implements InitializingBean, DisposableBean {
 
 	public static final String SPRING_EMBEDDED_ZOOKEEPER_CONNECT = "spring.embedded.zookeeper.connect";
 
+	private static final int DEFAULT_ADMIN_TIMEOUT = 30;
+
 	private final int count;
 
 	private final boolean controlledShutdown;
@@ -106,6 +109,8 @@ public class EmbeddedKafkaBroker implements InitializingBean, DisposableBean {
 	private String zkConnect;
 
 	private int[] kafkaPorts;
+
+	private int adminTimeout = DEFAULT_ADMIN_TIMEOUT;
 
 	public EmbeddedKafkaBroker(int count) {
 		this(count, false);
@@ -177,6 +182,15 @@ public class EmbeddedKafkaBroker implements InitializingBean, DisposableBean {
 		return this;
 	}
 
+	/**
+	 * Set the timeout in seconds for admin operations (e.g. topic creation, close).
+	 * Default 30 seconds.
+	 * @param adminTimeout the timeout.
+	 */
+	public void setAdminTimeout(int adminTimeout) {
+		this.adminTimeout = adminTimeout;
+	}
+
 	@Override
 	public void afterPropertiesSet() {
 		this.zookeeper = new EmbeddedZookeeper();
@@ -218,6 +232,41 @@ public class EmbeddedKafkaBroker implements InitializingBean, DisposableBean {
 	}
 
 	/**
+	 * Add topics to the existing broker(s) using the configured number of partitions.
+	 * The broker(s) must be running.
+	 * @param topics the topics.
+	 */
+	public void addTopics(String... topics) {
+		Assert.notNull(this.zookeeper, "Broker must be started before this method can be called");
+		HashSet<String> set = new HashSet<>(Arrays.asList(topics));
+		createKafkaTopics(set);
+		this.topics.addAll(set);
+	}
+
+	/**
+	 * Add topics to the existing broker(s).
+ 	 * The broker(s) must be running.
+	 * @param topics the topics.
+	 * @since 2.2
+	 */
+	public void addTopics(NewTopic... topics) {
+		Assert.notNull(this.zookeeper, "Broker must be started before this method can be called");
+		doWithAdmin(admin -> {
+			createTopics(admin,
+				Arrays.stream(topics).
+					map(topic -> {
+						Assert.isTrue(this.topics.add(topic.name()), () -> "topic already exists: " + topic);
+						Assert.isTrue(topic.replicationFactor() <= this.count
+								&& (topic.replicasAssignments() == null
+									|| topic.replicasAssignments().size() <= this.count),
+								() -> "Embedded kafka does not support the requested replication factor: " + topic);
+						return topic;
+					})
+					.collect(Collectors.toList()));
+		});
+	}
+
+	/**
 	 * Create topics in the existing broker(s) using the configured number of partitions.
 	 * @param topics the topics.
 	 */
@@ -226,25 +275,18 @@ public class EmbeddedKafkaBroker implements InitializingBean, DisposableBean {
 			List<NewTopic> newTopics = topics.stream()
 					.map(t -> new NewTopic(t, this.partitionsPerTopic, (short) this.count))
 					.collect(Collectors.toList());
-			CreateTopicsResult createTopics = admin.createTopics(newTopics);
-			try {
-				createTopics.all().get();
-			}
-			catch (Exception e) {
-				throw new KafkaException(e);
-			}
+			createTopics(admin, newTopics);
 		});
 	}
 
-
-	/**
-	 * Add topics to the existing broker(s) using the configured number of partitions.
-	 * @param topics the topics.
-	 */
-	public void addTopics(String... topics) {
-		HashSet<String> set = new HashSet<>(Arrays.asList(topics));
-		createKafkaTopics(set);
-		this.topics.addAll(set);
+	private void createTopics(AdminClient admin, List<NewTopic> newTopics) {
+		CreateTopicsResult createTopics = admin.createTopics(newTopics);
+		try {
+			createTopics.all().get(this.adminTimeout, TimeUnit.SECONDS);
+		}
+		catch (Exception e) {
+			throw new KafkaException(e);
+		}
 	}
 
 	/**
@@ -254,8 +296,15 @@ public class EmbeddedKafkaBroker implements InitializingBean, DisposableBean {
 	public void doWithAdmin(java.util.function.Consumer<AdminClient> callback) {
 		Map<String, Object> adminConfigs = new HashMap<>();
 		adminConfigs.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, getBrokersAsString());
-		try (AdminClient admin = AdminClient.create(adminConfigs)) {
+		AdminClient admin = null;
+		try {
+			admin = AdminClient.create(adminConfigs);
 			callback.accept(admin);
+		}
+		finally {
+			if (admin != null) {
+				admin.close(this.adminTimeout, TimeUnit.SECONDS);
+			}
 		}
 	}
 

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafka.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafka.java
@@ -53,6 +53,7 @@ import org.springframework.kafka.test.EmbeddedKafkaBroker;
  * @author Artem Bilan
  * @author Elliot Metsger
  * @author Zach Olauson
+ * @author Gary Russell
  *
  * @since 1.3
  *
@@ -87,8 +88,11 @@ public @interface EmbeddedKafka {
 	int partitions() default 2;
 
 	/**
-	 * Topics that should be created
-	 * Topics may contain property placeholders, e.g. {@code topics = "${kafka.topic.one:topicOne}"}
+	 * Topics that should be created Topics may contain property placeholders, e.g.
+	 * {@code topics = "${kafka.topic.one:topicOne}"} The topics will be created with
+	 * {@link #partitions()} partitions; to provision other topics with other partition
+	 * counts call the {@code addPartitions(NewTopic... topics)} method on the autowired
+	 * broker.
 	 * @return the topics to create
 	 */
 	String[] topics() default { };

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/rule/KafkaEmbedded.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/rule/KafkaEmbedded.java
@@ -132,15 +132,6 @@ public class KafkaEmbedded extends EmbeddedKafkaRule implements KafkaRule, Initi
 	}
 
 	/**
-	 * Add topics to the existing broker(s) using the configured number of partitions.
-	 * @param topics the topics.
-	 * @since 2.1.6
-	 */
-	public void addTopics(String... topics) {
-		getEmbeddedKafka().addTopics(topics);
-	}
-
-	/**
 	 * Create an {@link AdminClient}; invoke the callback and reliably close the
 	 * admin.
 	 * @param callback the callback.

--- a/src/reference/asciidoc/testing.adoc
+++ b/src/reference/asciidoc/testing.adoc
@@ -103,41 +103,65 @@ Convenient constants `EmbeddedKafkaBroker.SPRING_EMBEDDED_KAFKA_BROKERS` and `Em
 With the `EmbeddedKafkaBroker.brokerProperties(Map<String, String>)` you can provide additional properties for the Kafka server(s).
 See https://kafka.apache.org/documentation/#brokerconfigs[Kafka Config] for more information about possible broker properties.
 
+==== Configuring Topics
+
+====
+[source, java]
+----
+public class MyTests {
+
+    private static EmbeddedKafkaRule embeddedKafka = new EmbeddedKafkaRule(1, false, 5, "foo", "bar");
+
+    @Test
+    public void test() {
+        embeddedKafkaRule.getEmbeddedKafka()
+              .addTopics(new NewTopic("baz", 10, (short) 1), new NewTopic("qux", 5, (short) 1));
+        ...
+  	}
+
+}
+----
+====
+
+The above configuration will create topics `foo` and `bar` with 5 partitions, `baz` with 10 and `qux` with 15.
 
 ==== Using the Same Broker(s) for Multiple Test Classes
 
 There is no built-in support for this, but it can be achieved with something similar to the following:
 
+====
 [source, java]
 ----
 public final class EmbeddedKafkaHolder {
 
-	private static EmbeddedKafkaRule embeddedKafka = new EmbeddedKafkaRule(1, false);
+    private static EmbeddedKafkaRule embeddedKafka = new EmbeddedKafkaRule(1, false);
 
-	private static boolean started;
+    private static boolean started;
 
-	public static EmbeddedKafkaRule getEmbeddedKafka() {
-		if (!started) {
-			try {
-				embeddedKafka.before();
-			}
-			catch (Exception e) {
-				throw new KafkaException(e);
-			}
-			started = true;
-		}
-		return embeddedKafka;
-	}
+    public static EmbeddedKafkaRule getEmbeddedKafka() {
+        if (!started) {
+            try {
+                embeddedKafka.before();
+            }
+            catch (Exception e) {
+                throw new KafkaException(e);
+            }
+            started = true;
+        }
+        return embeddedKafka;
+    }
 
-	private EmbeddedKafkaHolder() {
-		super();
-	}
+    private EmbeddedKafkaHolder() {
+        super();
+    }
 
 }
 ----
+====
 
 And then, in each test class:
 
+====
 [source, java]
 ----
 static {
@@ -146,6 +170,7 @@ static {
 
 private static EmbeddedKafkaRule embeddedKafka = EmbeddedKafkaHolder.getEmbeddedKafka();
 ----
+====
 
 IMPORTANT: This example provides no mechanism for shutting down the broker(s) when all tests are complete.
 This could be a problem if, say, you run your tests in a Gradle daemon.
@@ -333,8 +358,8 @@ public class KafkaTemplateTests {
         final BlockingQueue<ConsumerRecord<Integer, String>> records = new LinkedBlockingQueue<>();
         container.setupMessageListener(new MessageListener<Integer, String>() {
 
-        	@Override
-        	public void onMessage(ConsumerRecord<Integer, String> record) {
+            @Override
+            public void onMessage(ConsumerRecord<Integer, String> record) {
                 System.out.println(record);
                 records.add(record);
             }

--- a/src/reference/asciidoc/testing.adoc
+++ b/src/reference/asciidoc/testing.adoc
@@ -110,12 +110,13 @@ See https://kafka.apache.org/documentation/#brokerconfigs[Kafka Config] for more
 ----
 public class MyTests {
 
-    private static EmbeddedKafkaRule embeddedKafka = new EmbeddedKafkaRule(1, false, 5, "foo", "bar");
+    @ClassRule
+    public static EmbeddedKafkaRule embeddedKafka = new EmbeddedKafkaRule(1, false, 5, "foo", "bar");
 
     @Test
     public void test() {
         embeddedKafkaRule.getEmbeddedKafka()
-              .addTopics(new NewTopic("baz", 10, (short) 1), new NewTopic("qux", 5, (short) 1));
+              .addTopics(new NewTopic("baz", 10, (short) 1), new NewTopic("qux", 15, (short) 1));
         ...
   	}
 


### PR DESCRIPTION
Add `addTopics(NewTopic... topics)` to the embedded broker to enable
creation of topics with different parition counts.