### PR TITLE
GH-834: Remove transactional producers

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/ProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/ProducerFactory.java
@@ -44,7 +44,7 @@ public interface ProducerFactory<K, V> {
 
 	/**
 	 * Remove the specified producer from the cache and close it.
-	 * @param transactionId the producer's transaction id suffix.
+	 * @param transactionIdSuffix the producer's transaction id suffix.
 	 * @since 1.3.8
 	 */
 	default void closeProducerFor(String transactionIdSuffix) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/ProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/ProducerFactory.java
@@ -28,10 +28,27 @@ import org.apache.kafka.clients.producer.Producer;
  */
 public interface ProducerFactory<K, V> {
 
+	/**
+	 * Create a producer.
+	 * @return the producer.
+	 */
 	Producer<K, V> createProducer();
 
+	/**
+	 * Return true if the factory supports transactions.
+	 * @return true if transactional.
+	 */
 	default boolean transactionCapable() {
 		return false;
+	}
+
+	/**
+	 * Remove the specified producer from the cache and close it.
+	 * @param transactionId the producer's transaction id suffix.
+	 * @since 1.3.8
+	 */
+	default void closeProducerFor(String transactionIdSuffix) {
+		// NOSONAR
 	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -55,6 +55,7 @@ import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.kafka.KafkaException;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.KafkaResourceHolder;
+import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.core.ProducerFactoryUtils;
 import org.springframework.kafka.event.ConsumerPausedEvent;
 import org.springframework.kafka.event.ConsumerResumedEvent;
@@ -562,6 +563,9 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 					if (this.consumerAwareListener != null) {
 						this.consumerAwareListener.onPartitionsRevokedAfterCommit(consumer, partitions);
 					}
+					if (ListenerConsumer.this.kafkaTxManager != null) {
+						closeProducers(partitions);
+					}
 				}
 
 				@Override
@@ -785,6 +789,9 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 					catch (WakeupException e) {
 						// No-op. Continue process
 					}
+				}
+				else {
+					closeProducers(getAssignedPartitions());
 				}
 			}
 			else {
@@ -1064,8 +1071,8 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 					this.logger.trace("Processing " + record);
 				}
 				try {
-					TransactionSupport.setTransactionIdSuffix(
-							this.consumerGroupId + "." + record.topic() + "." + record.partition());
+					TransactionSupport
+							.setTransactionIdSuffix(zombieFenceTxIdSuffix(record.topic(), record.partition()));
 					this.transactionTemplate.execute(new TransactionCallbackWithoutResult() {
 
 						@Override
@@ -1445,6 +1452,23 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 					+ ", consumerGroupId=" + this.consumerGroupId
 					+ ", clientIdSuffix=" + KafkaMessageListenerContainer.this.clientIdSuffix
 					+ "]";
+		}
+
+		private void closeProducers(Collection<TopicPartition> partitions) {
+			ProducerFactory<?, ?> producerFactory = this.kafkaTxManager.getProducerFactory();
+			partitions.forEach(tp -> {
+				try {
+					producerFactory.closeProducerFor(zombieFenceTxIdSuffix(tp.topic(), tp.partition()));
+				}
+				catch (Exception e) {
+					this.logger.error("Failed to close producer with transaction id suffix: "
+							+ zombieFenceTxIdSuffix(tp.topic(), tp.partition()), e);
+				}
+			});
+		}
+
+		private String zombieFenceTxIdSuffix(String topic, int partition) {
+			return this.consumerGroupId + "." + topic + "." + partition;
 		}
 
 		private final class ConsumerAcknowledgment implements Acknowledgment {

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/TransactionalContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/TransactionalContainerTests.java
@@ -473,9 +473,9 @@ public class TransactionalContainerTests {
 		// depending on timing, the position might include the offset representing the commit in the log
 		assertThat(consumer.position(new TopicPartition(topic1, 0))).isGreaterThanOrEqualTo(1L);
 		assertThat(transactionalId.get()).startsWith("rr.group.txTopic");
+		assertThat(KafkaTestUtils.getPropertyValue(pf, "consumerProducers", Map.class)).isEmpty();
 		logger.info("Stop testRollbackRecord");
 		pf.destroy();
-		assertThat(KafkaTestUtils.getPropertyValue(pf, "consumerProducers", Map.class)).isEmpty();
 		consumer.close();
 	}
 


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/834

To solve the zombie fencing problem there is a producer for each
group/topic/partition.

Close these producers when a partition is revoked or the container stopped.

**cherry-pick to 2.1.x, 2.0.x**

I will backport to 1.3.x (without lambdas etc) after review/merge.