### PR TITLE
Polish InvocationResult.toString()

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/InvocationResult.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/InvocationResult.java
@@ -52,7 +52,7 @@ public final class InvocationResult {
 
 	@Override
 	public String toString() {
-		return "InvocationResult [result=" + this.result == null ? null : this.result
+		return "InvocationResult [result=" + this.result
 				+ ", sendTo=" + this.sendTo == null ? null : this.sendTo.getExpressionString()
 				+ ", messageReturnType=" + this.messageReturnType + "]";
 	}


### PR DESCRIPTION
This PR polishes `InvocationResult.toString()` by removing an unnecessary ternary operator.