### PR TITLE
Log TX Exceptions

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
@@ -466,6 +466,7 @@ public class DefaultKafkaProducerFactory<K, V> implements ProducerFactory<K, V>,
 				this.delegate.commitTransaction();
 			}
 			catch (RuntimeException e) {
+				logger.error("Commit failed", e);
 				this.txFailed = true;
 				throw e;
 			}
@@ -477,6 +478,7 @@ public class DefaultKafkaProducerFactory<K, V> implements ProducerFactory<K, V>,
 				this.delegate.abortTransaction();
 			}
 			catch (RuntimeException e) {
+				logger.error("Abort failed", e);
 				this.txFailed = true;
 				throw e;
 			}

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
@@ -274,15 +274,15 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V> {
 		}
 
 		this.producers.set(producer);
-		boolean commitFailed = false;
+		boolean callbackSuccessful = false;
 		try {
 			T result = callback.doInOperations(this);
-			commitFailed = true;
+			callbackSuccessful = true;
 			producer.commitTransaction();
 			return result;
 		}
 		catch (Exception e) {
-			if (!commitFailed) {
+			if (!callbackSuccessful) {
 				producer.abortTransaction();
 			}
 			throw e;

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
@@ -274,13 +274,17 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V> {
 		}
 
 		this.producers.set(producer);
+		boolean commitFailed = false;
 		try {
 			T result = callback.doInOperations(this);
+			commitFailed = true;
 			producer.commitTransaction();
 			return result;
 		}
 		catch (Exception e) {
-			producer.abortTransaction();
+			if (!commitFailed) {
+				producer.abortTransaction();
+			}
 			throw e;
 		}
 		finally {

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTransactionTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTransactionTests.java
@@ -78,7 +78,8 @@ public class KafkaTemplateTransactionTests {
 	@ClassRule
 	public static EmbeddedKafkaRule embeddedKafkaRule = new EmbeddedKafkaRule(1, true, STRING_KEY_TOPIC)
 			.brokerProperty(KafkaConfig.TransactionsTopicReplicationFactorProp(), "1")
-			.brokerProperty(KafkaConfig.TransactionsTopicMinISRProp(), "1");
+			.brokerProperty(KafkaConfig.TransactionsTopicMinISRProp(), "1")
+			.brokerProperty(KafkaConfig.TransactionsAbortTimedOutTransactionCleanupIntervalMsProp(), "2000");
 
 	private static EmbeddedKafkaBroker embeddedKafka = embeddedKafkaRule.getEmbeddedKafka();
 
@@ -86,6 +87,7 @@ public class KafkaTemplateTransactionTests {
 	public void testLocalTransaction() throws Exception {
 		Map<String, Object> senderProps = KafkaTestUtils.producerProps(embeddedKafka);
 		senderProps.put(ProducerConfig.RETRIES_CONFIG, 1);
+		senderProps.put(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG, 1000);
 		DefaultKafkaProducerFactory<String, String> pf = new DefaultKafkaProducerFactory<>(senderProps);
 		pf.setKeySerializer(new StringSerializer());
 		pf.setTransactionIdPrefix("my.transaction.");
@@ -100,6 +102,12 @@ public class KafkaTemplateTransactionTests {
 		template.executeInTransaction(t -> {
 			t.sendDefault("foo", "bar");
 			t.sendDefault("baz", "qux");
+			try {
+				Thread.sleep(5000);
+			}
+			catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
 			return null;
 		});
 		ConsumerRecords<String, String> records = KafkaTestUtils.getRecords(consumer);

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTransactionTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTransactionTests.java
@@ -78,8 +78,7 @@ public class KafkaTemplateTransactionTests {
 	@ClassRule
 	public static EmbeddedKafkaRule embeddedKafkaRule = new EmbeddedKafkaRule(1, true, STRING_KEY_TOPIC)
 			.brokerProperty(KafkaConfig.TransactionsTopicReplicationFactorProp(), "1")
-			.brokerProperty(KafkaConfig.TransactionsTopicMinISRProp(), "1")
-			.brokerProperty(KafkaConfig.TransactionsAbortTimedOutTransactionCleanupIntervalMsProp(), "2000");
+			.brokerProperty(KafkaConfig.TransactionsTopicMinISRProp(), "1");
 
 	private static EmbeddedKafkaBroker embeddedKafka = embeddedKafkaRule.getEmbeddedKafka();
 
@@ -87,7 +86,6 @@ public class KafkaTemplateTransactionTests {
 	public void testLocalTransaction() throws Exception {
 		Map<String, Object> senderProps = KafkaTestUtils.producerProps(embeddedKafka);
 		senderProps.put(ProducerConfig.RETRIES_CONFIG, 1);
-		senderProps.put(ProducerConfig.TRANSACTION_TIMEOUT_CONFIG, 1000);
 		DefaultKafkaProducerFactory<String, String> pf = new DefaultKafkaProducerFactory<>(senderProps);
 		pf.setKeySerializer(new StringSerializer());
 		pf.setTransactionIdPrefix("my.transaction.");
@@ -102,12 +100,6 @@ public class KafkaTemplateTransactionTests {
 		template.executeInTransaction(t -> {
 			t.sendDefault("foo", "bar");
 			t.sendDefault("baz", "qux");
-			try {
-				Thread.sleep(5000);
-			}
-			catch (InterruptedException e) {
-				Thread.currentThread().interrupt();
-			}
 			return null;
 		});
 		ConsumerRecords<String, String> records = KafkaTestUtils.getRecords(consumer);


### PR DESCRIPTION
- Log exceptions on commit/abort transaction
- Don't attempt to abort if commit fails, otherwise we see

`Abort failed`
`org.apache.kafka.common.KafkaException: Cannot execute transactional method because we are in an error state`

**cherry-pick to 2.1.x**