### PR TITLE
GH-853: Type Safe ErrorHandlingDeserializer

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -16,6 +16,9 @@
 
 package org.springframework.kafka.listener;
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.lang.reflect.Type;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -50,6 +53,9 @@ import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.WakeupException;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.kafka.KafkaException;
@@ -70,6 +76,7 @@ import org.springframework.kafka.support.TopicPartitionInitialOffset;
 import org.springframework.kafka.support.TopicPartitionInitialOffset.SeekPosition;
 import org.springframework.kafka.support.TransactionSupport;
 import org.springframework.kafka.support.serializer.DeserializationException;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer2;
 import org.springframework.kafka.transaction.KafkaAwareTransactionManager;
 import org.springframework.scheduling.SchedulingAwareRunnable;
 import org.springframework.scheduling.TaskScheduler;
@@ -417,6 +424,10 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 
 		private final Duration pollTimeout = Duration.ofMillis(this.containerProperties.getPollTimeout());
 
+		private final boolean checkNullKeyForExceptions;
+
+		private final boolean checkNullValueForExceptions;
+
 		private volatile Map<TopicPartition, OffsetMetadata> definedPartitions;
 
 		private volatile Collection<TopicPartition> assignedPartitions;
@@ -521,6 +532,18 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 			if (this.containerProperties.isLogContainerConfig()) {
 				this.logger.info(this);
 			}
+			Map<String, Object> props = KafkaMessageListenerContainer.this.consumerFactory.getConfigurationProperties();
+			this.checkNullKeyForExceptions = checkDeserializer(props.get(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG));
+			this.checkNullValueForExceptions = checkDeserializer(
+					props.get(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG));
+		}
+
+		private boolean checkDeserializer(Object deser) {
+			return deser instanceof Class
+					? ((Class<?>) deser).equals(ErrorHandlingDeserializer2.class)
+					: deser instanceof String
+						? ((String) deser).equals(ErrorHandlingDeserializer2.class.getName())
+						: false;
 		}
 
 		protected void checkConsumer() {
@@ -1136,6 +1159,12 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 				if (record.key() instanceof DeserializationException) {
 					throw (DeserializationException) record.key();
 				}
+				if (record.value() == null && this.checkNullValueForExceptions) {
+					checkDeser(record, ErrorHandlingDeserializer2.VALUE_DESERIALIZER_EXCEPTION_HEADER);
+				}
+				if (record.key() == null && this.checkNullValueForExceptions) {
+					checkDeser(record, ErrorHandlingDeserializer2.KEY_DESERIALIZER_EXCEPTION_HEADER);
+				}
 				switch (this.listenerType) {
 					case ACKNOWLEDGING_CONSUMER_AWARE:
 						this.listener.onMessage(record,
@@ -1195,6 +1224,27 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 				}
 			}
 			return null;
+		}
+
+		public void checkDeser(final ConsumerRecord<K, V> record, String headerName) {
+			Header header = record.headers().lastHeader(headerName);
+			if (header != null) {
+				try {
+					DeserializationException ex = (DeserializationException) new ObjectInputStream(
+							new ByteArrayInputStream(header.value())).readObject();
+					Headers headers = new RecordHeaders();
+					record.headers().forEach(h -> {
+						if (!h.key().startsWith(ErrorHandlingDeserializer2.KEY_DESERIALIZER_EXCEPTION_HEADER_PREFIX)) {
+							headers.add(h.key(), h.value());
+						}
+					});
+					ex.setHeaders(headers);
+					throw ex;
+				}
+				catch (IOException | ClassNotFoundException | ClassCastException e) {
+					this.logger.error("Failed to deserialize a deserialization exception", e);
+				}
+			}
 		}
 
 		public void ackCurrent(final ConsumerRecord<K, V> record, @SuppressWarnings("rawtypes") Producer producer) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -1162,7 +1162,7 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 				if (record.value() == null && this.checkNullValueForExceptions) {
 					checkDeser(record, ErrorHandlingDeserializer2.VALUE_DESERIALIZER_EXCEPTION_HEADER);
 				}
-				if (record.key() == null && this.checkNullValueForExceptions) {
+				if (record.key() == null && this.checkNullKeyForExceptions) {
 					checkDeser(record, ErrorHandlingDeserializer2.KEY_DESERIALIZER_EXCEPTION_HEADER);
 				}
 				switch (this.listenerType) {
@@ -1232,12 +1232,10 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 				try {
 					DeserializationException ex = (DeserializationException) new ObjectInputStream(
 							new ByteArrayInputStream(header.value())).readObject();
-					Headers headers = new RecordHeaders();
-					record.headers().forEach(h -> {
-						if (!h.key().startsWith(ErrorHandlingDeserializer2.KEY_DESERIALIZER_EXCEPTION_HEADER_PREFIX)) {
-							headers.add(h.key(), h.value());
-						}
-					});
+					Headers headers = new RecordHeaders(Arrays.stream(record.headers().toArray())
+							.filter(h -> !h.key()
+									.startsWith(ErrorHandlingDeserializer2.KEY_DESERIALIZER_EXCEPTION_HEADER_PREFIX))
+							.collect(Collectors.toList()));
 					ex.setHeaders(headers);
 					throw ex;
 				}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DeserializationException.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DeserializationException.java
@@ -35,14 +35,14 @@ import org.springframework.lang.Nullable;
 public class DeserializationException extends KafkaException {
 
 	@Nullable
-	private final Headers headers;
+	private Headers headers;
 
 	private final byte[] data;
 
 	private final boolean isKey;
 
 	public DeserializationException(String message, byte[] data, boolean isKey, Throwable cause) {
-		this(message, null, data, isKey, cause); // NOSONAR test coverage
+		this(message, null, data, isKey, cause);
 	}
 
 	public DeserializationException(String message, @Nullable Headers headers, byte[] data, // NOSONAR array reference
@@ -57,6 +57,10 @@ public class DeserializationException extends KafkaException {
 	@Nullable
 	public Headers getHeaders() {
 		return this.headers;
+	}
+
+	public void setHeaders(@Nullable Headers headers) {
+		this.headers = headers;
 	}
 
 	public byte[] getData() {

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/BatchListenerConversion2Tests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/BatchListenerConversion2Tests.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.annotation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BiFunction;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.config.KafkaListenerContainerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.converter.BytesJsonMessageConverter;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer2;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.test.rule.EmbeddedKafkaRule;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Gary Russell
+ *
+ * @since 2.1.1
+ *
+ */
+@ContextConfiguration
+@RunWith(SpringJUnit4ClassRunner.class)
+@DirtiesContext
+public class BatchListenerConversion2Tests {
+
+	private static final String DEFAULT_TEST_GROUP_ID = "blc2";
+
+	@ClassRule // one topic to preserve order
+	public static EmbeddedKafkaRule embeddedKafka = new EmbeddedKafkaRule(1, true, 1, "blc.2.1");
+
+	@Autowired
+	private Config config;
+
+	@Autowired
+	private KafkaTemplate<Integer, String> template;
+
+	@Test
+	public void testBatchOfPojosWithABadOne() throws Exception {
+		Listener listener = this.config.listener1();
+		String topic = "blc.2.1";
+		this.template.send(topic, "{\"bar\":\"baz\"}");
+		this.template.send(topic, "junk");
+		this.template.send(topic, "{\"bar\":\"baz\"}");
+		assertThat(listener.latch1.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(listener.badFoo).isInstanceOf(BadFoo.class);
+		assertThat(listener.receivedFoos).isEqualTo(2);
+	}
+
+	@Configuration
+	@EnableKafka
+	public static class Config {
+
+		@Bean
+		public KafkaListenerContainerFactory<?> kafkaListenerContainerFactory() {
+			ConcurrentKafkaListenerContainerFactory<Integer, Foo> factory =
+					new ConcurrentKafkaListenerContainerFactory<>();
+			factory.setConsumerFactory(consumerFactory());
+			factory.setBatchListener(true);
+			factory.setReplyTemplate(template());
+			return factory;
+		}
+
+		@Bean
+		public DefaultKafkaConsumerFactory<Integer, Foo> consumerFactory() {
+			return new DefaultKafkaConsumerFactory<>(consumerConfigs());
+		}
+
+		@Bean
+		public Map<String, Object> consumerConfigs() {
+			Map<String, Object> consumerProps =
+					KafkaTestUtils.consumerProps(DEFAULT_TEST_GROUP_ID, "false", embeddedKafka.getEmbeddedKafka());
+			consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer2.class);
+			consumerProps.put(ErrorHandlingDeserializer2.VALUE_DESERIALIZER_CLASS, JsonDeserializer.class);
+			consumerProps.put(ErrorHandlingDeserializer2.VALUE_FUNCTION, FailedFooProvider.class);
+			consumerProps.put(JsonDeserializer.VALUE_DEFAULT_TYPE, Foo.class.getName());
+			consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+			return consumerProps;
+		}
+
+		@Bean
+		public KafkaTemplate<Integer, String> template() {
+			KafkaTemplate<Integer, String> kafkaTemplate = new KafkaTemplate<>(producerFactory());
+			return kafkaTemplate;
+		}
+
+		@Bean
+		public BytesJsonMessageConverter converter() {
+			return new BytesJsonMessageConverter();
+		}
+
+		@Bean
+		public ProducerFactory<Integer, String> producerFactory() {
+			return new DefaultKafkaProducerFactory<>(producerConfigs());
+		}
+
+		@Bean
+		public Map<String, Object> producerConfigs() {
+			Map<String, Object> props = KafkaTestUtils.producerProps(embeddedKafka.getEmbeddedKafka());
+			props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+			return props;
+		}
+
+		@Bean
+		public Listener listener1() {
+			return new Listener();
+		}
+
+	}
+
+	public static class Listener {
+
+		private final CountDownLatch latch1 = new CountDownLatch(3);
+
+		private volatile Foo badFoo;
+
+		private volatile int receivedFoos;
+
+		@KafkaListener(id = "deser", topics = "blc.2.1")
+		public void listen1(List<Foo> foos) {
+			foos.forEach(f -> {
+				if (f.getBar() == null) {
+					this.badFoo = f;
+				}
+				else {
+					this.receivedFoos++;
+				}
+				this.latch1.countDown();
+			});
+		}
+
+	}
+
+	public static class Foo {
+
+		private String bar;
+
+		public Foo() {
+			super();
+		}
+
+		public Foo(String bar) {
+			this.bar = bar;
+		}
+
+		public String getBar() {
+			return this.bar;
+		}
+
+		public void setBar(String bar) {
+			this.bar = bar;
+		}
+
+		@Override
+		public String toString() {
+			return "Foo [bar=" + this.bar + "]";
+		}
+
+	}
+
+	public static class BadFoo extends Foo {
+
+		private final byte[] failedDecode;
+
+		public BadFoo(byte[] failedDecode) {
+			this.failedDecode = failedDecode;
+		}
+
+		public byte[] getFailedDecode() {
+			return this.failedDecode;
+		}
+
+	}
+
+	public static class FailedFooProvider implements BiFunction<byte[], Headers, Foo> {
+
+		@Override
+		public Foo apply(byte[] t, Headers u) {
+			return new BadFoo(t);
+		}
+
+	}
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
@@ -84,7 +84,7 @@ import org.springframework.kafka.listener.adapter.FilteringMessageListenerAdapte
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.kafka.support.TopicPartitionInitialOffset;
 import org.springframework.kafka.support.TopicPartitionInitialOffset.SeekPosition;
-import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer2;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 import org.springframework.kafka.support.serializer.JsonSerializer;
 import org.springframework.kafka.test.EmbeddedKafkaBroker;
@@ -1696,8 +1696,8 @@ public class KafkaMessageListenerContainerTests {
 		this.logger.info("Start JSON4");
 		Map<String, Object> props = KafkaTestUtils.consumerProps("testJson", "false", embeddedKafka);
 
-		ErrorHandlingDeserializer<Foo1> errorHandlingDeserializer =
-				new ErrorHandlingDeserializer<>(new JsonDeserializer<>(Foo1.class, false));
+		ErrorHandlingDeserializer2<Foo1> errorHandlingDeserializer =
+				new ErrorHandlingDeserializer2<>(new JsonDeserializer<>(Foo1.class, false));
 
 		DefaultKafkaConsumerFactory<Integer, Foo1> cf = new DefaultKafkaConsumerFactory<>(props,
 				new IntegerDeserializer(), errorHandlingDeserializer);

--- a/src/checkstyle/checkstyle-suppressions.xml
+++ b/src/checkstyle/checkstyle-suppressions.xml
@@ -7,4 +7,5 @@
 	<suppress files="[\\/]test[\\/]" checks="RequireThis" />
 	<suppress files="[\\/]test[\\/]" checks="Javadoc*" />
 	<suppress files="KafkaMatchersTests" checks="RegexpSinglelineJava" />
+	<suppress files="DeserializationException" checks="MutableException" />
 </suppressions>

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -1941,7 +1941,13 @@ To solve this problem, version 2.2 introduced the `ErrorHandlingDeserializer2`.
 This deserializer delegates to a real deserializer (key or value).
 If the delegate fails to deserialize the record content, the `ErrorHandlingDeserializer2` returns a `null` value and a `DeserializationException` in a header, containing the cause and raw bytes.
 When using a record-level `MessageListener`, if either the key or value contains a `DeserializationException` header, the container's `ErrorHandler` is called with the failed `ConsumerRecord`; the record is not passed to the listener.
-When using a `BatchMessageListener`, the failed record is passed to the application along with the remaining records in the batch, so it is the responsibility of the application listener to check whether the key or value in a particular record is `null` a `DeserializationException` can be found (as a serialized Java object) in headers; see the javadocs for the `ErrorHandlingDeserializer2` for more information.
+
+Alternatively, you can configure a `failedDeserializationFunction` which is a `BiConsumer<byte[], Headers, T>`.
+This function is invoked to create an instance of `T` which is passed to the listener, as normal.
+The raw record value and headers are provided to the function.
+The `DeserializationException` can be found (as a serialized Java object) in headers; see the javadocs for the `ErrorHandlingDeserializer2` for more information.
+
+When using a `BatchMessageListener`, you **must** provide a `failedDeserializationFunction`, otherwise, the batch of records will not be type safe.
 
 You can use the `DefaultKafkaConsumerFactory` constructor that takes key and value `Deserializer` objects and wire in appropriate `ErrorHandlingDeserializer2` configured with the proper delegates.
 Alternatively, you can use consumer configuration properties which are used by the `ErrorHandlingDeserializer` to instantiate the delegates.
@@ -1959,6 +1965,45 @@ props.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, JsonDeserializer.c
 props.put(JsonDeserializer.VALUE_DEFAULT_TYPE, "com.example.MyValue")
 props.put(JsonDeserializer.TRUSTED_PACKAGES, "com.example")
 return new DefaultKafkaConsumerFactory<>(props);
+----
+
+The following is an example of using a `failedDeserializationFunction`.
+
+[source, java]
+----
+public class BadFoo extends Foo {
+
+  private final byte[] failedDecode;
+
+  public BadFoo(byte[] failedDecode) {
+    this.failedDecode = failedDecode;
+  }
+
+  public byte[] getFailedDecode() {
+    return this.failedDecode;
+  }
+
+}
+
+public class FailedFooProvider implements BiFunction<byte[], Headers, Foo> {
+
+  @Override
+  public Foo apply(byte[] t, Headers u) {
+    return new BadFoo(t);
+  }
+
+}
+----
+
+and config
+
+[source, java]
+----
+...
+consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer2.class);
+consumerProps.put(ErrorHandlingDeserializer2.VALUE_DESERIALIZER_CLASS, JsonDeserializer.class);
+consumerProps.put(ErrorHandlingDeserializer2.VALUE_FUNCTION, FailedFooProvider.class);
+...
 ----
 
 [[payload-conversion-with-batch]]

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -1937,22 +1937,22 @@ Generally, the `BytesJsonMessageConverter` is more efficient because it avoids a
 ===== ErrorHandlingDeserializer
 
 When a deserializer fails to deserialize a message, Spring has no way to handle the problem because it occurs before the `poll()` returns.
-To solve this problem, version 2.2 introduced the `ErrorHandlingDeserializer`.
+To solve this problem, version 2.2 introduced the `ErrorHandlingDeserializer2`.
 This deserializer delegates to a real deserializer (key or value).
-If the delegate fails to deserialize the record content, the `ErrorHandlingDeserializer` returns a `DeserializationException` instead, containing the cause and raw bytes.
-When using a record-level `MessageListener`, if either the key or value contains a `DeserializationException`, the container's `ErrorHandler` is called with the failed `ConsumerRecord`.
-When using a `BatchMessageListener`, the failed record is passed to the application along with the remaining records in the batch, so it is the responsibility of the application listener to check whether the key or value in a particular record is a `DeserializationException`.
+If the delegate fails to deserialize the record content, the `ErrorHandlingDeserializer2` returns a `null` value and a `DeserializationException` in a header, containing the cause and raw bytes.
+When using a record-level `MessageListener`, if either the key or value contains a `DeserializationException` header, the container's `ErrorHandler` is called with the failed `ConsumerRecord`; the record is not passed to the listener.
+When using a `BatchMessageListener`, the failed record is passed to the application along with the remaining records in the batch, so it is the responsibility of the application listener to check whether the key or value in a particular record is `null` a `DeserializationException` can be found (as a serialized Java object) in headers; see the javadocs for the `ErrorHandlingDeserializer2` for more information.
 
-You can use the `DefaultKafkaConsumerFactory` constructor that takes key and value `Deserializer` objects and wire in appropriate `ErrorHandlingDeserializer` configured with the proper delegates.
+You can use the `DefaultKafkaConsumerFactory` constructor that takes key and value `Deserializer` objects and wire in appropriate `ErrorHandlingDeserializer2` configured with the proper delegates.
 Alternatively, you can use consumer configuration properties which are used by the `ErrorHandlingDeserializer` to instantiate the delegates.
-The property names are `ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS` and `ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS`; the property value can be a class or class name.
+The property names are `ErrorHandlingDeserializer2.KEY_DESERIALIZER_CLASS` and `ErrorHandlingDeserializer2.VALUE_DESERIALIZER_CLASS`; the property value can be a class or class name.
 For example:
 
 [source, java]
 ----
 ... // other props
-props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
-props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer2.class);
+props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer2.class);
 props.put(ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS, JsonDeserializer.class);
 props.put(JsonDeserializer.KEY_DEFAULT_TYPE, "com.example.MyKey")
 props.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, JsonDeserializer.class.getName());


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/853

Since a `null` key is common, we only check for the exception header
if we detect that the error handling deserializer is configured.