### PR TITLE
GH-855: Dead letter publisher and transactions

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
@@ -411,7 +411,13 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V> {
 	}
 
 
-	protected boolean inTransaction() {
+	/**
+	 * Return true if the template is currently running in a transaction on the
+	 * calling thread.
+	 * @return true if a transaction is running.
+	 * @since 2.2.1
+	 */
+	public boolean inTransaction() {
 		return this.transactional && (this.producers.get() != null
 				|| TransactionSynchronizationManager.getResource(this.producerFactory) != null
 				|| TransactionSynchronizationManager.isActualTransactionActive());

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
@@ -88,7 +88,7 @@ public class DeadLetterPublishingRecoverer implements BiConsumer<ConsumerRecord<
 		RecordHeaders headers = new RecordHeaders(record.headers().toArray());
 		enhanceHeaders(headers, record, exception);
 		ProducerRecord<Object, Object> outRecord = createProducerRecord(record, tp, headers);
-		if (this.transactional) {
+		if (this.transactional && !this.template.inTransaction()) {
 			this.template.executeInTransaction(t -> {
 				publish(outRecord, t);
 				return null;

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTransactionTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTransactionTests.java
@@ -56,6 +56,7 @@ import org.mockito.InOrder;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
 import org.springframework.kafka.support.TransactionSupport;
 import org.springframework.kafka.support.transaction.ResourcelessTransactionManager;
 import org.springframework.kafka.test.EmbeddedKafkaBroker;
@@ -270,6 +271,37 @@ public class KafkaTemplateTransactionTests {
 
 		assertThat(producer.transactionCommitted()).isFalse();
 		assertThat(producer.closed()).isTrue();
+	}
+
+	@Test
+	public void testDeadLetterPublisherWhileTransactionActive() {
+		@SuppressWarnings("unchecked")
+		Producer<Object, Object> producer1 = mock(Producer.class);
+		@SuppressWarnings("unchecked")
+		Producer<Object, Object> producer2 = mock(Producer.class);
+		producer1.initTransactions();
+
+		@SuppressWarnings("unchecked")
+		ProducerFactory<Object, Object> pf = mock(ProducerFactory.class);
+		given(pf.transactionCapable()).willReturn(true);
+		given(pf.createProducer()).willReturn(producer1);
+
+		KafkaTemplate<Object, Object> template = new KafkaTemplate<>(pf);
+		template.setDefaultTopic(STRING_KEY_TOPIC);
+
+		KafkaTransactionManager<Object, Object> tm = new KafkaTransactionManager<>(pf);
+
+		new TransactionTemplate(tm).execute(s -> {
+			new DeadLetterPublishingRecoverer(template).accept(
+					new ConsumerRecord<>(STRING_KEY_TOPIC, 0, 0L, "key", "foo"),
+					new RuntimeException("foo"));
+			return null;
+		});
+
+		verify(producer1).beginTransaction();
+		verify(producer1).commitTransaction();
+		verify(producer1).close();
+		verify(producer2, never()).beginTransaction();
 	}
 
 	@Test

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTransactionTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTransactionTests.java
@@ -284,9 +284,9 @@ public class KafkaTemplateTransactionTests {
 		@SuppressWarnings("unchecked")
 		ProducerFactory<Object, Object> pf = mock(ProducerFactory.class);
 		given(pf.transactionCapable()).willReturn(true);
-		given(pf.createProducer()).willReturn(producer1);
+		given(pf.createProducer()).willReturn(producer1).willReturn(producer2);
 
-		KafkaTemplate<Object, Object> template = new KafkaTemplate<>(pf);
+		KafkaTemplate<Object, Object> template = spy(new KafkaTemplate<>(pf));
 		template.setDefaultTopic(STRING_KEY_TOPIC);
 
 		KafkaTransactionManager<Object, Object> tm = new KafkaTransactionManager<>(pf);
@@ -302,6 +302,7 @@ public class KafkaTemplateTransactionTests {
 		verify(producer1).commitTransaction();
 		verify(producer1).close();
 		verify(producer2, never()).beginTransaction();
+		verify(template, never()).executeInTransaction(any());
 	}
 
 	@Test


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/855

`DeadLetterPublishingRecoverer` should participate in the current transaction,
if present, or start a transaction otherwise (if the template is transactional).