### PR TITLE
GH-859: Fix nested transactions

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
@@ -190,6 +190,16 @@ public class DefaultKafkaProducerFactory<K, V> implements ProducerFactory<K, V>,
 	}
 
 	/**
+	 * Return the producerPerConsumerPartition.
+	 * @return the producerPerConsumerPartition.
+	 * @since 1.3.8
+	 */
+	@Override
+	public boolean isProducerPerConsumerPartition() {
+		return this.producerPerConsumerPartition;
+	}
+
+	/**
 	 * Return an unmodifiable reference to the configuration map for this factory.
 	 * Useful for cloning to make a similar factory.
 	 * @return the configs.
@@ -308,7 +318,7 @@ public class DefaultKafkaProducerFactory<K, V> implements ProducerFactory<K, V>,
 		return new KafkaProducer<K, V>(this.configs, this.keySerializer, this.valueSerializer);
 	}
 
-	private Producer<K, V> createTransactionalProducerForPartition() {
+	Producer<K, V> createTransactionalProducerForPartition() {
 		String suffix = TransactionSupport.getTransactionIdSuffix();
 		if (suffix == null) {
 			return createTransactionalProducer();

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
@@ -35,6 +35,7 @@ import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.support.LoggingProducerListener;
 import org.springframework.kafka.support.ProducerListener;
 import org.springframework.kafka.support.SendResult;
+import org.springframework.kafka.support.TransactionSupport;
 import org.springframework.kafka.support.converter.MessageConverter;
 import org.springframework.kafka.support.converter.MessagingMessageConverter;
 import org.springframework.kafka.support.converter.RecordMessageConverter;
@@ -263,6 +264,15 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V> {
 		Assert.state(this.transactional, "Producer factory does not support transactions");
 		Producer<K, V> producer = this.producers.get();
 		Assert.state(producer == null, "Nested calls to 'executeInTransaction' are not allowed");
+		String transactionIdSuffix;
+		if (this.producerFactory.isProducerPerConsumerPartition()) {
+			transactionIdSuffix = TransactionSupport.getTransactionIdSuffix();
+			TransactionSupport.clearTransactionIdSuffix();
+		}
+		else {
+			transactionIdSuffix = null;
+		}
+
 		producer = this.producerFactory.createProducer();
 
 		try {
@@ -292,6 +302,9 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V> {
 			throw e;
 		}
 		finally {
+			if (transactionIdSuffix != null) {
+				TransactionSupport.setTransactionIdSuffix(transactionIdSuffix);
+			}
 			this.producers.remove();
 			closeProducer(producer, false);
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/ProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/ProducerFactory.java
@@ -51,4 +51,13 @@ public interface ProducerFactory<K, V> {
 		// NOSONAR
 	}
 
+	/**
+	 * Return the producerPerConsumerPartition.
+	 * @return the producerPerConsumerPartition.
+	 * @since 1.3.8
+	 */
+	default boolean isProducerPerConsumerPartition() {
+		return false;
+	}
+
 }


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/859

When using `executeInTransaction` on a transactional container thread,
we cannot use the existing transaction - clear the TL to allow a new
Producer to be allocated.

Invalid state transition (in-trans to in-trans).

**cherry-pick to 2.1.x, 2.0.x, backport needed for 1.3.x**