### PR TITLE
GH-859: Fix nested transactions [1.3.x backport]

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
@@ -154,6 +154,15 @@ public class DefaultKafkaProducerFactory<K, V> implements ProducerFactory<K, V>,
 	}
 
 	/**
+	 * Return the producerPerConsumerPartition.
+	 * @return the producerPerConsumerPartition.
+	 * @since 1.3.8
+	 */
+	public boolean isProducerPerConsumerPartition() {
+		return this.producerPerConsumerPartition;
+	}
+
+	/**
 	 * Return an unmodifiable reference to the configuration map for this factory.
 	 * Useful for cloning to make a similar factory.
 	 * @return the configs.
@@ -247,7 +256,7 @@ public class DefaultKafkaProducerFactory<K, V> implements ProducerFactory<K, V>,
 		return new KafkaProducer<K, V>(this.configs, this.keySerializer, this.valueSerializer);
 	}
 
-	private Producer<K, V> createTransactionalProducerForPartition() {
+	Producer<K, V> createTransactionalProducerForPartition() {
 		String suffix = TransactionSupport.getTransactionIdSuffix();
 		if (suffix == null) {
 			return createTransactionalProducer();

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTransactionTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTransactionTests.java
@@ -28,9 +28,11 @@ import static org.mockito.Mockito.verify;
 import static org.springframework.kafka.test.assertj.KafkaConditions.key;
 import static org.springframework.kafka.test.assertj.KafkaConditions.value;
 
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -51,6 +53,7 @@ import org.mockito.InOrder;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.support.TransactionSupport;
 import org.springframework.kafka.support.transaction.ResourcelessTransactionManager;
 import org.springframework.kafka.test.rule.KafkaEmbedded;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
@@ -232,6 +235,58 @@ public class KafkaTemplateTransactionTests {
 
 		assertThat(producer.transactionCommitted()).isFalse();
 		assertThat(producer.closed()).isTrue();
+	}
+
+	@Test
+	public void testExcecuteInTransactionNewInnerTx() {
+		@SuppressWarnings("unchecked")
+		Producer<Object, Object> producer1 = mock(Producer.class);
+		@SuppressWarnings("unchecked")
+		Producer<Object, Object> producer2 = mock(Producer.class);
+		producer1.initTransactions();
+		AtomicBoolean first = new AtomicBoolean(true);
+
+		DefaultKafkaProducerFactory<Object, Object> pf = new DefaultKafkaProducerFactory<Object, Object>(
+				Collections.emptyMap()) {
+
+			@Override
+			protected Producer<Object, Object> createTransactionalProducer() {
+				return first.getAndSet(false) ? producer1 : producer2;
+			}
+
+			@Override
+			Producer<Object, Object> createTransactionalProducerForPartition() {
+				return createTransactionalProducer();
+			}
+
+		};
+		pf.setTransactionIdPrefix("tx.");
+
+		KafkaTemplate<Object, Object> template = new KafkaTemplate<>(pf);
+		template.setDefaultTopic(STRING_KEY_TOPIC);
+
+		KafkaTransactionManager<Object, Object> tm = new KafkaTransactionManager<>(pf);
+
+		try {
+			TransactionSupport.setTransactionIdSuffix("testExcecuteInTransactionNewInnerTx");
+			new TransactionTemplate(tm).execute(s -> {
+				return template.executeInTransaction(t -> {
+					template.sendDefault("foo", "bar");
+					return null;
+				});
+			});
+
+			InOrder inOrder = inOrder(producer1, producer2);
+			inOrder.verify(producer1).beginTransaction();
+			inOrder.verify(producer2).beginTransaction();
+			inOrder.verify(producer2).commitTransaction();
+			inOrder.verify(producer2).close();
+			inOrder.verify(producer1).commitTransaction();
+			inOrder.verify(producer1).close();
+		}
+		finally {
+			TransactionSupport.clearTransactionIdSuffix();
+		}
 	}
 
 	@Configuration


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/859

When using `executeInTransaction` on a transactional container thread,
we cannot use the existing transaction - clear the TL to allow a new
Producer to be allocated.

Invalid state transition (in-trans to in-trans).

**cherry-pick to 2.1.x, 2.0.x, backport needed for 1.3.x**