### PR TITLE
GH-869: fixed NPE in case of array target types

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java
@@ -51,6 +51,7 @@ import com.fasterxml.jackson.databind.ObjectReader;
  * @author Gary Russell
  * @author Yanming Zhou
  * @author Elliot Kennedy
+ * @author Torsten Schleede
  */
 public class JsonDeserializer<T> implements ExtendedDeserializer<T> {
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/JsonSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/JsonSerializationTests.java
@@ -40,6 +40,7 @@ import com.fasterxml.jackson.core.JsonParseException;
  * @author Igor Stepanov
  * @author Artem Bilan
  * @author Yanming Zhou
+ * @author Torsten Schleede
  */
 public class JsonSerializationTests {
 


### PR DESCRIPTION
This PR fixes the NPE that is thrown when an array targetType is passed to one of the `JsonDeserializer` constructors.

I tried to keep the implementation in sync with `DefaultJackson2JavaTypeMapper.isTrustedPackage(String requestedType)` by using the same method to get the target package name:

`ClassUtils.getPackageName(this.targetType).replaceFirst("\\[L", "")`

However, this method seems to only support single-dimensional arrays, indicated by a single square bracket at the beginning of the returned package name. If support for multi-dimensional arrays is also of interest (e.g. by switching to `replaceFirst("\\[+L", "")`), it should be added via another PR.