### PR TITLE
GH-885: Restore infinite retries STCEH

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/DefaultAfterRollbackProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/DefaultAfterRollbackProcessor.java
@@ -60,6 +60,16 @@ public class DefaultAfterRollbackProcessor<K, V> implements AfterRollbackProcess
 	}
 
 	/**
+	 * Construct an instance with the default recoverer which simply logs the record after
+	 * 'maxFailures' have occurred for a topic/partition/offset.
+	 * @param maxFailures the maxFailures; a negative value is treated as infinity.
+	 * @since 2.2.1
+	 */
+	public DefaultAfterRollbackProcessor(int maxFailures) {
+		this(null, maxFailures);
+	}
+
+	/**
 	 * Construct an instance with the provided recoverer which will be called after
 	 * {@value SeekUtils#DEFAULT_MAX_FAILURES} (maxFailures) have occurred for a
 	 * topic/partition/offset.
@@ -74,7 +84,7 @@ public class DefaultAfterRollbackProcessor<K, V> implements AfterRollbackProcess
 	 * Construct an instance with the provided recoverer which will be called after
 	 * maxFailures have occurred for a topic/partition/offset.
 	 * @param recoverer the recoverer; if null, the default (logging) recoverer is used.
-	 * @param maxFailures the maxFailures.
+	 * @param maxFailures the maxFailures; a negative value is treated as infinity.
 	 * @since 2.2
 	 */
 	public DefaultAfterRollbackProcessor(@Nullable BiConsumer<ConsumerRecord<?, ?>, Exception> recoverer,

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordTracker.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordTracker.java
@@ -56,7 +56,7 @@ class FailedRecordTracker {
 			return false;
 		}
 		else {
-			if (failedRecord.incrementAndGet() >= this.maxFailures) {
+			if (this.maxFailures >= 0 && failedRecord.incrementAndGet() >= this.maxFailures) {
 				this.recoverer.accept(record, exception);
 				return true;
 			}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/SeekToCurrentErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/SeekToCurrentErrorHandler.java
@@ -54,6 +54,16 @@ public class SeekToCurrentErrorHandler implements ContainerAwareErrorHandler {
 	}
 
 	/**
+	 * Construct an instance with the default recoverer which simply logs the record after
+	 * 'maxFailures' have occurred for a topic/partition/offset.
+	 * @param maxFailures the maxFailures; a negative value is treated as infinity.
+	 * @since 2.2.1
+	 */
+	public SeekToCurrentErrorHandler(int maxFailures) {
+		this(null, maxFailures);
+	}
+
+	/**
 	 * Construct an instance with the provided recoverer which will be called after
 	 * {@value SeekUtils#DEFAULT_MAX_FAILURES} (maxFailures) have occurred for a
 	 * topic/partition/offset.
@@ -68,7 +78,7 @@ public class SeekToCurrentErrorHandler implements ContainerAwareErrorHandler {
 	 * Construct an instance with the provided recoverer which will be called after
 	 * maxFailures have occurred for a topic/partition/offset.
 	 * @param recoverer the recoverer; if null, the default (logging) recoverer is used.
-	 * @param maxFailures the maxFailures.
+	 * @param maxFailures the maxFailures; a negative value is treated as infinity.
 	 * @since 2.2
 	 */
 	public SeekToCurrentErrorHandler(@Nullable BiConsumer<ConsumerRecord<?, ?>, Exception> recoverer, int maxFailures) {

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -2436,6 +2436,7 @@ If the `AckMode` was `BATCH`, the container commits the offsets for the first 2 
 Starting with version 2.2, the `SeekToCurrentErrorHandler` can now recover (skip) a record that keeps failing.
 By default, after 10 failures, the failed record will be logged (ERROR).
 You can configure the handler with a custom recoverer (`BiConsumer`) and/or max failures.
+Setting the `maxFailures` property to a negative number will cause infinite retries.
 
 ====
 [source, java]
@@ -2482,6 +2483,7 @@ For example, with a record-based listener, you might want to keep track of the f
 Starting with version 2.2, the `DefaultAfterRollbackProcessor` can now recover (skip) a record that keeps failing.
 By default, after 10 failures, the failed record will be logged (ERROR).
 You can configure the processor with a custom recoverer (`BiConsumer`) and/or max failures.
+Setting the `maxFailures` property to a negative number will cause infinite retries.
 
 ====
 [source, java]


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/885

`SeekToCurrentErrorHandler` and `DefaultAfterRollbackProcessor`,
with negative `maxFailures`, now never recovers and continues to retry
indefinitely.