### PR TITLE
GH-878: Polishing - Fix new tangle

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/event/ConsumerPausedEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/ConsumerPausedEvent.java
@@ -20,8 +20,6 @@ import java.util.Collection;
 
 import org.apache.kafka.common.TopicPartition;
 
-import org.springframework.kafka.listener.AbstractMessageListenerContainer;
-
 /**
  * An event published when a consumer is paused.
  *
@@ -52,7 +50,7 @@ public class ConsumerPausedEvent extends KafkaEvent {
 	 * @param partitions the partitions.
 	 * @since 2.2.1
 	 */
-	public ConsumerPausedEvent(Object source, AbstractMessageListenerContainer<?, ?> container,
+	public ConsumerPausedEvent(Object source, Object container,
 			Collection<TopicPartition> partitions) {
 		super(source, container);
 		this.partitions = partitions;

--- a/spring-kafka/src/main/java/org/springframework/kafka/event/ConsumerResumedEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/ConsumerResumedEvent.java
@@ -20,8 +20,6 @@ import java.util.Collection;
 
 import org.apache.kafka.common.TopicPartition;
 
-import org.springframework.kafka.listener.AbstractMessageListenerContainer;
-
 /**
  * An event published when a consumer is resumed.
  *
@@ -52,7 +50,7 @@ public class ConsumerResumedEvent extends KafkaEvent {
 	 * @param partitions the partitions.
 	 * @since 2.2.1
 	 */
-	public ConsumerResumedEvent(Object source, AbstractMessageListenerContainer<?, ?> container,
+	public ConsumerResumedEvent(Object source, Object container,
 			Collection<TopicPartition> partitions) {
 		super(source, container);
 		this.partitions = partitions;

--- a/spring-kafka/src/main/java/org/springframework/kafka/event/ConsumerStoppedEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/ConsumerStoppedEvent.java
@@ -16,8 +16,6 @@
 
 package org.springframework.kafka.event;
 
-import org.springframework.kafka.listener.AbstractMessageListenerContainer;
-
 /**
  * An event published when a consumer is stopped. While it is best practice to use
  * stateless listeners, you can consume this event to clean up any thread-based resources
@@ -47,7 +45,7 @@ public class ConsumerStoppedEvent extends KafkaEvent {
 	 * @param container the container or the parent container if the container is a child.
 	 * @since 2.2.1
 	 */
-	public ConsumerStoppedEvent(Object source, AbstractMessageListenerContainer<?, ?> container) {
+	public ConsumerStoppedEvent(Object source, Object container) {
 		super(source, container);
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/event/ConsumerStoppingEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/ConsumerStoppingEvent.java
@@ -21,8 +21,6 @@ import java.util.Collection;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.common.TopicPartition;
 
-import org.springframework.kafka.listener.AbstractMessageListenerContainer;
-
 /**
  * An event published when a consumer is stopped. While it is best practice to use
  * stateless listeners, you can consume this event to clean up any thread-based resources
@@ -60,7 +58,7 @@ public class ConsumerStoppingEvent extends KafkaEvent {
 	 * @param partitions the partitions.
 	 * @since 2.2.1
 	 */
-	public ConsumerStoppingEvent(Object source, AbstractMessageListenerContainer<?, ?> container,
+	public ConsumerStoppingEvent(Object source, Object container,
 			Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {
 		super(source, container);
 		this.consumer = consumer;

--- a/spring-kafka/src/main/java/org/springframework/kafka/event/ContainerStoppedEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/ContainerStoppedEvent.java
@@ -16,8 +16,6 @@
 
 package org.springframework.kafka.event;
 
-import org.springframework.kafka.listener.AbstractMessageListenerContainer;
-
 /**
  * An event published when a container is stopped.
  *
@@ -44,7 +42,7 @@ public class ContainerStoppedEvent extends KafkaEvent {
 	 * @param container the container or the parent container if the container is a child.
 	 * @since 2.2.1
 	 */
-	public ContainerStoppedEvent(Object source, AbstractMessageListenerContainer<?, ?> container) {
+	public ContainerStoppedEvent(Object source, Object container) {
 		super(source, container);
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/event/KafkaEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/KafkaEvent.java
@@ -17,7 +17,7 @@
 package org.springframework.kafka.event;
 
 import org.springframework.context.ApplicationEvent;
-import org.springframework.kafka.listener.AbstractMessageListenerContainer;
+import org.springframework.util.Assert;
 
 
 /**
@@ -30,20 +30,51 @@ public abstract class KafkaEvent extends ApplicationEvent {
 
 	private static final long serialVersionUID = 1L;
 
-	private final AbstractMessageListenerContainer<?, ?> container;
+	private final Object container;
 
 	@Deprecated
 	public KafkaEvent(Object source) {
 		this(source, null); // NOSONAR
 	}
 
-	public KafkaEvent(Object source, AbstractMessageListenerContainer<?, ?> container) {
+	public KafkaEvent(Object source, Object container) {
 		super(source);
 		this.container = container;
 	}
 
-	public AbstractMessageListenerContainer<?, ?> getContainer() {
-		return this.container;
+	/**
+	 * Get the container for which the event was published, which will be the parent
+	 * container if the source that emitted the event is a child container, or the source
+	 * itself otherwise. The type is required here to avoid a dependency tangle between
+	 * the event and listener packages.
+	 * @param type the container type (e.g. {@code MessageListenerContainer.class}).
+	 * @param <T> the type.
+	 * @return the container.
+	 * @see #getSource(Class)
+	 * @since 2.2.1
+	 */
+	@SuppressWarnings("unchecked")
+	public <T> T getContainer(Class<T> type) {
+		Assert.isInstanceOf(type, this.container);
+		return (T) this.container;
+	}
+
+	/**
+	 * Get the container (source) that published the event. This is provided as an
+	 * alternative to {@link #getSource()} to avoid the need to cast in user code. The
+	 * type is required here to avoid a dependency tangle between the event and listener
+	 * packages.
+	 * @param type the container type (e.g. {@code MessageListenerContainer.class}).
+	 * @param <T> the type.
+	 * @return the container.
+	 * @see #getContainer(Class)
+	 * @see #getSource()
+	 * @since 2.2.1
+	 */
+	@SuppressWarnings("unchecked")
+	public <T> T getSource(Class<T> type) {
+		Assert.isInstanceOf(type, getSource());
+		return (T) getSource();
 	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/event/ListenerContainerIdleEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/ListenerContainerIdleEvent.java
@@ -24,8 +24,6 @@ import java.util.List;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.common.TopicPartition;
 
-import org.springframework.kafka.listener.AbstractMessageListenerContainer;
-
 /**
  * An event that is emitted when a container is idle if the container
  * is configured to do so.
@@ -91,7 +89,7 @@ public class ListenerContainerIdleEvent extends KafkaEvent {
 	 * @param paused true if the consumer is paused.
 	 * @since 2.2.1
 	 */
-	public ListenerContainerIdleEvent(Object source, AbstractMessageListenerContainer<?, ?> container,
+	public ListenerContainerIdleEvent(Object source, Object container,
 			long idleTime, String id,
 			Collection<TopicPartition> topicPartitions, Consumer<?, ?> consumer, boolean paused) {
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/event/NonResponsiveConsumerEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/NonResponsiveConsumerEvent.java
@@ -24,8 +24,6 @@ import java.util.List;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.common.TopicPartition;
 
-import org.springframework.kafka.listener.AbstractMessageListenerContainer;
-
 /**
  * An event that is emitted when a consumer is not responding to
  * the poll; a possible indication that the broker is down.
@@ -63,7 +61,7 @@ public class NonResponsiveConsumerEvent extends KafkaEvent {
 	 * @param consumer the consumer.
 	 * @since 2.2.1
 	 */
-	public NonResponsiveConsumerEvent(Object source, AbstractMessageListenerContainer<?, ?> container,
+	public NonResponsiveConsumerEvent(Object source, Object container,
 			long timeSinceLastPoll, String id,
 			Collection<TopicPartition> topicPartitions, Consumer<?, ?> consumer) {
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
@@ -159,10 +159,10 @@ public class ConcurrentMessageListenerContainerTests {
 		container.stop();
 		assertThat(stopLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		events.forEach(e -> {
-			assertThat(e.getContainer()).isSameAs(container);
+			assertThat(e.getContainer(MessageListenerContainer.class)).isSameAs(container);
 			if (e instanceof ContainerStoppedEvent) {
 				if (e.getSource().equals(container)) {
-					assertThat(e.getContainer()).isSameAs(container);
+					assertThat(e.getContainer(MessageListenerContainer.class)).isSameAs(container);
 				}
 				else {
 					assertThat(children).contains((KafkaMessageListenerContainer<Integer, String>) e.getSource());


### PR DESCRIPTION
The fix for https://github.com/spring-projects/spring-kafka/issues/878
introduced a new tangle between `events` and `listener`.

The container publishes events so events can't directly reference the containers.