### PR TITLE
Fix NPE in InvocationResult's toString

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/InvocationResult.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/InvocationResult.java
@@ -58,7 +58,7 @@ public final class InvocationResult {
 	@Override
 	public String toString() {
 		return "InvocationResult [result=" + this.result // NOSONAR false positive
-				+ ", sendTo=" + this.sendTo == null ? "null" : this.sendTo.getExpressionString()
+				+ ", sendTo=" + (this.sendTo == null ? "null" : this.sendTo.getExpressionString())
 				+ ", messageReturnType=" + this.messageReturnType + "]";
 	}
 


### PR DESCRIPTION
Calling toString() in
 `org.springframework.kafka.listener.adapter.InvocationResultt` raises NPE, if `sendTo` is null. 
It can be checked by adding
 `<Logger name="org.springframework.kafka.listener.adapter" level="debug" />` and running `org.springframework.kafka.annotation.EnableKafkaIntegrationTests#testMultiJson` for example.