### PR TITLE
Add a missing closing pointy bracket in doc

### DIFF
--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -1476,7 +1476,7 @@ When using `@KafkaListener`, set the `RecordFilterStrategy` (and optionally `ack
 
 In addition, a `FilteringBatchMessageListenerAdapter` is provided, for when using a batch <<message-listeners, message listener>>.
 
-IMPORTANT: The `FilteringBatchMessageListenerAdapter` is ignored if your `@KafkaListener` receives a `ConsumerRecords<?, ?>` instead of `List<ConsumerRecord<?, ?>` because `ConsumerRecords` is immutable.
+IMPORTANT: The `FilteringBatchMessageListenerAdapter` is ignored if your `@KafkaListener` receives a `ConsumerRecords<?, ?>` instead of `List<ConsumerRecord<?, ?>>` because `ConsumerRecords` is immutable.
 
 [[retrying-deliveries]]
 ===== Retrying Deliveries


### PR DESCRIPTION
This PR adds a missing closing pointy bracket for `List<ConsumerRecord<?, ?>>` in doc.