### PR TITLE
GH-894: Use context CL in the JsonSerializer

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/JacksonPresent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/JacksonPresent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,7 +28,7 @@ import org.springframework.util.ClassUtils;
  */
 public final class JacksonPresent {
 
-	private static final ClassLoader classLoader = JacksonPresent.class.getClassLoader();  // NOSONAR
+	private static final ClassLoader classLoader = ClassUtils.getDefaultClassLoader();  // NOSONAR
 
 	private static final boolean jackson2Present = // NOSONAR
 			ClassUtils.isPresent("com.fasterxml.jackson.databind.ObjectMapper", classLoader) &&

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerializer.java
@@ -113,9 +113,9 @@ public class JsonSerializer<T> implements ExtendedSerializer<T> {
 	 * @since 2.1.3
 	 */
 	public void setUseTypeMapperForKey(boolean isKey) {
-		if (!this.typeMapperExplicitlySet
-				&& this.getTypeMapper() instanceof AbstractJavaTypeMapper) {
-			((AbstractJavaTypeMapper) this.getTypeMapper()).setUseForKey(isKey);
+		if (!this.typeMapperExplicitlySet && getTypeMapper() instanceof AbstractJavaTypeMapper) {
+			((AbstractJavaTypeMapper) getTypeMapper())
+					.setUseForKey(isKey);
 		}
 	}
 
@@ -149,7 +149,7 @@ public class JsonSerializer<T> implements ExtendedSerializer<T> {
 			Assert.isTrue(split.length == 2, "Each comma-delimited mapping entry must have exactly one ':'");
 			try {
 				mappingsMap.put(split[0].trim(),
-						ClassUtils.forName(split[1].trim(), JsonSerializer.class.getClassLoader()));
+						ClassUtils.forName(split[1].trim(), ClassUtils.getDefaultClassLoader()));
 			}
 			catch (ClassNotFoundException | LinkageError e) {
 				throw new IllegalArgumentException(e);
@@ -159,6 +159,7 @@ public class JsonSerializer<T> implements ExtendedSerializer<T> {
 	}
 
 	@Override
+	@Nullable
 	public byte[] serialize(String topic, Headers headers, @Nullable T data) {
 		if (data == null) {
 			return null;
@@ -170,7 +171,8 @@ public class JsonSerializer<T> implements ExtendedSerializer<T> {
 	}
 
 	@Override
-	public byte[] serialize(String topic, T data) {
+	@Nullable
+	public byte[] serialize(String topic, @Nullable T data) {
 		if (data == null) {
 			return null;
 		}


### PR DESCRIPTION
Fixes spring-projects/spring-kafka#894

According Spring Boot Dev Tools recommendations it is much safer to
use a `ClassLoader` for manually loading class with the
`Thread.currentThread().getContextClassLoader()`.
This way those classes are going to be loaded in the `RestartClassLoader`
instead of `Launcher$AppClassLoader` allowing the proper deserializaiton
logic in the application at runtime

* Use a `ClassUtils.getDefaultClassLoader()` in the `JsonSerializer`
instead of `getClass().getClassLoader()` to load classes for mapping
* Also use a `ClassUtils.getDefaultClassLoader()` in the `JacksonPresent`

*No cherry-picking since we know a workaround with the explicit
configuration on the `DefaultKafkaProducerFactory` and
`DefaultConsumerFactory`*