### PR TITLE
GH-900: Use correct txId for initial commit

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -1656,14 +1656,14 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 							ListenerConsumer.this.kafkaTxManager != null) {
 						try {
 							offsetsToCommit.forEach((partition, offsetAndMetadata) -> {
+								TransactionSupport.setTransactionIdSuffix(
+										zombieFenceTxIdSuffix(partition.topic(), partition.partition()));
 								ListenerConsumer.this.transactionTemplate
 										.execute(new TransactionCallbackWithoutResult() {
 
 									@SuppressWarnings({ "unchecked", RAWTYPES })
 									@Override
 									protected void doInTransactionWithoutResult(TransactionStatus status) {
-										TransactionSupport.setTransactionIdSuffix(
-												zombieFenceTxIdSuffix(partition.topic(), partition.partition()));
 										((KafkaResourceHolder) TransactionSynchronizationManager
 												.getResource(ListenerConsumer.this.kafkaTxManager.getProducerFactory()))
 												.getProducer().sendOffsetsToTransaction(

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -490,6 +490,12 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 							this.containerProperties.getClientId(),
 							KafkaMessageListenerContainer.this.clientIdSuffix);
 
+			if (this.transactionManager != null) {
+				this.transactionTemplate = new TransactionTemplate(this.transactionManager);
+			}
+			else {
+				this.transactionTemplate = null;
+			}
 			subscribeOrAssignTopics(this.consumer);
 			GenericErrorHandler<?> errHandler = KafkaMessageListenerContainer.this.getGenericErrorHandler();
 			this.genericListener = listener;
@@ -525,12 +531,6 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 				this.batchErrorHandler = new BatchLoggingErrorHandler();
 			}
 			Assert.state(!this.isBatchListener || !this.isRecordAck, "Cannot use AckMode.RECORD with a batch listener");
-			if (this.transactionManager != null) {
-				this.transactionTemplate = new TransactionTemplate(this.transactionManager);
-			}
-			else {
-				this.transactionTemplate = null;
-			}
 			if (this.containerProperties.getScheduler() != null) {
 				this.taskScheduler = this.containerProperties.getScheduler();
 				this.taskSchedulerExplicitlySet = true;
@@ -1654,18 +1654,29 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 					ListenerConsumer.this.commitLogger.log(() -> "Committing on assignment: " + offsetsToCommit);
 					if (ListenerConsumer.this.transactionTemplate != null &&
 							ListenerConsumer.this.kafkaTxManager != null) {
-						ListenerConsumer.this.transactionTemplate.execute(new TransactionCallbackWithoutResult() {
+						try {
+							offsetsToCommit.forEach((partition, offsetAndMetadata) -> {
+								ListenerConsumer.this.transactionTemplate
+										.execute(new TransactionCallbackWithoutResult() {
 
-							@SuppressWarnings({ "unchecked", RAWTYPES })
-							@Override
-							protected void doInTransactionWithoutResult(TransactionStatus status) {
-								((KafkaResourceHolder) TransactionSynchronizationManager
-										.getResource(ListenerConsumer.this.kafkaTxManager.getProducerFactory()))
-										.getProducer().sendOffsetsToTransaction(offsetsToCommit, // NOSONAR
-												ListenerConsumer.this.consumerGroupId);
-							}
+									@SuppressWarnings({ "unchecked", RAWTYPES })
+									@Override
+									protected void doInTransactionWithoutResult(TransactionStatus status) {
+										TransactionSupport.setTransactionIdSuffix(
+												zombieFenceTxIdSuffix(partition.topic(), partition.partition()));
+										((KafkaResourceHolder) TransactionSynchronizationManager
+												.getResource(ListenerConsumer.this.kafkaTxManager.getProducerFactory()))
+												.getProducer().sendOffsetsToTransaction(
+														Collections.singletonMap(partition, offsetAndMetadata),
+														ListenerConsumer.this.consumerGroupId);
+									}
 
-						});
+								});
+							});
+						}
+						finally {
+							TransactionSupport.clearTransactionIdSuffix();
+						}
 					}
 					else if (KafkaMessageListenerContainer.this.getContainerProperties().isSyncCommits()) {
 						ListenerConsumer.this.consumer.commitSync(offsetsToCommit);


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-kafka/issues/900

Use the proper zombie-fencing `transational.id` when committing initial
offsets after assignment.

**cherry-pick to all, 1.3.x will probable need a backport**