### PR TITLE
Sonar fix

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -1664,11 +1664,15 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 									@SuppressWarnings({ "unchecked", RAWTYPES })
 									@Override
 									protected void doInTransactionWithoutResult(TransactionStatus status) {
-										((KafkaResourceHolder) TransactionSynchronizationManager
-												.getResource(ListenerConsumer.this.kafkaTxManager.getProducerFactory()))
-												.getProducer().sendOffsetsToTransaction(// NODSONAR never null
-														Collections.singletonMap(partition, offsetAndMetadata),
-														ListenerConsumer.this.consumerGroupId);
+										KafkaResourceHolder holder =
+											(KafkaResourceHolder) TransactionSynchronizationManager
+												.getResource(
+													ListenerConsumer.this.kafkaTxManager.getProducerFactory());
+										if (holder != null) {
+											holder.getProducer().sendOffsetsToTransaction(
+													Collections.singletonMap(partition, offsetAndMetadata),
+													ListenerConsumer.this.consumerGroupId);
+										}
 									}
 
 								});


### PR DESCRIPTION
I am not sure why, but I couldn't squash this one with `//NOSONAR`.