### PR TITLE
GH-915: Fix JSON default object mapper config

### DIFF
--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/JsonSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/JsonSerializationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2017 the original author or authors.
+ * Copyright 2016-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -170,6 +170,14 @@ public class JsonSerializationTests {
 	@Test
 	public void testDeserializedJsonNullEqualsNull() {
 		assertThat(jsonReader.deserialize(topic, null)).isEqualTo(null);
+	}
+
+	@Test
+	public void testExtraFieldIgnored() {
+		JsonDeserializer<DummyEntity> deser = new JsonDeserializer<>(DummyEntity.class);
+		assertThat(deser.deserialize(topic, "{\"intValue\":1,\"extra\":2}".getBytes()))
+				.isInstanceOf(DummyEntity.class);
+		deser.close();
 	}
 
 	static class DummyEntityJsonDeserializer extends JsonDeserializer<DummyEntity> {


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-kafka/issues/915

The configuration options were added after the reader was created.