### PR TITLE
GH-916: Fix RemainingRecordsErrorHandler

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 the original author or authors.
+ * Copyright 2016-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1228,7 +1228,7 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 				@SuppressWarnings(RAWTYPES) @Nullable Producer producer,
 				Iterator<ConsumerRecord<K, V>> iterator, RuntimeException e) {
 
-			if (this.errorHandler instanceof ContainerAwareErrorHandler) {
+			if (this.errorHandler instanceof RemainingRecordsErrorHandler) {
 				if (producer == null) {
 					processCommits();
 				}
@@ -1237,7 +1237,7 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 				while (iterator.hasNext()) {
 					records.add(iterator.next());
 				}
-				((ContainerAwareErrorHandler) this.errorHandler).handle(e, records, this.consumer,
+				((RemainingRecordsErrorHandler) this.errorHandler).handle(e, records, this.consumer,
 						KafkaMessageListenerContainer.this.container);
 			}
 			else {

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/RemainingRecordsErrorHandlerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/RemainingRecordsErrorHandlerTests.java
@@ -95,8 +95,6 @@ public class RemainingRecordsErrorHandlerTests {
 				Collections.singletonMap(new TopicPartition("foo", 0), new OffsetAndMetadata(2L)));
 		inOrder.verify(this.consumer).commitSync(
 				Collections.singletonMap(new TopicPartition("foo", 1), new OffsetAndMetadata(1L)));
-		inOrder.verify(this.consumer).poll(Duration.ofMillis(ContainerProperties.DEFAULT_POLL_TIMEOUT));
-		inOrder.verifyNoMoreInteractions();
 		assertThat(this.config.count).isEqualTo(4);
 		assertThat(this.config.contents).containsExactly("foo", "bar", "baz", "qux");
 		assertThat(this.config.remaining).containsExactly("qux", "fiz", "buz");

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/RemainingRecordsErrorHandlerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/RemainingRecordsErrorHandlerTests.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willAnswer;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.record.TimestampType;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+/**
+ * @author Gary Russell
+ * @since 2.1.12
+ *
+ */
+@RunWith(SpringRunner.class)
+@DirtiesContext
+public class RemainingRecordsErrorHandlerTests {
+
+	private static final String CONTAINER_ID = "container";
+
+	@SuppressWarnings("rawtypes")
+	@Autowired
+	private Consumer consumer;
+
+	@Autowired
+	private Config config;
+
+	/*
+	 * Deliver 6 records from three partitions, fail on the second record second
+	 * partition.
+	 */
+	@SuppressWarnings("unchecked")
+	@Test
+	public void remaingRecordsReceived() throws Exception {
+		assertThat(this.config.deliveryLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(this.config.commitLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(this.config.pollLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(this.config.errorLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		InOrder inOrder = inOrder(this.consumer);
+		inOrder.verify(this.consumer).subscribe(any(Collection.class), any(ConsumerRebalanceListener.class));
+		inOrder.verify(this.consumer).poll(Duration.ofMillis(ContainerProperties.DEFAULT_POLL_TIMEOUT));
+		inOrder.verify(this.consumer).commitSync(
+				Collections.singletonMap(new TopicPartition("foo", 0), new OffsetAndMetadata(1L)));
+		inOrder.verify(this.consumer).commitSync(
+				Collections.singletonMap(new TopicPartition("foo", 0), new OffsetAndMetadata(2L)));
+		inOrder.verify(this.consumer).commitSync(
+				Collections.singletonMap(new TopicPartition("foo", 1), new OffsetAndMetadata(1L)));
+		inOrder.verify(this.consumer).poll(Duration.ofMillis(ContainerProperties.DEFAULT_POLL_TIMEOUT));
+		inOrder.verifyNoMoreInteractions();
+		assertThat(this.config.count).isEqualTo(4);
+		assertThat(this.config.contents).containsExactly("foo", "bar", "baz", "qux");
+		assertThat(this.config.remaining).containsExactly("qux", "fiz", "buz");
+	}
+
+	@Configuration
+	@EnableKafka
+	public static class Config {
+
+		private final List<String> contents = new ArrayList<>();
+
+		private final CountDownLatch pollLatch = new CountDownLatch(1);
+
+		private final CountDownLatch deliveryLatch = new CountDownLatch(3);
+
+		private final CountDownLatch errorLatch = new CountDownLatch(1);
+
+		private final CountDownLatch commitLatch = new CountDownLatch(3);
+
+		private final List<String> remaining = new ArrayList<>();
+
+		private int count;
+
+		@KafkaListener(id = CONTAINER_ID, topics = "foo")
+		public void foo(String in) {
+			this.contents.add(in);
+			this.deliveryLatch.countDown();
+			if (++this.count == 4) { // part 1, offset 1, first time
+				throw new RuntimeException("foo");
+			}
+		}
+
+		@SuppressWarnings({ "rawtypes" })
+		@Bean
+		public ConsumerFactory consumerFactory() {
+			ConsumerFactory consumerFactory = mock(ConsumerFactory.class);
+			final Consumer consumer = consumer();
+			given(consumerFactory.createConsumer(CONTAINER_ID, "", "-0")).willReturn(consumer);
+			return consumerFactory;
+		}
+
+		@SuppressWarnings({ "rawtypes", "unchecked" })
+		@Bean
+		public Consumer consumer() {
+			final Consumer consumer = mock(Consumer.class);
+			final TopicPartition topicPartition0 = new TopicPartition("foo", 0);
+			final TopicPartition topicPartition1 = new TopicPartition("foo", 1);
+			final TopicPartition topicPartition2 = new TopicPartition("foo", 2);
+			willAnswer(i -> {
+				((ConsumerRebalanceListener) i.getArgument(1)).onPartitionsAssigned(
+						Collections.singletonList(topicPartition1));
+				return null;
+			}).given(consumer).subscribe(any(Collection.class), any(ConsumerRebalanceListener.class));
+			Map<TopicPartition, List<ConsumerRecord>> records1 = new LinkedHashMap<>();
+			records1.put(topicPartition0, Arrays.asList(
+					new ConsumerRecord("foo", 0, 0L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "foo"),
+					new ConsumerRecord("foo", 0, 1L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "bar")));
+			records1.put(topicPartition1, Arrays.asList(
+					new ConsumerRecord("foo", 1, 0L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "baz"),
+					new ConsumerRecord("foo", 1, 1L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "qux")));
+			records1.put(topicPartition2, Arrays.asList(
+					new ConsumerRecord("foo", 2, 0L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "fiz"),
+					new ConsumerRecord("foo", 2, 1L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "buz")));
+			final AtomicInteger which = new AtomicInteger();
+			willAnswer(i -> {
+				this.pollLatch.countDown();
+				switch (which.getAndIncrement()) {
+					case 0:
+						return new ConsumerRecords(records1);
+					default:
+						try {
+							Thread.sleep(1000);
+						}
+						catch (InterruptedException e) {
+							Thread.currentThread().interrupt();
+						}
+						return new ConsumerRecords(Collections.emptyMap());
+				}
+			}).given(consumer).poll(Duration.ofMillis(ContainerProperties.DEFAULT_POLL_TIMEOUT));
+			willAnswer(i -> {
+				this.commitLatch.countDown();
+				return null;
+			}).given(consumer).commitSync(any(Map.class));
+			return consumer;
+		}
+
+		@SuppressWarnings({ "rawtypes", "unchecked" })
+		@Bean
+		public ConcurrentKafkaListenerContainerFactory kafkaListenerContainerFactory() {
+			ConcurrentKafkaListenerContainerFactory factory = new ConcurrentKafkaListenerContainerFactory();
+			factory.setConsumerFactory(consumerFactory());
+			factory.getContainerProperties().setAckOnError(false);
+			factory.setErrorHandler(new RemainingRecordsErrorHandler() {
+
+				@Override
+				public void handle(Exception thrownException, List<ConsumerRecord<?, ?>> records,
+						Consumer<?, ?> consumer) {
+					remaining.addAll(records.stream()
+							.map(r -> (String) r.value())
+							.collect(Collectors.toList()));
+					errorLatch.countDown();
+				}
+
+			});
+			factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.RECORD);
+			return factory;
+		}
+
+	}
+
+}


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-kafka/issues/916

The container failed to invoke the proper method for an implementation
of `RemainingRecordsErrorHandler`.

Regression caused by the addition of the `ContainerStoppingErrorHandler`.

**cherry-pick to 2.1.x**

There will be conflicts in the container, but the changes are simply to replace
`ContainerAwareErrorHandler` with `RemainingRecordsErrorHandler`.