### PR TITLE
JsonDeserializer Header Removal Polishing

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/converter/DefaultJackson2JavaTypeMapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/converter/DefaultJackson2JavaTypeMapper.java
@@ -188,9 +188,6 @@ public class DefaultJackson2JavaTypeMapper extends AbstractJavaTypeMapper
 			headers.remove(getClassIdFieldName());
 			headers.remove(getContentClassIdFieldName());
 			headers.remove(getKeyClassIdFieldName());
-			headers.remove(KEY_DEFAULT_CLASSID_FIELD_NAME);
-			headers.remove(KEY_DEFAULT_CONTENT_CLASSID_FIELD_NAME);
-			headers.remove(KEY_DEFAULT_KEY_CLASSID_FIELD_NAME);
 		}
 		catch (Exception e) { // NOSONAR
 			// NOSONAR

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -1877,6 +1877,7 @@ In addition, the serializer/deserializer can be configured using Kafka propertie
 
 - `JsonSerializer.ADD_TYPE_INFO_HEADERS` (default `true`); set to `false` to disable this feature on the `JsonSerializer` (sets the `addTypeInfo` property).
 - `JsonSerializer.TYPE_MAPPINGS` (default `empty`); see below.
+- `JsonDeserializer.USE_TYPE_INFO_HEADERS` (default `true`); set to `false` to ignore headers set by the serializer.
 - `JsonDeserializer.REMOVE_TYPE_INFO_HEADERS` (default `true`); set to `false` to retain headers set by the serializer.
 - `JsonDeserializer.KEY_DEFAULT_TYPE`; fallback type for deserialization of keys if no header information is present.
 - `JsonDeserializer.VALUE_DEFAULT_TYPE`; fallback type for deserialization of values if no header information is present.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -81,7 +81,9 @@ You can now provide type mapping information using producer/consumer properties.
 
 New constructors are available on the deserializer to allow overriding the type header information with the supplied target type.
 
-The JsonDeserializer will now remove any type information headers by default.
+The `JsonDeserializer` will now remove any type information headers by default.
+
+The `JsonDeserializer` can now be configured to ignore type information headers using a kafka property (since 2.2.3).
 
 See <<serdes>> for more information.
 


### PR DESCRIPTION
Only remove the headers for the object being deserialized.

Previously, it removed all type headers, with explicit reference to the key
headers. This happened to work ok because the key was deserialized first.

If this ever changes, the key headers would be removed when the value is
deserialized and would not be available for key deserialization.