### PR TITLE
Better type handling for JsonSerde / JsonDeserializer constructors

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java
@@ -53,6 +53,7 @@ import com.fasterxml.jackson.databind.ObjectReader;
  * @author Yanming Zhou
  * @author Elliot Kennedy
  * @author Torsten Schleede
+ * @author Ivan Ponomarev
  */
 public class JsonDeserializer<T> implements ExtendedDeserializer<T> {
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java
@@ -138,7 +138,7 @@ public class JsonDeserializer<T> implements ExtendedDeserializer<T> {
 	 * {@link ObjectMapper}.
 	 * @param targetType the target type to use if no type info headers are present.
 	 */
-	public JsonDeserializer(Class<T> targetType) {
+	public JsonDeserializer(Class<? super T> targetType) {
 		this(targetType, true);
 	}
 
@@ -150,7 +150,7 @@ public class JsonDeserializer<T> implements ExtendedDeserializer<T> {
 	 * type if not.
 	 * @since 2.2
 	 */
-	public JsonDeserializer(Class<T> targetType, boolean useHeadersIfPresent) {
+	public JsonDeserializer(Class<? super T> targetType, boolean useHeadersIfPresent) {
 		this(targetType, new ObjectMapper(), useHeadersIfPresent, om -> {
 			om.configure(MapperFeature.DEFAULT_VIEW_INCLUSION, false);
 			om.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
@@ -162,7 +162,7 @@ public class JsonDeserializer<T> implements ExtendedDeserializer<T> {
 	 * @param targetType the target type to use if no type info headers are present.
 	 * @param objectMapper the mapper. type if not.
 	 */
-	public JsonDeserializer(Class<T> targetType, ObjectMapper objectMapper) {
+	public JsonDeserializer(Class<? super T> targetType, ObjectMapper objectMapper) {
 		this(targetType, objectMapper, true);
 	}
 
@@ -175,17 +175,17 @@ public class JsonDeserializer<T> implements ExtendedDeserializer<T> {
 	 * type if not.
 	 * @since 2.2
 	 */
-	public JsonDeserializer(@Nullable Class<T> targetType, ObjectMapper objectMapper, boolean useHeadersIfPresent) {
+	public JsonDeserializer(@Nullable Class<? super T> targetType, ObjectMapper objectMapper, boolean useHeadersIfPresent) {
 		this(targetType, objectMapper, useHeadersIfPresent, om -> { });
 	}
 
 	@SuppressWarnings("unchecked")
-	private JsonDeserializer(@Nullable Class<T> targetType, ObjectMapper objectMapper, boolean useHeadersIfPresent,
+	private JsonDeserializer(@Nullable Class<? super T> targetType, ObjectMapper objectMapper, boolean useHeadersIfPresent,
 			Consumer<ObjectMapper> configurer) {
 
 		Assert.notNull(objectMapper, "'objectMapper' must not be null.");
 		this.objectMapper = objectMapper;
-		this.targetType = targetType;
+		this.targetType = (Class<T>) targetType;
 		if (this.targetType == null) {
 			this.targetType = (Class<T>) ResolvableType.forClass(getClass()).getSuperType().resolveGeneric(0);
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerde.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerde.java
@@ -55,7 +55,7 @@ public class JsonSerde<T> implements Serde<T> {
 		this((ObjectMapper) null);
 	}
 
-	public JsonSerde(Class<T> targetType) {
+	public JsonSerde(Class<? super T> targetType) {
 		this(targetType, null);
 	}
 
@@ -64,9 +64,9 @@ public class JsonSerde<T> implements Serde<T> {
 	}
 
 	@SuppressWarnings("unchecked")
-	public JsonSerde(@Nullable Class<T> targetTypeArg, @Nullable ObjectMapper objectMapperArg) {
+	public JsonSerde(@Nullable Class<? super T> targetTypeArg, @Nullable ObjectMapper objectMapperArg) {
 		ObjectMapper objectMapper = objectMapperArg;
-		Class<T> targetType = targetTypeArg;
+		Class<T> targetType = (Class<T>) targetTypeArg;
 		if (objectMapper == null) {
 			objectMapper = new ObjectMapper();
 			objectMapper.configure(MapperFeature.DEFAULT_VIEW_INCLUSION, false);

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerde.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerde.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * @author Marius Bogoevici
  * @author Elliot Kennedy
  * @author Gary Russell
+ * @author Ivan Ponomarev
  *
  * @since 1.1.5
  */

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/JsonSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/JsonSerializationTests.java
@@ -46,6 +46,7 @@ import com.fasterxml.jackson.core.JsonParseException;
  * @author Yanming Zhou
  * @author Torsten Schleede
  * @author Gary Russell
+ * @author Ivan Ponomarev
  */
 public class JsonSerializationTests {
 
@@ -83,18 +84,18 @@ public class JsonSerializationTests {
 		topic = "topic-name";
 
 		jsonReader = new JsonDeserializer<DummyEntity>() { };
-		jsonReader.configure(new HashMap<String, Object>(), false);
+		jsonReader.configure(new HashMap<>(), false);
 		jsonReader.close(); // does nothing, so may be called any time, or not called at all
 		jsonArrayReader = new JsonDeserializer<DummyEntity[]>() { };
-		jsonArrayReader.configure(new HashMap<String, Object>(), false);
+		jsonArrayReader.configure(new HashMap<>(), false);
 		jsonArrayReader.close(); // does nothing, so may be called any time, or not called at all
 		jsonWriter = new JsonSerializer<>();
-		jsonWriter.configure(new HashMap<String, Object>(), false);
+		jsonWriter.configure(new HashMap<>(), false);
 		jsonWriter.close(); // does nothing, so may be called any time, or not called at all
 		stringReader = new StringDeserializer();
-		stringReader.configure(new HashMap<String, Object>(), false);
+		stringReader.configure(new HashMap<>(), false);
 		stringWriter = new StringSerializer();
-		stringWriter.configure(new HashMap<String, Object>(), false);
+		stringWriter.configure(new HashMap<>(), false);
 		dummyEntityJsonDeserializer = new DummyEntityJsonDeserializer();
 		dummyEntityArrayJsonDeserializer = new DummyEntityArrayJsonDeserializer();
 	}
@@ -201,6 +202,14 @@ public class JsonSerializationTests {
 		this.jsonReader.configure(Collections.singletonMap(JsonDeserializer.USE_TYPE_INFO_HEADERS, true), false);
 		assertThat(KafkaTestUtils.getPropertyValue(this.jsonReader, "typeMapper.typePrecedence"))
 			.isEqualTo(TypePrecedence.INFERRED);
+	}
+
+	@Test
+	public void testDeserializerTypeInference(){
+		JsonSerializer<List<String>> ser = new JsonSerializer<>();
+		JsonDeserializer<List<String>> de = new JsonDeserializer<>(List.class);
+		List<String> dummy = Arrays.asList("foo", "bar", "baz");
+		assertThat(de.deserialize(topic, ser.serialize(topic, dummy))).isEqualTo(dummy);
 	}
 
 	static class DummyEntityJsonDeserializer extends JsonDeserializer<DummyEntity> {

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/JsonSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/JsonSerializationTests.java
@@ -205,7 +205,7 @@ public class JsonSerializationTests {
 	}
 
 	@Test
-	public void testDeserializerTypeInference(){
+	public void testDeserializerTypeInference() {
 		JsonSerializer<List<String>> ser = new JsonSerializer<>();
 		JsonDeserializer<List<String>> de = new JsonDeserializer<>(List.class);
 		List<String> dummy = Arrays.asList("foo", "bar", "baz");


### PR DESCRIPTION
Currently it is impossible to create `JsonSerde` / `JsonDeserializer` for parameterized containers (e. g. HashMap<K,V>) without unchecked typecasting.

E.g. the following problems occur: 

```java
//error: cannot infer arguments
JsonSerde<HashMap<String, String>> s = new JsonSerde<>(Map.class);
```

```java
//warning: unchecked assignment
JsonSerde<HashMap<String, String>> s = new JsonSerde(Map.class);
```

```java
//warning: unchecked type cast 
Consumed.with(Serdes.String(),
                        (JsonSerde<Map<String,Double>>) new JsonSerde(Map.class)
```

The proposed change (see e.g. Joshua Bloch, "Effective Java", Item 31: 'Use Bounded Wildcards to Increase API Flexibility") moves the typecast (`Class<? super T>` to `Class<T>`) into the library class and makes other code more clear. So now the following should be possible without errors/warnings with better type handling:

```java
JsonSerde<HashMap<String, String>> s = new JsonSerde<>(Map.class);
```
