### PR TITLE
Specify the port with annotation #917

### DIFF
--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafka.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafka.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,8 +53,9 @@ import org.springframework.core.annotation.AliasFor;
  * @author Elliot Metsger
  * @author Zach Olauson
  * @author Gary Russell
+ * @author Sergio Lourenco
  *
- * @since 1.3
+ * @since 2.24
  *
  * @see org.springframework.kafka.test.EmbeddedKafkaBroker
  */

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafka.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafka.java
@@ -81,7 +81,7 @@ public @interface EmbeddedKafka {
 	 * @return passed into {@code kafka.utils.TestUtils.createBrokerConfig()}.
 	 */
 	boolean controlledShutdown() default false;
-	
+
 	/**
 	 * Set explicit ports on which the kafka brokers will listen. Useful when running an
 	 * embedded broker that you want to access from other processes.

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafka.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafka.java
@@ -80,6 +80,11 @@ public @interface EmbeddedKafka {
 	 * @return passed into {@code kafka.utils.TestUtils.createBrokerConfig()}.
 	 */
 	boolean controlledShutdown() default false;
+	
+	/**
+	 * @return ports for brokers.
+	 */
+	int[] ports() default {0};
 
 	/**
 	 * @return partitions per topic

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafka.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafka.java
@@ -55,7 +55,7 @@ import org.springframework.core.annotation.AliasFor;
  * @author Gary Russell
  * @author Sergio Lourenco
  *
- * @since 2.24
+ * @since 1.3
  *
  * @see org.springframework.kafka.test.EmbeddedKafkaBroker
  */
@@ -83,7 +83,11 @@ public @interface EmbeddedKafka {
 	boolean controlledShutdown() default false;
 	
 	/**
+	 * Set explicit ports on which the kafka brokers will listen. Useful when running an
+	 * embedded broker that you want to access from other processes.
+	 * A port must be provided for each instance, which means the number of ports must match the value of the count attribute.
 	 * @return ports for brokers.
+	 * @since 2.2.4
 	 */
 	int[] ports() default {0};
 

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizer.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizer.java
@@ -43,7 +43,7 @@ import org.springframework.util.StringUtils;
  * @author Oleg Artyomov
  * @author Sergio Lourenco
  *
- * @since 2.2.4
+ * @since 1.3
  */
 class EmbeddedKafkaContextCustomizer implements ContextCustomizer {
 

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizer.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,8 +41,9 @@ import org.springframework.util.StringUtils;
  * @author Elliot Metsger
  * @author Zach Olauson
  * @author Oleg Artyomov
+ * @author Sergio Lourenco
  *
- * @since 1.3
+ * @since 2.2.4
  */
 class EmbeddedKafkaContextCustomizer implements ContextCustomizer {
 

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizer.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizer.java
@@ -70,6 +70,8 @@ class EmbeddedKafkaContextCustomizer implements ContextCustomizer {
 				this.embeddedKafka.partitions(),
 				topics);
 
+		embeddedKafkaBroker.kafkaPorts(this.embeddedKafka.ports());
+		
 		Properties properties = new Properties();
 
 		for (String pair : this.embeddedKafka.brokerProperties()) {

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizer.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizer.java
@@ -72,7 +72,7 @@ class EmbeddedKafkaContextCustomizer implements ContextCustomizer {
 				topics);
 
 		embeddedKafkaBroker.kafkaPorts(this.embeddedKafka.ports());
-		
+
 		Properties properties = new Properties();
 
 		for (String pair : this.embeddedKafka.brokerProperties()) {

--- a/spring-kafka-test/src/test/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizerTests.java
+++ b/spring-kafka-test/src/test/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizerTests.java
@@ -17,11 +17,12 @@
 package org.springframework.kafka.test.context;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.mock;
 
 import org.junit.Before;
 import org.junit.Test;
+
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
@@ -35,10 +36,8 @@ import org.springframework.kafka.test.EmbeddedKafkaBroker;
 /**
  * @author Oleg Artyomov
  * @author Sergio Lourenco
- * 
  * @since 1.3
  */
-
 public class EmbeddedKafkaContextCustomizerTests {
 
 	private EmbeddedKafka annotationFromFirstClass;
@@ -63,17 +62,17 @@ public class EmbeddedKafkaContextCustomizerTests {
 		assertThat(new EmbeddedKafkaContextCustomizer(annotationFromFirstClass)).isEqualTo(new EmbeddedKafkaContextCustomizer(annotationFromSecondClass));
 		assertThat(new EmbeddedKafkaContextCustomizer(annotationFromFirstClass)).isNotEqualTo(new Object());
 	}
-	
+
 	@Test
 	public void testPorts() {
 		EmbeddedKafka annotationWithPorts = AnnotationUtils.findAnnotation(TestWithEmbeddedKafkaPorts.class, EmbeddedKafka.class);
 		EmbeddedKafkaContextCustomizer customizer = new EmbeddedKafkaContextCustomizer(annotationWithPorts);
 		ConfigurableApplicationContext context = mock(ConfigurableApplicationContext.class);
 		BeanFactoryStub factoryStub = new BeanFactoryStub();
-		when(context.getBeanFactory()).thenReturn(factoryStub);
-		when(context.getEnvironment()).thenReturn(mock(ConfigurableEnvironment.class));
+		given(context.getBeanFactory()).willReturn(factoryStub);
+		given(context.getEnvironment()).willReturn(mock(ConfigurableEnvironment.class));
 		customizer.customizeContext(context, null);
-		
+
 		assertThat(factoryStub.getBroker().getBrokersAsString()).isEqualTo("127.0.0.1:" + annotationWithPorts.ports()[0]);
 	}
 
@@ -87,33 +86,33 @@ public class EmbeddedKafkaContextCustomizerTests {
 	private class SecondTestWithEmbeddedKafka {
 
 	}
-	
-	@EmbeddedKafka(ports=8085)
+
+	@EmbeddedKafka(ports = 8085)
 	private class TestWithEmbeddedKafkaPorts {
-		
+
 	}
-	
+
 	private class BeanFactoryStub extends DefaultListableBeanFactory {
 		private Object bean;
-		
+
 		public EmbeddedKafkaBroker getBroker() {
 			return (EmbeddedKafkaBroker) bean;
 		}
-		
+
 		@Override
 		public Object initializeBean(Object existingBean, String beanName) throws BeansException {
 			this.bean = existingBean;
 			return bean;
 		}
-		
+
 		@Override
 		public void registerSingleton(String beanName, Object singletonObject) {
-			
+
 		}
-		
+
 		@Override
 		public void registerDisposableBean(String beanName, DisposableBean bean) {
-			
+
 		}
 	}
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2018 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,16 +45,14 @@ import org.springframework.util.concurrent.ListenableFuture;
 
 /**
  * @author Gary Russell
- * @author Sergio Lourenco
  * 
- * @since 2.2.4
+ * @since 1.0.6
  *
  */
 @EmbeddedKafka(topics = { "txCache1", "txCache2", "txCacheSendFromListener" },
 		brokerProperties = {
 				"transaction.state.log.replication.factor=1",
-				"transaction.state.log.min.isr=1"},
-		ports= {8085}
+				"transaction.state.log.min.isr=1"}
 )
 @SpringJUnitConfig
 @DirtiesContext
@@ -156,15 +154,6 @@ public class DefaultKafkaConsumerFactoryTests {
 		}
 	}
 	
-	@Test
-	public void testKafkaEmbedded() {
-		assertThat(embeddedKafka.getBrokersAsString()).isEqualTo("127.0.0.1:" + 8085);
-		assertThat(embeddedKafka.getBrokersAsString())
-				.isEqualTo(System.getProperty(EmbeddedKafkaBroker.SPRING_EMBEDDED_KAFKA_BROKERS));
-		assertThat(embeddedKafka.getZookeeperConnectionString())
-				.isEqualTo(System.getProperty(EmbeddedKafkaBroker.SPRING_EMBEDDED_ZOOKEEPER_CONNECT));
-	}
-
 	@Configuration
 	public static class Config {
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,13 +45,16 @@ import org.springframework.util.concurrent.ListenableFuture;
 
 /**
  * @author Gary Russell
- * @since 1.0.6
+ * @author Sergio Lourenco
+ * 
+ * @since 2.2.4
  *
  */
 @EmbeddedKafka(topics = { "txCache1", "txCache2", "txCacheSendFromListener" },
 		brokerProperties = {
 				"transaction.state.log.replication.factor=1",
-				"transaction.state.log.min.isr=1"}
+				"transaction.state.log.min.isr=1"},
+		ports= {8085}
 )
 @SpringJUnitConfig
 @DirtiesContext
@@ -151,6 +154,15 @@ public class DefaultKafkaConsumerFactoryTests {
 			pf.destroy();
 			pfTx.destroy();
 		}
+	}
+	
+	@Test
+	public void testKafkaEmbedded() {
+		assertThat(embeddedKafka.getBrokersAsString()).isEqualTo("127.0.0.1:" + 8085);
+		assertThat(embeddedKafka.getBrokersAsString())
+				.isEqualTo(System.getProperty(EmbeddedKafkaBroker.SPRING_EMBEDDED_KAFKA_BROKERS));
+		assertThat(embeddedKafka.getZookeeperConnectionString())
+				.isEqualTo(System.getProperty(EmbeddedKafkaBroker.SPRING_EMBEDDED_ZOOKEEPER_CONNECT));
 	}
 
 	@Configuration

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
@@ -45,9 +45,7 @@ import org.springframework.util.concurrent.ListenableFuture;
 
 /**
  * @author Gary Russell
- * 
  * @since 1.0.6
- *
  */
 @EmbeddedKafka(topics = { "txCache1", "txCache2", "txCacheSendFromListener" },
 		brokerProperties = {
@@ -153,7 +151,7 @@ public class DefaultKafkaConsumerFactoryTests {
 			pfTx.destroy();
 		}
 	}
-	
+
 	@Configuration
 	public static class Config {
 

--- a/src/reference/asciidoc/testing.adoc
+++ b/src/reference/asciidoc/testing.adoc
@@ -224,7 +224,7 @@ public class KafkaStreamsTests {
 
 }
 ----
-Starting with _version 2.2.4_ the `@EmbeddedKafka` annotation can also be used to specify the kafka ports property.
+Starting with version 2.2.4, the `@EmbeddedKafka` annotation can also be used to specify the kafka ports property.
 
 The `topics`, `brokerProperties` and `brokerPropertiesLocation` attributes of `@EmbeddedKafka` support property placeholder resolutions:
 [source, java]

--- a/src/reference/asciidoc/testing.adoc
+++ b/src/reference/asciidoc/testing.adoc
@@ -224,8 +224,9 @@ public class KafkaStreamsTests {
 
 }
 ----
+Starting with _version 2.2.4_ the `@EmbeddedKafka` annotation can also be used to specify the kafka ports property.
 
-The `topics`, `brokerProperties`, and `brokerPropertiesLocation` attributes of `@EmbeddedKafka` support property placeholder resolutions:
+The `topics`, `brokerProperties` and `brokerPropertiesLocation` attributes of `@EmbeddedKafka` support property placeholder resolutions:
 [source, java]
 ----
 @TestPropertySource(locations = "classpath:/test.properties")

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -72,7 +72,7 @@ See <<headers>> for more information.
 The `KafkaEmbedded` class and its `KafkaRule` interface have need deprecated in favor of the `EmbeddedKafkaBroker` and its JUnit 4 `EmbeddedKafkaRule` wrapper.
 The `@EmbeddedKafka` annotation now populates an `EmbeddedKafkaBroker` bean instead of the deprecated `KafkaEmbedded`.
 This allows the use of `@EmbeddedKafka` in JUnit 5 tests.
-The `@EmbeddedKafka` annotation now has the attribute `ports` to specify the port which will populate the `EmbeddedKafkaBroker` (since 2.2.4).
+The `@EmbeddedKafka` annotation now has the attribute `ports` to specify the port which will populate the `EmbeddedKafkaBroker`.
 
 See <<testing>> for more information.
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -72,6 +72,7 @@ See <<headers>> for more information.
 The `KafkaEmbedded` class and its `KafkaRule` interface have need deprecated in favor of the `EmbeddedKafkaBroker` and its JUnit 4 `EmbeddedKafkaRule` wrapper.
 The `@EmbeddedKafka` annotation now populates an `EmbeddedKafkaBroker` bean instead of the deprecated `KafkaEmbedded`.
 This allows the use of `@EmbeddedKafka` in JUnit 5 tests.
+The `@EmbeddedKafka` annotation now has the attribute `ports` to specify the port which will populate the `EmbeddedKafkaBroker` (since 2.2.4).
 
 See <<testing>> for more information.
 


### PR DESCRIPTION
Added ports attribute to EmbeddedKafka annotation.
It has a default value of 0 to be consistent with the count attribute.