### PR TITLE
GH-787: Fix upper-bounds for generics

### DIFF
--- a/spring-kafka-test/src/test/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizerTests.java
+++ b/spring-kafka-test/src/test/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizerTests.java
@@ -32,40 +32,45 @@ import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.kafka.test.EmbeddedKafkaBroker;
 
 
-
 /**
  * @author Oleg Artyomov
  * @author Sergio Lourenco
+ *
  * @since 1.3
  */
 public class EmbeddedKafkaContextCustomizerTests {
 
 	private EmbeddedKafka annotationFromFirstClass;
+
 	private EmbeddedKafka annotationFromSecondClass;
 
 	@Before
 	public void beforeEachTest() {
 		annotationFromFirstClass = AnnotationUtils.findAnnotation(TestWithEmbeddedKafka.class, EmbeddedKafka.class);
-		annotationFromSecondClass = AnnotationUtils.findAnnotation(SecondTestWithEmbeddedKafka.class, EmbeddedKafka.class);
+		annotationFromSecondClass =
+				AnnotationUtils.findAnnotation(SecondTestWithEmbeddedKafka.class, EmbeddedKafka.class);
 	}
 
 
 	@Test
 	public void testHashCode() {
 		assertThat(new EmbeddedKafkaContextCustomizer(annotationFromFirstClass).hashCode()).isNotEqualTo(0);
-		assertThat(new EmbeddedKafkaContextCustomizer(annotationFromFirstClass).hashCode()).isEqualTo(new EmbeddedKafkaContextCustomizer(annotationFromSecondClass).hashCode());
+		assertThat(new EmbeddedKafkaContextCustomizer(annotationFromFirstClass).hashCode())
+				.isEqualTo(new EmbeddedKafkaContextCustomizer(annotationFromSecondClass).hashCode());
 	}
 
 
 	@Test
 	public void testEquals() {
-		assertThat(new EmbeddedKafkaContextCustomizer(annotationFromFirstClass)).isEqualTo(new EmbeddedKafkaContextCustomizer(annotationFromSecondClass));
+		assertThat(new EmbeddedKafkaContextCustomizer(annotationFromFirstClass))
+				.isEqualTo(new EmbeddedKafkaContextCustomizer(annotationFromSecondClass));
 		assertThat(new EmbeddedKafkaContextCustomizer(annotationFromFirstClass)).isNotEqualTo(new Object());
 	}
 
 	@Test
 	public void testPorts() {
-		EmbeddedKafka annotationWithPorts = AnnotationUtils.findAnnotation(TestWithEmbeddedKafkaPorts.class, EmbeddedKafka.class);
+		EmbeddedKafka annotationWithPorts =
+				AnnotationUtils.findAnnotation(TestWithEmbeddedKafkaPorts.class, EmbeddedKafka.class);
 		EmbeddedKafkaContextCustomizer customizer = new EmbeddedKafkaContextCustomizer(annotationWithPorts);
 		ConfigurableApplicationContext context = mock(ConfigurableApplicationContext.class);
 		BeanFactoryStub factoryStub = new BeanFactoryStub();
@@ -73,7 +78,8 @@ public class EmbeddedKafkaContextCustomizerTests {
 		given(context.getEnvironment()).willReturn(mock(ConfigurableEnvironment.class));
 		customizer.customizeContext(context, null);
 
-		assertThat(factoryStub.getBroker().getBrokersAsString()).isEqualTo("127.0.0.1:" + annotationWithPorts.ports()[0]);
+		assertThat(factoryStub.getBroker().getBrokersAsString())
+				.isEqualTo("127.0.0.1:" + annotationWithPorts.ports()[0]);
 	}
 
 
@@ -92,7 +98,9 @@ public class EmbeddedKafkaContextCustomizerTests {
 
 	}
 
+	@SuppressWarnings("serial")
 	private class BeanFactoryStub extends DefaultListableBeanFactory {
+
 		private Object bean;
 
 		public EmbeddedKafkaBroker getBroker() {
@@ -114,5 +122,7 @@ public class EmbeddedKafkaContextCustomizerTests {
 		public void registerDisposableBean(String beanName, DisposableBean bean) {
 
 		}
+
 	}
+
 }

--- a/spring-kafka-test/src/test/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizerTests.java
+++ b/spring-kafka-test/src/test/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizerTests.java
@@ -35,6 +35,7 @@ import org.springframework.kafka.test.EmbeddedKafkaBroker;
 /**
  * @author Oleg Artyomov
  * @author Sergio Lourenco
+ * @author Artem Bilan
  *
  * @since 1.3
  */

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
@@ -258,11 +258,13 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 		if (this.errorHandler != null) {
 			if (Boolean.TRUE.equals(this.batchListener)) {
 				Assert.state(this.errorHandler instanceof BatchErrorHandler,
-						"The error handler must be a BatchErrorHandler, not " + this.errorHandler.getClass().getName());
+						() -> "The error handler must be a BatchErrorHandler, not " +
+								this.errorHandler.getClass().getName());
 			}
 			else {
 				Assert.state(this.errorHandler instanceof ErrorHandler,
-						"The error handler must be an ErrorHandler, not " + this.errorHandler.getClass().getName());
+						() -> "The error handler must be an ErrorHandler, not " +
+								this.errorHandler.getClass().getName());
 			}
 		}
 	}

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2018 the original author or authors.
+ * Copyright 2014-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,7 +61,7 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 
 	private GenericErrorHandler<?> errorHandler;
 
-	private ConsumerFactory<K, V> consumerFactory;
+	private ConsumerFactory<? super K, ? super V> consumerFactory;
 
 	private Boolean autoStartup;
 
@@ -69,7 +69,7 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 
 	private MessageConverter messageConverter;
 
-	private RecordFilterStrategy<K, V> recordFilterStrategy;
+	private RecordFilterStrategy<? super K, ? super V> recordFilterStrategy;
 
 	private Boolean ackDiscarded;
 
@@ -85,7 +85,7 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 
 	private KafkaTemplate<?, ?> replyTemplate;
 
-	private AfterRollbackProcessor<K, V> afterRollbackProcessor;
+	private AfterRollbackProcessor<? super K, ? super V> afterRollbackProcessor;
 
 	private ReplyHeadersConfigurer replyHeadersConfigurer;
 
@@ -93,11 +93,11 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 	 * Specify a {@link ConsumerFactory} to use.
 	 * @param consumerFactory The consumer factory.
 	 */
-	public void setConsumerFactory(ConsumerFactory<K, V> consumerFactory) {
+	public void setConsumerFactory(ConsumerFactory<? super K, ? super V> consumerFactory) {
 		this.consumerFactory = consumerFactory;
 	}
 
-	public ConsumerFactory<K, V> getConsumerFactory() {
+	public ConsumerFactory<? super K, ? super V> getConsumerFactory() {
 		return this.consumerFactory;
 	}
 
@@ -131,7 +131,7 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 	 * Set the record filter strategy.
 	 * @param recordFilterStrategy the strategy.
 	 */
-	public void setRecordFilterStrategy(RecordFilterStrategy<K, V> recordFilterStrategy) {
+	public void setRecordFilterStrategy(RecordFilterStrategy<? super K, ? super V> recordFilterStrategy) {
 		this.recordFilterStrategy = recordFilterStrategy;
 	}
 
@@ -231,7 +231,7 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 	 * @param afterRollbackProcessor the processor.
 	 * @since 1.3.5
 	 */
-	public void setAfterRollbackProcessor(AfterRollbackProcessor<K, V> afterRollbackProcessor) {
+	public void setAfterRollbackProcessor(AfterRollbackProcessor<? super K, ? super V> afterRollbackProcessor) {
 		this.afterRollbackProcessor = afterRollbackProcessor;
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2018 the original author or authors.
+ * Copyright 2014-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -268,7 +268,7 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 		return this.replyTemplate;
 	}
 
-	protected RecordFilterStrategy<K, V> getRecordFilterStrategy() {
+	protected RecordFilterStrategy<? super K, ? super V> getRecordFilterStrategy() {
 		return this.recordFilterStrategy;
 	}
 
@@ -286,8 +286,7 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 	}
 
 	/**
-	 * Set to true if the {@link #setRecordFilterStrategy(RecordFilterStrategy)
-	 * recordFilterStrategy} is in use.
+	 * Set to true if the {@link #setRecordFilterStrategy(RecordFilterStrategy)} is in use.
 	 * @param ackDiscarded the ackDiscarded.
 	 */
 	public void setAckDiscarded(boolean ackDiscarded) {
@@ -311,8 +310,7 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 	}
 
 	/**
-	 * Set a callback to be used with the {@link #setRetryTemplate(RetryTemplate)
-	 * retryTemplate}.
+	 * Set a callback to be used with the {@link #setRetryTemplate(RetryTemplate)}.
 	 * @param recoveryCallback the callback.
 	 */
 	public void setRecoveryCallback(RecoveryCallback<? extends Object> recoveryCallback) {
@@ -429,9 +427,8 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 		Object messageListener = adapter;
 		Assert.state(messageListener != null, "Endpoint [" + this + "] must provide a non null message listener");
 		if (this.retryTemplate != null) {
-			messageListener =
-					new RetryingMessageListenerAdapter<>((MessageListener<K, V>) messageListener,
-							this.retryTemplate, this.recoveryCallback, this.statefulRetry);
+			messageListener = new RetryingMessageListenerAdapter<>((MessageListener<K, V>) messageListener,
+					this.retryTemplate, this.recoveryCallback, this.statefulRetry);
 		}
 		if (this.recordFilterStrategy != null) {
 			if (this.batchListener) {
@@ -442,16 +439,13 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 					}
 				}
 				else {
-					messageListener =
-							new FilteringBatchMessageListenerAdapter<>(
-									(BatchMessageListener<K, V>) messageListener, this.recordFilterStrategy,
-									this.ackDiscarded);
+					messageListener = new FilteringBatchMessageListenerAdapter<>(
+						(BatchMessageListener<K, V>) messageListener, this.recordFilterStrategy, this.ackDiscarded);
 				}
 			}
 			else {
-				messageListener =
-						new FilteringMessageListenerAdapter<>((MessageListener<K, V>) messageListener,
-								this.recordFilterStrategy, this.ackDiscarded);
+				messageListener = new FilteringMessageListenerAdapter<>((MessageListener<K, V>) messageListener,
+						this.recordFilterStrategy, this.ackDiscarded);
 			}
 		}
 		container.setupMessageListener(messageListener);

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
@@ -276,8 +276,9 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 	 * Set a {@link RecordFilterStrategy} implementation.
 	 * @param recordFilterStrategy the strategy implementation.
 	 */
-	public void setRecordFilterStrategy(RecordFilterStrategy<K, V> recordFilterStrategy) {
-		this.recordFilterStrategy = recordFilterStrategy;
+	@SuppressWarnings("unchecked")
+	public void setRecordFilterStrategy(RecordFilterStrategy<? super K, ? super V> recordFilterStrategy) {
+		this.recordFilterStrategy = (RecordFilterStrategy<K, V>) recordFilterStrategy;
 	}
 
 	protected boolean isAckDiscarded() {
@@ -428,8 +429,9 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 		Object messageListener = adapter;
 		Assert.state(messageListener != null, "Endpoint [" + this + "] must provide a non null message listener");
 		if (this.retryTemplate != null) {
-			messageListener = new RetryingMessageListenerAdapter<>((MessageListener<K, V>) messageListener,
-					this.retryTemplate, this.recoveryCallback, this.statefulRetry);
+			messageListener =
+					new RetryingMessageListenerAdapter<>((MessageListener<K, V>) messageListener,
+							this.retryTemplate, this.recoveryCallback, this.statefulRetry);
 		}
 		if (this.recordFilterStrategy != null) {
 			if (this.batchListener) {
@@ -440,13 +442,16 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 					}
 				}
 				else {
-					messageListener = new FilteringBatchMessageListenerAdapter<>(
-						(BatchMessageListener<K, V>) messageListener, this.recordFilterStrategy, this.ackDiscarded);
+					messageListener =
+							new FilteringBatchMessageListenerAdapter<>(
+									(BatchMessageListener<K, V>) messageListener, this.recordFilterStrategy,
+									this.ackDiscarded);
 				}
 			}
 			else {
-				messageListener = new FilteringMessageListenerAdapter<>((MessageListener<K, V>) messageListener,
-						this.recordFilterStrategy, this.ackDiscarded);
+				messageListener =
+						new FilteringMessageListenerAdapter<>((MessageListener<K, V>) messageListener,
+								this.recordFilterStrategy, this.ackDiscarded);
 			}
 		}
 		container.setupMessageListener(messageListener);

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
@@ -36,6 +36,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.event.ContainerStoppedEvent;
+import org.springframework.kafka.support.TopicPartitionInitialOffset;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -76,7 +77,8 @@ public abstract class AbstractMessageListenerContainer<K, V>
 
 	private int phase = DEFAULT_PHASE;
 
-	private AfterRollbackProcessor<K, V> afterRollbackProcessor = new DefaultAfterRollbackProcessor<>();
+	private AfterRollbackProcessor<? super K, ? super V> afterRollbackProcessor =
+			new DefaultAfterRollbackProcessor<>();
 
 	private volatile boolean running = false;
 
@@ -98,11 +100,12 @@ public abstract class AbstractMessageListenerContainer<K, V>
 	 * @param consumerFactory the factory.
 	 * @param containerProperties the properties.
 	 */
-	protected AbstractMessageListenerContainer(ConsumerFactory<K, V> consumerFactory,
+	@SuppressWarnings("unchecked")
+	protected AbstractMessageListenerContainer(ConsumerFactory<? super K, ? super V> consumerFactory,
 			ContainerProperties containerProperties) {
 
 		Assert.notNull(containerProperties, "'containerProperties' cannot be null");
-		this.consumerFactory = consumerFactory;
+		this.consumerFactory = (ConsumerFactory<K, V>) consumerFactory;
 		if (containerProperties.getTopics() != null) {
 			this.containerProperties = new ContainerProperties(containerProperties.getTopics());
 		}
@@ -221,7 +224,7 @@ public abstract class AbstractMessageListenerContainer<K, V>
 		return this.phase;
 	}
 
-	protected AfterRollbackProcessor<K, V> getAfterRollbackProcessor() {
+	protected AfterRollbackProcessor<? super K, ? super V> getAfterRollbackProcessor() {
 		return this.afterRollbackProcessor;
 	}
 
@@ -232,7 +235,7 @@ public abstract class AbstractMessageListenerContainer<K, V>
 	 * @param afterRollbackProcessor the processor.
 	 * @since 1.3.5
 	 */
-	public void setAfterRollbackProcessor(AfterRollbackProcessor<K, V> afterRollbackProcessor) {
+	public void setAfterRollbackProcessor(AfterRollbackProcessor<? super K, ? super V> afterRollbackProcessor) {
 		Assert.notNull(afterRollbackProcessor, "'afterRollbackProcessor' cannot be null");
 		this.afterRollbackProcessor = afterRollbackProcessor;
 	}
@@ -262,13 +265,14 @@ public abstract class AbstractMessageListenerContainer<K, V>
 
 	protected void checkTopics() {
 		if (this.containerProperties.isMissingTopicsFatal() && this.containerProperties.getTopicPattern() == null) {
-			try (Consumer<K, V> consumer = this.consumerFactory.createConsumer(this.containerProperties.getGroupId(),
-					this.containerProperties.getClientId(), null)) {
+			try (Consumer<K, V> consumer =
+					this.consumerFactory.createConsumer(this.containerProperties.getGroupId(),
+							this.containerProperties.getClientId(), null)) {
 				if (consumer != null) {
 					String[] topics = this.containerProperties.getTopics();
 					if (topics == null) {
 						topics = Arrays.stream(this.containerProperties.getTopicPartitions())
-								.map(tp -> tp.topic())
+								.map(TopicPartitionInitialOffset::topic)
 								.toArray(String[]::new);
 					}
 					List<String> missing = new ArrayList<>();
@@ -293,12 +297,12 @@ public abstract class AbstractMessageListenerContainer<K, V>
 			if (this.consumerFactory != null) { // we always have one for standard containers
 				Object groupIdConfig = this.consumerFactory.getConfigurationProperties()
 						.get(ConsumerConfig.GROUP_ID_CONFIG);
-				hasGroupIdConsumerConfig = groupIdConfig != null && groupIdConfig instanceof String
-						&& StringUtils.hasText((String) groupIdConfig);
+				hasGroupIdConsumerConfig =
+						groupIdConfig instanceof String && StringUtils.hasText((String) groupIdConfig);
 			}
 			Assert.state(hasGroupIdConsumerConfig || StringUtils.hasText(this.containerProperties.getGroupId()),
 					"No group.id found in consumer config, container properties, or @KafkaListener annotation; "
-					+ "a group.id is required when group management is used.");
+							+ "a group.id is required when group management is used.");
 		}
 	}
 
@@ -309,13 +313,7 @@ public abstract class AbstractMessageListenerContainer<K, V>
 		synchronized (this.lifecycleMonitor) {
 			if (isRunning()) {
 				final CountDownLatch latch = new CountDownLatch(1);
-				doStop(new Runnable() {
-
-					@Override
-					public void run() {
-						latch.countDown();
-					}
-				});
+				doStop(latch::countDown);
 				try {
 					latch.await(this.containerProperties.getShutdownTimeout(), TimeUnit.MILLISECONDS); // NOSONAR
 					publishContainerStoppedEvent();
@@ -370,13 +368,14 @@ public abstract class AbstractMessageListenerContainer<K, V>
 	}
 
 	protected void publishContainerStoppedEvent() {
-		if (getApplicationEventPublisher() != null) {
-			getApplicationEventPublisher().publishEvent(new ContainerStoppedEvent(this, parentOrThis()));
+		ApplicationEventPublisher applicationEventPublisher = getApplicationEventPublisher();
+		if (applicationEventPublisher != null) {
+			applicationEventPublisher.publishEvent(new ContainerStoppedEvent(this, parentOrThis()));
 		}
 	}
 
 	/**
-	 * Ruturn this or a parent container if this has a parent.
+	 * Return this or a parent container if this has a parent.
 	 * @return the parent or this.
 	 * @since 2.2.1
 	 */

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 the original author or authors.
+ * Copyright 2016-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -255,9 +255,8 @@ public abstract class AbstractMessageListenerContainer<K, V>
 		checkGroupId();
 		synchronized (this.lifecycleMonitor) {
 			if (!isRunning()) {
-				Assert.isTrue(
-						this.containerProperties.getMessageListener() instanceof GenericMessageListener,
-						"A " + GenericMessageListener.class.getName() + " implementation must be provided");
+				Assert.isTrue(this.containerProperties.getMessageListener() instanceof GenericMessageListener,
+						() -> "A " + GenericMessageListener.class.getName() + " implementation must be provided");
 				doStart();
 			}
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,6 +67,7 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 	 */
 	public ConcurrentMessageListenerContainer(ConsumerFactory<? super K, ? super V> consumerFactory,
 			ContainerProperties containerProperties) {
+
 		super(consumerFactory, containerProperties);
 		Assert.notNull(consumerFactory, "A ConsumerFactory must be provided");
 	}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
@@ -65,7 +65,7 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 	 * @param consumerFactory the consumer factory.
 	 * @param containerProperties the container properties.
 	 */
-	public ConcurrentMessageListenerContainer(ConsumerFactory<K, V> consumerFactory,
+	public ConcurrentMessageListenerContainer(ConsumerFactory<? super K, ? super V> consumerFactory,
 			ContainerProperties containerProperties) {
 		super(consumerFactory, containerProperties);
 		Assert.notNull(consumerFactory, "A ConsumerFactory must be provided");
@@ -100,7 +100,7 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 		return this.containers.stream()
 				.map(KafkaMessageListenerContainer::getAssignedPartitions)
 				.filter(Objects::nonNull)
-				.flatMap(assignedPartitions -> assignedPartitions.stream())
+				.flatMap(Collection::stream)
 				.collect(Collectors.toList());
 	}
 
@@ -135,8 +135,7 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 			checkTopics();
 			ContainerProperties containerProperties = getContainerProperties();
 			TopicPartitionInitialOffset[] topicPartitions = containerProperties.getTopicPartitions();
-			if (topicPartitions != null
-					&& this.concurrency > topicPartitions.length) {
+			if (topicPartitions != null && this.concurrency > topicPartitions.length) {
 				this.logger.warn("When specific partitions are provided, the concurrency must be less than or "
 						+ "equal to the number of partitions; reduced from " + this.concurrency + " to "
 						+ topicPartitions.length);
@@ -147,8 +146,7 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 			for (int i = 0; i < this.concurrency; i++) {
 				KafkaMessageListenerContainer<K, V> container;
 				if (topicPartitions == null) {
-					container = new KafkaMessageListenerContainer<>(this, this.consumerFactory,
-							containerProperties);
+					container = new KafkaMessageListenerContainer<>(this, this.consumerFactory, containerProperties);
 				}
 				else {
 					container = new KafkaMessageListenerContainer<>(this, this.consumerFactory,
@@ -213,15 +211,10 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 			}
 			for (KafkaMessageListenerContainer<K, V> container : this.containers) {
 				if (container.isRunning()) {
-					container.stop(new Runnable() {
-
-						@Override
-						public void run() {
-							if (count.decrementAndGet() <= 0) {
-								callback.run();
-							}
+					container.stop(() -> {
+						if (count.decrementAndGet() <= 0) {
+							callback.run();
 						}
-
 					});
 				}
 			}
@@ -232,13 +225,13 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 	@Override
 	public void pause() {
 		super.pause();
-		this.containers.forEach(c -> c.pause());
+		this.containers.forEach(AbstractMessageListenerContainer::pause);
 	}
 
 	@Override
 	public void resume() {
 		super.resume();
-		this.containers.forEach(c -> c.resume());
+		this.containers.forEach(AbstractMessageListenerContainer::resume);
 	}
 
 	@Override

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 the original author or authors.
+ * Copyright 2016-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -183,7 +183,7 @@ public class EnableKafkaIntegrationTests {
 	private RecordPassAllFilter recordFilter;
 
 	@Autowired
-	private DefaultKafkaConsumerFactory<Integer, String> consumerFactory;
+	private DefaultKafkaConsumerFactory<Integer, CharSequence> consumerFactory;
 
 	@Autowired
 	private AtomicReference<Consumer<?, ?>> consumerRef;
@@ -873,7 +873,7 @@ public class EnableKafkaIntegrationTests {
 					new ConcurrentKafkaListenerContainerFactory<>();
 			ConsumerFactory spiedCf = mock(ConsumerFactory.class);
 			willAnswer(i -> {
-				Consumer<Integer, String> spy =
+				Consumer<Integer, CharSequence> spy =
 						spy(consumerFactory().createConsumer(i.getArgument(0), i.getArgument(1),
 								i.getArgument(2)));
 				willAnswer(invocation -> {
@@ -978,7 +978,7 @@ public class EnableKafkaIntegrationTests {
 		}
 
 		@Bean
-		public DefaultKafkaConsumerFactory<Integer, String> consumerFactory() {
+		public DefaultKafkaConsumerFactory<Integer, CharSequence> consumerFactory() {
 			return new DefaultKafkaConsumerFactory<>(consumerConfigs());
 		}
 
@@ -1840,12 +1840,12 @@ public class EnableKafkaIntegrationTests {
 
 	}
 
-	public static class RecordPassAllFilter implements RecordFilterStrategy<Integer, String> {
+	public static class RecordPassAllFilter implements RecordFilterStrategy<Integer, CharSequence> {
 
 		private boolean called;
 
 		@Override
-		public boolean filter(ConsumerRecord<Integer, String> consumerRecord) {
+		public boolean filter(ConsumerRecord<Integer, CharSequence> consumerRecord) {
 			called = true;
 			return false;
 		}


### PR DESCRIPTION
Fixes spring-projects/spring-kafka#787

* Allow to configure listener container with strategies based on the
super classes of key and value generics