### PR TITLE
Fix typo in KafkaListenerErrorHandler class description

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaListenerErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaListenerErrorHandler.java
@@ -21,7 +21,7 @@ import org.apache.kafka.clients.consumer.Consumer;
 import org.springframework.messaging.Message;
 
 /**
- * An error handler which is called when a {code @KafkaListener} method
+ * An error handler which is called when a {@code @KafkaListener} method
  * throws an exception. This is invoked higher up the stack than the
  * listener container's error handler. For methods annotated with
  * {@code @SendTo}, the error handler can return a result.


### PR DESCRIPTION
This PR fixes a very minor typo in the `KafkaListenerErrorHandler` class description to get better code rendering.