### PR TITLE
GH-948: Enhance LEFException with group.id

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/KafkaException.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/KafkaException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.kafka;
 
 import org.springframework.core.NestedRuntimeException;
+import org.springframework.lang.Nullable;
 
 /**
  * The Spring Kafka specific {@link NestedRuntimeException} implementation.
@@ -31,7 +32,7 @@ public class KafkaException extends NestedRuntimeException {
 		super(message);
 	}
 
-	public KafkaException(String message, Throwable cause) {
+	public KafkaException(String message, @Nullable Throwable cause) {
 		super(message, cause);
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ListenerExecutionFailedException.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ListenerExecutionFailedException.java
@@ -59,10 +59,12 @@ public class ListenerExecutionFailedException extends KafkaException {
 	}
 
 	/**
-	 * Return the consumer group.id of the container that threw this exception.
-	 * @return the group id.
+	 * Return the consumer group.id property of the container that threw this exception.
+	 * @return the group id; may be null, but not when the exception is passed to an error
+	 * handler by a listener container.
 	 * @since 2.2.4
 	 */
+	@Nullable
 	public String getGroupId() {
 		return this.groupId;
 	}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ListenerExecutionFailedException.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ListenerExecutionFailedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 the original author or authors.
+ * Copyright 2016-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.kafka.listener;
 
 import org.springframework.kafka.KafkaException;
+import org.springframework.lang.Nullable;
 
 /**
  * The listener specific {@link KafkaException} extension.
@@ -26,12 +27,44 @@ import org.springframework.kafka.KafkaException;
 @SuppressWarnings("serial")
 public class ListenerExecutionFailedException extends KafkaException {
 
+	private final String groupId;
+
+	/**
+	 * Construct an instance with the provided properties.
+	 * @param message the exception message.
+	 */
 	public ListenerExecutionFailedException(String message) {
-		super(message);
+		this(message, null, null);
 	}
 
-	public ListenerExecutionFailedException(String message, Throwable cause) {
+	/**
+	 * Construct an instance with the provided properties.
+	 * @param message the exception message.
+	 * @param cause the cause.
+	 */
+	public ListenerExecutionFailedException(String message, @Nullable Throwable cause) {
+		this(message, null, cause);
+	}
+
+	/**
+	 * Construct an instance with the provided properties.
+	 * @param message the exception message.
+	 * @param groupId the container's group.id property.
+	 * @param cause the cause.
+	 * @since 2.2.4
+	 */
+	public ListenerExecutionFailedException(String message, @Nullable String groupId, @Nullable Throwable cause) {
 		super(message, cause);
+		this.groupId = groupId;
+	}
+
+	/**
+	 * Return the consumer group.id of the container that threw this exception.
+	 * @return the group id.
+	 * @since 2.2.4
+	 */
+	public String getGroupId() {
+		return this.groupId;
 	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/SeekToCurrentErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/SeekToCurrentErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,6 +88,7 @@ public class SeekToCurrentErrorHandler implements ContainerAwareErrorHandler {
 	@Override
 	public void handle(Exception thrownException, List<ConsumerRecord<?, ?>> records,
 			Consumer<?, ?> consumer, MessageListenerContainer container) {
+
 		if (!SeekUtils.doSeeks(records, consumer, thrownException, true, this.failureTracker::skip, logger)) {
 			throw new KafkaException("Seek to current after exception", thrownException);
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/SeekUtils.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/SeekUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,6 +57,7 @@ public final class SeekUtils {
 	 */
 	public static boolean doSeeks(List<ConsumerRecord<?, ?>> records, Consumer<?, ?> consumer, Exception exception,
 			boolean recoverable, BiPredicate<ConsumerRecord<?, ?>, Exception> skipper, Log logger) {
+
 		Map<TopicPartition, Long> partitions = new LinkedHashMap<>();
 		AtomicBoolean first = new AtomicBoolean(true);
 		AtomicBoolean skipped = new AtomicBoolean();

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -692,6 +692,9 @@ public class EnableKafkaIntegrationTests {
 		template.send("annotated32", 0, 1, "foobar");
 		assertThat(this.config.listen16ErrorLatch.await(30, TimeUnit.SECONDS)).isTrue();
 		assertThat(this.config.listen16Exception).isNotNull();
+		assertThat(this.config.listen16Exception).isInstanceOf(ListenerExecutionFailedException.class);
+		assertThat(((ListenerExecutionFailedException) this.config.listen16Exception).getGroupId())
+				.isEqualTo("converter.explicitGroupId");
 		assertThat(this.config.listen16Message).isEqualTo("foobar");
 	}
 

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -2527,6 +2527,9 @@ It also, optionally, can be configured with a `BiFunction<ConsumerRecord<?, ?>, 
 By default, the dead-letter record is sent to a topic named `<originalTopic>.DLT` (the original topic name suffixed with `.DLT`) and to the same partition as the original record.
 Therefore, when using the default resolver, the dead-letter topic must have at least as many partitions as the original topic.
 If the returned `TopicPartition` has a negative partition, the partition is not set in the `ProducerRecord` and so the partition will be selected by Kafka.
+Starting with version 2.2.4, any `ListenerExcutionFailedException` (e.g. thrown when an exception is detected in a `@KafkaListener` method) will be enhanced with the `groupId` property.
+This will allow the destination resolver to use this in addition to the information in the `ConsumerRecord` to select the dead letter topic.
+
 The following is an example of wiring a custom destination resolver.
 
 ====

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -38,6 +38,8 @@ See <<batch-listeners>> for more information.
 The `DefaultAfterRollbackProcessor` and `SeekToCurrentErrorHandler` can now recover (skip) records that keep failing, and will do so after 10 failures, by default.
 They can be configured to publish failed records to a dead-letter topic.
 
+Starting with version 2.2.4, the consumer's group id can be used while selecting the dead letter topic name.
+
 See <<after-rollback>>, <<seek-to-current>> and <<dead-letters>> for more information.
 
 The `ConsumerStoppingEvent` has been added.


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/948

For example, this can be used by the `DeadLetterPublishingRecoverer`'s
destination resolver to choose a topic based on the group in addition
to the information in the consumer record.