### PR TITLE
fix outdated references to DEFAULT_STREAMS_CONFIG_BEAN_NAME

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/EnableKafkaStreams.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/EnableKafkaStreams.java
@@ -35,7 +35,7 @@ import org.springframework.context.annotation.Import;
  * public class AppConfig {
  *
  * 	&#064;Bean(name = KafkaStreamsDefaultConfiguration.DEFAULT_STREAMS_CONFIG_BEAN_NAME)
- *  public StreamsConfig kStreamsConfigs() {
+ *  public KafkaStreamsConfiguration kStreamsConfigs() {
  *     ...
  *  }
  * 	// other &#064;Bean definitions

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaStreamsDefaultConfiguration.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaStreamsDefaultConfiguration.java
@@ -64,7 +64,8 @@ public class KafkaStreamsDefaultConfiguration {
 		else {
 			throw new UnsatisfiedDependencyException(KafkaStreamsDefaultConfiguration.class.getName(),
 					DEFAULT_STREAMS_BUILDER_BEAN_NAME, "streamsConfig", "There is no '" +
-					DEFAULT_STREAMS_CONFIG_BEAN_NAME + "' Properties bean in the application context.\n" +
+					DEFAULT_STREAMS_CONFIG_BEAN_NAME + "' " + KafkaStreamsConfiguration.class.getName() +
+					" bean in the application context.\n" +
 					"Consider declaring one or don't use @EnableKafkaStreams.");
 		}
 	}

--- a/src/reference/asciidoc/testing.adoc
+++ b/src/reference/asciidoc/testing.adoc
@@ -227,11 +227,11 @@ public class KafkaStreamsTests {
         private String brokerAddresses;
 
         @Bean(name = KafkaStreamsDefaultConfiguration.DEFAULT_STREAMS_CONFIG_BEAN_NAME)
-        public StreamsConfig kStreamsConfigs() {
+        public KafkaStreamsConfiguration kStreamsConfigs() {
             Map<String, Object> props = new HashMap<>();
             props.put(StreamsConfig.APPLICATION_ID_CONFIG, "testStreams");
             props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, this.brokerAddresses);
-            return new StreamsConfig(props);
+            return new KafkaStreamsConfiguration(props);
         }
 
     }


### PR DESCRIPTION
Fix existing code that show declaration of bean DEFAULT_STREAMS_CONFIG_BEAN_NAME
as a `Properties` object or a `StreamsConfig` object instead of `KafkaStreamsConfiguration`.

- `EnableKafkaStreams.java` : update documentation that used a `StreamsConfig` object

- `KafkaStreamsDefaultConfiguration.java` : fix the exception message when missing bean named `KafkaStreamsDefaultConfiguration.DEFAULT_STREAMS_CONFIG_BEAN_NAME`. The exception stated that a `Properties` object is required.

- `testing.adoc` : update an example that used a `StreamsConfig` object to create a bean named `KafkaStreamsDefaultConfiguration.DEFAULT_STREAMS_CONFIG_BEAN_NAME`

Hope it will prevent someone else from having trouble with starting working with `spring-kafka` 😄 