### PR TITLE
GH-960: Seek-to-Current - commit recovered offset

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
@@ -194,9 +194,7 @@ public class ContainerProperties {
 
 	/**
 	 * Whether or not to call consumer.commitSync() or commitAsync() when the
-	 * container is responsible for commits. Default true. See
-	 * https://github.com/spring-projects/spring-kafka/issues/62 At the time of
-	 * writing, async commits are not entirely reliable.
+	 * container is responsible for commits. Default true.
 	 */
 	private boolean syncCommits = true;
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -1741,26 +1741,6 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR comment density
 
 	}
 
-	private static final class LoggingCommitCallback implements OffsetCommitCallback {
-
-		private static final Log logger = LogFactory.getLog(LoggingCommitCallback.class); // NOSONAR
-
-		LoggingCommitCallback() {
-			super();
-		}
-
-		@Override
-		public void onComplete(Map<TopicPartition, OffsetAndMetadata> offsets, Exception exception) {
-			if (exception != null) {
-				logger.error("Commit failed for " + offsets, exception);
-			}
-			else if (logger.isDebugEnabled()) {
-				logger.debug("Commits for " + offsets + " completed");
-			}
-		}
-
-	}
-
 	private static final class OffsetMetadata {
 
 		private final Long offset;

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/LoggingCommitCallback.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/LoggingCommitCallback.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import java.util.Map;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetCommitCallback;
+import org.apache.kafka.common.TopicPartition;
+
+/**
+ * Logs commit results at DEBUG level for success and ERROR for failures.
+ *
+ * @author Gary Russell
+ * @since 2.2.4
+ */
+public final class LoggingCommitCallback implements OffsetCommitCallback {
+
+	private static final Log logger = LogFactory.getLog(LoggingCommitCallback.class); // NOSONAR
+
+	@Override
+	public void onComplete(Map<TopicPartition, OffsetAndMetadata> offsets, Exception exception) {
+		if (exception != null) {
+			logger.error("Commit failed for " + offsets, exception);
+		}
+		else if (logger.isDebugEnabled()) {
+			logger.debug("Commits for " + offsets + " completed");
+		}
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/SeekToCurrentErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/SeekToCurrentErrorHandler.java
@@ -16,6 +16,7 @@
 
 package org.springframework.kafka.listener;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.function.BiConsumer;
 
@@ -23,8 +24,12 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetCommitCallback;
+import org.apache.kafka.common.TopicPartition;
 
 import org.springframework.kafka.KafkaException;
+import org.springframework.kafka.listener.ContainerProperties.AckMode;
 import org.springframework.kafka.support.SeekUtils;
 import org.springframework.lang.Nullable;
 
@@ -39,9 +44,13 @@ import org.springframework.lang.Nullable;
  */
 public class SeekToCurrentErrorHandler implements ContainerAwareErrorHandler {
 
-	private static final Log logger = LogFactory.getLog(SeekToCurrentErrorHandler.class); // NOSONAR
+	protected static final Log LOGGER = LogFactory.getLog(SeekToCurrentErrorHandler.class); // NOSONAR visibility
+
+	private static final LoggingCommitCallback LOGGING_COMMIT_CALLBACK = new LoggingCommitCallback();
 
 	private final FailedRecordTracker failureTracker;
+
+	private boolean commitRecovered;
 
 	/**
 	 * Construct an instance with the default recoverer which simply logs the record after
@@ -82,15 +91,57 @@ public class SeekToCurrentErrorHandler implements ContainerAwareErrorHandler {
 	 * @since 2.2
 	 */
 	public SeekToCurrentErrorHandler(@Nullable BiConsumer<ConsumerRecord<?, ?>, Exception> recoverer, int maxFailures) {
-		this.failureTracker = new FailedRecordTracker(recoverer, maxFailures, logger);
+		this.failureTracker = new FailedRecordTracker(recoverer, maxFailures, LOGGER);
+	}
+
+	/**
+	 * Whether the offset for a recovered record should be committed.
+	 * @return true to commit recovered record offsets.
+	 * @since 2.2.4
+	 */
+	protected boolean isCommitRecovered() {
+		return this.commitRecovered;
+	}
+
+	/**
+	 * Set to true to commit the offset for a recovered record. The container
+	 * must be configured with {@link AckMode#MANUAL_IMMEDIATE}. Whether or not
+	 * the commit is sync or async depends on the container's syncCommits
+	 * property.
+	 * @param commitRecovered true to commit.
+	 * @since 2.2.4
+	 * @see #setOffsetCommitCallback(OffsetCommitCallback)
+	 */
+	public void setCommitRecovered(boolean commitRecovered) {
+		this.commitRecovered = commitRecovered;
 	}
 
 	@Override
 	public void handle(Exception thrownException, List<ConsumerRecord<?, ?>> records,
 			Consumer<?, ?> consumer, MessageListenerContainer container) {
 
-		if (!SeekUtils.doSeeks(records, consumer, thrownException, true, this.failureTracker::skip, logger)) {
+		if (!SeekUtils.doSeeks(records, consumer, thrownException, true, this.failureTracker::skip, LOGGER)) {
 			throw new KafkaException("Seek to current after exception", thrownException);
+		}
+		else if (this.commitRecovered) {
+			if (container.getContainerProperties().getAckMode().equals(AckMode.MANUAL_IMMEDIATE)) {
+				ConsumerRecord<?, ?> record = records.get(0);
+				if (container.getContainerProperties().isSyncCommits()) {
+					consumer.commitSync(Collections.singletonMap(new TopicPartition(record.topic(), record.partition()),
+							new OffsetAndMetadata(record.offset() + 1)));
+				}
+				else {
+					OffsetCommitCallback commitCallback = container.getContainerProperties().getCommitCallback();
+					if (commitCallback == null) {
+						commitCallback = LOGGING_COMMIT_CALLBACK;
+					}
+					consumer.commitAsync(Collections.singletonMap(new TopicPartition(record.topic(), record.partition()),
+							new OffsetAndMetadata(record.offset() + 1)), commitCallback);
+				}
+			}
+			else {
+				LOGGER.warn("'commitRecovered' ignored, container AckMode must be MANUAL_IMMEDIATE");
+			}
 		}
 	}
 

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -2770,6 +2770,8 @@ SeekToCurrentErrorHandler errorHandler =
 ----
 ====
 
+Starting with version 2.2.4, when the container is configured with `AckMode.MANUAL_IMMEDIATE`, the error handler can be configured to commit the offset of recovered records; set the `commitRecovered` property to `true`.
+
 See also <<dead-letters>>.
 
 When using transactions, similar functionality is provided by the `DefaultAfterRollbackProcessor`.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -45,6 +45,9 @@ See <<after-rollback>>, <<seek-to-current>>, and <<dead-letters>> for more infor
 The `ConsumerStoppingEvent` has been added.
 See <<events>> for more information.
 
+The `SeekToCurrentErrorHandler` can now be configured to commit the offset of a recovered record when the container is configured with `AckMode.MANUAL_IMMEDIATE` (since 2.2.4).
+See <<seek-to-current>> for more information.
+
 ==== @KafkaListener Changes
 
 You can now override the `concurrency` and `autoStartup` properties of the listener container factory by setting properties on the annotation.


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/960

When the container is configured with `AckMode.MANUAL_IMMEDIATE`, the
`SeekToCurrentErrorHandler` can be configured to commit the offset of
a recovered record.