### PR TITLE
Fix default deserializer getters

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/ConsumerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/ConsumerFactory.java
@@ -122,7 +122,7 @@ public interface ConsumerFactory<K, V> {
 	 */
 	@Nullable
 	default Deserializer<K> getKeyDeserializer() {
-		throw new UnsupportedOperationException("'getKeyDeserializer()' is not supported");
+		return null;
 	}
 
 	/**
@@ -133,7 +133,7 @@ public interface ConsumerFactory<K, V> {
 	 */
 	@Nullable
 	default Deserializer<V> getValueDeserializer() {
-		throw new UnsupportedOperationException("'getKeyDeserializer()' is not supported");
+		return null;
 	}
 
 }


### PR DESCRIPTION
Since the getters are `@Nullable` the default implementation should
return `null` instead of throwing an `UnsupportedOperationException`.