### PR TITLE
Remove uses of deprec. Extended(Des|S)erializer

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ErrorHandlingDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ErrorHandlingDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Deserializer;
-import org.apache.kafka.common.serialization.ExtendedDeserializer;
 
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
@@ -40,7 +39,7 @@ import org.springframework.util.ClassUtils;
  *
  */
 @Deprecated
-public class ErrorHandlingDeserializer<T> implements ExtendedDeserializer<T> {
+public class ErrorHandlingDeserializer<T> implements Deserializer<T> {
 
 	/**
 	 * Property name for the delegate key deserializer.
@@ -52,7 +51,7 @@ public class ErrorHandlingDeserializer<T> implements ExtendedDeserializer<T> {
 	 */
 	public static final String VALUE_DESERIALIZER_CLASS = "spring.deserializer.value.delegate.class";
 
-	private ExtendedDeserializer<T> delegate;
+	private Deserializer<T> delegate;
 
 	private boolean isKey;
 
@@ -91,11 +90,9 @@ public class ErrorHandlingDeserializer<T> implements ExtendedDeserializer<T> {
 	}
 
 	@SuppressWarnings("unchecked")
-	private ExtendedDeserializer<T> setupDelegate(Object delegate) {
+	private Deserializer<T> setupDelegate(Object delegate) {
 		Assert.isInstanceOf(Deserializer.class, delegate, "'delegate' must be a 'Deserializer', not a ");
-		return delegate instanceof ExtendedDeserializer
-				? (ExtendedDeserializer<T>) delegate
-				: ExtendedDeserializer.Wrapper.ensureExtended((Deserializer<T>) delegate);
+		return (Deserializer<T>) delegate;
 	}
 
 	@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ErrorHandlingDeserializer2.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ErrorHandlingDeserializer2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ import java.util.function.BiFunction;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.serialization.Deserializer;
-import org.apache.kafka.common.serialization.ExtendedDeserializer;
 
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
@@ -42,7 +41,7 @@ import org.springframework.util.ClassUtils;
  * @since 2.2
  *
  */
-public class ErrorHandlingDeserializer2<T> implements ExtendedDeserializer<T> {
+public class ErrorHandlingDeserializer2<T> implements Deserializer<T> {
 
 	/**
 	 * Header name for deserialization exceptions.
@@ -79,7 +78,7 @@ public class ErrorHandlingDeserializer2<T> implements ExtendedDeserializer<T> {
 	 */
 	public static final String VALUE_DESERIALIZER_CLASS = "spring.deserializer.value.delegate.class";
 
-	private ExtendedDeserializer<T> delegate;
+	private Deserializer<T> delegate;
 
 	private boolean isKey;
 
@@ -146,11 +145,9 @@ public class ErrorHandlingDeserializer2<T> implements ExtendedDeserializer<T> {
 	}
 
 	@SuppressWarnings("unchecked")
-	private ExtendedDeserializer<T> setupDelegate(Object delegate) {
+	private Deserializer<T> setupDelegate(Object delegate) {
 		Assert.isInstanceOf(Deserializer.class, delegate, "'delegate' must be a 'Deserializer', not a ");
-		return delegate instanceof ExtendedDeserializer
-				? (ExtendedDeserializer<T>) delegate
-				: ExtendedDeserializer.Wrapper.ensureExtended((Deserializer<T>) delegate);
+		return (Deserializer<T>) delegate;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java
@@ -23,7 +23,7 @@ import java.util.function.Consumer;
 
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.header.Headers;
-import org.apache.kafka.common.serialization.ExtendedDeserializer;
+import org.apache.kafka.common.serialization.Deserializer;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.kafka.support.converter.AbstractJavaTypeMapper;
@@ -55,7 +55,7 @@ import com.fasterxml.jackson.databind.ObjectReader;
  * @author Torsten Schleede
  * @author Ivan Ponomarev
  */
-public class JsonDeserializer<T> implements ExtendedDeserializer<T> {
+public class JsonDeserializer<T> implements Deserializer<T> {
 
 	private static final String KEY_DEFAULT_TYPE_STRING = "spring.json.key.default.type";
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 the original author or authors.
+ * Copyright 2016-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,7 +22,7 @@ import java.util.Map;
 
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.header.Headers;
-import org.apache.kafka.common.serialization.ExtendedSerializer;
+import org.apache.kafka.common.serialization.Serializer;
 
 import org.springframework.kafka.support.converter.AbstractJavaTypeMapper;
 import org.springframework.kafka.support.converter.DefaultJackson2JavaTypeMapper;
@@ -47,7 +47,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  * @author Gary Russell
  * @author Elliot Kennedy
  */
-public class JsonSerializer<T> implements ExtendedSerializer<T> {
+public class JsonSerializer<T> implements Serializer<T> {
 
 	/**
 	 * Kafka config property for disabling adding type headers.

--- a/spring-kafka/src/test/java/org/springframework/kafka/kstream/KafkaStreamsTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/kstream/KafkaStreamsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2018 the original author or authors.
+ * Copyright 2017-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package org.springframework.kafka.kstream;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -202,7 +203,7 @@ public class KafkaStreamsTests {
 					}))
 					.mapValues(Foo::getName)
 					.groupByKey()
-					.windowedBy(TimeWindows.of(1000))
+					.windowedBy(TimeWindows.of(Duration.ofMillis(1000)))
 					.reduce((value1, value2) -> value1 + value2, Materialized.as("windowStore"))
 					.toStream()
 					.map((windowedId, value) -> new KeyValue<>(windowedId.key(), value))

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ErrorHandlingDeserializerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ErrorHandlingDeserializerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,6 @@ import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.Deserializer;
-import org.apache.kafka.common.serialization.ExtendedDeserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.Test;
@@ -208,7 +207,7 @@ public class ErrorHandlingDeserializerTests {
 
 	}
 
-	public static class FailSometimesDeserializer implements ExtendedDeserializer<String> {
+	public static class FailSometimesDeserializer implements Deserializer<String> {
 
 		@Override
 		public void configure(Map<String, ?> configs, boolean isKey) {


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-kafka/issues/889

- also `TimeWindows.of(long)`