### PR TITLE
GH-970: Add getGroupId() to containers

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistry.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2016 the original author or authors.
+ * Copyright 2014-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,9 +112,26 @@ public class KafkaListenerEndpointRegistry implements DisposableBean, SmartLifec
 	/**
 	 * Return the managed {@link MessageListenerContainer} instance(s).
 	 * @return the managed {@link MessageListenerContainer} instance(s).
+	 * @see #getAllListenerContainers()
 	 */
 	public Collection<MessageListenerContainer> getListenerContainers() {
 		return Collections.unmodifiableCollection(this.listenerContainers.values());
+	}
+
+	/**
+	 * Return all {@link MessageListenerContainer} instances including those managed by
+	 * this registry and those declared as beans in the application context.
+	 * Prototype-scoped containers will be included. Lazy beans that have not yet been
+	 * created will not be initialized by a call to this method.
+	 * @return the {@link MessageListenerContainer} instance(s).
+	 * @since 2.2.5
+	 * @see #getListenerContainers()
+	 */
+	public Collection<MessageListenerContainer> getAllListenerContainers() {
+		List<MessageListenerContainer> containers = new ArrayList<>();
+		containers.addAll(getListenerContainers());
+		containers.addAll(this.applicationContext.getBeansOfType(MessageListenerContainer.class, true, false).values());
+		return containers;
 	}
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
@@ -37,6 +37,7 @@ import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.event.ContainerStoppedEvent;
 import org.springframework.kafka.support.TopicPartitionInitialOffset;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
@@ -243,6 +244,21 @@ public abstract class AbstractMessageListenerContainer<K, V>
 	@Override
 	public ContainerProperties getContainerProperties() {
 		return this.containerProperties;
+	}
+
+	@Override
+	public String getGroupId() {
+		return this.containerProperties.getGroupId() == null
+				? (String) this.consumerFactory
+						.getConfigurationProperties()
+						.get(ConsumerConfig.GROUP_ID_CONFIG)
+				: this.containerProperties.getGroupId();
+	}
+
+	@Override
+	@Nullable
+	public String getListenerId() {
+		return this.beanName; // the container factory sets the bean name to the id attribute
 	}
 
 	@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -448,10 +448,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 
 		private final TransactionTemplate transactionTemplate;
 
-		private final String consumerGroupId = this.containerProperties.getGroupId() == null
-				? (String) KafkaMessageListenerContainer.this.consumerFactory.getConfigurationProperties()
-				.get(ConsumerConfig.GROUP_ID_CONFIG)
-				: this.containerProperties.getGroupId();
+		private final String consumerGroupId = getGroupId();
 
 		private final TaskScheduler taskScheduler;
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/MessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/MessageListenerContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2018 the original author or authors.
+ * Copyright 2016-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.TopicPartition;
 
 import org.springframework.context.SmartLifecycle;
+import org.springframework.lang.Nullable;
 
 /**
  * Internal abstraction used by the framework representing a message
@@ -112,6 +113,27 @@ public interface MessageListenerContainer extends SmartLifecycle {
 	 */
 	default void setAutoStartup(boolean autoStartup) {
 		// empty
+	}
+
+	/**
+	 * Return the {@code group.id} property for this container whether specifically set on the
+	 * container or via a consumer property on the consumer factory.
+	 * @return the group id.
+	 * @since 2.2.5
+	 */
+	default String getGroupId() {
+		throw new UnsupportedOperationException("This container does not support retrieving the group id");
+	}
+
+	/**
+	 * The 'id' attribute of a {@code @KafkaListener} or the bean name for spring-managed
+	 * containers.
+	 * @return the id or bean name.
+	 * @since 2.2.5
+	 */
+	@Nullable
+	default String getListenerId() {
+		throw new UnsupportedOperationException("This container does not support retrieving the listener id");
 	}
 
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
@@ -186,6 +186,7 @@ public class KafkaMessageListenerContainerTests {
 						.collect(Collectors.toList()));
 			}
 		});
+		assertThat(container.getGroupId()).isEqualTo("delegate");
 		container.start();
 
 		Map<String, Object> senderProps = KafkaTestUtils.producerProps(embeddedKafka);
@@ -270,9 +271,11 @@ public class KafkaMessageListenerContainerTests {
 			trace.set(new RuntimeException().getStackTrace());
 			latch1.countDown();
 		});
+		containerProps.setGroupId("delegateGroup");
 		KafkaMessageListenerContainer<Integer, String> container =
 				new KafkaMessageListenerContainer<>(cf, containerProps);
 		container.setBeanName("delegate");
+		assertThat(container.getGroupId()).isEqualTo("delegateGroup");
 		container.start();
 
 		int n = 0;

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -1320,6 +1320,11 @@ private KafkaListenerEndpointRegistry registry;
 ----
 ====
 
+The registry only maintains the life cycle of containers it manages; containers declared as beans are not managed by the registry and can be obtained from the application context.
+A collection of managed containers can be obtained by calling the registry's `getListenerContainers()` method.
+Version 2.2.5 added a convenience method `getAllListenerContainers()`, which returns a collection of all containers, including those managed by the registry and those declared as beans.
+The collection returned will include any prototype beans that have been initialized, but it will not initialize any lazy bean declarations.
+
 [[kafka-validation]]
 ===== `@KafkaListener` `@Payload` Validation
 


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/970

- allow retrieval of the `group.id`, even if not set on the container properties
- also add `getAllListenerContainers` to the `RLERegistry` as a convenience
- also add `getListenerId` to return the id or bean name of the container

__cherry-pick to 2.2.x__