### PR TITLE
Add TopicBuilder

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/config/TopicBuilder.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/TopicBuilder.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.config;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.common.config.TopicConfig;
+
+/**
+ * Builder for a {@link NewTopic}.
+ *
+ * @author Gary Russell
+ * @since 2.3
+ *
+ */
+public final class TopicBuilder {
+
+	private final String name;
+
+	private int partitions = 1;
+
+	private short replicas = 1;
+
+	private Map<Integer, List<Integer>> replicasAssignments;
+
+	private final Map<String, String> configs = new HashMap<>();
+
+	private TopicBuilder(String name) {
+		this.name = name;
+	}
+
+	/**
+	 * Set the number of partitions (default 1).
+	 * @param partitions the partitions.
+	 * @return the builder.
+	 */
+	public TopicBuilder partitions(int partitions) {
+		this.partitions = partitions;
+		return this;
+	}
+
+	/**
+	 * Set the number of replicas (default 1).
+	 * @param replicas the replicas (which will be cast to short).
+	 * @return the builder.
+	 */
+	public TopicBuilder replicas(int replicas) {
+		this.replicas = (short) replicas;
+		return this;
+	}
+
+	/**
+	 * Set the replica assignments.
+	 * @param replicasAssignments the assignments.
+	 * @return the builder.
+	 * @see NewTopic#replicasAssignments()
+	 */
+	public TopicBuilder replicasAssignments(Map<Integer, List<Integer>> replicasAssignments) {
+		this.replicasAssignments = replicasAssignments;
+		return this;
+	}
+
+	/**
+	 * Set the configs.
+	 * @param configs the configs.
+	 * @return the builder.
+	 * @see NewTopic#configs()
+	 */
+	public TopicBuilder configs(Map<String, String> configs) {
+		this.configs.putAll(configs);
+		return this;
+	}
+
+	/**
+	 * Set a configuration option.
+	 * @param configName the name.
+	 * @param configValue the value.
+	 * @return the builder
+	 * @see TopicConfig
+	 */
+	public TopicBuilder config(String configName, String configValue) {
+		this.configs.put(configName, configValue);
+		return this;
+	}
+
+	/**
+	 * Set the {@link TopicConfig#CLEANUP_POLICY_CONFIG} to
+	 * {@link TopicConfig#CLEANUP_POLICY_COMPACT}.
+	 * @return the builder.
+	 */
+	public TopicBuilder compact() {
+		this.configs.put(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT);
+		return this;
+	}
+
+	public NewTopic build() {
+		NewTopic topic = this.replicasAssignments == null
+				? new NewTopic(this.name, this.partitions, this.replicas)
+				: new NewTopic(this.name, this.replicasAssignments);
+		if (this.configs.size() > 0) {
+			topic.configs(this.configs);
+		}
+		return topic;
+	}
+
+	/**
+	 * Create a TopicBuilder with the supplied name.
+	 * @param name the name.
+	 * @return the builder.
+	 */
+	public static TopicBuilder name(String name) {
+		return new TopicBuilder(name);
+	}
+
+}

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -4,10 +4,12 @@
 This section offers detailed explanations of the various concerns that impact using Spring for Apache Kafka.
 For a quick but less detailed introduction, see <<quick-tour>>.
 
+[[configuring-topics]]
 ==== Configuring Topics
 
 If you define a `KafkaAdmin` bean in your application context, it can automatically add topics to the broker.
 To do so, you can add a `NewTopic` `@Bean` for each topic to the application context.
+Version 2.3 introduced a new class `TopicBuilder` to make creation of such beans more convenient.
 The following example shows how to do so:
 
 ====
@@ -23,15 +25,25 @@ public KafkaAdmin admin() {
 
 @Bean
 public NewTopic topic1() {
-    return new NewTopic("thing1", 10, (short) 2);
+    return TopicBuilder.name("thing1")
+            .partitions(10)
+            .replicas(3)
+            .compact()
+            .build();
 }
 
 @Bean
 public NewTopic topic2() {
-    return new NewTopic("thing2", 10, (short) 2);
+    return TopicBuilder.name("thing2")
+            .partitions(10)
+            .replicas(3)
+            .config(TopicConfig.COMPRESSION_TYPE_CONFIG, "zstd")
+            .build();
 }
 ----
 ====
+
+IMPORTANT: When using Spring Boot, a `KafkaAdmin` bean is automatically registered so you only need the `NewTopic` `@Bean` s.
 
 By default, if the broker is not available, a message is logged, but the context continues to load.
 You can programmatically invoke the admin's `initialize()` method to try again later.
@@ -40,7 +52,7 @@ The context then fails to initialize.
 
 NOTE: If the broker supports it (1.0.0 or higher), the admin increases the number of partitions if it is found that an existing topic has fewer partitions than the `NewTopic.numPartitions`.
 
-For more advanced features, such as assigning partitions to replicas, you can use the `AdminClient` directly.
+For more advanced features, you can use the `AdminClient` directly.
 The following example shows how to do so:
 
 ====
@@ -462,12 +474,18 @@ public class KRequestingApplication {
 
     @Bean
     public NewTopic kRequests() {
-        return new NewTopic("kRequests", 10, (short) 2);
+        return TopicBuilder.name("kRequests")
+            .partitions(10)
+            .replicas(2)
+            .build();
     }
 
     @Bean
     public NewTopic kReplies() {
-        return new NewTopic("kReplies", 10, (short) 2);
+        return TopicBuilder.name("kReplies")
+            .partitions(10)
+            .replicas(2)
+            .build();
     }
 
 }
@@ -499,7 +517,10 @@ public class KReplyingApplication {
 
     @Bean
     public NewTopic kRequests() {
-        return new NewTopic("kRequests", 10, (short) 2);
+        return TopicBuilder.name("kRequests")
+            .partitions(10)
+            .replicas(2)
+            .build();
     }
 
     @Bean // not required if Jackson is on the classpath
@@ -1941,51 +1962,54 @@ The following Spring Boot application shows how to do this by overriding boot's 
 @SpringBootApplication
 public class Application {
 
-	public static void main(String[] args) {
-		SpringApplication.run(Application.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
 
-	@Bean
-	public ConsumerFactory<?, ?> kafkaConsumerFactory(KafkaProperties properties, SomeBean someBean) {
-		Map<String, Object> consumerProperties = properties.buildConsumerProperties();
-		consumerProperties.put(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG, MyConsumerInterceptor.class.getName());
-		consumerProperties.put("some.bean", someBean);
-		return new DefaultKafkaConsumerFactory<>(consumerProperties);
-	}
+    @Bean
+    public ConsumerFactory<?, ?> kafkaConsumerFactory(KafkaProperties properties, SomeBean someBean) {
+        Map<String, Object> consumerProperties = properties.buildConsumerProperties();
+        consumerProperties.put(ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG, MyConsumerInterceptor.class.getName());
+        consumerProperties.put("some.bean", someBean);
+        return new DefaultKafkaConsumerFactory<>(consumerProperties);
+    }
 
-	@Bean
-	public ProducerFactory<?, ?> kafkaProducerFactory(KafkaProperties properties, SomeBean someBean) {
-		Map<String, Object> producerProperties = properties.buildProducerProperties();
-		producerProperties.put(ProducerConfig.INTERCEPTOR_CLASSES_CONFIG, MyProducerInterceptor.class.getName());
-		producerProperties.put("some.bean", someBean);
-		DefaultKafkaProducerFactory<?, ?> factory = new DefaultKafkaProducerFactory<>(producerProperties);
-		String transactionIdPrefix = properties.getProducer()
-				.getTransactionIdPrefix();
-		if (transactionIdPrefix != null) {
-			factory.setTransactionIdPrefix(transactionIdPrefix);
-		}
-		return factory;
-	}
+    @Bean
+    public ProducerFactory<?, ?> kafkaProducerFactory(KafkaProperties properties, SomeBean someBean) {
+        Map<String, Object> producerProperties = properties.buildProducerProperties();
+        producerProperties.put(ProducerConfig.INTERCEPTOR_CLASSES_CONFIG, MyProducerInterceptor.class.getName());
+        producerProperties.put("some.bean", someBean);
+        DefaultKafkaProducerFactory<?, ?> factory = new DefaultKafkaProducerFactory<>(producerProperties);
+        String transactionIdPrefix = properties.getProducer()
+                .getTransactionIdPrefix();
+        if (transactionIdPrefix != null) {
+            factory.setTransactionIdPrefix(transactionIdPrefix);
+        }
+        return factory;
+    }
 
-	@Bean
-	public SomeBean someBean() {
-		return new SomeBean();
-	}
+    @Bean
+    public SomeBean someBean() {
+        return new SomeBean();
+    }
 
-	@KafkaListener(id = "kgk897", topics = "kgh897")
-	public void listen(String in) {
-		System.out.println("Received " + in);
-	}
+    @KafkaListener(id = "kgk897", topics = "kgh897")
+    public void listen(String in) {
+        System.out.println("Received " + in);
+    }
 
-	@Bean
-	public ApplicationRunner runner(KafkaTemplate<String, String> template) {
-		return args -> template.send("kgh897", "test");
-	}
+    @Bean
+    public ApplicationRunner runner(KafkaTemplate<String, String> template) {
+        return args -> template.send("kgh897", "test");
+    }
 
-	@Bean
-	public NewTopic topic() {
-		return new NewTopic("kgh897", 1, (short) 1);
-	}
+    @Bean
+    public NewTopic kRequests() {
+        return TopicBuilder.name("kgh897")
+            .partitions(1)
+            .replicas(1)
+            .build();
+    }
 
 }
 ----
@@ -1996,9 +2020,9 @@ public class Application {
 ----
 public class SomeBean {
 
-	public void someMethod(String what) {
-		System.out.println(what + " in my foo bean");
-	}
+    public void someMethod(String what) {
+        System.out.println(what + " in my foo bean");
+    }
 
 }
 ----
@@ -2008,26 +2032,26 @@ public class SomeBean {
 ----
 public class MyProducerInterceptor implements ProducerInterceptor<String, String> {
 
-	private SomeBean bean;
+    private SomeBean bean;
 
-	@Override
-	public void configure(Map<String, ?> configs) {
-		this.bean = (SomeBean) configs.get("some.bean");
-	}
+    @Override
+    public void configure(Map<String, ?> configs) {
+        this.bean = (SomeBean) configs.get("some.bean");
+    }
 
-	@Override
-	public ProducerRecord<String, String> onSend(ProducerRecord<String, String> record) {
-		this.bean.someMethod("producer interceptor");
-		return record;
-	}
+    @Override
+    public ProducerRecord<String, String> onSend(ProducerRecord<String, String> record) {
+        this.bean.someMethod("producer interceptor");
+        return record;
+    }
 
-	@Override
-	public void onAcknowledgement(RecordMetadata metadata, Exception exception) {
-	}
+    @Override
+    public void onAcknowledgement(RecordMetadata metadata, Exception exception) {
+    }
 
-	@Override
-	public void close() {
-	}
+    @Override
+    public void close() {
+    }
 
 }
 ----
@@ -2037,26 +2061,26 @@ public class MyProducerInterceptor implements ProducerInterceptor<String, String
 ----
 public class MyConsumerInterceptor implements ConsumerInterceptor<String, String> {
 
-	private SomeBean bean;
+    private SomeBean bean;
 
-	@Override
-	public void configure(Map<String, ?> configs) {
-		this.bean = (SomeBean) configs.get("some.bean");
-	}
+    @Override
+    public void configure(Map<String, ?> configs) {
+        this.bean = (SomeBean) configs.get("some.bean");
+    }
 
-	@Override
-	public ConsumerRecords<String, String> onConsume(ConsumerRecords<String, String> records) {
-		this.bean.someMethod("consumer interceptor");
-		return records;
-	}
+    @Override
+    public ConsumerRecords<String, String> onConsume(ConsumerRecords<String, String> records) {
+        this.bean.someMethod("consumer interceptor");
+        return records;
+    }
 
-	@Override
-	public void onCommit(Map<TopicPartition, OffsetAndMetadata> offsets) {
-	}
+    @Override
+    public void onCommit(Map<TopicPartition, OffsetAndMetadata> offsets) {
+    }
 
-	@Override
-	public void close() {
-	}
+    @Override
+    public void close() {
+    }
 
 }
 ----
@@ -2131,7 +2155,10 @@ public class Application implements ApplicationListener<KafkaEvent> {
 
     @Bean
     public NewTopic topic() {
-        return new NewTopic("pause.resume.topic", 2, (short) 1);
+        return TopicBuilder.name("pause.resume.topic")
+            .partitions(2)
+            .replicas(1)
+            .build();
     }
 
 }

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -7,7 +7,7 @@ This section covers the changes made from version 2.2 to version 2.3.
 
 This version requires the 2.1.0 `kafka-clients` or higher.
 
-==== Listener Contaienr Changes
+==== Listener Container Changes
 
 Previously, error handlers received `ListenerExectionFailedException` (with the actual listener exception as the `cause`) when the listener was invoked using a listener adapter (such as `@KafkaListener` s).
 Exceptions thrown by native `GenericMessageListener` s were passed to the error handler unchanged.
@@ -15,3 +15,8 @@ Now a `ListenerExecutionFailedException` is always the argument (with the actual
 
 Because the listener container has it's own mechanism for committing offsets, it prefers the Kafka `ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG` to be `false`.
 It now sets it to false automatically unless specifically set in the consumer factory or the container's consumer property overrides.
+
+==== TopicBuilder
+
+A new class `TopicBuilder` is provided for more convenient creation of `NewTopic` `@Bean` s for automatic topic provisioning.
+See <<configuring-topics>> for more information.


### PR DESCRIPTION
Convenient builder for `NewTopic` to avoid the cast to short when
creating `NewTopic`.
Also convenient fluent API for setting topic configuration properties.