### PR TITLE
GH-983: Add exception classifier to the Seeking EH

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordTracker.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,6 +66,10 @@ class FailedRecordTracker {
 
 	void clearThreadState() {
 		this.failures.remove();
+	}
+
+	BiConsumer<ConsumerRecord<?, ?>, Exception> getRecoverer() {
+		return this.recoverer;
 	}
 
 	private static final class FailedRecord {

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentErrorHandlerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentErrorHandlerTests.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.mock;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.kafka.KafkaException;
+import org.springframework.kafka.support.serializer.DeserializationException;
+
+/**
+ * @author Gary Russell
+ * @since 2.3
+ *
+ */
+public class SeekToCurrentErrorHandlerTests {
+
+	@Test
+	public void testClassifier() {
+		AtomicReference<ConsumerRecord<?, ?>> recovered = new AtomicReference<>();
+		SeekToCurrentErrorHandler handler = new SeekToCurrentErrorHandler((r, t) -> recovered.set(r));
+		ConsumerRecord<String, String> record = new ConsumerRecord<>("foo", 0, 0L, "foo", "bar");
+		List<ConsumerRecord<?, ?>> records = Collections.singletonList(record);
+		IllegalStateException illegalState = new IllegalStateException();
+		assertThatExceptionOfType(KafkaException.class).isThrownBy(() -> handler.handle(illegalState, records,
+					mock(Consumer.class), mock(MessageListenerContainer.class)))
+				.withCause(illegalState);
+		handler.handle(new DeserializationException("intended", null, false, illegalState), records,
+				mock(Consumer.class), mock(MessageListenerContainer.class));
+		assertThat(recovered.get()).isSameAs(record);
+		handler.addNotRetryableException(IllegalStateException.class);
+		recovered.set(null);
+		handler.handle(illegalState, records, mock(Consumer.class), mock(MessageListenerContainer.class));
+		assertThat(recovered.get()).isSameAs(record);
+	}
+
+}

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -2960,6 +2960,35 @@ See also <<dead-letters>>.
 When using transactions, similar functionality is provided by the `DefaultAfterRollbackProcessor`.
 See <<after-rollback>>.
 
+Starting with version 2.3, the `SeekToCurrentErrorHandler` considers certain exceptions to be fatal, and retries are skipped for such exceptions; the recoverer is invoked on the first failure.
+The exceptions that are considered fatal, by default, are:
+
+* `DeserializationException`
+* `MessageConversionException`
+* `MethodArgumentResolutionException`
+* `NoSuchMethodException`
+* `ClassCastException`
+
+since these exceptions are unlikely to be resolved on a retried delivery.
+
+You can add more exception types to the not-retryable category, or completely replace the `BinaryExceptionClassifier` with your own configured classifier.
+See the Javadocs for `SeekToCurrentErrorHandler` for more information, as well as those for the `spring-retry` `BinaryExceptionClassifier`.
+
+Here is an example that adds `IllegalArgumentException` to the not-retryable exceptions:
+
+====
+[source, java]
+----
+@Bean
+public SeekToCurrentErrorHandler errorHandler(BiConsumer<ConsumerRecord<?, ?>, Exception> recoverer) {
+    SeekToCurrentErrorHandler handler = new SeekToCurrentErrorHandler(recoverer);
+    handler.addNotRetryableException(IllegalArgumentException.class);
+    return handler;
+}
+----
+====
+
+
 The `SeekToCurrentBatchErrorHandler` seeks each partition to the first record in each partition in the batch, so the whole batch is replayed.
 This error handler does not support recovery, because the framework cannot know which message in the batch is failing.
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -16,6 +16,11 @@ Now a `ListenerExecutionFailedException` is always the argument (with the actual
 Because the listener container has it's own mechanism for committing offsets, it prefers the Kafka `ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG` to be `false`.
 It now sets it to false automatically unless specifically set in the consumer factory or the container's consumer property overrides.
 
+==== ErrorHandler Changes
+
+The `SeekToCurrentErrorHandler` now treats certain exceptions as fatal and disables retry for those, invoking the recoverer on first failure.
+See <<seek-to-current>> for more information.
+
 ==== TopicBuilder
 
 A new class `TopicBuilder` is provided for more convenient creation of `NewTopic` `@Bean` s for automatic topic provisioning.


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/983

Add a `spring-retry` `BinaryExceptionClassifier` to the
`SeekToCurrentErrorHandler` configured with default fatal
exception types.