### PR TITLE
GH-987: DeserializationException and dead-letters

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/SeekToCurrentErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/SeekToCurrentErrorHandler.java
@@ -241,7 +241,9 @@ public class SeekToCurrentErrorHandler implements ContainerAwareErrorHandler {
 		}
 	}
 
-	private BiPredicate<ConsumerRecord<?, ?>, Exception> getSkipPredicate(List<ConsumerRecord<?, ?>> records, Exception thrownException) {
+	private BiPredicate<ConsumerRecord<?, ?>, Exception> getSkipPredicate(List<ConsumerRecord<?, ?>> records,
+			Exception thrownException) {
+
 		if (this.classifier.classify(thrownException)) {
 			return this.failureTracker::skip;
 		}
@@ -263,7 +265,9 @@ public class SeekToCurrentErrorHandler implements ContainerAwareErrorHandler {
 		classified.put(MethodArgumentResolutionException.class, false);
 		classified.put(NoSuchMethodException.class, false);
 		classified.put(ClassCastException.class, false);
-		return new ExtendedBinaryExceptionClassifier(classified, true);
+		ExtendedBinaryExceptionClassifier defaultClassifier = new ExtendedBinaryExceptionClassifier(classified, true);
+		defaultClassifier.setTraverseCauses(true);
+		return defaultClassifier;
 	}
 
 	/**

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -3084,6 +3084,28 @@ The record sent to the dead-letter topic is enhanced with the following headers:
 * `KafkaHeaders.DLT_ORIGINAL_TIMESTAMP_TYPE`: The original timestamp type.
 
 
+Starting with version 2.3, when used in conjunction with an `ErrorHandlingDeserializer2`, the publisher will restore the record `value()`, in the dead-letter producer record, to the original value that failed to be deserialized.
+Previously, the `value()` was null and user code had to decode the `DeserializationException` from the message headers.
+In addition, you can provide multiple `KafkaTemplate` s to the publisher; this might be needed, for example, if you want to publish the `byte[]` from a `DeserializationException`, as well as values using a different serializer from records that were deserialized successfully.
+Here is an example of configuring the publisher with `KafkaTemplate` s that use a `String` and `byte[]` serializer:
+
+====
+[source, java]
+----
+@Bean
+public DeadLetterPublishingRecoverer publisher(KafkaTemplate<?, ?> stringTemplate,
+        KafkaTemplate<?, ?> bytesTemplate) {
+
+    Map<Class<?>, KafkaTemplate<?, ?>> templates = new LinkedHashMap<>();
+    templates.put(String.class, stringTemplate);
+    templates.put(byte[].class, bytesTemplate);
+    return new DeadLetterPublishingRecoverer(templates);
+}
+----
+====
+
+The publisher uses the map keys to locate a template that is suitable for the `value()` about to be published.
+A `LinkedHashMap` is recommended so that the keys are examined in order.
 
 [[kerberos]]
 ==== Kerberos

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -21,6 +21,10 @@ It now sets it to false automatically unless specifically set in the consumer fa
 The `SeekToCurrentErrorHandler` now treats certain exceptions as fatal and disables retry for those, invoking the recoverer on first failure.
 See <<seek-to-current>> for more information.
 
+The `DeadLetterPublishingRecoverer`, when used in conjunction with an `ErrorHandlingDeserializer2`, now sets the payload of the message sent to the dead-letter topic, to the original value that could not be deserialized.
+Previously, it was `null` and user code needed to extract the `DeserializationException` from the message headers.
+See <<dead-letters>> for more information.
+
 ==== TopicBuilder
 
 A new class `TopicBuilder` is provided for more convenient creation of `NewTopic` `@Bean` s for automatic topic provisioning.


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/987

`DeadLetterPublishingRecoverer` now detects `DeserializationException`s
and sets the value of the republished record to the original incoming
`byte[]`.

- STCEH - fix `defaultClassifier` to traverse exception causes