### PR TITLE
GH-990: Run AfterRollbackProcessor in Tx

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/AfterRollbackProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/AfterRollbackProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,11 +44,17 @@ public interface AfterRollbackProcessor<K, V> {
 	 * processing individual records; this allows the processor to recover (skip) the
 	 * failed record rather than re-seeking it. This is not possible with a batch listener
 	 * since only the listener itself knows which record in the batch keeps failing.
+	 * IMPORTANT: If invoked in a transaction when the listener was invoked with a single
+	 * record, the transaction id will be based on the container group.id and the
+	 * topic/partition of the failed record, to avoid issues with zombie fencing. So,
+	 * generally, only its offset should be sent to the transaction. For other behavior
+	 * the process method should manage its own transaction.
 	 * @param records the records.
 	 * @param consumer the consumer.
 	 * @param exception the exception
 	 * @param recoverable the recoverable.
 	 * @since 2.2
+	 * @see #isProcessInTransaction()
 	 */
 	void process(List<ConsumerRecord<K, V>> records, Consumer<K, V> consumer, Exception exception, boolean recoverable);
 
@@ -59,6 +65,19 @@ public interface AfterRollbackProcessor<K, V> {
 	 */
 	default void clearThreadState() {
 		// NOSONAR
+	}
+
+	/**
+	 * Return true to invoke {@link #process(List, Consumer, Exception, boolean)} in a new
+	 * transaction. Because the container cannot infer the desired behavior, the processor
+	 * is responsible for sending the offset to the transaction if it decides to skip the
+	 * failing record.
+	 * @return true to run in a transaction; default false.
+	 * @since 2.2.5
+	 * @see #process(List, Consumer, Exception, boolean)
+	 */
+	default boolean isProcessInTransaction() {
+		return false;
 	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
@@ -202,7 +202,13 @@ public class DeadLetterPublishingRecoverer implements BiConsumer<ConsumerRecord<
 				record.key(), value == null ? record.value() : value, headers);
 	}
 
-	private void publish(ProducerRecord<Object, Object> outRecord, KafkaOperations<Object, Object> kafkaTemplate) {
+	/**
+	 * Override this if you want more than just logging of the send result.
+	 * @param outRecord the record to send.
+	 * @param kafkaTemplate the template.
+	 * @since 2.2.5
+	 */
+	protected void publish(ProducerRecord<Object, Object> outRecord, KafkaOperations<Object, Object> kafkaTemplate) {
 		try {
 			kafkaTemplate.send(outRecord).addCallback(result -> {
 				if (logger.isDebugEnabled()) {

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -3041,6 +3041,10 @@ In such cases, the application listener must handle a record that keeps failing.
 
 See also <<dead-letters>>.
 
+Starting with version 2.2.5, the `DefaultAfterRollbackProcessor` can be invoked in a new transaction (started after the failed transaction rolls back).
+Then, if you are using the `DeadLetterPublishingRecoverer` to publish a failed record, the processor will send the recovered record's offset in the original topic/partition to the transaction.
+To enable this feature, set the `processInTransaction` and `kafkaTemplate` properties on the `DefaultAfterRollbackProcessor`.
+
 [[dead-letters]]
 ===== Publishing Dead-letter Records
 


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/990

Provide a mechanism to start a new transaction within which to invoke
the processor, so if it recovers the failed record, its offset can
be sent to the transaction.

**cherry-pick to 2.2.x**