### PR TITLE
GH-995: Close ObjectOutputStream in EHD2

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ErrorHandlingDeserializer2.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ErrorHandlingDeserializer2.java
@@ -199,16 +199,17 @@ public class ErrorHandlingDeserializer2<T> implements Deserializer<T> {
 	private void deserializationException(Headers headers, byte[] data, Exception e) {
 		ByteArrayOutputStream stream = new ByteArrayOutputStream();
 		DeserializationException exception = new DeserializationException("failed to deserialize", data, this.isKey, e);
-		try {
-			new ObjectOutputStream(stream).writeObject(exception);
+		try (ObjectOutputStream oos = new ObjectOutputStream(stream)) {
+			oos.writeObject(exception);
 		}
 		catch (IOException ex) {
-			try {
+			stream = new ByteArrayOutputStream();
+			try (ObjectOutputStream oos = new ObjectOutputStream(stream)) {
 				exception = new DeserializationException("failed to deserialize",
 						data, this.isKey, new RuntimeException("Could not deserialize type "
 								+ e.getClass().getName() + " with message " + e.getMessage()
 								+ " failure: " + ex.getMessage()));
-				new ObjectOutputStream(stream).writeObject(exception);
+				oos.writeObject(exception);
 			}
 			catch (IOException ex2) {
 				throw new IllegalStateException("Could not serialize a DeserializationException", ex2); // NOSONAR


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-kafka/issues/995

Doesn't really make a difference because `writeObject()` drains
all data to the underlying output stream and `flush()` and `close()`
are no-ops for `ByteArrayOutputStream`.

But, technically, correct.

**cherry-pick to 2.2.x**