### PR TITLE
GH-1012 Allow raw Strings in default header mapper

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/AbstractKafkaHeaderMapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/AbstractKafkaHeaderMapper.java
@@ -82,7 +82,7 @@ public abstract class AbstractKafkaHeaderMapper implements KafkaHeaderMapper {
 	 * Set to true to map all {@code String} valued outbound headers to {@code byte[]}.
 	 * To map to a {@code String} for inbound, there must be an entry in the rawMappedHeaders map.
 	 * @param mapAllStringsOut true to map all strings.
-	 * @since 2.5.1
+	 * @since 2.2.5
 	 * @see #setRawMappedHaeaders(Map)
 	 */
 	public void setMapAllStringsOut(boolean mapAllStringsOut) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/AbstractKafkaHeaderMapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/AbstractKafkaHeaderMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,23 @@
 
 package org.springframework.kafka.support;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.kafka.common.header.Header;
 
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.util.Assert;
+import org.springframework.util.ObjectUtils;
 import org.springframework.util.PatternMatchUtils;
 
 /**
@@ -58,10 +65,59 @@ public abstract class AbstractKafkaHeaderMapper implements KafkaHeaderMapper {
 
 	protected final List<SimplePatternBasedHeaderMatcher> matchers = new ArrayList<>(NEVER_MAPPED); // NOSONAR
 
+	private final Map<String, Boolean> rawMappedtHeaders = new HashMap<>();
+
+	private boolean mapAllStringsOut;
+
+	private Charset charset = StandardCharsets.UTF_8;
+
 	public AbstractKafkaHeaderMapper(String... patterns) {
 		Assert.notNull(patterns, "'patterns' must not be null");
 		for (String pattern : patterns) {
 			this.matchers.add(new SimplePatternBasedHeaderMatcher(pattern));
+		}
+	}
+
+	/**
+	 * Set to true to map all {@code String} valued outbound headers to {@code byte[]}.
+	 * To map to a {@code String} for inbound, there must be an entry in the rawMappedHeaders map.
+	 * @param mapAllStringsOut true to map all strings.
+	 * @since 2.5.1
+	 * @see #setRawMappedHaeaders(Map)
+	 */
+	public void setMapAllStringsOut(boolean mapAllStringsOut) {
+		this.mapAllStringsOut = mapAllStringsOut;
+	}
+
+	protected Charset getCharset() {
+		return this.charset;
+	}
+
+	/**
+	 * Set the charset to use when mapping String-valued headers to/from byte[]. Default UTF-8.
+	 * @param charset the charset.
+	 * @since 2.2.5
+	 * @see #setRawMappedHaeaders(Map)
+	 */
+	public void setCharset(Charset charset) {
+		Assert.notNull(charset, "'charset' cannot be null");
+		this.charset = charset;
+	}
+
+	/**
+	 * Set the headers to not perform any conversion on (except {@code String} to
+	 * {@code byte[]} for outbound). Inbound headers that match will be mapped as
+	 * {@code byte[]} unless the corresponding boolean in the map value is true,
+	 * in which case it will be mapped as a String.
+	 * @param rawMappedHeaders the header names to not convert and
+	 * @since 2.2.5
+	 * @see #setCharset(Charset)
+	 * @see #setMapAllStringsOut(boolean)
+	 */
+	public void setRawMappedHaeaders(Map<String, Boolean> rawMappedHeaders) {
+		if (!ObjectUtils.isEmpty(rawMappedHeaders)) {
+			this.rawMappedtHeaders.clear();
+			this.rawMappedtHeaders.putAll(rawMappedHeaders);
 		}
 	}
 
@@ -92,6 +148,57 @@ public abstract class AbstractKafkaHeaderMapper implements KafkaHeaderMapper {
 		}
 		return false;
 	}
+
+	/**
+	 * Check if the value is a String and convert to byte[], if so configured.
+	 * @param key the header name.
+	 * @param value the headet value.
+	 * @return the value to add.
+	 * @since 2.2.5
+	 */
+	protected Object headerValueToAddOut(String key, Object value) {
+		Object valueToAdd = mapRawOut(key, value);
+		if (valueToAdd == null) {
+			valueToAdd = value;
+		}
+		return valueToAdd;
+	}
+
+	@Nullable
+	private byte[] mapRawOut(String header, Object value) {
+		if (this.mapAllStringsOut || this.rawMappedtHeaders.containsKey(header)) {
+			if (value instanceof byte[]) {
+				return (byte[]) value;
+			}
+			else if (value instanceof String) {
+				return ((String) value).getBytes(this.charset);
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Check if the header value should be mapped to a String, if so configured.
+	 * @param header the header.
+	 * @return the value to add.
+	 */
+	protected Object headertValueToAddIn(Header header) {
+		Object mapped = mapRawIn(header.key(), header.value());
+		if (mapped == null) {
+			mapped = header.value();
+		}
+		return mapped;
+	}
+
+	@Nullable
+	private String mapRawIn(String header, byte[] value) {
+		Boolean asString = this.rawMappedtHeaders.get(header);
+		if (Boolean.TRUE.equals(asString)) {
+			return new String(value, this.charset);
+		}
+		return null;
+	}
+
 
 	/**
 	 * A pattern-based header matcher that matches if the specified

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/SimpleKafkaHeaderMapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/SimpleKafkaHeaderMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,8 @@ import org.springframework.messaging.MessageHeaders;
 /**
  * A simple header mapper that maps headers directly; for outbound,
  * only byte[] headers are mapped; for inbound, headers are mapped
- * unchanged, as byte[].
+ * unchanged, as byte[]. Strings can also be mapped to/from byte.
+ * See {@link #setRawMappedHaeaders(Map)}.
  * Most headers in {@link KafkaHeaders} are not mapped on outbound messages.
  * The exceptions are correlation and reply headers for request/reply
  *
@@ -64,16 +65,17 @@ public class SimpleKafkaHeaderMapper extends AbstractKafkaHeaderMapper {
 
 	@Override
 	public void fromHeaders(MessageHeaders headers, Headers target) {
-		headers.forEach((k, v) -> {
-			if (v instanceof byte[] && matches(k, v)) {
-				target.add(new RecordHeader(k, (byte[]) v));
+		headers.forEach((key, value) -> {
+			Object valueToAdd = headerValueToAddOut(key, value);
+			if (valueToAdd instanceof byte[] && matches(key, valueToAdd)) {
+				target.add(new RecordHeader(key, (byte[]) valueToAdd));
 			}
 		});
 	}
 
 	@Override
 	public void toHeaders(Headers source, Map<String, Object> target) {
-		source.forEach(header -> target.put(header.key(), header.value()));
+		source.forEach(header -> target.put(header.key(), headertValueToAddIn(header)));
 	}
 
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/SimpleKafkaHeaderMapperTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/SimpleKafkaHeaderMapperTests.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.messaging.MessageHeaders;
+
+/**
+ * @author Gary Russell
+ * @since 2.1.5
+ *
+ */
+public class SimpleKafkaHeaderMapperTests {
+
+	@Test
+	public void testSpecificStringConvert() {
+		SimpleKafkaHeaderMapper mapper = new SimpleKafkaHeaderMapper("*");
+		Map<String, Boolean> rawMappedHeaders = new HashMap<>();
+		rawMappedHeaders.put("thisOnesAString", true);
+		rawMappedHeaders.put("thisOnesBytes", false);
+		mapper.setRawMappedHaeaders(rawMappedHeaders);
+		Map<String, Object> headersMap = new HashMap<>();
+		headersMap.put("thisOnesAString", "foo");
+		headersMap.put("thisOnesBytes", "bar");
+		headersMap.put("neverConverted", "baz".getBytes());
+		MessageHeaders headers = new MessageHeaders(headersMap);
+		Headers target = new RecordHeaders();
+		mapper.fromHeaders(headers, target);
+		assertThat(target).containsExactlyInAnyOrder(
+				new RecordHeader("thisOnesAString", "foo".getBytes()),
+				new RecordHeader("thisOnesBytes", "bar".getBytes()),
+				new RecordHeader("neverConverted", "baz".getBytes()));
+		headersMap.clear();
+		mapper.toHeaders(target, headersMap);
+		assertThat(headersMap).contains(
+				entry("thisOnesAString", "foo"),
+				entry("thisOnesBytes", "bar".getBytes()),
+				entry("neverConverted", "baz".getBytes()));
+	}
+
+	@Test
+	public void testNotStringConvert() {
+		SimpleKafkaHeaderMapper mapper = new SimpleKafkaHeaderMapper("*");
+		Map<String, Boolean> rawMappedHeaders = new HashMap<>();
+		rawMappedHeaders.put("thisOnesBytes", false);
+		mapper.setRawMappedHaeaders(rawMappedHeaders);
+		Map<String, Object> headersMap = new HashMap<>();
+		headersMap.put("thisOnesAString", "foo");
+		headersMap.put("thisOnesBytes", "bar");
+		headersMap.put("neverConverted", "baz".getBytes());
+		MessageHeaders headers = new MessageHeaders(headersMap);
+		Headers target = new RecordHeaders();
+		mapper.fromHeaders(headers, target);
+		assertThat(target).containsExactlyInAnyOrder(
+				new RecordHeader("neverConverted", "baz".getBytes()),
+				new RecordHeader("thisOnesBytes", "bar".getBytes()));
+		headersMap.clear();
+		mapper.toHeaders(target, headersMap);
+		assertThat(headersMap).contains(
+				entry("thisOnesBytes", "bar".getBytes()),
+				entry("neverConverted", "baz".getBytes()));
+	}
+
+	@Test
+	public void testAlwaysStringConvert() {
+		SimpleKafkaHeaderMapper mapper = new SimpleKafkaHeaderMapper("*");
+		mapper.setMapAllStringsOut(true);
+		Map<String, Boolean> rawMappedHeaders = new HashMap<>();
+		rawMappedHeaders.put("thisOnesBytes", false);
+		mapper.setRawMappedHaeaders(rawMappedHeaders);
+		Map<String, Object> headersMap = new HashMap<>();
+		headersMap.put("thisOnesAString", "foo");
+		headersMap.put("thisOnesBytes", "bar");
+		headersMap.put("neverConverted", "baz".getBytes());
+		MessageHeaders headers = new MessageHeaders(headersMap);
+		Headers target = new RecordHeaders();
+		mapper.fromHeaders(headers, target);
+		assertThat(target).containsExactlyInAnyOrder(
+				new RecordHeader("thisOnesAString", "foo".getBytes()),
+				new RecordHeader("thisOnesBytes", "bar".getBytes()),
+				new RecordHeader("neverConverted", "baz".getBytes()));
+		headersMap.clear();
+		mapper.toHeaders(target, headersMap);
+		assertThat(headersMap).contains(
+				entry("thisOnesAString", "foo".getBytes()),
+				entry("thisOnesBytes", "bar".getBytes()),
+				entry("neverConverted", "baz".getBytes()));
+	}
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/SimpleKafkaHeaderMapperTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/SimpleKafkaHeaderMapperTests.java
@@ -31,7 +31,7 @@ import org.springframework.messaging.MessageHeaders;
 
 /**
  * @author Gary Russell
- * @since 2.1.5
+ * @since 2.2.5
  *
  */
 public class SimpleKafkaHeaderMapperTests {

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -2660,6 +2660,46 @@ You can trust other (or all) packages by adding trusted packages with the `addTr
 If you receive messages from untrusted sources, you may wish to add only those packages you trust.
 To trust all packages, you can use `mapper.addTrustedPackages("*")`.
 
+Starting with version 2.2.5, you can specify that certain string-valued headers should not be mapped using JSON, but to/from a raw `byte[]`.
+This is useful when communicating with systems that are not aware of the mapper's JSON format.
+The `AbstractKafkaHeaderMapper` has new properties `mapAllStringsOut` when set to true, all string-valued headers will be used to
+`byte[]` using the `charset` property (default `UTF-8`).
+In addition, there is a property `rawMappedHeaders`, which is a map of `header name : boolean`; if the map contains a header and the header contains a `String` value, it will be mapped as a raw `byte[]` using the charset.
+This map is also used to map raw incoming `byte[]` headers to `String` using the charset, if, and only if the boolean in the map value is `true`.
+If the boolean is false, or the header name is not in the map with a `true` value, the incoming header is simply the raw unmapped header.
+The following test case illustrates this mechanism.
+
+====
+[source, java]
+----
+@Test
+public void testSpecificStringConvert() {
+    DefaultKafkaHeaderMapper mapper = new DefaultKafkaHeaderMapper();
+    Map<String, Boolean> rawMappedHeaders = new HashMap<>();
+    rawMappedHeaders.put("thisOnesAString", true);
+    rawMappedHeaders.put("thisOnesBytes", false);
+    mapper.setRawMappedHaeaders(rawMappedHeaders);
+    Map<String, Object> headersMap = new HashMap<>();
+    headersMap.put("thisOnesAString", "thing1");
+    headersMap.put("thisOnesBytes", "thing2");
+    headersMap.put("alwaysRaw", "thing3".getBytes());
+    MessageHeaders headers = new MessageHeaders(headersMap);
+    Headers target = new RecordHeaders();
+    mapper.fromHeaders(headers, target);
+    assertThat(target).containsExactlyInAnyOrder(
+            new RecordHeader("thisOnesAString", "thing1".getBytes()),
+            new RecordHeader("thisOnesBytes", "thing2".getBytes()),
+            new RecordHeader("alwaysRaw", "thing3".getBytes()));
+    headersMap.clear();
+    mapper.toHeaders(target, headersMap);
+    assertThat(headersMap).contains(
+            entry("thisOnesAString", "thing1"),
+            entry("thisOnesBytes", "thing2".getBytes()),
+            entry("alwaysRaw", "thing3".getBytes()));
+}
+----
+====
+
 By default, the `DefaultKafkaHeaderMapper` is used in the `MessagingMessageConverter` and `BatchMessagingMessageConverter`, as long as Jackson is on the class path.
 
 With the batch converter, the converted headers are available in the `KafkaHeaders.BATCH_CONVERTED_HEADERS` as a `List<Map<String, Object>>` where the map in a position of the list corresponds to the data position in the payload.

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -2660,13 +2660,14 @@ You can trust other (or all) packages by adding trusted packages with the `addTr
 If you receive messages from untrusted sources, you may wish to add only those packages you trust.
 To trust all packages, you can use `mapper.addTrustedPackages("*")`.
 
+NOTE: Mapping `String` header values in a raw form is useful when communicating with systems that are not aware of the mapper's JSON format.
+
 Starting with version 2.2.5, you can specify that certain string-valued headers should not be mapped using JSON, but to/from a raw `byte[]`.
-This is useful when communicating with systems that are not aware of the mapper's JSON format.
-The `AbstractKafkaHeaderMapper` has new properties `mapAllStringsOut` when set to true, all string-valued headers will be used to
-`byte[]` using the `charset` property (default `UTF-8`).
-In addition, there is a property `rawMappedHeaders`, which is a map of `header name : boolean`; if the map contains a header and the header contains a `String` value, it will be mapped as a raw `byte[]` using the charset.
-This map is also used to map raw incoming `byte[]` headers to `String` using the charset, if, and only if the boolean in the map value is `true`.
-If the boolean is false, or the header name is not in the map with a `true` value, the incoming header is simply the raw unmapped header.
+The `AbstractKafkaHeaderMapper` has new properties; `mapAllStringsOut` when set to true, all string-valued headers will be converted to `byte[]` using the `charset` property (default `UTF-8`).
+In addition, there is a property `rawMappedHeaders`, which is a map of `header name : boolean`; if the map contains a header name, and the header contains a `String` value, it will be mapped as a raw `byte[]` using the charset.
+This map is also used to map raw incoming `byte[]` headers to `String` using the charset if, and only if, the boolean in the map value is `true`.
+If the boolean is `false`, or the header name is not in the map with a `true` value, the incoming header is simply mapped as the raw unmapped header.
+
 The following test case illustrates this mechanism.
 
 ====


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1012

Add configuration to map string-valued headers as raw `byte[]`
instead of adding to the map of json-mapped headers.

__cherry-pick to 2.2.x__