### PR TITLE
Add group.id to container info logs

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
@@ -372,12 +372,18 @@ public abstract class AbstractMessageListenerContainer<K, V>
 
 			@Override
 			public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
-				AbstractMessageListenerContainer.this.logger.info("partitions revoked: " + partitions);
+				Log logger2 = AbstractMessageListenerContainer.this.logger;
+				if (logger2.isInfoEnabled()) {
+					logger2.info(getGroupId() + ": partitions revoked: " + partitions);
+				}
 			}
 
 			@Override
 			public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
-				AbstractMessageListenerContainer.this.logger.info("partitions assigned: " + partitions);
+				Log logger2 = AbstractMessageListenerContainer.this.logger;
+				if (logger2.isInfoEnabled()) {
+					logger2.info(getGroupId() + ": partitions assigned: " + partitions);
+				}
 			}
 
 		};

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -893,7 +893,9 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			if (this.errorHandler != null) {
 				this.errorHandler.clearThreadState();
 			}
-			this.logger.info("Consumer stopped");
+			if (this.logger.isInfoEnabled()) {
+				this.logger.info(getGroupId() + ": Consumer stopped");
+			}
 			publishConsumerStoppedEvent();
 		}
 


### PR DESCRIPTION
Useful if multiple containers for the same topics in the same
application.