### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -35,7 +35,7 @@ Signing the CLA does not grant anyone commit rights to the main repository, but 
 
 1. Go to https://github.com/spring-projects/spring-kafka[https://github.com/spring-projects/spring-kafka]
 2. Hit the "fork" button and choose your own GitHub account as the target
-3. For more detail see http://help.github.com/fork-a-repo/[Fork A Repo].
+3. For more detail see https://help.github.com/fork-a-repo/[Fork A Repo].
 
 == Setup your Local Development Environment
 
@@ -56,7 +56,7 @@ _you should see branches on origin as well as upstream, including 'master' and '
   - For example, to create and switch to a new branch for issue GH-123: `git checkout -b GH-123`
 * You might be working on several different topic branches at any given time, but when at a stopping point for one of those branches, commit (a local operation).
 * Please follow the "Commit Guidelines" described in
-http://git-scm.com/book/en/Distributed-Git-Contributing-to-a-Project[this chapter of Pro Git].
+https://git-scm.com/book/en/Distributed-Git-Contributing-to-a-Project[this chapter of Pro Git].
 * Then to begin working on another issue (say GH-101): `git checkout GH-101`. The _-b_ flag is not needed if that
 branch already exists in your local repository.
 * When ready to resolve an issue or to collaborate with others, you can push your branch to origin (your fork),
@@ -74,7 +74,7 @@ add a comment about something that should be modified, or he might reject the pu
 **This is the responsibility of any contributor.**
 If your pull request cannot be applied cleanly, the project lead will most likely add a comment requesting that you make
 it merge-able.
-For a full explanation, see http://git-scm.com/book/en/Git-Branching-Rebasing[the Pro Git section on rebasing].
+For a full explanation, see https://git-scm.com/book/en/Git-Branching-Rebasing[the Pro Git section on rebasing].
 As stated there: _"> Often, you’ll do this to make sure your commits apply cleanly on a remote branch — perhaps in a
 project to which you’re trying to contribute but that you don’t maintain."_
 
@@ -91,11 +91,11 @@ and merging that into the branch you are in currently)
     - Then: `git pull upstream master`
     - Switch back to the topic branch: `git checkout GH-123` (no -b needed since the branch already exists)
     - Rebase the topic branch to minimize the distance between it and your recently synched master branch: `git rebase master`
-(Again, for more detail see http://git-scm.com/book/en/Git-Branching-Rebasing[the Pro Git section on rebasing]).
+(Again, for more detail see https://git-scm.com/book/en/Git-Branching-Rebasing[the Pro Git section on rebasing]).
 * **Note** You cannot rebase if you have already pushed your branch to your remote because you'd be rewriting history
 (see **'The Perils of Rebasing'** in the article).
 If you rebase by mistake, you can undo it as discussed
-http://stackoverflow.com/questions/134882/undoing-a-git-rebase[in this StackOverflow discussion].
+https://stackoverflow.com/questions/134882/undoing-a-git-rebase[in this StackOverflow discussion].
 Once you have published your branch, you need to merge in the master rather than rebasing.
 * Now, if you issue a pull request, it is much more likely to be merged without conflicts.
 Most likely, any pull request that would produce conflicts will be deferred until the issuer of that pull request makes

--- a/README.md
+++ b/README.md
@@ -54,16 +54,16 @@ To generate IDEA metadata (.iml and .ipr files), do the following:
 # Resources
 
 For more information, please visit the Spring Kafka website at:
-[Reference Manual](http://docs.spring.io/spring-kafka/docs/current/reference/html/)
+[Reference Manual](https://docs.spring.io/spring-kafka/docs/current/reference/html/)
 
 # Contributing to Spring Kafka
 
 Here are some ways for you to get involved in the community:
 
-* Get involved with the Spring community on the Spring Community Forums.  Please help out on the [StackOverflow](http://stackoverflow.com/questions/tagged/spring-kafka) by responding to questions and joining the debate.
+* Get involved with the Spring community on the Spring Community Forums.  Please help out on the [StackOverflow](https://stackoverflow.com/questions/tagged/spring-kafka) by responding to questions and joining the debate.
 * Create [GitHub issues](https://github.com/spring-projects/spring-kafka/issues) for bugs and new features and comment and vote on the ones that you are interested in.
-* Github is for social coding: if you want to write code, we encourage contributions through pull requests from [forks of this repository](http://help.github.com/forking/).  If you want to contribute code this way, please reference a JIRA ticket as well covering the specific issue you are addressing.
-* Watch for upcoming articles on Spring by [subscribing](http://www.springsource.org/node/feed) to springframework.org
+* Github is for social coding: if you want to write code, we encourage contributions through pull requests from [forks of this repository](https://help.github.com/forking/).  If you want to contribute code this way, please reference a JIRA ticket as well covering the specific issue you are addressing.
+* Watch for upcoming articles on Spring by [subscribing](https://www.springsource.org/node/feed) to springframework.org
 
 Before we accept a non-trivial patch or pull request we will need you to sign the [contributor's agreement](https://support.springsource.com/spring_committer_signup).
 Signing the contributor's agreement does not grant anyone commit rights to the main repository, but it does mean that we can accept your contributions, and you will get an author credit if we do.

--- a/src/api/overview.html
+++ b/src/api/overview.html
@@ -5,7 +5,7 @@ This document is the API specification for Spring for Apache Kafka project
 <div id="overviewBody">
     <p>
         For further API reference and developer documentation, see the
-        <a href="http://static.springsource.org/spring-kafka/reference" target="_top">Spring
+        <a href="https://docs.spring.io/spring-kafka/reference" target="_top">Spring
             Kafka reference documentation</a>.
         That documentation contains more detailed, developer-targeted
         descriptions, with conceptual overviews, definitions of terms,
@@ -14,8 +14,8 @@ This document is the API specification for Spring for Apache Kafka project
 
     <p>
         If you are interested in commercial training, consultancy, and
-        support for Spring Kafka, please visit <a href="http://www.springsource.com" target="_top">
-        http://www.springsource.com</a>
+        support for Spring Kafka, please visit <a href="https://www.springsource.com" target="_top">
+        https://www.springsource.com</a>
     </p>
 </div>
 </body>

--- a/src/reference/asciidoc/index.adoc
+++ b/src/reference/asciidoc/index.adoc
@@ -54,7 +54,7 @@ include::si-kafka.adoc[]
 In addition to this reference documentation, we recommend a number of other resources that may help you learn about Spring and Apache Kafka.
 
 - https://kafka.apache.org/[Apache Kafka Project Home Page]
-- http://projects.spring.io/spring-kafka/[Spring for Apache Kafka Home Page]
+- https://projects.spring.io/spring-kafka/[Spring for Apache Kafka Home Page]
 - https://github.com/spring-projects/spring-kafka[Spring for Apache Kafka GitHub Repository]
 - https://github.com/spring-projects/spring-integration-kafka[Spring Integration Kafka Extension GitHub Repository]
 

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -1656,7 +1656,7 @@ See <<annotation-error-handling>> for more information.
 In certain scenarios, such as rebalancing, a message that has already been processed may be redelivered.
 The framework cannot know whether such a message has been processed or not.
 That is an application-level function.
-This is known as the http://www.enterpriseintegrationpatterns.com/patterns/messaging/IdempotentReceiver.html[Idempotent Receiver] pattern and Spring Integration provides an http://docs.spring.io/spring-integration/reference/html/messaging-endpoints-chapter.html#idempotent-receiver[implementation of it].
+This is known as the https://www.enterpriseintegrationpatterns.com/patterns/messaging/IdempotentReceiver.html[Idempotent Receiver] pattern and Spring Integration provides an https://docs.spring.io/spring-integration/reference/html/messaging-endpoints-chapter.html#idempotent-receiver[implementation of it].
 
 The Spring for Apache Kafka project also provides some assistance by means of the `FilteringMessageListenerAdapter` class, which can wrap your `MessageListener`.
 This class takes an implementation of `RecordFilterStrategy` in which you implement the `filter` method to signal that a message is a duplicate and should be discarded.

--- a/src/reference/asciidoc/si-kafka.adoc
+++ b/src/reference/asciidoc/si-kafka.adoc
@@ -4,7 +4,7 @@
 This documentation pertains to versions 2.0.0 and above.
 For documentation for earlier releases, see the https://github.com/spring-projects/spring-integration-kafka/blob/1.3.x/README.md[1.3.x README].
 
-Spring Integration Kafka is now based on the http://projects.spring.io/spring-kafka/[Spring for Apache Kafka project].
+Spring Integration Kafka is now based on the https://projects.spring.io/spring-kafka/[Spring for Apache Kafka project].
 It provides the following components:
 
 * <<si-outbound>>
@@ -532,7 +532,7 @@ public void in(@Header(KafkaHeaders.RECEIVED_MESSAGE_KEY) String key,
 
 ==== What's New in Spring Integration for Apache Kafka
 
-See the http://projects.spring.io/spring-kafka/[Spring for Apache Kafka Project Page] for a matrix of compatible `spring-kafka` and `kafka-clients` versions.
+See the https://projects.spring.io/spring-kafka/[Spring for Apache Kafka Project Page] for a matrix of compatible `spring-kafka` and `kafka-clients` versions.
 
 ===== 2.1.x
 

--- a/src/reference/asciidoc/streams.adoc
+++ b/src/reference/asciidoc/streams.adoc
@@ -80,7 +80,7 @@ public KStream<?, ?> kStream(StreamsBuilder kStreamBuilder) {
 ----
 ====
 
-If you would like to control the lifecycle manually (for example, stopping and starting by some condition), you can reference the `StreamsBuilderFactoryBean` bean directly by using the factory bean (`&`) http://docs.spring.io/spring/docs/current/spring-framework-reference/html/beans.html#beans-factory-extension-factorybean[prefix].
+If you would like to control the lifecycle manually (for example, stopping and starting by some condition), you can reference the `StreamsBuilderFactoryBean` bean directly by using the factory bean (`&`) https://docs.spring.io/spring/docs/current/spring-framework-reference/html/beans.html#beans-factory-extension-factorybean[prefix].
 Since `StreamsBuilderFactoryBean` use its internal `KafkaStreams` instance, it is safe to stop and restart it again.
 A new `KafkaStreams` is created on each `start()`.
 You might also consider using different `StreamsBuilderFactoryBean` instances, if you would like to control the lifecycles for `KStream` instances separately.


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://docs.spring.io/spring-integration/reference/html/messaging-endpoints-chapter.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-integration/reference/html/messaging-endpoints-chapter.html ([https](https://docs.spring.io/spring-integration/reference/html/messaging-endpoints-chapter.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://docs.spring.io/spring-kafka/docs/current/reference/html/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-kafka/docs/current/reference/html/ ([https](https://docs.spring.io/spring-kafka/docs/current/reference/html/) result 200).
* [ ] http://projects.spring.io/spring-kafka/ with 3 occurrences migrated to:  
  https://projects.spring.io/spring-kafka/ ([https](https://projects.spring.io/spring-kafka/) result 200).
* [ ] http://stackoverflow.com/questions/134882/undoing-a-git-rebase with 1 occurrences migrated to:  
  https://stackoverflow.com/questions/134882/undoing-a-git-rebase ([https](https://stackoverflow.com/questions/134882/undoing-a-git-rebase) result 200).
* [ ] http://stackoverflow.com/questions/tagged/spring-kafka with 1 occurrences migrated to:  
  https://stackoverflow.com/questions/tagged/spring-kafka ([https](https://stackoverflow.com/questions/tagged/spring-kafka) result 200).
* [ ] http://www.enterpriseintegrationpatterns.com/patterns/messaging/IdempotentReceiver.html with 1 occurrences migrated to:  
  https://www.enterpriseintegrationpatterns.com/patterns/messaging/IdempotentReceiver.html ([https](https://www.enterpriseintegrationpatterns.com/patterns/messaging/IdempotentReceiver.html) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://static.springsource.org/spring-kafka/reference (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-kafka/reference ([https](https://static.springsource.org/spring-kafka/reference) result 301).
* [ ] http://docs.spring.io/spring/docs/current/spring-framework-reference/html/beans.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/spring-framework-reference/html/beans.html ([https](https://docs.spring.io/spring/docs/current/spring-framework-reference/html/beans.html) result 301).
* [ ] http://help.github.com/fork-a-repo/ with 1 occurrences migrated to:  
  https://help.github.com/fork-a-repo/ ([https](https://help.github.com/fork-a-repo/) result 301).
* [ ] http://help.github.com/forking/ with 1 occurrences migrated to:  
  https://help.github.com/forking/ ([https](https://help.github.com/forking/) result 301).
* [ ] http://www.springsource.com with 2 occurrences migrated to:  
  https://www.springsource.com ([https](https://www.springsource.com) result 301).
* [ ] http://git-scm.com/book/en/Distributed-Git-Contributing-to-a-Project with 1 occurrences migrated to:  
  https://git-scm.com/book/en/Distributed-Git-Contributing-to-a-Project ([https](https://git-scm.com/book/en/Distributed-Git-Contributing-to-a-Project) result 302).
* [ ] http://git-scm.com/book/en/Git-Branching-Rebasing with 2 occurrences migrated to:  
  https://git-scm.com/book/en/Git-Branching-Rebasing ([https](https://git-scm.com/book/en/Git-Branching-Rebasing) result 302).
* [ ] http://www.springsource.org/node/feed with 1 occurrences migrated to:  
  https://www.springsource.org/node/feed ([https](https://www.springsource.org/node/feed) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost:8080/send/bar/baz with 1 occurrences
* http://localhost:8080/send/foo/bar with 2 occurrences
* http://localhost:8080/send/foos/a,b,c,d,e with 1 occurrences
* http://localhost:8080/send/unknown/xxx with 1 occurrences