### PR TITLE
GH-1055: Add TypeReference support to JsonDeser

### DIFF
--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/JsonSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/JsonSerializationTests.java
@@ -39,6 +39,7 @@ import org.springframework.kafka.support.serializer.testentities.DummyEntity;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.type.TypeReference;
 
 /**
  * @author Igor Stepanov
@@ -210,6 +211,14 @@ public class JsonSerializationTests {
 		JsonDeserializer<List<String>> de = new JsonDeserializer<>(List.class);
 		List<String> dummy = Arrays.asList("foo", "bar", "baz");
 		assertThat(de.deserialize(topic, ser.serialize(topic, dummy))).isEqualTo(dummy);
+	}
+
+	@Test
+	public void testDeserializerTypeReference() {
+		JsonSerializer<List<DummyEntity>> ser = new JsonSerializer<>();
+		JsonDeserializer<List<DummyEntity>> de = new JsonDeserializer<>(new TypeReference<List<DummyEntity>>() { });
+		List<DummyEntity> dummy = Arrays.asList(this.entityArray);
+		assertThat(de.deserialize(this.topic, ser.serialize(this.topic, dummy))).isEqualTo(dummy);
 	}
 
 	static class DummyEntityJsonDeserializer extends JsonDeserializer<DummyEntity> {

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -2305,6 +2305,8 @@ Starting with version 2.3, all the JSON-aware components are configured by defau
 Also such an instance is supplied with well-known modules for custom data types, such a Java time and Kotlin support.
 See `JacksonUtils.enhancedObjectMapper()` JavaDocs for more information.
 
+Also starting with version 2.3, the `JsonDeserializer` provides `TypeReference`-based constructors for better handling of target generic container types.
+
 Starting with version 2.1, you can convey type information in record `Headers`, allowing the handling of multiple types.
 In addition, you can configure the serializer and deserializer by using the following Kafka properties:
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -44,4 +44,5 @@ See <<streams-config, Streams Configuration>> for more information.
 ==== JSON Components Changes
 
 Now all the JSON-aware components are configured by default with a Jackson `ObjectMapper` produced by the `JacksonUtils.enhancedObjectMapper()`.
+The `JsonDeserializer` now provides `TypeReference`-based constructors for better handling of target generic container types.
 See its JavaDocs and <<serdes>> for more information.


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-kafka/issues/1055

For better generics handling the `TypeReference`-aware ctors are added
to the `JsonDeserializer`

Apply some internal refactoring to the `JsonDeserializer` for code reuse