### PR TITLE
Fix close producers after a rebalance

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -487,11 +487,15 @@ public class KafkaMessageListenerContainer<K, V> extends AbstractMessageListener
 
 				@Override
 				public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
-					getContainerProperties().getConsumerRebalanceListener().onPartitionsRevoked(partitions);
-					// Wait until now to commit, in case the user listener added acks
-					commitPendingAcks();
-					if (ListenerConsumer.this.kafkaTxManager != null) {
-						closeProducers(partitions);
+					try {
+						getContainerProperties().getConsumerRebalanceListener().onPartitionsRevoked(partitions);
+						// Wait until now to commit, in case the user listener added acks
+						commitPendingAcks();
+					}
+					finally {
+						if (ListenerConsumer.this.kafkaTxManager != null) {
+							closeProducers(partitions);
+						}
 					}
 				}
 


### PR DESCRIPTION
With a transactional container if committing the offsets fails
during a rebalance, we would leave the producers open.

Move the close to a finally block.