### PR TITLE
Use empty array in toArray call.

### DIFF
--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaBroker.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaBroker.java
@@ -386,7 +386,7 @@ public class EmbeddedKafkaBroker implements InitializingBean, DisposableBean {
 		for (int i = 0; i < this.kafkaPorts.length; i++) {
 			addresses.add(new BrokerAddress("127.0.0.1", this.kafkaPorts[i]));
 		}
-		return addresses.toArray(new BrokerAddress[addresses.size()]);
+		return addresses.toArray(new BrokerAddress[0]);
 	}
 
 	public int getPartitionsPerTopic() {

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/ConcurrentKafkaListenerContainerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/ConcurrentKafkaListenerContainerFactory.java
@@ -62,13 +62,13 @@ public class ConcurrentKafkaListenerContainerFactory<K, V>
 		Collection<TopicPartitionInitialOffset> topicPartitions = endpoint.getTopicPartitions();
 		if (!topicPartitions.isEmpty()) {
 			ContainerProperties properties = new ContainerProperties(
-					topicPartitions.toArray(new TopicPartitionInitialOffset[topicPartitions.size()]));
+					topicPartitions.toArray(new TopicPartitionInitialOffset[0]));
 			return new ConcurrentMessageListenerContainer<K, V>(getConsumerFactory(), properties);
 		}
 		else {
 			Collection<String> topics = endpoint.getTopics();
 			if (!topics.isEmpty()) {
-				ContainerProperties properties = new ContainerProperties(topics.toArray(new String[topics.size()]));
+				ContainerProperties properties = new ContainerProperties(topics.toArray(new String[0]));
 				return new ConcurrentMessageListenerContainer<K, V>(getConsumerFactory(), properties);
 			}
 			else {


### PR DESCRIPTION
Seems like more performant version, at least in newer JDK versions.
See: https://github.com/spring-projects/spring-boot/pull/12153