### PR TITLE
Fix re-pausing consumer after a rebalance

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -1739,10 +1739,9 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			@Override
 			public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
 				if (ListenerConsumer.this.consumerPaused) {
-					ListenerConsumer.this.consumerPaused = false;
+					ListenerConsumer.this.consumer.pause(partitions);
 					ListenerConsumer.this.logger.warn("Paused consumer resumed by Kafka due to rebalance; "
-							+ "the container will pause again before polling, unless the container's "
-							+ "'paused' property is reset by a custom rebalance listener");
+							+ "consumer paused again, so the initial poll() will never return any records");
 				}
 				ListenerConsumer.this.assignedPartitions = partitions;
 				if (!ListenerConsumer.this.autoCommit) {


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-kafka/issues/1111

`pause()` the consumer in the rebalance listener so that the Consumer
will discard any fetched records that would otherwise be returned by
the initial poll.

**cherry-pick to 2.1.x**