### PR TITLE
GH-1111 Propagate the CMLC paused state on start

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
@@ -167,6 +167,9 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 					});
 					publishContainerStoppedEvent();
 				});
+				if (isPaused()) {
+					container.pause();
+				}
 				container.start();
 				this.containers.add(container);
 			}


### PR DESCRIPTION
The paused state from ConcurrentMessageListenerContainer was not
propagated to the newly instanciated KafkaMessageListenerContainers
when calling start().