### PR TITLE
GH-1080 allow supplier functions for Serializers and Deserializers

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
@@ -36,8 +36,8 @@ import org.springframework.util.StringUtils;
  * invocation.
  * <p>
  * If you are using {@link Deserializer}s that have no-arg constructors and require no setup, then simplest to
- * specify {@link Deserializer} classes against {@value ConsumerConfig#KEY_DESERIALIZER_CLASS_CONFIG} and
- * {@value ConsumerConfig#VALUE_DESERIALIZER_CLASS_CONFIG} keys in the {@code configs} passed to the
+ * specify {@link Deserializer} classes against {@link ConsumerConfig#KEY_DESERIALIZER_CLASS_CONFIG} and
+ * {@link ConsumerConfig#VALUE_DESERIALIZER_CLASS_CONFIG} keys in the {@code configs} passed to the
  * {@link DefaultKafkaConsumerFactory} constructor.
  * <p>
  * If that is not possible, but you are using {@link Deserializer}s that may be shared between all {@link Consumer}

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
@@ -36,8 +36,9 @@ import org.springframework.util.StringUtils;
  * invocation.
  * <p>
  * If you are using {@link Deserializer}s that have no-arg constructors and require no setup, then simplest to
- * specify {@link Deserializer} classes in spring.kafka.consumer configuration and create the
- * {@link DefaultKafkaConsumerFactory} with just a map of configs.
+ * specify {@link Deserializer} classes against {@value ConsumerConfig#KEY_DESERIALIZER_CLASS_CONFIG} and
+ * {@value ConsumerConfig#VALUE_DESERIALIZER_CLASS_CONFIG} keys in the {@code configs} passed to the
+ * {@link DefaultKafkaConsumerFactory} constructor.
  * <p>
  * If that is not possible, but you are using {@link Deserializer}s that may be shared between all {@link Consumer}
  * instances (and specifically that their close() method is a no-op), then you can pass in {@link Deserializer}

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
@@ -68,8 +68,9 @@ import org.springframework.util.StringUtils;
  * implementations on each {@link #createProducer()} invocation.
  * <p>
  * If you are using {@link Serializer}s that have no-arg constructors and require no setup, then simplest to
- * specify {@link Serializer} classes in spring.kafka.producer configuration and create the
- * {@link DefaultKafkaProducerFactory} with just a map of configs.
+ * specify {@link Serializer} classes against {@value ProducerConfig#KEY_SERIALIZER_CLASS_CONFIG} and
+ * {@value ProducerConfig#VALUE_SERIALIZER_CLASS_CONFIG} keys in the {@code configs} passed to the
+ * {@link DefaultKafkaProducerFactory} constructor.
  * <p>
  * If that is not possible, but you are sure that at least one of the following is true:
  * <ul>

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
@@ -30,6 +30,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
@@ -64,8 +65,24 @@ import org.springframework.util.StringUtils;
  * <p>
  * This implementation will return the same {@link Producer} instance (if transactions are
  * not enabled) for the provided {@link Map} {@code configs} and optional {@link Serializer}
- * {@code keySerializer}, {@code valueSerializer} implementations on each
- * {@link #createProducer()} invocation.
+ * implementations on each {@link #createProducer()} invocation.
+ * <p>
+ * If you are using {@link Serializer}s that have no-arg constructors and require no setup, then simplest to
+ * specify {@link Serializer} classes in spring.kafka.producer configuration and create the
+ * {@link DefaultKafkaProducerFactory} with just a map of configs.
+ * <p>
+ * If that is not possible, but you are sure that at least one of the following is true:
+ * <ul>
+ *     <li>only one {@link Producer} will use the {@link Serializer}s</li>
+ *     <li>you are using {@link Serializer}s that may be shared between {@link Producer} instances (and specifically
+ *     that their close() method is a no-op)</li>
+ *     <li>you are certain that there is no risk of any single {@link Producer} being closed while other
+ *     {@link Producer} instances with the same {@link Serializer}s are in use</li>
+ * </ul>
+ * then you can pass in {@link Serializer} instances for one or both of the key and value serializers.
+ * <p>
+ * If none of the above is true then you may provide a {@link Supplier} function for one or both {@link Serializer}s
+ * which will be used to obtain {@link Serializer}(s) each time a {@link Producer} is created by the factory.
  * <p>
  * The {@link Producer} is wrapped and the underlying {@link KafkaProducer} instance is
  * not actually closed when {@link Producer#close()} is invoked. The {@link KafkaProducer}
@@ -85,6 +102,7 @@ import org.springframework.util.StringUtils;
  * @author Murali Reddy
  * @author Nakul Mishra
  * @author Artem Bilan
+ * @author Chris Gilbert
  */
 public class DefaultKafkaProducerFactory<K, V> implements ProducerFactory<K, V>, ApplicationContextAware,
 		ApplicationListener<ContextStoppedEvent>, DisposableBean {
@@ -104,9 +122,9 @@ public class DefaultKafkaProducerFactory<K, V> implements ProducerFactory<K, V>,
 
 	private final Map<String, CloseSafeProducer<K, V>> consumerProducers = new HashMap<>();
 
-	private Serializer<K> keySerializer;
+	private Supplier<Serializer<K>> keySerializerSupplier;
 
-	private Serializer<V> valueSerializer;
+	private Supplier<Serializer<V>> valueSerializerSupplier;
 
 	private Duration physicalCloseTimeout = DEFAULT_PHYSICAL_CLOSE_TIMEOUT;
 
@@ -127,7 +145,7 @@ public class DefaultKafkaProducerFactory<K, V> implements ProducerFactory<K, V>,
 	 * @param configs the configuration.
 	 */
 	public DefaultKafkaProducerFactory(Map<String, Object> configs) {
-		this(configs, null, null);
+		this(configs, () -> null, () -> null);
 	}
 
 	/**
@@ -143,9 +161,25 @@ public class DefaultKafkaProducerFactory<K, V> implements ProducerFactory<K, V>,
 			@Nullable Serializer<K> keySerializer,
 			@Nullable Serializer<V> valueSerializer) {
 
+		this (configs, () -> keySerializer, () -> valueSerializer);
+	}
+
+	/**
+	 * Construct a factory with the provided configuration and {@link Serializer} Suppliers.
+	 * Also configures a {@link #transactionIdPrefix} as a value from the
+	 * {@link ProducerConfig#TRANSACTIONAL_ID_CONFIG} if provided.
+	 * This config is going to be overridden with a suffix for target {@link Producer} instance.
+	 * @param configs the configuration.
+	 * @param keySerializerSupplier the key {@link Serializer} supplier function.
+	 * @param valueSerializerSupplier the value {@link Serializer} supplier function.
+	 */
+	public DefaultKafkaProducerFactory(Map<String, Object> configs,
+									@Nullable Supplier<Serializer<K>> keySerializerSupplier,
+									@Nullable Supplier<Serializer<V>> valueSerializerSupplier) {
+
 		this.configs = new HashMap<>(configs);
-		this.keySerializer = keySerializer;
-		this.valueSerializer = valueSerializer;
+		this.keySerializerSupplier = keySerializerSupplier == null ? () -> null : keySerializerSupplier;
+		this.valueSerializerSupplier = valueSerializerSupplier == null ? () -> null : valueSerializerSupplier;
 
 		String txId = (String) this.configs.get(ProducerConfig.TRANSACTIONAL_ID_CONFIG);
 		if (StringUtils.hasText(txId)) {
@@ -162,11 +196,11 @@ public class DefaultKafkaProducerFactory<K, V> implements ProducerFactory<K, V>,
 	}
 
 	public void setKeySerializer(@Nullable Serializer<K> keySerializer) {
-		this.keySerializer = keySerializer;
+		this.keySerializerSupplier = () -> keySerializer;
 	}
 
 	public void setValueSerializer(@Nullable Serializer<V> valueSerializer) {
-		this.valueSerializer = valueSerializer;
+		this.valueSerializerSupplier = () -> valueSerializer;
 	}
 
 	/**
@@ -356,7 +390,7 @@ public class DefaultKafkaProducerFactory<K, V> implements ProducerFactory<K, V>,
 	 * @return the producer.
 	 */
 	protected Producer<K, V> createKafkaProducer() {
-		return new KafkaProducer<>(this.configs, this.keySerializer, this.valueSerializer);
+		return new KafkaProducer<>(this.configs, this.keySerializerSupplier.get(), this.valueSerializerSupplier.get());
 	}
 
 	protected Producer<K, V> createTransactionalProducerForPartition() {
@@ -423,7 +457,7 @@ public class DefaultKafkaProducerFactory<K, V> implements ProducerFactory<K, V>,
 		Producer<K, V> newProducer;
 		Map<String, Object> newProducerConfigs = new HashMap<>(this.configs);
 		newProducerConfigs.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, prefix + suffix);
-		newProducer = new KafkaProducer<>(newProducerConfigs, this.keySerializer, this.valueSerializer);
+		newProducer = new KafkaProducer<>(newProducerConfigs, this.keySerializerSupplier.get(), this.valueSerializerSupplier.get());
 		newProducer.initTransactions();
 		return new CloseSafeProducer<>(newProducer, this.cache.get(prefix), remover,
 				(String) newProducerConfigs.get(ProducerConfig.TRANSACTIONAL_ID_CONFIG));

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
@@ -68,8 +68,8 @@ import org.springframework.util.StringUtils;
  * implementations on each {@link #createProducer()} invocation.
  * <p>
  * If you are using {@link Serializer}s that have no-arg constructors and require no setup, then simplest to
- * specify {@link Serializer} classes against {@value ProducerConfig#KEY_SERIALIZER_CLASS_CONFIG} and
- * {@value ProducerConfig#VALUE_SERIALIZER_CLASS_CONFIG} keys in the {@code configs} passed to the
+ * specify {@link Serializer} classes against {@link ProducerConfig#KEY_SERIALIZER_CLASS_CONFIG} and
+ * {@link ProducerConfig#VALUE_SERIALIZER_CLASS_CONFIG} keys in the {@code configs} passed to the
  * {@link DefaultKafkaProducerFactory} constructor.
  * <p>
  * If that is not possible, but you are sure that at least one of the following is true:

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.AbstractMap;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
@@ -81,133 +82,154 @@ public class DefaultKafkaConsumerFactoryTests {
 	}
 
 	@Test
-	public void testNoOverrides() {
+	public void testNoOverridesWhenCreatingConsumer() {
 		Map<String, Object> originalConfig = Collections.emptyMap();
+		final Map<String, Object> configPassedToKafkaConsumer = new HashMap<>();
 		new DefaultKafkaConsumerFactory<String, String>(originalConfig) {
 			protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
-				assertThat(configProps).isEqualTo(originalConfig);
+				configPassedToKafkaConsumer.putAll(configProps);
 				return null;
 			}
 		}.createConsumer(null, null, null, null);
+		assertThat(configPassedToKafkaConsumer).isEqualTo(originalConfig);
 	}
 
 	@Test
-	public void testPropertyOverrides() {
+	public void testPropertyOverridesWhenCreatingConsumer() {
 		Map<String, Object> originalConfig = Stream
 				.of(new AbstractMap.SimpleEntry<>("config1", new Object()),
 						new AbstractMap.SimpleEntry<>("config2", new Object()))
 				.collect(Collectors.toMap(AbstractMap.SimpleEntry::getKey, AbstractMap.SimpleEntry::getValue));
-
 		Properties overrides = new Properties();
 		overrides.setProperty("config1", "overridden");
+		final Map<String, Object> configPassedToKafkaConsumer = new HashMap<>();
 		new DefaultKafkaConsumerFactory<String, String>(originalConfig) {
 			protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
-				assertThat(configProps.get("config1")).isEqualTo("overridden");
-				assertThat(configProps.get("config2")).isSameAs(originalConfig.get("config2"));
+				configPassedToKafkaConsumer.putAll(configProps);
 				return null;
 			}
 		}.createConsumer(null, null, null, overrides);
+		assertThat(configPassedToKafkaConsumer.get("config1")).isEqualTo("overridden");
+		assertThat(configPassedToKafkaConsumer.get("config2")).isSameAs(originalConfig.get("config2"));
 	}
 
 	@Test
-	public void testClientIdSuffixOnDefault() {
+	public void testSuffixOnExistingClientIdWhenCreatingConsumer() {
 		Map<String, Object> originalConfig = Collections.singletonMap(ConsumerConfig.CLIENT_ID_CONFIG, "original");
+		final Map<String, Object> configPassedToKafkaConsumer = new HashMap<>();
 		new DefaultKafkaConsumerFactory<String, String>(originalConfig) {
 			protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
-				assertThat(configProps.get(ConsumerConfig.CLIENT_ID_CONFIG)).isEqualTo("original-1");
+				configPassedToKafkaConsumer.putAll(configProps);
 				return null;
 			}
 		}.createConsumer(null, null, "-1", null);
+		assertThat(configPassedToKafkaConsumer.get(ConsumerConfig.CLIENT_ID_CONFIG)).isEqualTo("original-1");
 	}
 
 	@Test
-	public void testClientIdSuffixWithoutDefault() {
+	public void testSuffixWithoutExistingClientIdWhenCreatingConsumer() {
+		final Map<String, Object> configPassedToKafkaConsumer = new HashMap<>();
 		new DefaultKafkaConsumerFactory<String, String>(Collections.emptyMap()) {
 			protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
-				assertThat(configProps.get(ConsumerConfig.CLIENT_ID_CONFIG)).isNull();
+				configPassedToKafkaConsumer.putAll(configProps);
 				return null;
 			}
 		}.createConsumer(null, null, "-1", null);
+		assertThat(configPassedToKafkaConsumer.get(ConsumerConfig.CLIENT_ID_CONFIG)).isNull();
 	}
 
 	@Test
-	public void testClientIdPrefixOnDefault() {
+	public void testPrefixOnExistingClientIdWhenCreatingConsumer() {
 		Map<String, Object> originalConfig = Collections.singletonMap(ConsumerConfig.CLIENT_ID_CONFIG, "original");
+		final Map<String, Object> configPassedToKafkaConsumer = new HashMap<>();
 		new DefaultKafkaConsumerFactory<String, String>(originalConfig) {
 			protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
-				assertThat(configProps.get(ConsumerConfig.CLIENT_ID_CONFIG)).isEqualTo("overridden");
+				configPassedToKafkaConsumer.putAll(configProps);
 				return null;
 			}
 		}.createConsumer(null, "overridden", null, null);
+		assertThat(configPassedToKafkaConsumer.get(ConsumerConfig.CLIENT_ID_CONFIG)).isEqualTo("overridden");
 	}
 
 	@Test
-	public void testClientIdPrefixWithoutDefault() {
+	public void testPrefixWithoutExistingClientIdWhenCreatingConsumer() {
+		final Map<String, Object> configPassedToKafkaConsumer = new HashMap<>();
 		new DefaultKafkaConsumerFactory<String, String>(Collections.emptyMap()) {
 			protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
-				assertThat(configProps.get(ConsumerConfig.CLIENT_ID_CONFIG)).isEqualTo("overridden");
+				configPassedToKafkaConsumer.putAll(configProps);
 				return null;
 			}
 		}.createConsumer(null, "overridden", null, null);
+		assertThat(configPassedToKafkaConsumer.get(ConsumerConfig.CLIENT_ID_CONFIG)).isEqualTo("overridden");
 	}
 
 	@Test
-	public void testClientIdSuffixAndPrefixOnDefault() {
+	public void testSuffixAndPrefixOnExistingClientIdWhenCreatingConsumer() {
 		Map<String, Object> originalConfig = Collections.singletonMap(ConsumerConfig.CLIENT_ID_CONFIG, "original");
+		final Map<String, Object> configPassedToKafkaConsumer = new HashMap<>();
 		new DefaultKafkaConsumerFactory<String, String>(originalConfig) {
 			protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
-				assertThat(configProps.get(ConsumerConfig.CLIENT_ID_CONFIG)).isEqualTo("overridden-1");
+				configPassedToKafkaConsumer.putAll(configProps);
 				return null;
 			}
 		}.createConsumer(null, "overridden", "-1", null);
+		assertThat(configPassedToKafkaConsumer.get(ConsumerConfig.CLIENT_ID_CONFIG)).isEqualTo("overridden-1");
 	}
 
 	@Test
-	public void testClientIdSuffixAndPrefixOnPropertyOverride() {
+	public void testSuffixAndPrefixOnOverridenClientIdWhenCreatingConsumer() {
 		Map<String, Object> originalConfig = Collections.singletonMap(ConsumerConfig.CLIENT_ID_CONFIG, "original");
 		Properties overrides = new Properties();
 		overrides.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, "property-overridden");
+		final Map<String, Object> configPassedToKafkaConsumer = new HashMap<>();
 		new DefaultKafkaConsumerFactory<String, String>(originalConfig) {
 			protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
-				assertThat(configProps.get(ConsumerConfig.CLIENT_ID_CONFIG)).isEqualTo("overridden-1");
+				configPassedToKafkaConsumer.putAll(configProps);
 				return null;
 			}
 		}.createConsumer(null, "overridden", "-1", overrides);
+		assertThat(configPassedToKafkaConsumer.get(ConsumerConfig.CLIENT_ID_CONFIG)).isEqualTo("overridden-1");
 	}
 
 
 	@Test
-	public void testGroupIdOnDefault() {
+	public void testOverriddenGroupIdWhenCreatingConsumer() {
 		Map<String, Object> originalConfig = Collections.singletonMap(ConsumerConfig.GROUP_ID_CONFIG, "original");
+		final Map<String, Object> configPassedToKafkaConsumer = new HashMap<>();
 		new DefaultKafkaConsumerFactory<String, String>(originalConfig) {
 			protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
-				assertThat(configProps.get(ConsumerConfig.GROUP_ID_CONFIG)).isEqualTo("overridden");
+				configPassedToKafkaConsumer.putAll(configProps);
 				return null;
 			}
 		}.createConsumer("overridden", null, null, null);
+		assertThat(configPassedToKafkaConsumer.get(ConsumerConfig.GROUP_ID_CONFIG)).isEqualTo("overridden");
 	}
 
 	@Test
-	public void testGroupIdWithoutDefault() {
+	public void testOverriddenGroupIdWithoutExistingGroupIdWhenCreatingConsumer() {
+		final Map<String, Object> configPassedToKafkaConsumer = new HashMap<>();
 		new DefaultKafkaConsumerFactory<String, String>(Collections.emptyMap()) {
 			protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
-				assertThat(configProps.get(ConsumerConfig.GROUP_ID_CONFIG)).isEqualTo("overridden");
+				configPassedToKafkaConsumer.putAll(configProps);
 				return null;
 			}
 		}.createConsumer("overridden", null, null, null);
+		assertThat(configPassedToKafkaConsumer.get(ConsumerConfig.GROUP_ID_CONFIG)).isEqualTo("overridden");
 	}
 
 	@Test
-	public void testGroupIdOnPropertyOverride() {
+	public void testOverriddenGroupIdOnOverriddenPropertyWhenCreatingConsumer() {
 		Map<String, Object> originalConfig = Collections.singletonMap(ConsumerConfig.GROUP_ID_CONFIG, "original");
 		Properties overrides = new Properties();
 		overrides.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "property-overridden");
+		final Map<String, Object> configPassedToKafkaConsumer = new HashMap<>();
 		new DefaultKafkaConsumerFactory<String, String>(originalConfig) {
 			protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
-				assertThat(configProps.get(ConsumerConfig.GROUP_ID_CONFIG)).isEqualTo("overridden");
+				configPassedToKafkaConsumer.putAll(configProps);
 				return null;
 			}
 		}.createConsumer("overridden", null, null, overrides);
+		assertThat(configPassedToKafkaConsumer.get(ConsumerConfig.GROUP_ID_CONFIG)).isEqualTo("overridden");
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
@@ -85,12 +85,13 @@ public class DefaultKafkaConsumerFactoryTests {
 	public void testNoOverridesWhenCreatingConsumer() {
 		Map<String, Object> originalConfig = Collections.emptyMap();
 		final Map<String, Object> configPassedToKafkaConsumer = new HashMap<>();
-		new DefaultKafkaConsumerFactory<String, String>(originalConfig) {
+		DefaultKafkaConsumerFactory<String, String> target = new DefaultKafkaConsumerFactory<String, String>(originalConfig) {
 			protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
 				configPassedToKafkaConsumer.putAll(configProps);
 				return null;
 			}
-		}.createConsumer(null, null, null, null);
+		};
+		target.createConsumer(null, null, null, null);
 		assertThat(configPassedToKafkaConsumer).isEqualTo(originalConfig);
 	}
 
@@ -103,12 +104,13 @@ public class DefaultKafkaConsumerFactoryTests {
 		Properties overrides = new Properties();
 		overrides.setProperty("config1", "overridden");
 		final Map<String, Object> configPassedToKafkaConsumer = new HashMap<>();
-		new DefaultKafkaConsumerFactory<String, String>(originalConfig) {
+		DefaultKafkaConsumerFactory<String, String> target = new DefaultKafkaConsumerFactory<String, String>(originalConfig) {
 			protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
 				configPassedToKafkaConsumer.putAll(configProps);
 				return null;
 			}
-		}.createConsumer(null, null, null, overrides);
+		};
+		target.createConsumer(null, null, null, overrides);
 		assertThat(configPassedToKafkaConsumer.get("config1")).isEqualTo("overridden");
 		assertThat(configPassedToKafkaConsumer.get("config2")).isSameAs(originalConfig.get("config2"));
 	}
@@ -117,24 +119,26 @@ public class DefaultKafkaConsumerFactoryTests {
 	public void testSuffixOnExistingClientIdWhenCreatingConsumer() {
 		Map<String, Object> originalConfig = Collections.singletonMap(ConsumerConfig.CLIENT_ID_CONFIG, "original");
 		final Map<String, Object> configPassedToKafkaConsumer = new HashMap<>();
-		new DefaultKafkaConsumerFactory<String, String>(originalConfig) {
+		DefaultKafkaConsumerFactory<String, String> target = new DefaultKafkaConsumerFactory<String, String>(originalConfig) {
 			protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
 				configPassedToKafkaConsumer.putAll(configProps);
 				return null;
 			}
-		}.createConsumer(null, null, "-1", null);
+		};
+		target.createConsumer(null, null, "-1", null);
 		assertThat(configPassedToKafkaConsumer.get(ConsumerConfig.CLIENT_ID_CONFIG)).isEqualTo("original-1");
 	}
 
 	@Test
 	public void testSuffixWithoutExistingClientIdWhenCreatingConsumer() {
 		final Map<String, Object> configPassedToKafkaConsumer = new HashMap<>();
-		new DefaultKafkaConsumerFactory<String, String>(Collections.emptyMap()) {
+		DefaultKafkaConsumerFactory<String, String> target = new DefaultKafkaConsumerFactory<String, String>(Collections.emptyMap()) {
 			protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
 				configPassedToKafkaConsumer.putAll(configProps);
 				return null;
 			}
-		}.createConsumer(null, null, "-1", null);
+		};
+		target.createConsumer(null, null, "-1", null);
 		assertThat(configPassedToKafkaConsumer.get(ConsumerConfig.CLIENT_ID_CONFIG)).isNull();
 	}
 
@@ -142,24 +146,26 @@ public class DefaultKafkaConsumerFactoryTests {
 	public void testPrefixOnExistingClientIdWhenCreatingConsumer() {
 		Map<String, Object> originalConfig = Collections.singletonMap(ConsumerConfig.CLIENT_ID_CONFIG, "original");
 		final Map<String, Object> configPassedToKafkaConsumer = new HashMap<>();
-		new DefaultKafkaConsumerFactory<String, String>(originalConfig) {
+		DefaultKafkaConsumerFactory<String, String> target = new DefaultKafkaConsumerFactory<String, String>(originalConfig) {
 			protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
 				configPassedToKafkaConsumer.putAll(configProps);
 				return null;
 			}
-		}.createConsumer(null, "overridden", null, null);
+		};
+		target.createConsumer(null, "overridden", null, null);
 		assertThat(configPassedToKafkaConsumer.get(ConsumerConfig.CLIENT_ID_CONFIG)).isEqualTo("overridden");
 	}
 
 	@Test
 	public void testPrefixWithoutExistingClientIdWhenCreatingConsumer() {
 		final Map<String, Object> configPassedToKafkaConsumer = new HashMap<>();
-		new DefaultKafkaConsumerFactory<String, String>(Collections.emptyMap()) {
+		DefaultKafkaConsumerFactory<String, String> target = new DefaultKafkaConsumerFactory<String, String>(Collections.emptyMap()) {
 			protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
 				configPassedToKafkaConsumer.putAll(configProps);
 				return null;
 			}
-		}.createConsumer(null, "overridden", null, null);
+		};
+		target.createConsumer(null, "overridden", null, null);
 		assertThat(configPassedToKafkaConsumer.get(ConsumerConfig.CLIENT_ID_CONFIG)).isEqualTo("overridden");
 	}
 
@@ -167,12 +173,13 @@ public class DefaultKafkaConsumerFactoryTests {
 	public void testSuffixAndPrefixOnExistingClientIdWhenCreatingConsumer() {
 		Map<String, Object> originalConfig = Collections.singletonMap(ConsumerConfig.CLIENT_ID_CONFIG, "original");
 		final Map<String, Object> configPassedToKafkaConsumer = new HashMap<>();
-		new DefaultKafkaConsumerFactory<String, String>(originalConfig) {
+		DefaultKafkaConsumerFactory<String, String> target = new DefaultKafkaConsumerFactory<String, String>(originalConfig) {
 			protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
 				configPassedToKafkaConsumer.putAll(configProps);
 				return null;
 			}
-		}.createConsumer(null, "overridden", "-1", null);
+		};
+		target.createConsumer(null, "overridden", "-1", null);
 		assertThat(configPassedToKafkaConsumer.get(ConsumerConfig.CLIENT_ID_CONFIG)).isEqualTo("overridden-1");
 	}
 
@@ -182,12 +189,13 @@ public class DefaultKafkaConsumerFactoryTests {
 		Properties overrides = new Properties();
 		overrides.setProperty(ConsumerConfig.CLIENT_ID_CONFIG, "property-overridden");
 		final Map<String, Object> configPassedToKafkaConsumer = new HashMap<>();
-		new DefaultKafkaConsumerFactory<String, String>(originalConfig) {
+		DefaultKafkaConsumerFactory<String, String> target = new DefaultKafkaConsumerFactory<String, String>(originalConfig) {
 			protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
 				configPassedToKafkaConsumer.putAll(configProps);
 				return null;
 			}
-		}.createConsumer(null, "overridden", "-1", overrides);
+		};
+		target.createConsumer(null, "overridden", "-1", overrides);
 		assertThat(configPassedToKafkaConsumer.get(ConsumerConfig.CLIENT_ID_CONFIG)).isEqualTo("overridden-1");
 	}
 
@@ -196,24 +204,26 @@ public class DefaultKafkaConsumerFactoryTests {
 	public void testOverriddenGroupIdWhenCreatingConsumer() {
 		Map<String, Object> originalConfig = Collections.singletonMap(ConsumerConfig.GROUP_ID_CONFIG, "original");
 		final Map<String, Object> configPassedToKafkaConsumer = new HashMap<>();
-		new DefaultKafkaConsumerFactory<String, String>(originalConfig) {
+		DefaultKafkaConsumerFactory<String, String> target = new DefaultKafkaConsumerFactory<String, String>(originalConfig) {
 			protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
 				configPassedToKafkaConsumer.putAll(configProps);
 				return null;
 			}
-		}.createConsumer("overridden", null, null, null);
+		};
+		target.createConsumer("overridden", null, null, null);
 		assertThat(configPassedToKafkaConsumer.get(ConsumerConfig.GROUP_ID_CONFIG)).isEqualTo("overridden");
 	}
 
 	@Test
 	public void testOverriddenGroupIdWithoutExistingGroupIdWhenCreatingConsumer() {
 		final Map<String, Object> configPassedToKafkaConsumer = new HashMap<>();
-		new DefaultKafkaConsumerFactory<String, String>(Collections.emptyMap()) {
+		DefaultKafkaConsumerFactory<String, String> target = new DefaultKafkaConsumerFactory<String, String>(Collections.emptyMap()) {
 			protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
 				configPassedToKafkaConsumer.putAll(configProps);
 				return null;
 			}
-		}.createConsumer("overridden", null, null, null);
+		};
+		target.createConsumer("overridden", null, null, null);
 		assertThat(configPassedToKafkaConsumer.get(ConsumerConfig.GROUP_ID_CONFIG)).isEqualTo("overridden");
 	}
 
@@ -223,12 +233,13 @@ public class DefaultKafkaConsumerFactoryTests {
 		Properties overrides = new Properties();
 		overrides.setProperty(ConsumerConfig.GROUP_ID_CONFIG, "property-overridden");
 		final Map<String, Object> configPassedToKafkaConsumer = new HashMap<>();
-		new DefaultKafkaConsumerFactory<String, String>(originalConfig) {
+		DefaultKafkaConsumerFactory<String, String> target = new DefaultKafkaConsumerFactory<String, String>(originalConfig) {
 			protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
 				configPassedToKafkaConsumer.putAll(configProps);
 				return null;
 			}
-		}.createConsumer("overridden", null, null, overrides);
+		};
+		target.createConsumer("overridden", null, null, overrides);
 		assertThat(configPassedToKafkaConsumer.get(ConsumerConfig.GROUP_ID_CONFIG)).isEqualTo("overridden");
 	}
 

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -295,7 +295,7 @@ IMPORTANT: When `producerPerThread` is `true`, user code **must** call `closeThr
 This will physically close the producer and remove it from the `ThreadLocal`.
 Calling `reset()` or `destroy()` will not clean up these producers.
 
-When creating a `DefaultKafkaProducerFactory`, key and/or value `Serializer` classes can be picked up from configuration by calling the constructor that only takes in a `Map` of properties (see example in <<kafka-template>>), or `Serializer` instances may be passed to the `DefaultKafkaProducerFactory` constructor (in which case all `Producer`s share the same instances).
+When creating a `DefaultKafkaProducerFactory`, key and/or value `Serializer` classes can be picked up from configuration by calling the constructor that only takes in a Map of properties (see example in <<kafka-template>>), or `Serializer` instances may be passed to the `DefaultKafkaProducerFactory` constructor (in which case all `Producer`s share the same instances).
 Alternatively you can provide `Supplier`s of `Serializer`s that will be used to obtain separate `Serializer` instances for each `Producer`:
 
 ====
@@ -313,7 +313,6 @@ public KafkaTemplate<Integer, CustomValue> kafkaTemplate() {
 }
 
 ----
-
 ====
 [[transactions]]
 ===== Transactions

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -164,26 +164,6 @@ public KafkaTemplate<Integer, String> kafkaTemplate() {
 ----
 ====
 
-or if you are using Spring Boot, you can make use of the `KafkaProperties` ConfigurationProperties class to pull in application properties, rather than manually adding them to a map:
-
-====
-[source, java]
-----
-
-private KafkaProperties properties;
-
-@Bean
-public ProducerFactory<Integer, String> producerFactory() {
-    return new DefaultKafkaProducerFactory<>(properties.buildProducerProperties());
-}
-
-@Bean
-public KafkaTemplate<Integer, String> kafkaTemplate() {
-    return new KafkaTemplate<Integer, String>(producerFactory());
-}
-----
-====
-
 You can also configure the template by using standard `<bean/>` definitions.
 
 Then, to use the template, you can invoke one of its methods.
@@ -315,9 +295,8 @@ IMPORTANT: When `producerPerThread` is `true`, user code **must** call `closeThr
 This will physically close the producer and remove it from the `ThreadLocal`.
 Calling `reset()` or `destroy()` will not clean up these producers.
 
-When creating a `DefaultKafkaProducerFactory`, key and/or value `Serializer` classes can be picked up from configuration by calling the constructor that only takes in a Map of properties (see example in <<kafka-template>>),
-or `Serializer` instances may be passed to the `DefaultKafkaProducerFactory` constructor (in which case all Producers share the same instances).
-Alternatively you can provide Suppliers of Serializers that will be used to obtain separate `Serializer` instances for each `Producer`:
+When creating a `DefaultKafkaProducerFactory`, key and/or value `Serializer` classes can be picked up from configuration by calling the constructor that only takes in a `Map` of properties (see example in <<kafka-template>>), or `Serializer` instances may be passed to the `DefaultKafkaProducerFactory` constructor (in which case all `Producer`s share the same instances).
+Alternatively you can provide `Supplier`s of `Serializer`s that will be used to obtain separate `Serializer` instances for each `Producer`:
 
 ====
 [source, java]
@@ -325,7 +304,7 @@ Alternatively you can provide Suppliers of Serializers that will be used to obta
 
 @Bean
 public ProducerFactory<Integer, CustomValue> producerFactory() {
-    return new DefaultKafkaProducerFactory<>(producerConfigs(), null, () -> new CustomValueSerializer();
+    return new DefaultKafkaProducerFactory<>(producerConfigs(), null, () -> new CustomValueSerializer());
 }
 
 @Bean
@@ -2414,7 +2393,7 @@ For more complex or particular cases, the `KafkaConsumer` (and, therefore, `Kafk
 constructors to accept `Serializer` and `Deserializer` instances for `keys` and `values`, respectively.
 
 When you use this API, the `DefaultKafkaProducerFactory` and `DefaultKafkaConsumerFactory` also provide properties (through constructors or setter methods) to inject custom `Serializer` and `Deserializer` instances into the target `Producer` or `Consumer`.
-Also, you can pass in Supplier functions for custom `Serializer` and `Deserializer` instances through constructors - these functions are called on creation of each `Producer` or `Consumer`
+Also, you can pass in `Supplier` functions for custom `Serializer` and `Deserializer` instances through constructors - these functions are called on creation of each `Producer` or `Consumer`.
 
 Spring for Apache Kafka also provides `JsonSerializer` and `JsonDeserializer` implementations that are based on the
 Jackson JSON object mapper.

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -164,6 +164,26 @@ public KafkaTemplate<Integer, String> kafkaTemplate() {
 ----
 ====
 
+or if you are using Spring Boot, you can make use of the `KafkaProperties` ConfigurationProperties class to pull in application properties, rather than manually adding them to a map:
+
+====
+[source, java]
+----
+
+private KafkaProperties properties;
+
+@Bean
+public ProducerFactory<Integer, String> producerFactory() {
+    return new DefaultKafkaProducerFactory<>(properties.buildProducerProperties());
+}
+
+@Bean
+public KafkaTemplate<Integer, String> kafkaTemplate() {
+    return new KafkaTemplate<Integer, String>(producerFactory());
+}
+----
+====
+
 You can also configure the template by using standard `<bean/>` definitions.
 
 Then, to use the template, you can invoke one of its methods.
@@ -295,6 +315,27 @@ IMPORTANT: When `producerPerThread` is `true`, user code **must** call `closeThr
 This will physically close the producer and remove it from the `ThreadLocal`.
 Calling `reset()` or `destroy()` will not clean up these producers.
 
+When creating a `DefaultKafkaProducerFactory`, key and/or value `Serializer` classes can be picked up from configuration by calling the constructor that only takes in a Map of properties (see example in <<kafka-template>>),
+or `Serializer` instances may be passed to the `DefaultKafkaProducerFactory` constructor (in which case all Producers share the same instances).
+Alternatively you can provide Suppliers of Serializers that will be used to obtain separate `Serializer` instances for each `Producer`:
+
+====
+[source, java]
+----
+
+@Bean
+public ProducerFactory<Integer, CustomValue> producerFactory() {
+    return new DefaultKafkaProducerFactory<>(producerConfigs(), null, () -> new CustomValueSerializer();
+}
+
+@Bean
+public KafkaTemplate<Integer, CustomValue> kafkaTemplate() {
+    return new KafkaTemplate<Integer, CustomValue>(producerFactory());
+}
+
+----
+
+====
 [[transactions]]
 ===== Transactions
 
@@ -810,7 +851,23 @@ containerProps.setMessageListener(new MessageListener<Integer, String>() {
     ...
 });
 DefaultKafkaConsumerFactory<Integer, String> cf =
-                        new DefaultKafkaConsumerFactory<Integer, String>(consumerProps());
+                        new DefaultKafkaConsumerFactory<>(consumerProps());
+KafkaMessageListenerContainer<Integer, String> container =
+                        new KafkaMessageListenerContainer<>(cf, containerProps);
+return container;
+----
+====
+
+Note that when creating a `DefaultKafkaConsumerFactory`, using the constructor that just takes in the properties as above means that key and value `Deserializer` classes are picked up from configuration.
+Alternatively, `Deserializer` instances may be passed to the `DefaultKafkaConsumerFactory` constructor for key and/or value, in which case all Consumers share the same instances.
+Another option is to provide Suppliers of Deserializers that will be used to obtain separate `Deserializer` instances for each `Consumer`:
+
+====
+[source, java]
+----
+
+DefaultKafkaConsumerFactory<Integer, CustomValue> cf =
+                        new DefaultKafkaConsumerFactory<>(consumerProps(), null, () -> new CustomValueDeserializer());
 KafkaMessageListenerContainer<Integer, String> container =
                         new KafkaMessageListenerContainer<>(cf, containerProps);
 return container;
@@ -2357,6 +2414,7 @@ For more complex or particular cases, the `KafkaConsumer` (and, therefore, `Kafk
 constructors to accept `Serializer` and `Deserializer` instances for `keys` and `values`, respectively.
 
 When you use this API, the `DefaultKafkaProducerFactory` and `DefaultKafkaConsumerFactory` also provide properties (through constructors or setter methods) to inject custom `Serializer` and `Deserializer` instances into the target `Producer` or `Consumer`.
+Also, you can pass in Supplier functions for custom `Serializer` and `Deserializer` instances through constructors - these functions are called on creation of each `Producer` or `Consumer`
 
 Spring for Apache Kafka also provides `JsonSerializer` and `JsonDeserializer` implementations that are based on the
 Jackson JSON object mapper.

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -838,7 +838,7 @@ return container;
 
 Note that when creating a `DefaultKafkaConsumerFactory`, using the constructor that just takes in the properties as above means that key and value `Deserializer` classes are picked up from configuration.
 Alternatively, `Deserializer` instances may be passed to the `DefaultKafkaConsumerFactory` constructor for key and/or value, in which case all Consumers share the same instances.
-Another option is to provide Suppliers of Deserializers that will be used to obtain separate `Deserializer` instances for each `Consumer`:
+Another option is to provide `Supplier<Deserializer>`s that will be used to obtain separate `Deserializer` instances for each `Consumer`:
 
 ====
 [source, java]
@@ -2392,7 +2392,7 @@ For more complex or particular cases, the `KafkaConsumer` (and, therefore, `Kafk
 constructors to accept `Serializer` and `Deserializer` instances for `keys` and `values`, respectively.
 
 When you use this API, the `DefaultKafkaProducerFactory` and `DefaultKafkaConsumerFactory` also provide properties (through constructors or setter methods) to inject custom `Serializer` and `Deserializer` instances into the target `Producer` or `Consumer`.
-Also, you can pass in `Supplier` functions for custom `Serializer` and `Deserializer` instances through constructors - these functions are called on creation of each `Producer` or `Consumer`.
+Also, you can pass in `Supplier<Serializer>` or `Supplier<Deserializer>` instances through constructors - these `Supplier`s are called on creation of each `Producer` or `Consumer`.
 
 Spring for Apache Kafka also provides `JsonSerializer` and `JsonDeserializer` implementations that are based on the
 Jackson JSON object mapper.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -19,10 +19,9 @@ This version requires the 2.2.0 `kafka-clients` or higher.
 The `DefaultKafkaProducerFactory` can now be configured to create a producer per thread.
 See <<producer-factory>> for more information.
 
-You can also provide `Serializer` suppliers in the constructor as an alternative to either configured classes (which require no-arg constructors).
-or constructing with `Serializer` instances, which are then shared between all Producers.
+You can also provide `Supplier<Serializer>` instances in the constructor as an alternative to either configured classes (which require no-arg constructors), or constructing with `Serializer` instances, which are then shared between all Producers.
 
-The same option is also available with `Deserializer` suppliers in `DefaultKafkaConsumerFactory` - see <<kafka-container>>
+The same option is available with `Supplier<Deserializer>` instances in `DefaultKafkaConsumerFactory` - see <<kafka-container>>.
 
 ==== Listener Container Changes
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -14,10 +14,15 @@ Please submit GitHub issues and/or pull requests for additional entries in that 
 
 This version requires the 2.2.0 `kafka-clients` or higher.
 
-==== Producer Factory Changes
+==== Producer and Consumer Factory Changes
 
 The `DefaultKafkaProducerFactory` can now be configured to create a producer per thread.
 See <<producer-factory>> for more information.
+
+You can also provide `Serializer` suppliers in the constructor as an alternative to either configured classes (which require no-arg constructors)
+or constructing with `Serializer` instances, which are then shared between all Producers.
+
+The same option is also available with `Deserializer` suppliers in `DefaultKafkaConsumerFactory` - see <<kafka-container>>
 
 ==== Listener Container Changes
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -19,7 +19,7 @@ This version requires the 2.2.0 `kafka-clients` or higher.
 The `DefaultKafkaProducerFactory` can now be configured to create a producer per thread.
 See <<producer-factory>> for more information.
 
-You can also provide `Serializer` suppliers in the constructor as an alternative to either configured classes (which require no-arg constructors)
+You can also provide `Serializer` suppliers in the constructor as an alternative to either configured classes (which require no-arg constructors).
 or constructing with `Serializer` instances, which are then shared between all Producers.
 
 The same option is also available with `Deserializer` suppliers in `DefaultKafkaConsumerFactory` - see <<kafka-container>>


### PR DESCRIPTION
Provides an alternative way of ensuring each consumer/producer has its own instances if configuration is not an option.

Also extend DefaultKafkaConsumerFactory unit test coverage to ensure compliance with the ConsumerFactory documented behaviour.

see https://github.com/spring-projects/spring-kafka/issues/1080 for more detail