### PR TITLE
GH-1129: Add JacksonMimeTypeModule

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/DefaultKafkaHeaderMapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/DefaultKafkaHeaderMapper.java
@@ -66,12 +66,6 @@ public class DefaultKafkaHeaderMapper extends AbstractKafkaHeaderMapper {
 					"org.springframework.util"
 			);
 
-	private static final List<String> DEFAULT_TO_STRING_CLASSES =
-			Arrays.asList(
-					"org.springframework.util.MimeType",
-					"org.springframework.http.MediaType"
-			);
-
 	/**
 	 * Header name for java types of other headers.
 	 */
@@ -81,7 +75,7 @@ public class DefaultKafkaHeaderMapper extends AbstractKafkaHeaderMapper {
 
 	private final Set<String> trustedPackages = new LinkedHashSet<>(DEFAULT_TRUSTED_PACKAGES);
 
-	private final Set<String> toStringClasses = new LinkedHashSet<>(DEFAULT_TO_STRING_CLASSES);
+	private final Set<String> toStringClasses = new LinkedHashSet<>();
 
 	/**
 	 * Construct an instance with the default object mapper and default header patterns

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/JacksonMimeTypeModule.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/JacksonMimeTypeModule.java
@@ -32,7 +32,7 @@ import com.fasterxml.jackson.databind.module.SimpleModule;
  *
  * @since 2.3
  */
-public class JacksonMimeTypeModule extends SimpleModule {
+public final class JacksonMimeTypeModule extends SimpleModule {
 
 	private static final long serialVersionUID = 1L;
 
@@ -45,6 +45,10 @@ public class JacksonMimeTypeModule extends SimpleModule {
 	 * target JSON as a plain string.
 	 */
 	private static final class MimeTypeSerializer extends JsonSerializer<MimeType> {
+
+		MimeTypeSerializer() {
+			super();
+		}
 
 		@Override
 		public void serialize(MimeType value, JsonGenerator generator, SerializerProvider serializers)

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/JacksonMimeTypeModule.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/JacksonMimeTypeModule.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support;
+
+import java.io.IOException;
+
+import org.springframework.util.MimeType;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+/**
+ * A {@link SimpleModule} extension for {@link MimeType} serialization.
+ *
+ * @author Artem Bilan
+ *
+ * @since 2.3
+ */
+public class JacksonMimeTypeModule extends SimpleModule {
+
+	private static final long serialVersionUID = 1L;
+
+	public JacksonMimeTypeModule() {
+		addSerializer(MimeType.class, new MimeTypeSerializer());
+	}
+
+	/**
+	 * Simple {@link JsonSerializer} extension to represent a {@link MimeType} object in the
+	 * target JSON as a plain string.
+	 */
+	private static final class MimeTypeSerializer extends JsonSerializer<MimeType> {
+
+		@Override
+		public void serialize(MimeType value, JsonGenerator generator, SerializerProvider serializers)
+				throws IOException {
+
+			generator.writeString(value.toString());
+		}
+
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/JacksonUtils.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/JacksonUtils.java
@@ -63,6 +63,7 @@ public final class JacksonUtils {
 
 	@SuppressWarnings("unchecked")
 	private static void registerWellKnownModulesIfAvailable(ObjectMapper objectMapper, ClassLoader classLoader) {
+		objectMapper.registerModule(new JacksonMimeTypeModule());
 		try {
 			Class<? extends Module> jdk8Module = (Class<? extends Module>)
 					ClassUtils.forName("com.fasterxml.jackson.datatype.jdk8.Jdk8Module", classLoader);

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/DefaultKafkaHeaderMapperTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/DefaultKafkaHeaderMapperTests.java
@@ -62,7 +62,7 @@ public class DefaultKafkaHeaderMapperTests {
 				.setHeader(MessageHeaders.REPLY_CHANNEL, new ExecutorSubscribableChannel())
 				.setHeader(MessageHeaders.ERROR_CHANNEL, "errors")
 				.setHeader(MessageHeaders.CONTENT_TYPE, utf8Text)
-				.setHeader("simpleContentType", MimeTypeUtils.TEXT_PLAIN)
+				.setHeader("simpleContentType", MimeTypeUtils.TEXT_PLAIN_VALUE)
 				.setHeader("customToString", new Bar("fiz"))
 				.build();
 		RecordHeaders recordHeaders = new RecordHeaders();
@@ -75,8 +75,8 @@ public class DefaultKafkaHeaderMapperTests {
 		assertThat(headers.get("baz")).isEqualTo("qux");
 		assertThat(headers.get("fix")).isInstanceOf(NonTrustedHeaderType.class);
 		assertThat(headers.get("linkedMVMap")).isInstanceOf(LinkedMultiValueMap.class);
-		assertThat(headers.get(MessageHeaders.CONTENT_TYPE)).isEqualTo(utf8Text.toString());
-		assertThat(headers.get("simpleContentType")).isEqualTo(MimeTypeUtils.TEXT_PLAIN.toString());
+		assertThat(headers.get(MessageHeaders.CONTENT_TYPE)).isEqualTo(utf8Text);
+		assertThat(headers.get("simpleContentType")).isEqualTo(MimeTypeUtils.TEXT_PLAIN_VALUE);
 		assertThat(headers.get(MessageHeaders.REPLY_CHANNEL)).isNull();
 		assertThat(headers.get(MessageHeaders.ERROR_CHANNEL)).isEqualTo("errors");
 		assertThat(headers.get("customToString")).isEqualTo("Bar [field=fiz]");

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/DefaultKafkaHeaderMapperTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/DefaultKafkaHeaderMapperTests.java
@@ -19,13 +19,12 @@ package org.springframework.kafka.support;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeader;
@@ -33,7 +32,6 @@ import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.junit.Test;
 
 import org.springframework.kafka.support.DefaultKafkaHeaderMapper.NonTrustedHeaderType;
-import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.support.ExecutorSubscribableChannel;
@@ -55,7 +53,7 @@ public class DefaultKafkaHeaderMapperTests {
 	public void testTrustedAndNot() {
 		DefaultKafkaHeaderMapper mapper = new DefaultKafkaHeaderMapper();
 		mapper.addToStringClasses(Bar.class.getName());
-		MimeType utf8Text = new MimeType(MimeTypeUtils.TEXT_PLAIN, Charset.forName("UTF-8"));
+		MimeType utf8Text = new MimeType(MimeTypeUtils.TEXT_PLAIN, StandardCharsets.UTF_8);
 		Message<String> message = MessageBuilder.withPayload("foo")
 				.setHeader("foo", "bar".getBytes())
 				.setHeader("baz", "qux")

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -2450,6 +2450,8 @@ You can also extend them to implement some particular configuration logic in the
 Starting with version 2.3, all the JSON-aware components are configured by default with a `JacksonUtils.enhancedObjectMapper()` instance, which comes with the `MapperFeature.DEFAULT_VIEW_INCLUSION` and `DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES` features disabled.
 Also such an instance is supplied with well-known modules for custom data types, such a Java time and Kotlin support.
 See `JacksonUtils.enhancedObjectMapper()` JavaDocs for more information.
+This method also registers a `org.springframework.kafka.support.JacksonMimeTypeModule` for `org.springframework.util.MimeType` objects serialization into the plain string for inter-platform compatibility over the network.
+A `JacksonMimeTypeModule` can be registered as a bean in the application context and it will be auto-configured into https://docs.spring.io/spring-boot/docs/current/reference/html/howto-spring-mvc.html#howto-customize-the-jackson-objectmapper[Spring Boot `ObjectMapper` instance].
 
 Also starting with version 2.3, the `JsonDeserializer` provides `TypeReference`-based constructors for better handling of target generic container types.
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -71,6 +71,7 @@ See <<streams-messaging>> and <<streams-integration>> for more information.
 
 Now all the JSON-aware components are configured by default with a Jackson `ObjectMapper` produced by the `JacksonUtils.enhancedObjectMapper()`.
 The `JsonDeserializer` now provides `TypeReference`-based constructors for better handling of target generic container types.
+Also a `JacksonMimeTypeModule` has been introduced for serialization of `org.springframework.util.MimeType` to plain string.
 See its JavaDocs and <<serdes>> for more information.
 
 A `ByteArrayJsonMessageConverter` has been provided as well as a new super class for all Json converters, `JsonMessageConverter`.


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-kafka/issues/1129

Introduce a `JacksonMimeTypeModule` with a simple `MimeTypeSerializer`
for the proper inter-platform `MimeType` objects serialization.
Essentially we call its `toString()` which is enough to carry mime-type
info over the network.
Register this module in the `JacksonUtils.enhancedObjectMapper()` which
is used from the `DefaultKafkaHeaderMapper`.
Such a module can be registered as a bean in the application context
and will be automatically discovered by Spring Boot auto-configuration
for Jackson
* Modify a `DefaultKafkaHeaderMapper` to not deal with `MimeType`
directly any more since it is covered by the `JacksonMimeTypeModule`
even if `MimeType` is a part of collection like it is in case of
mapped HTTP headers.
* Modify `DefaultKafkaHeaderMapperTests` to check that `MimeType` is
properly serialized into its string representation even if it in the
collection