### PR TITLE
Add JSON array serde

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonArrayDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonArrayDeserializer.java
@@ -1,0 +1,43 @@
+package org.springframework.kafka.support.serializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.springframework.core.ResolvableType;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public class JsonArrayDeserializer<T> implements Deserializer<List<T>> {
+    private final ObjectMapper objectMapper;
+    private final Class<? super T> targetType;
+
+    @SuppressWarnings("unchecked")
+    public JsonArrayDeserializer(Class<? super T> targetType, ObjectMapper objectMapper) {
+        this.targetType = targetType == null ? (Class<T>) ResolvableType.forClass(getClass()).getSuperType().resolveGeneric(0) : targetType;
+        this.objectMapper = objectMapper;
+    }
+
+    public JsonArrayDeserializer() {
+        this(null, new ObjectMapper());
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+    }
+
+    @Override
+    public List<T> deserialize(String topic, byte[] data) {
+        try {
+            return objectMapper.readValue(data, objectMapper.getTypeFactory().constructCollectionType(List.class, targetType));
+        } catch (IOException e) {
+            throw new SerializationException("Can't deserialize data [" + Arrays.toString(data) + "] from topic [" + topic + "]", e);
+        }
+    }
+
+    @Override
+    public void close() {
+    }
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonArraySerde.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonArraySerde.java
@@ -13,7 +13,7 @@ public class JsonArraySerde<T> implements Serde<List<T>> {
     private final Deserializer<List<T>> jsonArrayDeserializer;
 
     public JsonArraySerde(Class<T> targetType) {
-        var objectMapper = new ObjectMapper();
+        ObjectMapper objectMapper = new ObjectMapper();
 
         this.jsonArraySerializer = new JsonArraySerializer<>(objectMapper);
         this.jsonArrayDeserializer = new JsonArrayDeserializer<>(targetType, objectMapper);

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonArraySerde.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonArraySerde.java
@@ -1,0 +1,39 @@
+package org.springframework.kafka.support.serializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serializer;
+
+import java.util.List;
+import java.util.Map;
+
+public class JsonArraySerde<T> implements Serde<List<T>> {
+    private final Serializer<List<T>> jsonArraySerializer;
+    private final Deserializer<List<T>> jsonArrayDeserializer;
+
+    public JsonArraySerde(Class<T> targetType) {
+        var objectMapper = new ObjectMapper();
+
+        this.jsonArraySerializer = new JsonArraySerializer<>(objectMapper);
+        this.jsonArrayDeserializer = new JsonArrayDeserializer<>(targetType, objectMapper);
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public Serializer<List<T>> serializer() {
+        return jsonArraySerializer;
+    }
+
+    @Override
+    public Deserializer<List<T>> deserializer() {
+        return jsonArrayDeserializer;
+    }
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonArraySerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonArraySerializer.java
@@ -1,0 +1,38 @@
+package org.springframework.kafka.support.serializer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.serialization.Serializer;
+
+import java.util.List;
+import java.util.Map;
+
+public class JsonArraySerializer<T> implements Serializer<List<T>> {
+    private final ObjectMapper objectMapper;
+
+    public JsonArraySerializer(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    public JsonArraySerializer() {
+        this(new ObjectMapper());
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs, boolean isKey) {
+    }
+
+    @Override
+    public byte[] serialize(String topic, List<T> data) {
+        try {
+            return objectMapper.writeValueAsBytes(data);
+        } catch (JsonProcessingException e) {
+            throw new SerializationException("Can't serialize data [" + data + "] for topic [" + topic + "]", e);
+        }
+    }
+
+    @Override
+    public void close() {
+    }
+}


### PR DESCRIPTION
When building a Kafka Streams application, you often have to group and aggregate some events into a List of events, possibly to join them afterwards with another event stream.

While you could wrap the list into an class, that makes for some very ugly code when accessing / modifying that list.

That's why I've implemented a JsonArraySerde which allows you to serialize a List<T> to a JSON Array and vice versa.

The implementation is probably missing a few things but should be sufficient for a first draft.