### PR TITLE
GH-1134: Fix `stop(Runnable)` usage

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistry.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistry.java
@@ -269,14 +269,19 @@ public class KafkaListenerEndpointRegistry implements DisposableBean, SmartLifec
 	@Override
 	public void stop(Runnable callback) {
 		Collection<MessageListenerContainer> listenerContainersToStop = getListenerContainers();
-		AggregatingCallback aggregatingCallback = new AggregatingCallback(listenerContainersToStop.size(), callback);
-		for (MessageListenerContainer listenerContainer : listenerContainersToStop) {
-			if (listenerContainer.isRunning()) {
-				listenerContainer.stop(aggregatingCallback);
+		if (listenerContainersToStop.size() > 0) {
+			AggregatingCallback aggregatingCallback = new AggregatingCallback(listenerContainersToStop.size(), callback);
+			for (MessageListenerContainer listenerContainer : listenerContainersToStop) {
+				if (listenerContainer.isRunning()) {
+					listenerContainer.stop(aggregatingCallback);
+				}
+				else {
+					aggregatingCallback.run();
+				}
 			}
-			else {
-				aggregatingCallback.run();
-			}
+		}
+		else {
+			callback.run();
 		}
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
@@ -408,6 +408,9 @@ public abstract class AbstractMessageListenerContainer<K, V>
 				doStop(callback);
 				publishContainerStoppedEvent();
 			}
+			else {
+				callback.run();
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-kafka/issues/1134

We always have to call `callback` in the `stop(Runnable)` implementation
independently of the component state

**Cherry-pick until 1.3.x to support Spring Boot 1.5.x**