### PR TITLE
GH-1137: Fix Json Type Headers for KStream

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/converter/AbstractJavaTypeMapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/converter/AbstractJavaTypeMapper.java
@@ -19,7 +19,6 @@ package org.springframework.kafka.support.converter;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.Map;
 
 import org.apache.kafka.common.header.Header;
@@ -157,12 +156,11 @@ public abstract class AbstractJavaTypeMapper implements BeanClassLoaderAware {
 	}
 
 	protected String retrieveHeaderAsString(Headers headers, String headerName) {
-		Iterator<Header> headerValues = headers.headers(headerName).iterator();
-		if (headerValues.hasNext()) {
-			Header headerValue = headerValues.next();
+		Header header = headers.lastHeader(headerName);
+		if (header != null) {
 			String classId = null;
-			if (headerValue.value() != null) {
-				classId = new String(headerValue.value(), StandardCharsets.UTF_8);
+			if (header.value() != null) {
+				classId = new String(header.value(), StandardCharsets.UTF_8);
 			}
 			return classId;
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/converter/DefaultJackson2JavaTypeMapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/converter/DefaultJackson2JavaTypeMapper.java
@@ -160,7 +160,12 @@ public class DefaultJackson2JavaTypeMapper extends AbstractJavaTypeMapper
 
 	@Override
 	public void fromJavaType(JavaType javaType, Headers headers) {
-		addHeader(headers, getClassIdFieldName(), javaType.getRawClass());
+		String classIdFieldName = getClassIdFieldName();
+		if (headers.lastHeader(classIdFieldName) != null) {
+			removeHeaders(headers);
+		}
+
+		addHeader(headers, classIdFieldName, javaType.getRawClass());
 
 		if (javaType.isContainerType() && !javaType.isArrayType()) {
 			addHeader(headers, getContentClassIdFieldName(), javaType.getContentType().getRawClass());

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java
@@ -18,6 +18,7 @@ package org.springframework.kafka.support.serializer;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Map;
 
 import org.apache.kafka.common.errors.SerializationException;
@@ -118,6 +119,8 @@ public class JsonDeserializer<T> implements Deserializer<T> {
 	private boolean typeMapperExplicitlySet = false;
 
 	private boolean removeTypeHeaders = true;
+
+	private boolean useTypeHeaders = true;
 
 	/**
 	 * Construct an instance with a default {@link ObjectMapper}.
@@ -305,6 +308,21 @@ public class JsonDeserializer<T> implements Deserializer<T> {
 		this.removeTypeHeaders = removeTypeHeaders;
 	}
 
+	/**
+	 * Set to false to ignore type information in headers and use the configured
+	 * target type instead.
+	 * Only applies if the preconfigured type mapper is used.
+	 * Default true.
+	 * @param useTypeHeaders false to ignore type headers.
+	 * @since 2.2.8
+	 */
+	public void setUseTypeHeaders(boolean useTypeHeaders) {
+		if (!this.typeMapperExplicitlySet) {
+			this.useTypeHeaders = useTypeHeaders;
+			setUpTypePrecedence(Collections.emptyMap());
+		}
+	}
+
 	@Override
 	public void configure(Map<String, ?> configs, boolean isKey) {
 		setUseTypeMapperForKey(isKey);
@@ -327,11 +345,10 @@ public class JsonDeserializer<T> implements Deserializer<T> {
 
 	private void setUpTypePrecedence(Map<String, ?> configs) {
 		if (!this.typeMapperExplicitlySet) {
-			boolean useTypeHeaders = true;
 			if (configs.containsKey(USE_TYPE_INFO_HEADERS)) {
-				useTypeHeaders = Boolean.parseBoolean(configs.get(USE_TYPE_INFO_HEADERS).toString());
+				this.useTypeHeaders = Boolean.parseBoolean(configs.get(USE_TYPE_INFO_HEADERS).toString());
 			}
-			this.typeMapper.setTypePrecedence(useTypeHeaders ? TypePrecedence.TYPE_ID : TypePrecedence.INFERRED);
+			this.typeMapper.setTypePrecedence(this.useTypeHeaders ? TypePrecedence.TYPE_ID : TypePrecedence.INFERRED);
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-kafka/issues/1137

- use `lastHeader()` to ensure we retrieve the latest header
- clear the headers when serializing, if already present
- also expose the existing deser `useTypeHeaders` Kafka property as a property directly

**cherry-pick to 2.2.x**