### PR TITLE
GH-1125 Handle deserialization errors by using FailedDeserialization POJO

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ErrorHandlingDeserializer2.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ErrorHandlingDeserializer2.java
@@ -104,8 +104,8 @@ public class ErrorHandlingDeserializer2<T> implements Deserializer<T> {
 		setFailedDeserializationFunction((failed) -> failedDeserializationFunction.apply(failed.getData(), failed.getHeaders()));
 	}
 	/**
-	 * Set in order to have a supplier for a T value when deserialization fails.
-	 * @param failedDeserializationFunction Function type param to he invoked.
+	 * Called this method passing a Function<FailedDeserializationInfo, T> in order to have a supplier for a T value when deserialization fails.
+	 * @param failedDeserializationFunction Function type param to be invoked.
 	 * @since 2.3
 	 */
 	public void setFailedDeserializationFunction(Function<FailedDeserializationInfo, T> failedDeserializationFunction) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ErrorHandlingDeserializer2.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ErrorHandlingDeserializer2.java
@@ -105,7 +105,7 @@ public class ErrorHandlingDeserializer2<T> implements Deserializer<T> {
 	 */
 	@Deprecated
 	public void setFailedDeserializationFunction(BiFunction<byte[], Headers, T> failedDeserializationFunction) {
-		this.failedDeserializationFunction = (failed) -> failedDeserializationFunction.apply(failed.getData(), failed.getHeaders());
+		setFailedDeserializationFunction((failed) -> failedDeserializationFunction.apply(failed.getData(), failed.getHeaders()));
 	}
 
 	public void setFailedDeserializationFunction(Function<FailedDeserializationInfo, T> failedDeserializationFunction) {
@@ -188,7 +188,7 @@ public class ErrorHandlingDeserializer2<T> implements Deserializer<T> {
 			return this.delegate.deserialize(topic, data);
 		}
 		catch (Exception e) {
-			return recoverFromSupplier(topic, data, e);
+			return recoverFromSupplier(topic, null, data, e);
 		}
 	}
 
@@ -205,18 +205,8 @@ public class ErrorHandlingDeserializer2<T> implements Deserializer<T> {
 
 	private T recoverFromSupplier(String topic, Headers headers, byte[] data, Exception exception) {
 		if (this.failedDeserializationFunction != null) {
-			FailedDeserializationInfo t = new FailedDeserializationInfo(topic, headers, data, this.isForKey, exception);
-			return this.failedDeserializationFunction.apply(t);
-		}
-		else {
-			return null;
-		}
-	}
-
-	private T recoverFromSupplier(String topic, byte[] data, Exception exception) {
-		if (this.failedDeserializationFunction != null) {
-			FailedDeserializationInfo t = new FailedDeserializationInfo(topic, null, data, this.isForKey, exception);
-			return this.failedDeserializationFunction.apply(t);
+			FailedDeserializationInfo failedDeserializationInfo = new FailedDeserializationInfo(topic, headers, data, this.isForKey, exception);
+			return this.failedDeserializationFunction.apply(failedDeserializationInfo);
 		}
 		else {
 			return null;

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ErrorHandlingDeserializer2.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ErrorHandlingDeserializer2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,10 +83,6 @@ public class ErrorHandlingDeserializer2<T> implements Deserializer<T> {
 
 	private boolean isForKey;
 
-	/**
-	 * Set in order to have a supplier for a T value when deserialization fails.
-	 * @since 2.3
-	 */
 	private Function<FailedDeserializationInfo, T> failedDeserializationFunction;
 
 	public ErrorHandlingDeserializer2() {
@@ -100,14 +96,18 @@ public class ErrorHandlingDeserializer2<T> implements Deserializer<T> {
 	/**
 	 * Provides an alternative supplying mechanism when deserialization fails.
 	 * @param failedDeserializationFunction BiFunction type param to he invoked.
-	 * @since 1.3
+	 * @since 2.3
 	 * @deprecated in favor of {@link ErrorHandlingDeserializer2#setFailedDeserializationFunction(Function)}.
 	 */
-	@Deprecated
+	@Deprecated(since = "2.8")
 	public void setFailedDeserializationFunction(BiFunction<byte[], Headers, T> failedDeserializationFunction) {
 		setFailedDeserializationFunction((failed) -> failedDeserializationFunction.apply(failed.getData(), failed.getHeaders()));
 	}
-
+	/**
+	 * Set in order to have a supplier for a T value when deserialization fails.
+	 * @param failedDeserializationFunction Function type param to he invoked.
+	 * @since 2.3
+	 */
 	public void setFailedDeserializationFunction(Function<FailedDeserializationInfo, T> failedDeserializationFunction) {
 		this.failedDeserializationFunction = failedDeserializationFunction;
 	}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ErrorHandlingDeserializer2.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ErrorHandlingDeserializer2.java
@@ -104,7 +104,7 @@ public class ErrorHandlingDeserializer2<T> implements Deserializer<T> {
 		setFailedDeserializationFunction((failed) -> failedDeserializationFunction.apply(failed.getData(), failed.getHeaders()));
 	}
 	/**
-	 * Called this method passing a Function<FailedDeserializationInfo, T> in order to have a supplier for a T value when deserialization fails.
+	 * Set this method by passing a Function that provides an alternative T value supplier when deserialization fails.
 	 * @param failedDeserializationFunction Function type param to be invoked.
 	 * @since 2.3
 	 */

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ErrorHandlingDeserializer2.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ErrorHandlingDeserializer2.java
@@ -97,9 +97,9 @@ public class ErrorHandlingDeserializer2<T> implements Deserializer<T> {
 	 * Provides an alternative supplying mechanism when deserialization fails.
 	 * @param failedDeserializationFunction BiFunction type param to he invoked.
 	 * @since 2.3
-	 * @deprecated in favor of {@link ErrorHandlingDeserializer2#setFailedDeserializationFunction(Function)}.
+	 * @deprecated since 2.3 in favor of {@link ErrorHandlingDeserializer2#setFailedDeserializationFunction(Function)}.
 	 */
-	@Deprecated(since = "2.8")
+	@Deprecated
 	public void setFailedDeserializationFunction(BiFunction<byte[], Headers, T> failedDeserializationFunction) {
 		setFailedDeserializationFunction((failed) -> failedDeserializationFunction.apply(failed.getData(), failed.getHeaders()));
 	}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ErrorHandlingDeserializer2.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ErrorHandlingDeserializer2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2018-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/FailedDeserializationInfo.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/FailedDeserializationInfo.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 the original author or authors.
+ * Copyright 2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/FailedDeserializationInfo.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/FailedDeserializationInfo.java
@@ -79,7 +79,7 @@ public class FailedDeserializationInfo {
 	public String toString() {
 		return "FailedDeserializationInfo{" +
 				"topic='" + this.topic + '\'' +
-				", headers=" + headers +
+				", headers=" + this.headers +
 				", data=" + Arrays.toString(this.data) +
 				", isForKey=" + this.isForKey +
 				", exception=" + this.exception +

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/FailedDeserializationInfo.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/FailedDeserializationInfo.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2018-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support.serializer;
+
+import java.util.Arrays;
+
+import org.apache.kafka.common.header.Headers;
+
+/**
+ * Class containing all the contextual information around a deserialization error.
+ *
+ * @author Victor Perez Rey
+ *
+ * @since 2.3
+ */
+public class FailedDeserializationInfo {
+
+	private final String topic;
+
+	private final Headers headers;
+
+	private final byte[] data;
+
+	private final boolean isForKey;
+
+	private final Exception exception;
+
+	/**
+	 * Construct an instance with the contextual information.
+	 * @param topic    topic associated with the data.
+	 * @param headers  headers associated with the record; may be empty.
+	 * @param data     serialized bytes; may be null; implementations are recommended to handle null by returning a value or null rather than throwing an exception.
+	 * @param isForKey true for a key deserializer, false otherwise.
+	 * @param exception exception causing the deserialization error.
+	 */
+	public FailedDeserializationInfo(String topic, Headers headers, byte[] data, boolean isForKey, Exception exception) {
+		this.topic = topic;
+		this.headers = headers;
+		this.data = data;
+		this.isForKey = isForKey;
+		this.exception = exception;
+	}
+
+	public String getTopic() {
+		return this.topic;
+	}
+
+	public Headers getHeaders() {
+		return this.headers;
+	}
+
+	public byte[] getData() {
+		return this.data;
+	}
+
+	public boolean isForKey() {
+		return this.isForKey;
+	}
+
+	public Exception getException() {
+		return this.exception;
+	}
+
+	@Override
+	public String toString() {
+		return "FailedDeserializationInfo{" +
+				"topic='" + this.topic + '\'' +
+				", headers=" + headers +
+				", data=" + Arrays.toString(this.data) +
+				", isForKey=" + this.isForKey +
+				", exception=" + this.exception +
+				'}';
+	}
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/BatchListenerConversion2Tests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/BatchListenerConversion2Tests.java
@@ -22,11 +22,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
-import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -43,6 +42,7 @@ import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.support.converter.BytesJsonMessageConverter;
 import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer2;
+import org.springframework.kafka.support.serializer.FailedDeserializationInfo;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 import org.springframework.kafka.test.rule.EmbeddedKafkaRule;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
@@ -197,23 +197,22 @@ public class BatchListenerConversion2Tests {
 
 	public static class BadFoo extends Foo {
 
-		private final byte[] failedDecode;
+		private final FailedDeserializationInfo failedDeserializationInfo;
 
-		public BadFoo(byte[] failedDecode) {
-			this.failedDecode = failedDecode;
+		public BadFoo(FailedDeserializationInfo failedDeserializationInfo) {
+			this.failedDeserializationInfo = failedDeserializationInfo;
 		}
 
-		public byte[] getFailedDecode() {
-			return this.failedDecode;
+		public FailedDeserializationInfo getFailedDeserializationInfo() {
+			return failedDeserializationInfo;
 		}
-
 	}
 
-	public static class FailedFooProvider implements BiFunction<byte[], Headers, Foo> {
+	public static class FailedFooProvider implements Function<FailedDeserializationInfo, Foo> {
 
 		@Override
-		public Foo apply(byte[] t, Headers u) {
-			return new BadFoo(t);
+		public Foo apply(FailedDeserializationInfo failedDeserializationInfo) {
+			return new BadFoo(failedDeserializationInfo);
 		}
 
 	}

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -2710,9 +2710,9 @@ If the delegate fails to deserialize the record content, the `ErrorHandlingDeser
 When you use a record-level `MessageListener`, if the `ConsumerRecord` contains a `DeserializationException` header for either the key or value, the container's `ErrorHandler` is called with the failed `ConsumerRecord`.
 The record is not passed to the listener.
 
-Alternatively, you can configure the `ErrorHandlingDeserializer2` to create a custom value by providing a `failedDeserializationFunction`, which is a `BiConsumer<byte[], Headers, T>`.
+Alternatively, you can configure the `ErrorHandlingDeserializer2` to create a custom value by providing a `failedDeserializationFunction`, which is a `Function<FailedDeserializationInfo, T>`.
 This function is invoked to create an instance of `T`, which is passed to the listener in the usual fashion.
-The raw record value and headers are provided to the function.
+An object of type `FailedDeserializationInfo`, which contains all the contextual information is provided to the function.
 You can find the `DeserializationException` (as a serialized Java object) in headers.
 See the https://docs.spring.io/spring-kafka/api/org/springframework/kafka/support/serializer/ErrorHandlingDeserializer2.html[Javadoc] for the `ErrorHandlingDeserializer2` for more information.
 
@@ -2747,23 +2747,23 @@ The following example uses a `failedDeserializationFunction`.
 ----
 public class BadFoo extends Foo {
 
-  private final byte[] failedDecode;
+  private final FailedDeserializationInfo failedDeserializationInfo;
 
-  public BadFoo(byte[] failedDecode) {
-    this.failedDecode = failedDecode;
+  public BadFoo(FailedDeserializationInfo failedDeserializationInfo) {
+    this.failedDeserializationInfo = failedDeserializationInfo;
   }
 
-  public byte[] getFailedDecode() {
-    return this.failedDecode;
+  public FailedDeserializationInfo getFailedDeserializationInfo() {
+    return this.failedDeserializationInfo;
   }
 
 }
 
-public class FailedFooProvider implements BiFunction<byte[], Headers, Foo> {
+public class FailedFooProvider implements Function<FailedDeserializationInfo, Foo> {
 
   @Override
-  public Foo apply(byte[] t, Headers u) {
-    return new BadFoo(t);
+  public Foo apply(FailedDeserializationInfo info) {
+    return new BadFoo(info);
   }
 
 }

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -99,3 +99,10 @@ See <<transaction-id-prefix>> for more information.
 
 The framework now provides a delegating `Serializer` and `Deserializer`, utilizing a header to enable producing and consuming records with multiple key/value types.
 See <<delegating-serialization>> for more information.
+
+==== New function for recovering from deserializing errors
+
+`ErrorHandlingDeserializer2` now uses a POJO (`FailedDeserializationInfo`) for passing all the contextual information
+around a deserialization error.
+This enables the code to access to extra information that was missing in the old
+`BiFunction<byte[], Headers, T> failedDeserializationFunction`

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -102,7 +102,5 @@ See <<delegating-serialization>> for more information.
 
 ==== New function for recovering from deserializing errors
 
-`ErrorHandlingDeserializer2` now uses a POJO (`FailedDeserializationInfo`) for passing all the contextual information
-around a deserialization error.
-This enables the code to access to extra information that was missing in the old
-`BiFunction<byte[], Headers, T> failedDeserializationFunction`
+`ErrorHandlingDeserializer2` now uses a POJO (`FailedDeserializationInfo`) for passing all the contextual information around a deserialization error.
+This enables the code to access to extra information that was missing in the old `BiFunction<byte[], Headers, T> failedDeserializationFunction`

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -103,4 +103,4 @@ See <<delegating-serialization>> for more information.
 ==== New function for recovering from deserializing errors
 
 `ErrorHandlingDeserializer2` now uses a POJO (`FailedDeserializationInfo`) for passing all the contextual information around a deserialization error.
-This enables the code to access to extra information that was missing in the old `BiFunction<byte[], Headers, T> failedDeserializationFunction`
+This enables the code to access to extra information that was missing in the old `BiFunction<byte[], Headers, T> failedDeserializationFunction`.


### PR DESCRIPTION
Addresses GH-1125.

Main ideas:
+ It does not enforces one single function to be set, it simply makes the new one to take precedence.
+ When setting the function/supplier via configuration, one single configuration key/value pair is enough. It tries to fit in any of the two possible options, otherwise, raises errors.
+ I'd personally rename `private BiFunction<byte[], Headers, T> failedDeserializationFunction;` to `failedDeserializationBiFunction`, respecting the name at setter level. However i read about avoiding sugar refactoring as rule of thumb.