### PR TITLE
AckMode.MANUAL_IMMEDIATE - wake Consumer

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -756,7 +756,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 					pollAndInvoke();
 				}
 				catch (@SuppressWarnings(UNUSED) WakeupException e) {
-					// Ignore, we're stopping
+					// Ignore, we're stopping or applying immediate foreign acks
 				}
 				catch (NoOffsetForPartitionException nofpe) {
 					this.fatalError = true;
@@ -947,6 +947,9 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			if (!Thread.currentThread().equals(this.consumerThread)) {
 				try {
 					this.acks.put(record);
+					if (this.isManualImmediateAck) {
+						this.consumer.wakeup();
+					}
 				}
 				catch (InterruptedException e) {
 					Thread.currentThread().interrupt();


### PR DESCRIPTION
When processing manual acks on a "foreign" thread, the commits are
not made until the consumer wakes from his `poll()`.

For `AckMode.MANUAL_IMMEDIATE`, we should wake the consumer so the
offset(s) are committed as soon as possible.

**cherry-pick to 2.2.x**