### PR TITLE
Use StreamsBuilder#build(Properties) to allow topology optimization

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/config/StreamsBuilderFactoryBean.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/StreamsBuilderFactoryBean.java
@@ -49,6 +49,7 @@ import org.springframework.util.Assert;
  * @author Soby Chacko
  * @author Zach Olauson
  * @author Nurettin Yilmaz
+ * @author Denis Washington
  *
  * @since 1.1.4
  */
@@ -290,7 +291,12 @@ public class StreamsBuilderFactoryBean extends AbstractFactoryBean<StreamsBuilde
 			try {
 				Assert.state(this.streamsConfig != null || this.properties != null,
 						"'streamsConfig' or streams configuration properties must not be null");
-				Topology topology = getObject().build(); // NOSONAR
+				Properties topologyProps = this.properties;
+				if (topologyProps == null) {
+					topologyProps = new Properties();
+					topologyProps.putAll(this.streamsConfig.originals());
+				}
+				Topology topology = getObject().build(topologyProps); // NOSONAR: getObject() cannot return null
 				LOGGER.debug(() -> topology.describe().toString());
 				if (this.properties != null) {
 					this.kafkaStreams = new KafkaStreams(topology, this.properties, this.clientSupplier);

--- a/spring-kafka/src/test/java/org/springframework/kafka/config/StreamsBuilderFactoryBeanTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/config/StreamsBuilderFactoryBeanTests.java
@@ -51,6 +51,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
  * @author Pawel Szymczyk
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Denis Washington
  */
 @SpringJUnitConfig
 @DirtiesContext

--- a/spring-kafka/src/test/java/org/springframework/kafka/config/StreamsBuilderFactoryBeanTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/config/StreamsBuilderFactoryBeanTests.java
@@ -17,6 +17,8 @@
 package org.springframework.kafka.config;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -24,7 +26,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Properties;
 
+import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -66,6 +70,9 @@ public class StreamsBuilderFactoryBeanTests {
 	@Autowired
 	private StreamsBuilderFactoryBean streamsBuilderFactoryBean;
 
+	@Autowired
+	private KafkaStreamsConfiguration kafkaStreamsConfiguration;
+
 	@Test
 	public void testCleanupStreams() throws IOException {
 		Files.createDirectory(Paths.get(stateStoreDir.toString(), APPLICATION_ID));
@@ -78,6 +85,36 @@ public class StreamsBuilderFactoryBeanTests {
 		assertThat(stateStore).exists();
 		streamsBuilderFactoryBean.start();
 		assertThat(stateStore).doesNotExist();
+	}
+
+	@Test
+	public void testBuildWithProperties() throws Exception {
+		streamsBuilderFactoryBean = new StreamsBuilderFactoryBean(kafkaStreamsConfiguration) {
+			@Override
+			protected StreamsBuilder createInstance() {
+				return spy(super.createInstance());
+			}
+		};
+		streamsBuilderFactoryBean.afterPropertiesSet();
+		streamsBuilderFactoryBean.start();
+		StreamsBuilder streamsBuilder = streamsBuilderFactoryBean.getObject();
+		verify(streamsBuilder).build(kafkaStreamsConfiguration.asProperties());
+	}
+
+	@Test
+	@SuppressWarnings("deprecation")
+	public void testBuildWithStreamsConfig() throws Exception {
+		StreamsConfig streamsConfig = new StreamsConfig(kafkaStreamsConfiguration.asProperties());
+		streamsBuilderFactoryBean = new StreamsBuilderFactoryBean(streamsConfig) {
+			@Override
+			protected StreamsBuilder createInstance() {
+				return spy(super.createInstance());
+			}
+		};
+		streamsBuilderFactoryBean.afterPropertiesSet();
+		streamsBuilderFactoryBean.start();
+		StreamsBuilder streamsBuilder = streamsBuilderFactoryBean.getObject();
+		verify(streamsBuilder).build(kafkaStreamsConfiguration.asProperties());
 	}
 
 	@Configuration
@@ -97,6 +134,7 @@ public class StreamsBuilderFactoryBeanTests {
 			Map<String, Object> props = new HashMap<>();
 			props.put(StreamsConfig.APPLICATION_ID_CONFIG, APPLICATION_ID);
 			props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, this.brokerAddresses);
+			props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION, StreamsConfig.OPTIMIZE);
 			props.put(StreamsConfig.STATE_DIR_CONFIG, stateStoreDir.toString());
 			return new KafkaStreamsConfiguration(props);
 		}

--- a/spring-kafka/src/test/java/org/springframework/kafka/config/StreamsBuilderFactoryBeanTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/config/StreamsBuilderFactoryBeanTests.java
@@ -26,7 +26,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
 
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;


### PR DESCRIPTION
Since Kafka Streams 2.1, StreamsBuilder has a `build(Properties)` method whose use is required to benefit from [topology optimization](https://docs.confluent.io/current/streams/developer-guide/optimizing-streams.html) (i.e., the `topology.optimization=all`). 

However, currently `StreamsBuilderFactoryBean` calls the older `build()` without arguments, which, since 2.3, doesn't do any topology optimization at all. (In 2.1.x and 2.2.x, it at least did the KTable
source changelog reuse optimization if `topology.optimization` is set on the `KafkaStreams` level.)

With this PR, we always use `build(Properties)` and thus allow Spring Kafka to make full use of topology optimization by just setting `topology.optimization`.