### PR TITLE
Add relative seek to ConsumerSeekCallback

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerSeekAware.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerSeekAware.java
@@ -91,6 +91,18 @@ public interface ConsumerSeekAware {
 		 */
 		void seekToEnd(String topic, int partition);
 
+		/**
+		 * Queue a seek to a position relative to the start or end of the current position.
+		 * @param topic the topic.
+		 * @param partition the partition.
+		 * @param offset the offset; positive values are relative to the start, negative
+		 * values are relative to the end, unless toCurrent is true.
+		 * @param toCurrent true for the offset to be relative to the current position rather
+		 * than the beginning or end.
+		 * @since 2.3
+		 */
+		void seekRelative(String topic, int partition, long offset, boolean toCurrent);
+
 	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/TopicPartitionInitialOffset.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/TopicPartitionInitialOffset.java
@@ -20,6 +20,8 @@ import java.util.Objects;
 
 import org.apache.kafka.common.TopicPartition;
 
+import org.springframework.lang.Nullable;
+
 /**
  * A configuration container to represent a topic name, partition number and, optionally,
  * an initial offset for it. The initial offset can be:
@@ -35,6 +37,7 @@ import org.apache.kafka.common.TopicPartition;
  * {@link #isRelativeToCurrent()}.</li>
  * </ul>
  * Offsets are applied when the container is {@code start()}ed.
+ * This class is also used for deferred seek operations.
  *
  * @author Artem Bilan
  * @author Gary Russell
@@ -114,6 +117,21 @@ public class TopicPartitionInitialOffset {
 	public TopicPartitionInitialOffset(String topic, int partition, SeekPosition position) {
 		this.topicPartition = new TopicPartition(topic, partition);
 		this.initialOffset = null;
+		this.relativeToCurrent = false;
+		this.position = position;
+	}
+
+	/**
+	 * Construct an instance with the provided {@link SeekPosition}.
+	 * @param topic the topic.
+	 * @param partition the partition.
+	 * @param offset the offset from the seek position.
+	 * @param position {@link SeekPosition}.
+	 * @since 2.3
+	 */
+	public TopicPartitionInitialOffset(String topic, int partition, Long offset, @Nullable SeekPosition position) {
+		this.topicPartition = new TopicPartition(topic, partition);
+		this.initialOffset = offset;
 		this.relativeToCurrent = false;
 		this.position = position;
 	}

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -2058,8 +2058,17 @@ void seek(String topic, int partition, long offset);
 void seekToBeginning(String topic, int partition);
 
 void seekToEnd(String topic, int partition);
+
+void seekRelative(String topic, int partition, long offset, boolean toCurrent);
 ----
 ====
+
+`seekRelative` was added in version 2.3, to perform relative seeks.
+
+* `offset` negative and `toCurrent` `false` - seek relative to the end of the partition.
+* `offset` positive and `toCurrent` `false` - seek relative to the beginning of the partition.
+* `offset` negative and `toCurrent` `true` - seek relative to the current position (rewind).
+* `offset` positive and `toCurrent` `true` - seek relative to the current position (fast forward).
 
 You can also perform seek operations from `onIdleContainer()` when an idle container is detected.
 See <<idle-containers>> for how to enable idle container detection.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -42,6 +42,9 @@ The container has a new property `recordInterceptor` allowing records to be insp
 A `CompositeRecordInterceptor` is also provided in case you need to invoke multiple interceptors.
 See <<message-listener-container>> for more information.
 
+The `ConsumerSeekAware` has a new method allowing you to perform seeks relative to the beginning, end, or current position.
+See <<seek>> for more information.
+
 ==== ErrorHandler Changes
 
 The `SeekToCurrentErrorHandler` now treats certain exceptions as fatal and disables retry for those, invoking the recoverer on first failure.


### PR DESCRIPTION
- enable users to perform seeks, relative to the partition start, end,
or current position.