### PR TITLE
Bump to the latest BUILD-SNAPSHOTs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,8 +92,8 @@ subprojects { subproject ->
 		scalaVersion = '2.12'
 		springRetryVersion = '1.2.4.RELEASE'
 		springVersion = '5.2.0.BUILD-SNAPSHOT'
-		springDataCommonsVersion = '2.2.0.RC1'
-		reactorVersion = '3.3.0.M2'
+		springDataCommonsVersion = '2.2.0.BUILD-SNAPSHOT'
+		reactorVersion = '3.3.0.BUILD-SNAPSHOT'
 		reactorKafkaVersion = '1.1.1.RELEASE'
 
 		idPrefix = 'kafka'
@@ -241,7 +241,10 @@ project ('spring-kafka') {
 		compile ("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion", optional)
 
 		// Spring Data projection message binding support
-		compile ("org.springframework.data:spring-data-commons:$springDataCommonsVersion", optional)
+		compile ("org.springframework.data:spring-data-commons:$springDataCommonsVersion") {
+			optional(it)
+			exclude group: 'org.springframework'
+		}
 		compile ("com.jayway.jsonpath:json-path:$jaywayJsonPathVersion", optional)
 
 		//Reactive

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -1742,9 +1742,9 @@ public class EnableKafkaIntegrationTests {
 		@KafkaListener(id = "seekOnIdle", topics = "seekOnIdle", autoStartup = "false", concurrency = "2",
 				clientIdPrefix = "seekOnIdle", containerFactory = "kafkaManualAckListenerContainerFactory")
 		public void listen(@SuppressWarnings("unused") String in, Acknowledgment ack) {
-			this.latch1.countDown();
-			this.latch2.countDown();
 			this.latch3.countDown();
+			this.latch2.countDown();
+			this.latch1.countDown();
 			ack.acknowledge();
 		}
 


### PR DESCRIPTION
After introducing a `BeanDefinition.getResolvableType()` we have
several failed builds because of `NoSuchMethodError`.
Looks like interface and its implementation classes are loaded from
different versions.

* Exclude `org.springframework` from `spring-data-commons` to avoid
CLASSPATH conflicts

Related to
https://build.spring.io/browse/SK-SON-1242/
https://github.com/spring-projects/spring-framework/issues/23178