### PR TITLE
Update assert messages to supplier messages

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
@@ -546,12 +546,12 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 	private List<TopicPartitionOffset> resolveTopicPartitionsList(TopicPartition topicPartition) {
 		Object topic = resolveExpression(topicPartition.topic());
 		Assert.state(topic instanceof String,
-				"topic in @TopicPartition must resolve to a String, not " + topic.getClass());
+				() -> "topic in @TopicPartition must resolve to a String, not " + topic.getClass());
 		Assert.state(StringUtils.hasText((String) topic), "topic in @TopicPartition must not be empty");
 		String[] partitions = topicPartition.partitions();
 		PartitionOffset[] partitionOffsets = topicPartition.partitionOffsets();
 		Assert.state(partitions.length > 0 || partitionOffsets.length > 0,
-				"At least one 'partition' or 'partitionOffset' required in @TopicPartition for topic '" + topic + "'");
+				() -> "At least one 'partition' or 'partitionOffset' required in @TopicPartition for topic '" + topic + "'");
 		List<TopicPartitionOffset> result = new ArrayList<>();
 		for (String partition : partitions) {
 			resolvePartitionAsInteger((String) topic, resolveExpression(partition), result);
@@ -580,7 +580,7 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 		Integer partition;
 		if (partitionValue instanceof String) {
 			Assert.state(StringUtils.hasText((String) partitionValue),
-					"partition in @PartitionOffset for topic '" + topic + "' cannot be empty");
+					() -> "partition in @PartitionOffset for topic '" + topic + "' cannot be empty");
 			partition = Integer.valueOf((String) partitionValue);
 		}
 		else if (partitionValue instanceof Integer) {
@@ -599,7 +599,7 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 		Long initialOffset;
 		if (initialOffsetValue instanceof String) {
 			Assert.state(StringUtils.hasText((String) initialOffsetValue),
-					"'initialOffset' in @PartitionOffset for topic '" + topic + "' cannot be empty");
+					() -> "'initialOffset' in @PartitionOffset for topic '" + topic + "' cannot be empty");
 			initialOffset = Long.valueOf((String) initialOffsetValue);
 		}
 		else if (initialOffsetValue instanceof Long) {
@@ -661,7 +661,7 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 		}
 		else if (resolvedValue instanceof String) {
 			Assert.state(StringUtils.hasText((String) resolvedValue),
-					"partition in @TopicPartition for topic '" + topic + "' cannot be empty");
+					() -> "partition in @TopicPartition for topic '" + topic + "' cannot be empty");
 			result.add(new TopicPartitionOffset(topic, Integer.valueOf((String) resolvedValue)));
 		}
 		else if (resolvedValue instanceof Integer[]) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
@@ -471,7 +471,8 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 			adapter.setReplyHeadersConfigurer(this.replyHeadersConfigurer);
 		}
 		Object messageListener = adapter;
-		Assert.state(messageListener != null, "Endpoint [" + this + "] must provide a non null message listener");
+		Assert.state(messageListener != null,
+				() -> "Endpoint [" + this + "] must provide a non null message listener");
 		if (this.retryTemplate != null) {
 			messageListener = new RetryingMessageListenerAdapter<>((MessageListener<K, V>) messageListener,
 					this.retryTemplate, this.recoveryCallback, this.statefulRetry);

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -752,7 +752,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			Assert.state(batch
 						? BatchErrorHandler.class.isAssignableFrom(clazz)
 						: ErrorHandler.class.isAssignableFrom(clazz),
-					"Error handler is not compatible with the message listener, expecting an instance of "
+					() -> "Error handler is not compatible with the message listener, expecting an instance of "
 					+ (batch ? "BatchErrorHandler" : "ErrorHandler") + " not " + errHandler.getClass().getName());
 		}
 


### PR DESCRIPTION
Improve the code by using supplier in the assert messages instead of static messages.

We had a problem in our project, because of the string generation in AbstractKafkaListenerEndpoint Line [474](https://github.com/spring-projects/spring-kafka/blob/2a05612410788ddaa1527da2ad9e4dd0ed63486e/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java#L474). The method endpointDescription in MethodKafkaListenerEndpoint needs the EventListener Bean, which in our case was not yet correctly initialized.

By using the lazy message generation our problem was solved and in the same context I also updated the other assert calls.