### PR TITLE
Embeded broker - automatically set num.partitions

### DIFF
--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaBroker.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaBroker.java
@@ -231,6 +231,9 @@ public class EmbeddedKafkaBroker implements InitializingBean, DisposableBean {
 			if (this.brokerProperties != null) {
 				this.brokerProperties.forEach(brokerConfigProperties::put);
 			}
+			if (!this.brokerProperties.containsKey(KafkaConfig.NumPartitionsProp())) {
+				brokerConfigProperties.setProperty(KafkaConfig.NumPartitionsProp(), "" + this.partitionsPerTopic);
+			}
 			KafkaServer server = TestUtils.createServer(new KafkaConfig(brokerConfigProperties), Time.SYSTEM);
 			this.kafkaServers.add(server);
 			if (this.kafkaPorts[i] == 0) {


### PR DESCRIPTION
(if not specified by the user).

See https://stackoverflow.com/questions/57481979/embedded-kafka-starting-with-wrong-number-of-partitions/57482246#57482246