### PR TITLE
Use close(Duration) instead of close()

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaResourceHolder.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaResourceHolder.java
@@ -16,9 +16,12 @@
 
 package org.springframework.kafka.core;
 
+import java.time.Duration;
+
 import org.apache.kafka.clients.producer.Producer;
 
 import org.springframework.transaction.support.ResourceHolderSupport;
+import org.springframework.util.Assert;
 
 /**
  * Kafka resource holder, wrapping a Kafka producer. KafkaTransactionManager binds instances of this
@@ -33,12 +36,18 @@ public class KafkaResourceHolder<K, V> extends ResourceHolderSupport {
 
 	private final Producer<K, V> producer;
 
+	private final Duration closeTimeout;
+
 	/**
 	 * Construct an instance for the producer.
 	 * @param producer the producer.
+	 * @param closeTimeout the close timeout.
 	 */
-	public KafkaResourceHolder(Producer<K, V> producer) {
+	public KafkaResourceHolder(Producer<K, V> producer, Duration closeTimeout) {
+		Assert.notNull(producer, "'producer' cannot be null");
+		Assert.notNull(closeTimeout, "'closeTimeout' cannot be null");
 		this.producer = producer;
+		this.closeTimeout = closeTimeout;
 	}
 
 	public Producer<K, V> getProducer() {
@@ -50,7 +59,7 @@ public class KafkaResourceHolder<K, V> extends ResourceHolderSupport {
 	}
 
 	public void close() {
-		this.producer.close();
+		this.producer.close(this.closeTimeout);
 	}
 
 	public void rollback() {

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
@@ -174,7 +174,7 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V> {
 	/**
 	 * Set the maximum time to wait when closing a producer; default 5 seconds.
 	 * @param closeTimeout the close timeout.
-	 * @since 1.3.11
+	 * @since 2.3
 	 */
 	public void setCloseTimeout(Duration closeTimeout) {
 		Assert.notNull(closeTimeout, "'closeTimeout' cannot be null");

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
@@ -16,6 +16,7 @@
 
 package org.springframework.kafka.core;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
@@ -80,6 +81,7 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V> {
 
 	private String transactionIdPrefix;
 
+	private Duration closeTimeout = ProducerFactoryUtils.DEFAULT_CLOSE_TIMEOUT;
 
 	/**
 	 * Create an instance using the supplied producer factory and autoFlush false.
@@ -167,6 +169,16 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V> {
 	 */
 	public void setTransactionIdPrefix(String transactionIdPrefix) {
 		this.transactionIdPrefix = transactionIdPrefix;
+	}
+
+	/**
+	 * Set the maximum time to wait when closing a producer; default 5 seconds.
+	 * @param closeTimeout the close timeout.
+	 * @since 1.3.11
+	 */
+	public void setCloseTimeout(Duration closeTimeout) {
+		Assert.notNull(closeTimeout, "'closeTimeout' cannot be null");
+		this.closeTimeout = closeTimeout;
 	}
 
 	/**
@@ -365,9 +377,9 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V> {
 		producer.sendOffsetsToTransaction(offsets, consumerGroupId);
 	}
 
-	protected void closeProducer(Producer<K, V> producer, boolean inLocalTx) {
-		if (!inLocalTx) {
-			producer.close();
+	protected void closeProducer(Producer<K, V> producer, boolean inTx) {
+		if (!inTx) {
+			producer.close(this.closeTimeout);
 		}
 	}
 
@@ -444,7 +456,7 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V> {
 				return producer;
 			}
 			KafkaResourceHolder<K, V> holder = ProducerFactoryUtils
-					.getTransactionalResourceHolder(this.producerFactory, this.transactionIdPrefix);
+					.getTransactionalResourceHolder(this.producerFactory, this.transactionIdPrefix, this.closeTimeout);
 			return holder.getProducer();
 		}
 		else {

--- a/spring-kafka/src/main/java/org/springframework/kafka/transaction/KafkaTransactionManager.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/transaction/KafkaTransactionManager.java
@@ -111,7 +111,7 @@ public class KafkaTransactionManager<K, V> extends AbstractPlatformTransactionMa
 	/**
 	 * Set the maximum time to wait when closing a producer; default 5 seconds.
 	 * @param closeTimeout the close timeout.
-	 * @since 1.3.11
+	 * @since 2.3
 	 */
 	public void setCloseTimeout(Duration closeTimeout) {
 		Assert.notNull(closeTimeout, "'closeTimeout' cannot be null");

--- a/spring-kafka/src/main/java/org/springframework/kafka/transaction/KafkaTransactionManager.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/transaction/KafkaTransactionManager.java
@@ -16,6 +16,8 @@
 
 package org.springframework.kafka.transaction;
 
+import java.time.Duration;
+
 import org.springframework.kafka.core.KafkaResourceHolder;
 import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.core.ProducerFactoryUtils;
@@ -42,9 +44,9 @@ import org.springframework.util.Assert;
  *
  * <p>
  * Application code is required to retrieve the transactional Kafka resources via
- * {@link ProducerFactoryUtils#getTransactionalResourceHolder(ProducerFactory)}. Spring's
- * {@link org.springframework.kafka.core.KafkaTemplate KafkaTemplate} will auto detect a
- * thread-bound Producer and automatically participate in it.
+ * {@link ProducerFactoryUtils#getTransactionalResourceHolder(ProducerFactory, String, java.time.Duration)}.
+ * Spring's {@link org.springframework.kafka.core.KafkaTemplate KafkaTemplate} will auto
+ * detect a thread-bound Producer and automatically participate in it.
  *
  * <p>
  * <b>The use of {@link org.springframework.kafka.core.DefaultKafkaProducerFactory
@@ -71,6 +73,8 @@ public class KafkaTransactionManager<K, V> extends AbstractPlatformTransactionMa
 	private final ProducerFactory<K, V> producerFactory;
 
 	private String transactionIdPrefix;
+
+	private Duration closeTimeout = ProducerFactoryUtils.DEFAULT_CLOSE_TIMEOUT;
 
 	/**
 	 * Create a new KafkaTransactionManager, given a ProducerFactory.
@@ -102,6 +106,16 @@ public class KafkaTransactionManager<K, V> extends AbstractPlatformTransactionMa
 	@Override
 	public ProducerFactory<K, V> getProducerFactory() {
 		return this.producerFactory;
+	}
+
+	/**
+	 * Set the maximum time to wait when closing a producer; default 5 seconds.
+	 * @param closeTimeout the close timeout.
+	 * @since 1.3.11
+	 */
+	public void setCloseTimeout(Duration closeTimeout) {
+		Assert.notNull(closeTimeout, "'closeTimeout' cannot be null");
+		this.closeTimeout = closeTimeout;
 	}
 
 	/**
@@ -144,7 +158,7 @@ public class KafkaTransactionManager<K, V> extends AbstractPlatformTransactionMa
 		KafkaResourceHolder<K, V> resourceHolder = null;
 		try {
 			resourceHolder = ProducerFactoryUtils.getTransactionalResourceHolder(getProducerFactory(),
-					this.transactionIdPrefix);
+					this.transactionIdPrefix, this.closeTimeout);
 			if (logger.isDebugEnabled()) {
 				logger.debug("Created Kafka transaction on producer [" + resourceHolder.getProducer() + "]");
 			}

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaProducerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaProducerFactoryTests.java
@@ -101,7 +101,7 @@ public class DefaultKafkaProducerFactoryTests {
 		inOrder.verify(producer).send(any(), any());
 		inOrder.verify(producer).commitTransaction();
 		inOrder.verify(producer).beginTransaction();
-		inOrder.verify(producer).close();
+		inOrder.verify(producer).close(ProducerFactoryUtils.DEFAULT_CLOSE_TIMEOUT);
 		inOrder.verifyNoMoreInteractions();
 		pf.destroy();
 	}
@@ -120,7 +120,7 @@ public class DefaultKafkaProducerFactoryTests {
 		};
 		Producer aProducer = pf.createProducer();
 		assertThat(aProducer).isNotNull();
-		aProducer.close();
+		aProducer.close(ProducerFactoryUtils.DEFAULT_CLOSE_TIMEOUT);
 		assertThat(KafkaTestUtils.getPropertyValue(pf, "producer")).isNotNull();
 		Map<?, ?> cache = KafkaTestUtils.getPropertyValue(pf, "cache", Map.class);
 		assertThat(cache.size()).isEqualTo(0);

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/TransactionalContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/TransactionalContainerTests.java
@@ -162,7 +162,7 @@ public class TransactionalContainerTests {
 		willAnswer(i -> {
 			closeLatch.countDown();
 			return null;
-		}).given(producer).close();
+		}).given(producer).close(any());
 		ProducerFactory pf = mock(ProducerFactory.class);
 		given(pf.transactionCapable()).willReturn(true);
 		final List<String> transactionalIds = new ArrayList<>();
@@ -197,7 +197,7 @@ public class TransactionalContainerTests {
 		inOrder.verify(producer).sendOffsetsToTransaction(Collections.singletonMap(topicPartition,
 				new OffsetAndMetadata(0)), "group");
 		inOrder.verify(producer).commitTransaction();
-		inOrder.verify(producer).close();
+		inOrder.verify(producer).close(any());
 		inOrder.verify(producer).beginTransaction();
 		ArgumentCaptor<ProducerRecord> captor = ArgumentCaptor.forClass(ProducerRecord.class);
 		inOrder.verify(producer).send(captor.capture(), any(Callback.class));
@@ -205,7 +205,7 @@ public class TransactionalContainerTests {
 		inOrder.verify(producer).sendOffsetsToTransaction(Collections.singletonMap(topicPartition,
 				new OffsetAndMetadata(1)), "group");
 		inOrder.verify(producer).commitTransaction();
-		inOrder.verify(producer).close();
+		inOrder.verify(producer).close(any());
 		container.stop();
 		verify(pf, times(2)).createProducer(isNull());
 		verifyNoMoreInteractions(producer);
@@ -245,7 +245,7 @@ public class TransactionalContainerTests {
 		willAnswer(i -> {
 			closeLatch.countDown();
 			return null;
-		}).given(producer).close();
+		}).given(producer).close(any());
 		ProducerFactory pf = mock(ProducerFactory.class);
 		given(pf.transactionCapable()).willReturn(true);
 		given(pf.createProducer(isNull())).willReturn(producer);
@@ -272,7 +272,7 @@ public class TransactionalContainerTests {
 		inOrder.verify(producer, never()).sendOffsetsToTransaction(anyMap(), anyString());
 		inOrder.verify(producer, never()).commitTransaction();
 		inOrder.verify(producer).abortTransaction();
-		inOrder.verify(producer).close();
+		inOrder.verify(producer).close(any());
 		verify(consumer).seek(topicPartition0, 0);
 		verify(consumer).seek(topicPartition1, 0);
 		verify(consumer, never()).commitSync(anyMap(), any());
@@ -312,7 +312,7 @@ public class TransactionalContainerTests {
 		willAnswer(i -> {
 			closeLatch.countDown();
 			return null;
-		}).given(producer).close();
+		}).given(producer).close(any());
 		ProducerFactory pf = mock(ProducerFactory.class);
 		given(pf.transactionCapable()).willReturn(true);
 		given(pf.createProducer(isNull())).willReturn(producer);
@@ -339,7 +339,7 @@ public class TransactionalContainerTests {
 		inOrder.verify(producer, never()).sendOffsetsToTransaction(anyMap(), anyString());
 		inOrder.verify(producer, never()).commitTransaction();
 		inOrder.verify(producer).abortTransaction();
-		inOrder.verify(producer).close();
+		inOrder.verify(producer).close(any());
 		verify(consumer).seek(topicPartition0, 0);
 		verify(consumer).seek(topicPartition1, 0);
 		verify(consumer, never()).commitSync(anyMap(), any());
@@ -378,7 +378,7 @@ public class TransactionalContainerTests {
 		willAnswer(i -> {
 			closeLatch.countDown();
 			return null;
-		}).given(producer).close();
+		}).given(producer).close(any());
 
 		final ProducerFactory pf = mock(ProducerFactory.class);
 		given(pf.transactionCapable()).willReturn(true);
@@ -406,7 +406,7 @@ public class TransactionalContainerTests {
 		inOrder.verify(producer).sendOffsetsToTransaction(Collections.singletonMap(topicPartition,
 				new OffsetAndMetadata(1)), "group");
 		inOrder.verify(producer).commitTransaction();
-		inOrder.verify(producer).close();
+		inOrder.verify(producer).close(any());
 		container.stop();
 		verify(pf).createProducer(isNull());
 	}


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1196

Add `closeTimeout` to `KafkaTemplate` and `KafkaTransactionManager` (default 5s).
Use a zero timeout if a transaction operation failed with a timeout.