### PR TITLE
GH-1186: Add `idleBetweenPolls` container option

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
@@ -222,6 +222,8 @@ public class ContainerProperties {
 
 	private boolean missingTopicsFatal = true;
 
+	private long idleBetweenPolls;
+
 	private Properties consumerProperties = new Properties();
 
 	/**
@@ -701,6 +703,21 @@ public class ContainerProperties {
 	public void setConsumerProperties(Properties consumerProperties) {
 		Assert.notNull(consumerProperties, "'consumerProperties' cannot be null");
 		this.consumerProperties = consumerProperties;
+	}
+
+	/**
+	 * The sleep interval in milliseconds used in the main loop between
+	 * {@link org.apache.kafka.clients.consumer.Consumer#poll(Duration)} calls.
+	 * Defaults to {@code 0} - no idling.
+	 * @param idleBetweenPolls the interval to sleep between polling cycles.
+	 * @since 2.3
+	 */
+	public void setIdleBetweenPolls(long idleBetweenPolls) {
+		this.idleBetweenPolls = idleBetweenPolls;
+	}
+
+	public long getIdleBetweenPolls() {
+		return this.idleBetweenPolls;
 	}
 
 	@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -648,7 +648,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			boolean isAutoCommit;
 			String autoCommitOverride = consumerProperties.getProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG);
 			if (!KafkaMessageListenerContainer.this.consumerFactory.getConfigurationProperties()
-					.containsKey(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG)
+							.containsKey(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG)
 					&& autoCommitOverride == null) {
 				consumerProperties.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
 				isAutoCommit = false;
@@ -689,9 +689,9 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 					if (timeout != null) {
 						Object timeoutToLog = timeout;
 						this.logger.warn(() -> "Unexpected type: " + timeoutToLog.getClass().getName()
-								+ " in property '"
-								+ ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG
-								+ "'; defaulting to 60 seconds for sync commit timeouts");
+							+ " in property '"
+							+ ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG
+							+ "'; defaulting to 60 seconds for sync commit timeouts");
 					}
 					return Duration.ofSeconds(SIXTY);
 				}
@@ -782,11 +782,10 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			}
 			Class<?> clazz = errHandler.getClass();
 			Assert.state(batch
-							? BatchErrorHandler.class.isAssignableFrom(clazz)
-							: ErrorHandler.class.isAssignableFrom(clazz),
+						? BatchErrorHandler.class.isAssignableFrom(clazz)
+						: ErrorHandler.class.isAssignableFrom(clazz),
 					() -> "Error handler is not compatible with the message listener, expecting an instance of "
-							+ (batch ? "BatchErrorHandler" : "ErrorHandler") + " not " + errHandler.getClass()
-							.getName());
+					+ (batch ? "BatchErrorHandler" : "ErrorHandler") + " not " + errHandler.getClass().getName());
 		}
 
 		@Override
@@ -917,13 +916,19 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			}
 		}
 
-		private void idleBetweenPollIfNecessary() throws InterruptedException {
+		private void idleBetweenPollIfNecessary() {
 			long idleBetweenPolls = this.containerProperties.getIdleBetweenPolls();
 			if (idleBetweenPolls > 0) {
 				idleBetweenPolls = Math.min(idleBetweenPolls,
 						this.maxPollInterval - (System.currentTimeMillis() - this.lastPoll));
 				if (idleBetweenPolls > 0) {
-					TimeUnit.MILLISECONDS.sleep(idleBetweenPolls);
+					try {
+						TimeUnit.MILLISECONDS.sleep(idleBetweenPolls);
+					}
+					catch (InterruptedException ex) {
+						Thread.currentThread().interrupt();
+						throw new IllegalStateException("Consumer Thread [" + this + "] has been interrupted", ex);
+					}
 				}
 			}
 		}
@@ -1092,7 +1097,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 						if (ListenerConsumer.this.kafkaTxManager != null) {
 							producer = ((KafkaResourceHolder) TransactionSynchronizationManager
 									.getResource(ListenerConsumer.this.kafkaTxManager.getProducerFactory()))
-									.getProducer(); // NOSONAR nullable
+										.getProducer(); // NOSONAR nullable
 						}
 						RuntimeException aborted = doInvokeBatchListener(records, recordList, producer);
 						if (aborted != null) {
@@ -1271,7 +1276,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 							if (ListenerConsumer.this.kafkaTxManager != null) {
 								producer = ((KafkaResourceHolder) TransactionSynchronizationManager
 										.getResource(ListenerConsumer.this.kafkaTxManager.getProducerFactory()))
-										.getProducer(); // NOSONAR
+												.getProducer(); // NOSONAR
 							}
 							RuntimeException aborted = doInvokeRecordListener(record, producer, iterator);
 							if (aborted != null) {
@@ -1948,8 +1953,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 						}
 					}
 					else {
-						ContainerProperties containerProps =
-								KafkaMessageListenerContainer.this.getContainerProperties();
+						ContainerProperties containerProps = KafkaMessageListenerContainer.this.getContainerProperties();
 						if (containerProps.isSyncCommits()) {
 							ListenerConsumer.this.consumer.commitSync(offsetsToCommit,
 									containerProps.getSyncCommitTimeout());

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -920,7 +920,8 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			long idleBetweenPolls = this.containerProperties.getIdleBetweenPolls();
 			if (idleBetweenPolls > 0) {
 				idleBetweenPolls = Math.min(idleBetweenPolls,
-						this.maxPollInterval - (System.currentTimeMillis() - this.lastPoll));
+						this.maxPollInterval - (System.currentTimeMillis() - this.lastPoll)
+								- 5000); // NOSONAR - less by five seconds to avoid race condition with rebalance
 				if (idleBetweenPolls > 0) {
 					try {
 						TimeUnit.MILLISECONDS.sleep(idleBetweenPolls);

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -648,7 +648,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			boolean isAutoCommit;
 			String autoCommitOverride = consumerProperties.getProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG);
 			if (!KafkaMessageListenerContainer.this.consumerFactory.getConfigurationProperties()
-							.containsKey(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG)
+					.containsKey(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG)
 					&& autoCommitOverride == null) {
 				consumerProperties.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
 				isAutoCommit = false;
@@ -689,9 +689,9 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 					if (timeout != null) {
 						Object timeoutToLog = timeout;
 						this.logger.warn(() -> "Unexpected type: " + timeoutToLog.getClass().getName()
-							+ " in property '"
-							+ ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG
-							+ "'; defaulting to 60 seconds for sync commit timeouts");
+								+ " in property '"
+								+ ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG
+								+ "'; defaulting to 60 seconds for sync commit timeouts");
 					}
 					return Duration.ofSeconds(SIXTY);
 				}
@@ -782,10 +782,11 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			}
 			Class<?> clazz = errHandler.getClass();
 			Assert.state(batch
-						? BatchErrorHandler.class.isAssignableFrom(clazz)
-						: ErrorHandler.class.isAssignableFrom(clazz),
+							? BatchErrorHandler.class.isAssignableFrom(clazz)
+							: ErrorHandler.class.isAssignableFrom(clazz),
 					() -> "Error handler is not compatible with the message listener, expecting an instance of "
-					+ (batch ? "BatchErrorHandler" : "ErrorHandler") + " not " + errHandler.getClass().getName());
+							+ (batch ? "BatchErrorHandler" : "ErrorHandler") + " not " + errHandler.getClass()
+							.getName());
 		}
 
 		@Override
@@ -806,6 +807,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			while (isRunning()) {
 				try {
 					pollAndInvoke();
+					idleBetweenPollIfNecessary();
 				}
 				catch (@SuppressWarnings(UNUSED) WakeupException e) {
 					// Ignore, we're stopping or applying immediate foreign acks
@@ -827,7 +829,6 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 					wrapUp();
 					throw e;
 				}
-				idleBetweenPollIfNecessary();
 			}
 			wrapUp();
 		}
@@ -851,8 +852,8 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 				processSeeks();
 			}
 			checkPaused();
-			ConsumerRecords<K, V> records = this.consumer.poll(this.pollTimeout);
 			this.lastPoll = System.currentTimeMillis();
+			ConsumerRecords<K, V> records = this.consumer.poll(this.pollTimeout);
 			checkResumed();
 			debugRecords(records);
 			if (records != null && records.count() > 0) {
@@ -916,19 +917,13 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			}
 		}
 
-		private void idleBetweenPollIfNecessary() {
+		private void idleBetweenPollIfNecessary() throws InterruptedException {
 			long idleBetweenPolls = this.containerProperties.getIdleBetweenPolls();
 			if (idleBetweenPolls > 0) {
 				idleBetweenPolls = Math.min(idleBetweenPolls,
 						this.maxPollInterval - (System.currentTimeMillis() - this.lastPoll));
 				if (idleBetweenPolls > 0) {
-					try {
-						TimeUnit.MILLISECONDS.sleep(idleBetweenPolls);
-					}
-					catch (InterruptedException ex) {
-						Thread.currentThread().interrupt();
-						throw new IllegalStateException("Consumer Thread [" + this + "] has been interrupted", ex);
-					}
+					TimeUnit.MILLISECONDS.sleep(idleBetweenPolls);
 				}
 			}
 		}
@@ -1097,7 +1092,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 						if (ListenerConsumer.this.kafkaTxManager != null) {
 							producer = ((KafkaResourceHolder) TransactionSynchronizationManager
 									.getResource(ListenerConsumer.this.kafkaTxManager.getProducerFactory()))
-										.getProducer(); // NOSONAR nullable
+									.getProducer(); // NOSONAR nullable
 						}
 						RuntimeException aborted = doInvokeBatchListener(records, recordList, producer);
 						if (aborted != null) {
@@ -1276,7 +1271,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 							if (ListenerConsumer.this.kafkaTxManager != null) {
 								producer = ((KafkaResourceHolder) TransactionSynchronizationManager
 										.getResource(ListenerConsumer.this.kafkaTxManager.getProducerFactory()))
-												.getProducer(); // NOSONAR
+										.getProducer(); // NOSONAR
 							}
 							RuntimeException aborted = doInvokeRecordListener(record, producer, iterator);
 							if (aborted != null) {
@@ -1953,7 +1948,8 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 						}
 					}
 					else {
-						ContainerProperties containerProps = KafkaMessageListenerContainer.this.getContainerProperties();
+						ContainerProperties containerProps =
+								KafkaMessageListenerContainer.this.getContainerProperties();
 						if (containerProps.isSyncCommits()) {
 							ListenerConsumer.this.consumer.commitSync(offsetsToCommit,
 									containerProps.getSyncCommitTimeout());

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -934,6 +934,9 @@ Starting with version 1.3, the `MessageListenerContainer` provides access to the
 In the case of `ConcurrentMessageListenerContainer`, the `metrics()` method returns the metrics for all the target `KafkaMessageListenerContainer` instances.
 The metrics are grouped into the `Map<MetricName, ? extends Metric>` by the `client-id` provided for the underlying `KafkaConsumer`.
 
+Starting with version 2.3, the `ContainerProperties` provides an `idleBetweenPolls` option to let the main loop in the listener container to sleep between `KafkaConsumer.poll()` calls.
+An actual sleep interval is selected as a minimum from the provided option and difference between a `max.poll.interval.ms` consumer config and the current records batch processing time.
+
 [[committing-offsets]]
 ====== Committing Offsets
 

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -935,7 +935,7 @@ In the case of `ConcurrentMessageListenerContainer`, the `metrics()` method retu
 The metrics are grouped into the `Map<MetricName, ? extends Metric>` by the `client-id` provided for the underlying `KafkaConsumer`.
 
 Starting with version 2.3, the `ContainerProperties` provides an `idleBetweenPolls` option to let the main loop in the listener container to sleep between `KafkaConsumer.poll()` calls.
-An actual sleep interval is selected as a minimum from the provided option and difference between a `max.poll.interval.ms` consumer config and the current records batch processing time.
+An actual sleep interval is selected as the minimum from the provided option and difference between the `max.poll.interval.ms` consumer config and the current records batch processing time.
 
 [[committing-offsets]]
 ====== Committing Offsets

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -52,6 +52,9 @@ See <<seek>> for more information.
 A convenience class `AbstractConsumerSeekAware` is now provided to simplify seeking.
 See <<seek>> for more information.
 
+The `ContainerProperties` provides an `idleBetweenPolls` option to let the main loop in the listener container to sleep between `KafkaConsumer.poll()` calls.
+See its JavaDocs and <<kafka-container>> for more information.
+
 ==== ErrorHandler Changes
 
 The `SeekToCurrentErrorHandler` now treats certain exceptions as fatal and disables retry for those, invoking the recoverer on first failure.


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-kafka/issues/1186

A new `ContainerProperties.idleBetweenPolls` option allows to configure
a sleep interval between `poll` calls in the main container loop.
The actual sleep interval is selected as a minimum from provided
option and difference between `max.poll.interval.ms` and records
processing time