### PR TITLE
GH-1234: Fix FailedRecordTracker [2.2.x]

### DIFF
--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/FailedRecordTrackerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/FailedRecordTrackerTests.java
@@ -19,6 +19,8 @@ package org.springframework.kafka.listener;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.commons.logging.Log;
@@ -55,6 +57,23 @@ public class FailedRecordTrackerTests {
 		assertThat(tracker.skip(record, new RuntimeException())).isFalse();
 		assertThat(tracker.skip(record, new RuntimeException())).isTrue();
 		assertThat(recovered.get()).isTrue();
+	}
+
+	@Test
+	public void testDifferentOrder() {
+		List<ConsumerRecord<?, ?>> records = new ArrayList<>();
+		FailedRecordTracker tracker = new FailedRecordTracker((rec, ex) -> {
+			records.add(rec);
+		}, 3, mock(Log.class));
+		ConsumerRecord<?, ?> record1 = new ConsumerRecord<>("foo", 0, 0L, "bar", "baz");
+		ConsumerRecord<?, ?> record2 = new ConsumerRecord<>("foo", 1, 0L, "bar", "baz");
+		assertThat(tracker.skip(record1, new RuntimeException())).isFalse();
+		assertThat(tracker.skip(record2, new RuntimeException())).isFalse();
+		assertThat(tracker.skip(record1, new RuntimeException())).isFalse();
+		assertThat(tracker.skip(record2, new RuntimeException())).isFalse();
+		assertThat(tracker.skip(record1, new RuntimeException())).isTrue();
+		assertThat(tracker.skip(record2, new RuntimeException())).isTrue();
+		assertThat(records).hasSize(2);
 	}
 
 }


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-kafka/issues/1234

Previous implementation assumed the first redelivered record would be
the one that failed; this is not always the case.

Maintain state for each topic/partition/offset.