### PR TITLE
Pull Up Consumer Properties

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
@@ -376,7 +376,7 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 				.acceptIfNotNull(endpoint.getGroupId(), instance.getContainerProperties()::setGroupId)
 				.acceptIfNotNull(endpoint.getClientIdPrefix(), instance.getContainerProperties()::setClientId)
 				.acceptIfNotNull(endpoint.getConsumerProperties(),
-						instance.getContainerProperties()::setConsumerProperties);
+						instance.getContainerProperties()::setKafkaConsumerProperties);
 	}
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerProperties.java
@@ -18,6 +18,7 @@ package org.springframework.kafka.listener;
 
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Properties;
 import java.util.regex.Pattern;
 
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
@@ -93,6 +94,8 @@ public class ConsumerProperties {
 	private boolean syncCommits = true;
 
 	private LogIfLevelEnabled.Level commitLogLevel = LogIfLevelEnabled.Level.DEBUG;
+
+	private Properties kafkaConsumerProperties = new Properties();
 
 	/**
 	 * Create properties for a container that will subscribe to the specified topics.
@@ -270,6 +273,35 @@ public class ConsumerProperties {
 		this.commitLogLevel = commitLogLevel;
 	}
 
+	/**
+	 * Get the consumer properties that will be merged with the consumer properties
+	 * provided by the consumer factory; properties here will supersede any with the same
+	 * name(s) in the consumer factory.
+	 * {@code group.id} and {@code client.id} are ignored.
+	 * @return the properties.
+	 * @see org.apache.kafka.clients.consumer.ConsumerConfig
+	 * @see #setGroupId(String)
+	 * @see #setClientId(String)
+	 */
+	public Properties getKafkaConsumerProperties() {
+		return this.kafkaConsumerProperties;
+	}
+
+	/**
+	 * Set the consumer properties that will be merged with the consumer properties
+	 * provided by the consumer factory; properties here will supersede any with the same
+	 * name(s) in the consumer factory.
+	 * {@code group.id} and {@code client.id} are ignored.
+	 * @param kafkaConsumerProperties the properties.
+	 * @see org.apache.kafka.clients.consumer.ConsumerConfig
+	 * @see #setGroupId(String)
+	 * @see #setClientId(String)
+	 */
+	public void setKafkaConsumerProperties(Properties kafkaConsumerProperties) {
+		Assert.notNull(kafkaConsumerProperties, "'consumerProperties' cannot be null");
+		this.kafkaConsumerProperties = kafkaConsumerProperties;
+	}
+
 	@Override
 	public String toString() {
 		return "ConsumerProperties ["
@@ -287,7 +319,8 @@ public class ConsumerProperties {
 						: "")
 				+ (this.commitCallback != null ? ", commitCallback=" + this.commitCallback : "")
 				+ ", syncCommits=" + this.syncCommits
-				+ (this.syncCommitTimeout != null ? ", syncCommitTimeout=" + this.syncCommitTimeout : "");
+				+ (this.syncCommitTimeout != null ? ", syncCommitTimeout=" + this.syncCommitTimeout : "")
+				+ (this.kafkaConsumerProperties.size() > 0 ? ", properties=" + this.kafkaConsumerProperties : "");
 	}
 
 	private String renderTopics() {

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerProperties.java
@@ -298,7 +298,7 @@ public class ConsumerProperties {
 	 * @see #setClientId(String)
 	 */
 	public void setKafkaConsumerProperties(Properties kafkaConsumerProperties) {
-		Assert.notNull(kafkaConsumerProperties, "'consumerProperties' cannot be null");
+		Assert.notNull(kafkaConsumerProperties, "'kafkaConsumerProperties' cannot be null");
 		this.kafkaConsumerProperties = kafkaConsumerProperties;
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
@@ -169,8 +169,6 @@ public class ContainerProperties extends ConsumerProperties {
 
 	private long idleBetweenPolls;
 
-	private Properties consumerProperties = new Properties();
-
 	/**
 	 * Create properties for a container that will subscribe to the specified topics.
 	 * @param topics the topics.
@@ -295,7 +293,7 @@ public class ContainerProperties extends ConsumerProperties {
 	 * <ul>
 	 * <li>this property</li>
 	 * <li>{@code ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG} in
-	 * {@link #setConsumerProperties(Properties)}</li>
+	 * {@link #setKafkaConsumerProperties(Properties)}</li>
 	 * <li>{@code ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG} in the consumer factory
 	 * properties</li>
 	 * <li>60 seconds</li>
@@ -498,9 +496,11 @@ public class ContainerProperties extends ConsumerProperties {
 	 * @see org.apache.kafka.clients.consumer.ConsumerConfig
 	 * @see #setGroupId(String)
 	 * @see #setClientId(String)
+	 * @deprecated in favor of {@link #getKafkaConsumerProperties()}.
 	 */
+	@Deprecated
 	public Properties getConsumerProperties() {
-		return this.consumerProperties;
+		return getKafkaConsumerProperties();
 	}
 
 	/**
@@ -513,10 +513,11 @@ public class ContainerProperties extends ConsumerProperties {
 	 * @see org.apache.kafka.clients.consumer.ConsumerConfig
 	 * @see #setGroupId(String)
 	 * @see #setClientId(String)
+	 * @deprecated in favor of {@link #setKafkaConsumerProperties(Properties)}.
 	 */
+	@Deprecated
 	public void setConsumerProperties(Properties consumerProperties) {
-		Assert.notNull(consumerProperties, "'consumerProperties' cannot be null");
-		this.consumerProperties = consumerProperties;
+		setKafkaConsumerProperties(consumerProperties);
 	}
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -534,7 +534,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 
 		@SuppressWarnings(UNCHECKED)
 		ListenerConsumer(GenericMessageListener<?> listener, ListenerType listenerType) {
-			Properties consumerProperties = new Properties(this.containerProperties.getConsumerProperties());
+			Properties consumerProperties = new Properties(this.containerProperties.getKafkaConsumerProperties());
 			this.autoCommit = determineAutoCommit(consumerProperties);
 			this.consumer =
 					KafkaMessageListenerContainer.this.consumerFactory.createConsumer(
@@ -676,7 +676,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 				return this.containerProperties.getSyncCommitTimeout();
 			}
 			else {
-				Object timeout = this.containerProperties.getConsumerProperties()
+				Object timeout = this.containerProperties.getKafkaConsumerProperties()
 						.get(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG);
 				if (timeout == null) {
 					timeout = KafkaMessageListenerContainer.this.consumerFactory.getConfigurationProperties()

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
@@ -86,6 +86,7 @@ public class DefaultKafkaConsumerFactoryTests {
 		DefaultKafkaConsumerFactory<String, String> target =
 				new DefaultKafkaConsumerFactory<String, String>(originalConfig) {
 
+					@Override
 					protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
 						configPassedToKafkaConsumer.putAll(configProps);
 						return null;
@@ -107,6 +108,7 @@ public class DefaultKafkaConsumerFactoryTests {
 		DefaultKafkaConsumerFactory<String, String> target =
 				new DefaultKafkaConsumerFactory<String, String>(originalConfig) {
 
+					@Override
 					protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
 						configPassedToKafkaConsumer.putAll(configProps);
 						return null;
@@ -124,6 +126,7 @@ public class DefaultKafkaConsumerFactoryTests {
 		DefaultKafkaConsumerFactory<String, String> target =
 				new DefaultKafkaConsumerFactory<String, String>(originalConfig) {
 
+					@Override
 					protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
 						configPassedToKafkaConsumer.putAll(configProps);
 						return null;
@@ -139,6 +142,7 @@ public class DefaultKafkaConsumerFactoryTests {
 		DefaultKafkaConsumerFactory<String, String> target =
 				new DefaultKafkaConsumerFactory<String, String>(Collections.emptyMap()) {
 
+					@Override
 					protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
 						configPassedToKafkaConsumer.putAll(configProps);
 						return null;
@@ -155,6 +159,7 @@ public class DefaultKafkaConsumerFactoryTests {
 		DefaultKafkaConsumerFactory<String, String> target =
 				new DefaultKafkaConsumerFactory<String, String>(originalConfig) {
 
+					@Override
 					protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
 						configPassedToKafkaConsumer.putAll(configProps);
 						return null;
@@ -170,6 +175,7 @@ public class DefaultKafkaConsumerFactoryTests {
 		DefaultKafkaConsumerFactory<String, String> target =
 				new DefaultKafkaConsumerFactory<String, String>(Collections.emptyMap()) {
 
+					@Override
 					protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
 						configPassedToKafkaConsumer.putAll(configProps);
 						return null;
@@ -186,6 +192,7 @@ public class DefaultKafkaConsumerFactoryTests {
 		DefaultKafkaConsumerFactory<String, String> target =
 				new DefaultKafkaConsumerFactory<String, String>(originalConfig) {
 
+					@Override
 					protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
 						configPassedToKafkaConsumer.putAll(configProps);
 						return null;
@@ -204,6 +211,7 @@ public class DefaultKafkaConsumerFactoryTests {
 		DefaultKafkaConsumerFactory<String, String> target =
 				new DefaultKafkaConsumerFactory<String, String>(originalConfig) {
 
+					@Override
 					protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
 						configPassedToKafkaConsumer.putAll(configProps);
 						return null;
@@ -221,6 +229,7 @@ public class DefaultKafkaConsumerFactoryTests {
 		DefaultKafkaConsumerFactory<String, String> target =
 				new DefaultKafkaConsumerFactory<String, String>(originalConfig) {
 
+					@Override
 					protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
 						configPassedToKafkaConsumer.putAll(configProps);
 						return null;
@@ -236,6 +245,7 @@ public class DefaultKafkaConsumerFactoryTests {
 		DefaultKafkaConsumerFactory<String, String> target =
 				new DefaultKafkaConsumerFactory<String, String>(Collections.emptyMap()) {
 
+					@Override
 					protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
 						configPassedToKafkaConsumer.putAll(configProps);
 						return null;
@@ -254,6 +264,7 @@ public class DefaultKafkaConsumerFactoryTests {
 		DefaultKafkaConsumerFactory<String, String> target =
 				new DefaultKafkaConsumerFactory<String, String>(originalConfig) {
 
+					@Override
 					protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
 						configPassedToKafkaConsumer.putAll(configProps);
 						return null;
@@ -261,6 +272,26 @@ public class DefaultKafkaConsumerFactoryTests {
 				};
 		target.createConsumer("overridden", null, null, overrides);
 		assertThat(configPassedToKafkaConsumer.get(ConsumerConfig.GROUP_ID_CONFIG)).isEqualTo("overridden");
+	}
+
+	@Test
+	public void testOverriddenMaxPollRecordsOnly() {
+		Map<String, Object> originalConfig = Collections.singletonMap(ConsumerConfig.GROUP_ID_CONFIG, "original");
+		Properties overrides = new Properties();
+		overrides.setProperty(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, "2");
+		final Map<String, Object> configPassedToKafkaConsumer = new HashMap<>();
+		DefaultKafkaConsumerFactory<String, String> target =
+				new DefaultKafkaConsumerFactory<String, String>(originalConfig) {
+
+					@Override
+					protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
+						configPassedToKafkaConsumer.putAll(configProps);
+						return null;
+					}
+
+				};
+		target.createConsumer(null, null, null, overrides);
+		assertThat(configPassedToKafkaConsumer.get(ConsumerConfig.MAX_POLL_RECORDS_CONFIG)).isEqualTo("2");
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
@@ -236,7 +236,7 @@ public class ConcurrentMessageListenerContainerTests {
 		});
 		Properties consumerProperties = new Properties();
 		consumerProperties.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
-		containerProps.setConsumerProperties(consumerProperties);
+		containerProps.setKafkaConsumerProperties(consumerProperties);
 		final CountDownLatch rebalancePartitionsAssignedLatch = new CountDownLatch(2);
 		final CountDownLatch rebalancePartitionsRevokedLatch = new CountDownLatch(2);
 		containerProps.setConsumerRebalanceListener(new ConsumerRebalanceListener() {
@@ -571,7 +571,7 @@ public class ConcurrentMessageListenerContainerTests {
 		});
 		Properties consumerProperties = new Properties();
 		consumerProperties.setProperty(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "true");
-		containerProps.setConsumerProperties(consumerProperties);
+		containerProps.setKafkaConsumerProperties(consumerProperties);
 
 		ConcurrentMessageListenerContainer<Integer, String> container =
 				new ConcurrentMessageListenerContainer<>(cf, containerProps);

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
@@ -575,6 +575,7 @@ public class KafkaMessageListenerContainerTests {
 		ContainerProperties containerProps = new ContainerProperties(topicPartition);
 		containerProps.setGroupId("grp");
 		containerProps.setAckMode(AckMode.RECORD);
+		containerProps.setMissingTopicsFatal(false);
 		final CountDownLatch latch = new CountDownLatch(2);
 		MessageListener<Integer, String> messageListener = spy(
 				new MessageListener<Integer, String>() { // Cannot be lambda: Mockito doesn't mock final classes
@@ -728,6 +729,7 @@ public class KafkaMessageListenerContainerTests {
 		containerProps.setPollTimeout(10);
 		containerProps.setMonitorInterval(1);
 		containerProps.setMessageListener(mock(MessageListener.class));
+		containerProps.setMissingTopicsFatal(false);
 		KafkaMessageListenerContainer<Integer, String> container =
 				new KafkaMessageListenerContainer<>(cf, containerProps);
 		final CountDownLatch latch = new CountDownLatch(1);
@@ -761,6 +763,7 @@ public class KafkaMessageListenerContainerTests {
 		containerProps.setPollTimeout(100);
 		containerProps.setMonitorInterval(1);
 		containerProps.setMessageListener(mock(MessageListener.class));
+		containerProps.setMissingTopicsFatal(false);
 		KafkaMessageListenerContainer<Integer, String> container =
 				new KafkaMessageListenerContainer<>(cf, containerProps);
 		final AtomicInteger eventCounter = new AtomicInteger();
@@ -1288,7 +1291,7 @@ public class KafkaMessageListenerContainerTests {
 		Properties defaultProperties = new Properties();
 		defaultProperties.setProperty(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, "42");
 		Properties consumerProperties = new Properties(defaultProperties);
-		container1Props.setConsumerProperties(consumerProperties);
+		container1Props.setKafkaConsumerProperties(consumerProperties);
 		CountDownLatch stubbingComplete1 = new CountDownLatch(1);
 		KafkaMessageListenerContainer<Integer, String> container1 = spyOnContainer(
 				new KafkaMessageListenerContainer<>(cf, container1Props), stubbingComplete1);
@@ -1317,7 +1320,7 @@ public class KafkaMessageListenerContainerTests {
 			logger.info("defined part: " + message);
 			latch2.countDown();
 		});
-		container2Props.setConsumerProperties(consumerProperties);
+		container2Props.setKafkaConsumerProperties(consumerProperties);
 		CountDownLatch stubbingComplete2 = new CountDownLatch(1);
 		KafkaMessageListenerContainer<Integer, String> container2 = spyOnContainer(
 				new KafkaMessageListenerContainer<>(cf, container2Props), stubbingComplete2);
@@ -2124,7 +2127,7 @@ public class KafkaMessageListenerContainerTests {
 		containerProps.setMissingTopicsFatal(false);
 		Properties consumerProps = new Properties();
 		consumerProps.setProperty(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, "42000");
-		containerProps.setConsumerProperties(consumerProps);
+		containerProps.setKafkaConsumerProperties(consumerProps);
 		containerProps.setSyncCommitTimeout(Duration.ofSeconds(41)); // wins
 		KafkaMessageListenerContainer<Integer, String> container =
 				new KafkaMessageListenerContainer<>(cf, containerProps);
@@ -2183,6 +2186,7 @@ public class KafkaMessageListenerContainerTests {
 		containerProps.setAckMode(AckMode.RECORD);
 		containerProps.setClientId("clientId");
 		containerProps.setMessageListener((MessageListener) r -> { });
+		containerProps.setMissingTopicsFatal(false);
 		KafkaMessageListenerContainer<Integer, String> container =
 				new KafkaMessageListenerContainer<>(cf, containerProps);
 		container.start();
@@ -2324,13 +2328,15 @@ public class KafkaMessageListenerContainerTests {
 		containerProps.setAckMode(AckMode.COUNT);
 		containerProps.setAckCount(3);
 		containerProps.setClientId("clientId");
+		containerProps.setMissingTopicsFatal(false);
 		AtomicInteger recordCount = new AtomicInteger();
 		containerProps.setMessageListener((MessageListener) r -> {
 			recordCount.incrementAndGet();
 		});
 		Properties consumerProps = new Properties();
 		consumerProps.setProperty(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, "42000"); // wins
-		containerProps.setConsumerProperties(consumerProps);
+		containerProps.setKafkaConsumerProperties(consumerProps);
+		containerProps.setMissingTopicsFatal(false);
 		KafkaMessageListenerContainer<Integer, String> container =
 				new KafkaMessageListenerContainer<>(cf, containerProps);
 		container.start();
@@ -2374,6 +2380,7 @@ public class KafkaMessageListenerContainerTests {
 		containerProps.setIdleEventInterval(100L);
 		containerProps.setMessageListener((MessageListener) r -> {
 		});
+		containerProps.setMissingTopicsFatal(false);
 		KafkaMessageListenerContainer<Integer, String> container =
 				new KafkaMessageListenerContainer<>(cf, containerProps);
 		final CountDownLatch ehl = new CountDownLatch(1);


### PR DESCRIPTION
- move `consumerProperties` from `ContainerProperties` to `ConsumerProperties`
- rename to `kafkaConsumerProperties`
- deprecate old accessors

- allows overriding factory consumer properties in SIK message source