### PR TITLE
GH-1244: ReplyingKTemplate reply timeout per send

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/requestreply/ReplyingKafkaOperations.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/requestreply/ReplyingKafkaOperations.java
@@ -16,7 +16,11 @@
 
 package org.springframework.kafka.requestreply;
 
+import java.time.Duration;
+
 import org.apache.kafka.clients.producer.ProducerRecord;
+
+import org.springframework.lang.Nullable;
 
 /**
  * Request/reply operations.
@@ -32,10 +36,19 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 public interface ReplyingKafkaOperations<K, V, R> {
 
 	/**
-	 * Send a request and receive a reply.
+	 * Send a request and receive a reply with the default timeout.
 	 * @param record the record to send.
 	 * @return a RequestReplyFuture.
 	 */
 	RequestReplyFuture<K, V, R> sendAndReceive(ProducerRecord<K, V> record);
+
+	/**
+	 * Send a request and receive a reply.
+	 * @param record the record to send.
+	 * @param replyTimeout the reply timeout; if null, the default will be used.
+	 * @return a RequestReplyFuture.
+	 * @since 2.3
+	 */
+	RequestReplyFuture<K, V, R> sendAndReceive(ProducerRecord<K, V> record, @Nullable Duration replyTimeout);
 
 }

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -329,18 +329,23 @@ public KafkaTemplate<Integer, CustomValue> kafkaTemplate() {
 
 Version 2.1.3 introduced a subclass of `KafkaTemplate` to provide request/reply semantics.
 The class is named `ReplyingKafkaTemplate` and has one method (in addition to those in the superclass).
-The following listing shows the method's signature:
+The following listing shows the method signatures:
 
 ====
 [source, java]
 ----
 RequestReplyFuture<K, V, R> sendAndReceive(ProducerRecord<K, V> record);
+
+RequestReplyFuture<K, V, R> sendAndReceive(ProducerRecord<K, V> record,
+    Duration replyTimeout);
 ----
 ====
 
 The result is a `ListenableFuture` that is asynchronously populated with the result (or an exception, for a timeout).
 The result also has a `sendFuture` property, which is the result of calling `KafkaTemplate.send()`.
 You can use this future to determine the result of the send operation.
+
+If the first method is used, or the `replyTimeout` argument is `null`, the template's `defaultReplyTimeout` property is used (5 seconds by default).
 
 The following Spring Boot application shows an example of how to use the feature:
 
@@ -359,9 +364,9 @@ public class KRequestingApplication {
         return args -> {
             ProducerRecord<String, String> record = new ProducerRecord<>("kRequests", "foo");
             RequestReplyFuture<String, String, String> replyFuture = template.sendAndReceive(record);
-            SendResult<String, String> sendResult = replyFuture.getSendFuture().get();
+            SendResult<String, String> sendResult = replyFuture.getSendFuture().get(10, TimeUnit.SECONDS);
             System.out.println("Sent ok: " + sendResult.getRecordMetadata());
-            ConsumerRecord<String, String> consumerRecord = replyFuture.get();
+            ConsumerRecord<String, String> consumerRecord = replyFuture.get(10, TimeUnit.SECONDS);
             System.out.println("Return value: " + consumerRecord.value());
         };
     }

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -112,6 +112,8 @@ See the javadocs, <<serdes>>, and <<serde>> for more informaion.
 
 When a reply times out, the future is completed exceptionally with a `KafkaReplyTimeoutException` instead of a `KafkaException`.
 
+Also, an overloaded `sendAndReceive` method is now provided that allows specifying the reply timeout on a per message basis.
+
 ==== AggregatingReplyingKafkaTemplate
 
 Extends the `ReplyingKafkaTemplate` by aggregating replies from multiple receivers.


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1244

Overloaded `sendAndReceive` with a timeout parameter