### PR TITLE
Upgrade to Jackson 2.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ ext {
 	googleJsr305Version = '3.0.2'
 	hamcrestVersion = '2.1'
 	hibernateValidationVersion = '6.0.17.Final'
-	jacksonVersion = '2.10.0.pr3'
+	jacksonVersion = '2.10.0'
 	jaywayJsonPathVersion = '2.4.0'
 	junit4Version = '4.12'
 	junitJupiterVersion = '5.5.2'

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ ext {
 	googleJsr305Version = '3.0.2'
 	hamcrestVersion = '2.1'
 	hibernateValidationVersion = '6.0.17.Final'
-	jacksonVersion = '2.9.9.20190807'
+	jacksonVersion = '2.10.0.pr3'
 	jaywayJsonPathVersion = '2.4.0'
 	junit4Version = '4.12'
 	junitJupiterVersion = '5.5.2'

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/JacksonUtils.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/JacksonUtils.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.json.JsonMapper;
 
 /**
  * The utilities for Jackson {@link ObjectMapper} instances.
@@ -54,9 +55,10 @@ public final class JacksonUtils {
 	 * @return the {@link ObjectMapper} instance.
 	 */
 	public static ObjectMapper enhancedObjectMapper(ClassLoader classLoader) {
-		ObjectMapper objectMapper = new ObjectMapper();
-		objectMapper.configure(MapperFeature.DEFAULT_VIEW_INCLUSION, false);
-		objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+		ObjectMapper objectMapper = JsonMapper.builder()
+			.configure(MapperFeature.DEFAULT_VIEW_INCLUSION, false)
+			.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+			.build();
 		registerWellKnownModulesIfAvailable(objectMapper, classLoader);
 		return objectMapper;
 	}


### PR DESCRIPTION
- one deprecated method replaced by `JsonBuilder.configure(...)`.

GA is expected before our GA.