### PR TITLE
GH-1254: Configurable Embedded Zookeeper Port

### DIFF
--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/condition/EmbeddedKafkaCondition.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/condition/EmbeddedKafkaCondition.java
@@ -115,9 +115,9 @@ public class EmbeddedKafkaCondition implements ExecutionCondition, AfterAllCallb
 	@SuppressWarnings("unchecked")
 	private EmbeddedKafkaBroker createBroker(EmbeddedKafka embedded) {
 		EmbeddedKafkaBroker broker;
-		broker = new EmbeddedKafkaBroker(embedded.count(),
-				embedded.controlledShutdown(), embedded.topics());
-		broker.kafkaPorts(embedded.ports());
+		broker = new EmbeddedKafkaBroker(embedded.count(), embedded.controlledShutdown(), embedded.topics())
+				.zkPort(embedded.zookeeperPort())
+				.kafkaPorts(embedded.ports());
 		Properties properties = new Properties();
 
 		for (String pair : embedded.brokerProperties()) {

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafka.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafka.java
@@ -96,6 +96,13 @@ public @interface EmbeddedKafka {
 	int[] ports() default {0};
 
 	/**
+	 * Set the port on which the embedded Zookeeper should listen;
+	 * @return the port.
+	 * @since 2.3
+	 */
+	int zookeeperPort() default 0;
+
+	/**
 	 * @return partitions per topic
 	 */
 	int partitions() default 2;

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizer.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizer.java
@@ -67,11 +67,11 @@ class EmbeddedKafkaContextCustomizer implements ContextCustomizer {
 						.toArray(String[]::new);
 
 		EmbeddedKafkaBroker embeddedKafkaBroker = new EmbeddedKafkaBroker(this.embeddedKafka.count(),
-				this.embeddedKafka.controlledShutdown(),
-				this.embeddedKafka.partitions(),
-				topics);
-
-		embeddedKafkaBroker.kafkaPorts(this.embeddedKafka.ports());
+					this.embeddedKafka.controlledShutdown(),
+					this.embeddedKafka.partitions(),
+					topics)
+				.kafkaPorts(this.embeddedKafka.ports())
+				.zkPort(this.embeddedKafka.zookeeperPort());
 
 		Properties properties = new Properties();
 

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/rule/EmbeddedKafkaRule.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/rule/EmbeddedKafkaRule.java
@@ -96,6 +96,11 @@ public class EmbeddedKafkaRule extends ExternalResource implements TestRule {
 		return this;
 	}
 
+	public EmbeddedKafkaRule zkPort(int port) {
+		this.embeddedKafka.setZkPort(port);
+		return this;
+	}
+
 	/**
 	 * Return an underlying delegator {@link EmbeddedKafkaBroker} instance.
 	 * @return the {@link EmbeddedKafkaBroker} instance.

--- a/spring-kafka-test/src/test/java/org/springframework/kafka/test/EmbeddedKafkaBrokerTests.java
+++ b/spring-kafka-test/src/test/java/org/springframework/kafka/test/EmbeddedKafkaBrokerTests.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Gary Russell
+ * @since 2.3
+ *
+ */
+public class EmbeddedKafkaBrokerTests {
+
+	@Test
+	void testUpDown() {
+		EmbeddedKafkaBroker kafka = new EmbeddedKafkaBroker(1);
+		kafka.afterPropertiesSet();
+		assertThat(kafka.getZookeeperConnectionString()).startsWith("127");
+		kafka.destroy();
+		assertThat(kafka.getZookeeperConnectionString()).isNull();
+	}
+
+}

--- a/spring-kafka-test/src/test/java/org/springframework/kafka/test/rule/AddressableEmbeddedBrokerTests.java
+++ b/spring-kafka-test/src/test/java/org/springframework/kafka/test/rule/AddressableEmbeddedBrokerTests.java
@@ -61,7 +61,8 @@ public class AddressableEmbeddedBrokerTests {
 
 	@Test
 	public void testKafkaEmbedded() {
-		assertThat(broker.getBrokersAsString()).isEqualTo("127.0.0.1:" + this.config.port);
+		assertThat(broker.getBrokersAsString()).isEqualTo("127.0.0.1:" + this.config.kafkaPort);
+		assertThat(broker.getZkPort()).isEqualTo(this.config.zkPort);
 		assertThat(broker.getBrokersAsString())
 				.isEqualTo(System.getProperty(EmbeddedKafkaBroker.SPRING_EMBEDDED_KAFKA_BROKERS));
 		assertThat(broker.getZookeeperConnectionString())
@@ -69,7 +70,7 @@ public class AddressableEmbeddedBrokerTests {
 	}
 
 	@Test
-	public void testLateStartedConsumer() throws Exception {
+	public void testLateStartedConsumer() {
 		Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(TEST_EMBEDDED, "false", this.broker);
 		consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 		Consumer<Integer, String> consumer = new KafkaConsumer<>(consumerProps);
@@ -93,16 +94,22 @@ public class AddressableEmbeddedBrokerTests {
 	@Configuration
 	public static class Config {
 
-		private int port;
+		private int kafkaPort;
+
+		private int zkPort;
 
 		@Bean
 		public EmbeddedKafkaBroker broker() throws IOException {
 			ServerSocket ss = ServerSocketFactory.getDefault().createServerSocket(0);
-			this.port = ss.getLocalPort();
+			this.kafkaPort = ss.getLocalPort();
+			ss.close();
+			ss = ServerSocketFactory.getDefault().createServerSocket(0);
+			this.zkPort = ss.getLocalPort();
 			ss.close();
 
 			return new EmbeddedKafkaBroker(1, true, TEST_EMBEDDED)
-					.kafkaPorts(this.port);
+					.zkPort(this.zkPort)
+					.kafkaPorts(this.kafkaPort);
 		}
 
 	}


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1254

- port `EmbeddedKafkaBroker` from scala and add ZK port configuration
- add `zookeeperPort` to `@EmbeddedKafka`