### PR TITLE
GH-1225: @KL - skip conversion when not needed

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/BatchMessagingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/BatchMessagingMessageListenerAdapter.java
@@ -28,7 +28,6 @@ import org.springframework.kafka.listener.BatchAcknowledgingConsumerAwareMessage
 import org.springframework.kafka.listener.KafkaListenerErrorHandler;
 import org.springframework.kafka.listener.ListenerExecutionFailedException;
 import org.springframework.kafka.support.Acknowledgment;
-import org.springframework.kafka.support.KafkaNull;
 import org.springframework.kafka.support.converter.BatchMessageConverter;
 import org.springframework.kafka.support.converter.BatchMessagingMessageConverter;
 import org.springframework.messaging.Message;
@@ -58,8 +57,6 @@ import org.springframework.messaging.support.MessageBuilder;
  */
 public class BatchMessagingMessageListenerAdapter<K, V> extends MessagingMessageListenerAdapter<K, V>
 		implements BatchAcknowledgingConsumerAwareMessageListener<K, V> {
-
-	private static final Message<KafkaNull> NULL_MESSAGE = new GenericMessage<>(KafkaNull.INSTANCE);
 
 	private BatchMessageConverter batchMessageConverter = new BatchMessagingMessageConverter();
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/RecordMessagingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/RecordMessagingMessageListenerAdapter.java
@@ -26,6 +26,7 @@ import org.springframework.kafka.listener.KafkaListenerErrorHandler;
 import org.springframework.kafka.listener.ListenerExecutionFailedException;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.support.GenericMessage;
 
 
 /**
@@ -71,8 +72,17 @@ public class RecordMessagingMessageListenerAdapter<K, V> extends MessagingMessag
 	 */
 	@Override
 	public void onMessage(ConsumerRecord<K, V> record, Acknowledgment acknowledgment, Consumer<?, ?> consumer) {
-		Message<?> message = toMessagingMessage(record, acknowledgment, consumer);
-		logger.debug(() -> "Processing [" + message + "]");
+		Message<?> message;
+		if (isConversionNeeded()) {
+			message = toMessagingMessage(record, acknowledgment, consumer);
+		}
+		else {
+			message = NULL_MESSAGE;
+		}
+		if (logger.isDebugEnabled()) {
+			final Message<?> toLog = message;
+			logger.debug(() -> "Processing [" + toLog + "]");
+		}
 		try {
 			Object result = invokeHandler(record, acknowledgment, message, consumer);
 			if (result != null) {
@@ -82,6 +92,9 @@ public class RecordMessagingMessageListenerAdapter<K, V> extends MessagingMessag
 		catch (ListenerExecutionFailedException e) { // NOSONAR ex flow control
 			if (this.errorHandler != null) {
 				try {
+					if (message.equals(NULL_MESSAGE)) {
+						message = new GenericMessage<>(record);
+					}
 					Object result = this.errorHandler.handleError(message, e, consumer);
 					if (result != null) {
 						handleResult(result, record, message);

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/RecordMessagingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/RecordMessagingMessageListenerAdapter.java
@@ -80,8 +80,7 @@ public class RecordMessagingMessageListenerAdapter<K, V> extends MessagingMessag
 			message = NULL_MESSAGE;
 		}
 		if (logger.isDebugEnabled()) {
-			final Message<?> toLog = message;
-			logger.debug(() -> "Processing [" + toLog + "]");
+			logger.debug("Processing [" + message + "]");
 		}
 		try {
 			Object result = invokeHandler(record, acknowledgment, message, consumer);


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1225

When no argument is sourced from a `Message<?>` (no `@Headers`, `@Payload`,
etc - only `ConsumerRecord`, `Acknowledgment` or `Consumer`) then don't
convert.