### PR TITLE
GH-1259: Failed recovery with no retry

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/SeekUtils.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/SeekUtils.java
@@ -76,7 +76,8 @@ public final class SeekUtils {
 					skipped.set(test);
 				}
 				catch (Exception ex) {
-					logger.error(ex, "Failed to determine if this record should be recovererd, including in seeks");
+					logger.error(ex, "Failed to determine if this record (" + record
+							+ ") should be recovererd, including in seeks");
 					skipped.set(false);
 				}
 				if (skipped.get()) {


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1259

When a record fails with an exception that is not classified for retry,
handle a failed recovery and re-seek the failed record.

`FailedRecordTracker.skip()` is not used for unclassified exceptions,
it's recoverer is called directly.