### PR TITLE
GH-1260: Add exception classification to DARP

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordProcessor.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.BiPredicate;
+
+import org.apache.commons.logging.LogFactory;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+import org.springframework.classify.BinaryExceptionClassifier;
+import org.springframework.core.log.LogAccessor;
+import org.springframework.kafka.support.serializer.DeserializationException;
+import org.springframework.lang.Nullable;
+import org.springframework.messaging.converter.MessageConversionException;
+import org.springframework.messaging.handler.invocation.MethodArgumentResolutionException;
+import org.springframework.util.Assert;
+import org.springframework.util.backoff.BackOff;
+import org.springframework.util.backoff.FixedBackOff;
+
+/**
+ * Common super class for classes that deal with failing to consume a consumer record.
+ *
+ * @author Gary Russell
+ * @since 2.3.1
+ *
+ */
+public abstract class FailedRecordProcessor {
+
+	private static final BiPredicate<ConsumerRecord<?, ?>, Exception> ALWAYS_SKIP_PREDICATE = (r, e) -> true;
+
+	private static final BiPredicate<ConsumerRecord<?, ?>, Exception> NEVER_SKIP_PREDICATE = (r, e) -> false;
+
+	protected static final LogAccessor LOGGER =
+			new LogAccessor(LogFactory.getLog(SeekToCurrentErrorHandler.class)); // NOSONAR
+
+	private final FailedRecordTracker failureTracker;
+
+	private BinaryExceptionClassifier classifier;
+
+	private boolean commitRecovered;
+
+	protected FailedRecordProcessor(@Nullable BiConsumer<ConsumerRecord<?, ?>, Exception> recoverer, BackOff backOff) {
+		this.failureTracker = new FailedRecordTracker(recoverer, backOff, LOGGER);
+		this.classifier = configureDefaultClassifier();
+	}
+
+	/**
+	 * TODO: remove when the deprecated dependent CTORs are removed.
+	 * @param recoverer the recoverer.
+	 * @param maxFailures the max failures.
+	 */
+	FailedRecordProcessor(@Nullable BiConsumer<ConsumerRecord<?, ?>, Exception> recoverer, int maxFailures) {
+		this.failureTracker = new FailedRecordTracker(recoverer, new FixedBackOff(0L, maxFailures - 1), LOGGER);
+		this.classifier = configureDefaultClassifier();
+	}
+
+	/**
+	 * Return the exception classifier.
+	 * @return the classifier.
+	 */
+	protected BinaryExceptionClassifier getClassifier() {
+		return this.classifier;
+	}
+
+	/**
+	 * Set an exception classifier to determine whether the exception should cause a retry
+	 * (until exhaustion) or not. If not, we go straight to the recoverer. By default,
+	 * the following exceptions will not be retried:
+	 * <ul>
+	 * <li>{@link DeserializationException}</li>
+	 * <li>{@link MessageConversionException}</li>
+	 * <li>{@link MethodArgumentResolutionException}</li>
+	 * <li>{@link NoSuchMethodException}</li>
+	 * <li>{@link ClassCastException}</li>
+	 * </ul>
+	 * All others will be retried.
+	 * The classifier's {@link BinaryExceptionClassifier#setTraverseCauses(boolean) traverseCauses}
+	 * will be set to true because the container always wraps exceptions in a
+	 * {@link ListenerExecutionFailedException}.
+	 * This replaces the default classifier.
+	 * @param classifier the classifier.
+	 */
+	public void setClassifier(BinaryExceptionClassifier classifier) {
+		Assert.notNull(classifier, "'classifier' + cannot be null");
+		classifier.setTraverseCauses(true);
+		this.classifier = classifier;
+	}
+
+	/**
+	 * Whether the offset for a recovered record should be committed.
+	 * @return true to commit recovered record offsets.
+	 */
+	protected boolean isCommitRecovered() {
+		return this.commitRecovered;
+	}
+
+	/**
+	 * Set to true to commit the offset for a recovered record.
+	 * @param commitRecovered true to commit.
+	 */
+	public void setCommitRecovered(boolean commitRecovered) {
+		this.commitRecovered = commitRecovered;
+	}
+
+	/**
+	 * Add an exception type to the default list; if and only if an external classifier
+	 * has not been provided. By default, the following exceptions will not be retried:
+	 * <ul>
+	 * <li>{@link DeserializationException}</li>
+	 * <li>{@link MessageConversionException}</li>
+	 * <li>{@link MethodArgumentResolutionException}</li>
+	 * <li>{@link NoSuchMethodException}</li>
+	 * <li>{@link ClassCastException}</li>
+	 * </ul>
+	 * All others will be retried.
+	 * @param exceptionType the exception type.
+	 * @see #removeNotRetryableException(Class)
+	 * @see #setClassifier(BinaryExceptionClassifier)
+	 */
+	public void addNotRetryableException(Class<? extends Exception> exceptionType) {
+		Assert.isTrue(this.classifier instanceof ExtendedBinaryExceptionClassifier,
+				"Cannot add exception types to a supplied classifier");
+		((ExtendedBinaryExceptionClassifier) this.classifier).getClassified().put(exceptionType, false);
+	}
+
+	/**
+	 * Remove an exception type from the configured list; if and only if an external
+	 * classifier has not been provided. By default, the following exceptions will not be
+	 * retried:
+	 * <ul>
+	 * <li>{@link DeserializationException}</li>
+	 * <li>{@link MessageConversionException}</li>
+	 * <li>{@link MethodArgumentResolutionException}</li>
+	 * <li>{@link NoSuchMethodException}</li>
+	 * <li>{@link ClassCastException}</li>
+	 * </ul>
+	 * All others will be retried.
+	 * @param exceptionType the exception type.
+	 * @return true if the removal was successful.
+	 * @see #addNotRetryableException(Class)
+	 * @see #setClassifier(BinaryExceptionClassifier)
+	 */
+	public boolean removeNotRetryableException(Class<? extends Exception> exceptionType) {
+		Assert.isTrue(this.classifier instanceof ExtendedBinaryExceptionClassifier,
+				"Cannot remove exception types from a supplied classifier");
+		return ((ExtendedBinaryExceptionClassifier) this.classifier).getClassified().remove(exceptionType);
+	}
+
+	protected BiPredicate<ConsumerRecord<?, ?>, Exception> getSkipPredicate(List<ConsumerRecord<?, ?>> records,
+			Exception thrownException) {
+
+		if (getClassifier().classify(thrownException)) {
+			return this.failureTracker::skip;
+		}
+		else {
+			try {
+				this.failureTracker.getRecoverer().accept(records.get(0), thrownException);
+			}
+			catch (Exception ex) {
+				LOGGER.error(ex, () -> "Recovery of record (" + records.get(0) + ") failed");
+				return NEVER_SKIP_PREDICATE;
+			}
+			return ALWAYS_SKIP_PREDICATE;
+		}
+	}
+
+	public void clearThreadState() {
+		this.failureTracker.clearThreadState();
+	}
+
+	private static BinaryExceptionClassifier configureDefaultClassifier() {
+		Map<Class<? extends Throwable>, Boolean> classified = new HashMap<>();
+		classified.put(DeserializationException.class, false);
+		classified.put(MessageConversionException.class, false);
+		classified.put(MethodArgumentResolutionException.class, false);
+		classified.put(NoSuchMethodException.class, false);
+		classified.put(ClassCastException.class, false);
+		ExtendedBinaryExceptionClassifier defaultClassifier = new ExtendedBinaryExceptionClassifier(classified, true);
+		defaultClassifier.setTraverseCauses(true);
+		return defaultClassifier;
+	}
+
+	/**
+	 * Extended to provide visibility to the current classified exceptions.
+	 *
+	 * @author Gary Russell
+	 *
+	 */
+	@SuppressWarnings("serial")
+	private static class ExtendedBinaryExceptionClassifier extends BinaryExceptionClassifier {
+
+
+		ExtendedBinaryExceptionClassifier(Map<Class<? extends Throwable>, Boolean> typeMap, boolean defaultValue) {
+			super(typeMap, defaultValue);
+		}
+
+		@Override
+		protected Map<Class<? extends Throwable>, Boolean> getClassified() { // NOSONAR worthless override
+			return super.getClassified();
+		}
+
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/SeekToCurrentErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/SeekToCurrentErrorHandler.java
@@ -17,29 +17,20 @@
 package org.springframework.kafka.listener;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiConsumer;
-import java.util.function.BiPredicate;
 
-import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetCommitCallback;
 import org.apache.kafka.common.TopicPartition;
 
-import org.springframework.classify.BinaryExceptionClassifier;
-import org.springframework.core.log.LogAccessor;
 import org.springframework.kafka.KafkaException;
 import org.springframework.kafka.listener.ContainerProperties.AckMode;
 import org.springframework.kafka.support.SeekUtils;
-import org.springframework.kafka.support.serializer.DeserializationException;
 import org.springframework.lang.Nullable;
-import org.springframework.messaging.converter.MessageConversionException;
-import org.springframework.messaging.handler.invocation.MethodArgumentResolutionException;
-import org.springframework.util.Assert;
 import org.springframework.util.backoff.BackOff;
 import org.springframework.util.backoff.FixedBackOff;
 
@@ -54,22 +45,9 @@ import org.springframework.util.backoff.FixedBackOff;
  * @since 2.0.1
  *
  */
-public class SeekToCurrentErrorHandler implements ContainerAwareErrorHandler {
-
-	private static final BiPredicate<ConsumerRecord<?, ?>, Exception> ALWAYS_SKIP_PREDICATE = (r, e) -> true;
-
-	private static final BiPredicate<ConsumerRecord<?, ?>, Exception> NEVER_SKIP_PREDICATE = (r, e) -> false;
-
-	protected static final LogAccessor LOGGER =
-			new LogAccessor(LogFactory.getLog(SeekToCurrentErrorHandler.class)); // NOSONAR visibility
+public class SeekToCurrentErrorHandler extends FailedRecordProcessor implements ContainerAwareErrorHandler {
 
 	private static final LoggingCommitCallback LOGGING_COMMIT_CALLBACK = new LoggingCommitCallback();
-
-	private final FailedRecordTracker failureTracker;
-
-	private boolean commitRecovered;
-
-	private BinaryExceptionClassifier classifier;
 
 	/**
 	 * Construct an instance with the default recoverer which simply logs the record after
@@ -135,8 +113,8 @@ public class SeekToCurrentErrorHandler implements ContainerAwareErrorHandler {
 	 */
 	@Deprecated
 	public SeekToCurrentErrorHandler(@Nullable BiConsumer<ConsumerRecord<?, ?>, Exception> recoverer, int maxFailures) {
-		this.failureTracker = new FailedRecordTracker(recoverer, new FixedBackOff(0L, maxFailures - 1), LOGGER);
-		this.classifier = configureDefaultClassifier();
+		// Remove super CTOR when this is removed.
+		super(recoverer, maxFailures);
 	}
 
 	/**
@@ -147,109 +125,20 @@ public class SeekToCurrentErrorHandler implements ContainerAwareErrorHandler {
 	 * @since 2.3
 	 */
 	public SeekToCurrentErrorHandler(@Nullable BiConsumer<ConsumerRecord<?, ?>, Exception> recoverer, BackOff backOff) {
-		this.failureTracker = new FailedRecordTracker(recoverer, backOff, LOGGER);
-		this.classifier = configureDefaultClassifier();
+		super(recoverer, backOff);
 	}
 
 	/**
-	 * Whether the offset for a recovered record should be committed.
-	 * @return true to commit recovered record offsets.
-	 * @since 2.2.4
-	 */
-	protected boolean isCommitRecovered() {
-		return this.commitRecovered;
-	}
-
-	/**
-	 * Set to true to commit the offset for a recovered record. The container
+	 * {@inheritDoc}
+	 * The container
 	 * must be configured with {@link AckMode#MANUAL_IMMEDIATE}. Whether or not
 	 * the commit is sync or async depends on the container's syncCommits
 	 * property.
 	 * @param commitRecovered true to commit.
-	 * @since 2.2.4
 	 */
-	public void setCommitRecovered(boolean commitRecovered) {
-		this.commitRecovered = commitRecovered;
-	}
-
-	/**
-	 * Return the exception classifier.
-	 * @return the classifier.
-	 * @since 2.3
-	 */
-	protected BinaryExceptionClassifier getClassifier() {
-		return this.classifier;
-	}
-
-	/**
-	 * Set an exception classifier to determine whether the exception should cause a retry
-	 * (until exhaustion) or not. If not, we go straight to the recoverer. By default,
-	 * the following exceptions will not be retried:
-	 * <ul>
-	 * <li>{@link DeserializationException}</li>
-	 * <li>{@link MessageConversionException}</li>
-	 * <li>{@link MethodArgumentResolutionException}</li>
-	 * <li>{@link NoSuchMethodException}</li>
-	 * <li>{@link ClassCastException}</li>
-	 * </ul>
-	 * All others will be retried.
-	 * The classifier's {@link BinaryExceptionClassifier#setTraverseCauses(boolean) traverseCauses}
-	 * will be set to true because the container always wraps exceptions in a
-	 * {@link ListenerExecutionFailedException}.
-	 * This replaces the default classifier.
-	 * @param classifier the classifier.
-	 * @since 2.3
-	 */
-	public void setClassifier(BinaryExceptionClassifier classifier) {
-		Assert.notNull(classifier, "'classifier' + cannot be null");
-		classifier.setTraverseCauses(true);
-		this.classifier = classifier;
-	}
-
-	/**
-	 * Add an exception type to the default list; if and only if an external classifier
-	 * has not been provided. By default, the following exceptions will not be retried:
-	 * <ul>
-	 * <li>{@link DeserializationException}</li>
-	 * <li>{@link MessageConversionException}</li>
-	 * <li>{@link MethodArgumentResolutionException}</li>
-	 * <li>{@link NoSuchMethodException}</li>
-	 * <li>{@link ClassCastException}</li>
-	 * </ul>
-	 * All others will be retried.
-	 * @param exceptionType the exception type.
-	 * @since 2.3
-	 * @see #removeNotRetryableException(Class)
-	 * @see #setClassifier(BinaryExceptionClassifier)
-	 */
-	public void addNotRetryableException(Class<? extends Exception> exceptionType) {
-		Assert.isTrue(this.classifier instanceof ExtendedBinaryExceptionClassifier,
-				"Cannot add exception types to a supplied classifier");
-		((ExtendedBinaryExceptionClassifier) this.classifier).getClassified().put(exceptionType, false);
-	}
-
-	/**
-	 * Remove an exception type from the configured list; if and only if an external
-	 * classifier has not been provided. By default, the following exceptions will not be
-	 * retried:
-	 * <ul>
-	 * <li>{@link DeserializationException}</li>
-	 * <li>{@link MessageConversionException}</li>
-	 * <li>{@link MethodArgumentResolutionException}</li>
-	 * <li>{@link NoSuchMethodException}</li>
-	 * <li>{@link ClassCastException}</li>
-	 * </ul>
-	 * All others will be retried.
-	 * @param exceptionType the exception type.
-	 * @return true if the removal was successful.
-	 * @since 2.3
-	 * @see #addNotRetryableException(Class)
-	 * @see #setClassifier(BinaryExceptionClassifier)
-	 */
-	public boolean removeNotRetryableException(Class<? extends Exception> exceptionType) {
-		Assert.isTrue(this.classifier instanceof ExtendedBinaryExceptionClassifier,
-				"Cannot remove exception types from a supplied classifier");
-		return ((ExtendedBinaryExceptionClassifier) this.classifier).getClassified().remove(exceptionType);
+	@Override
+	public void setCommitRecovered(boolean commitRecovered) { // NOSONAR enhanced javadoc
+		super.setCommitRecovered(commitRecovered);
 	}
 
 	@Override
@@ -260,7 +149,7 @@ public class SeekToCurrentErrorHandler implements ContainerAwareErrorHandler {
 				LOGGER)) {
 			throw new KafkaException("Seek to current after exception", thrownException);
 		}
-		if (this.commitRecovered) {
+		if (isCommitRecovered()) {
 			if (container.getContainerProperties().getAckMode().equals(AckMode.MANUAL_IMMEDIATE)) {
 				ConsumerRecord<?, ?> record = records.get(0);
 				Map<TopicPartition, OffsetAndMetadata> offsetToCommit = Collections.singletonMap(
@@ -282,64 +171,6 @@ public class SeekToCurrentErrorHandler implements ContainerAwareErrorHandler {
 						+ container.getContainerProperties().getAckMode());
 			}
 		}
-	}
-
-	private BiPredicate<ConsumerRecord<?, ?>, Exception> getSkipPredicate(List<ConsumerRecord<?, ?>> records,
-			Exception thrownException) {
-
-		if (this.classifier.classify(thrownException)) {
-			return this.failureTracker::skip;
-		}
-		else {
-			try {
-				this.failureTracker.getRecoverer().accept(records.get(0), thrownException);
-			}
-			catch (Exception ex) {
-				LOGGER.error(ex, () -> "Recovery of record (" + records.get(0) + ") failed");
-				return NEVER_SKIP_PREDICATE;
-			}
-			return ALWAYS_SKIP_PREDICATE;
-		}
-	}
-
-	@Override
-	public void clearThreadState() {
-		this.failureTracker.clearThreadState();
-	}
-
-	private static BinaryExceptionClassifier configureDefaultClassifier() {
-		Map<Class<? extends Throwable>, Boolean> classified = new HashMap<>();
-		classified.put(DeserializationException.class, false);
-		classified.put(MessageConversionException.class, false);
-		classified.put(MethodArgumentResolutionException.class, false);
-		classified.put(NoSuchMethodException.class, false);
-		classified.put(ClassCastException.class, false);
-		ExtendedBinaryExceptionClassifier defaultClassifier = new ExtendedBinaryExceptionClassifier(classified, true);
-		defaultClassifier.setTraverseCauses(true);
-		return defaultClassifier;
-	}
-
-	/**
-	 * Extended to provide visibility to the current classified exceptions.
-	 *
-	 * @author Gary Russell
-	 *
-	 * @since 2.3
-	 *
-	 */
-	@SuppressWarnings("serial")
-	private static class ExtendedBinaryExceptionClassifier extends BinaryExceptionClassifier {
-
-
-		ExtendedBinaryExceptionClassifier(Map<Class<? extends Throwable>, Boolean> typeMap, boolean defaultValue) {
-			super(typeMap, defaultValue);
-		}
-
-		@Override
-		protected Map<Class<? extends Throwable>, Boolean> getClassified() { // NOSONAR worthless override
-			return super.getClassified();
-		}
-
 	}
 
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/DefaultAfterRollbackProcessorTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/DefaultAfterRollbackProcessorTests.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.serializer.DeserializationException;
+
+/**
+ * @author Gary Russell
+ * @since 2.3.1
+ *
+ */
+public class DefaultAfterRollbackProcessorTests {
+
+	@Test
+	public void testClassifier() {
+		AtomicReference<ConsumerRecord<?, ?>> recovered = new AtomicReference<>();
+		AtomicBoolean recovererShouldFail = new AtomicBoolean(false);
+		DefaultAfterRollbackProcessor<String, String> processor = new DefaultAfterRollbackProcessor<>((r, t) -> {
+			if (recovererShouldFail.getAndSet(false)) {
+				throw new RuntimeException("test recoverer failure");
+			}
+			recovered.set(r);
+		});
+		@SuppressWarnings("unchecked")
+		KafkaTemplate<String, String> template = mock(KafkaTemplate.class);
+		given(template.isTransactional()).willReturn(true);
+		processor.setKafkaTemplate(template);
+		processor.setCommitRecovered(true);
+		ConsumerRecord<String, String> record1 = new ConsumerRecord<>("foo", 0, 0L, "foo", "bar");
+		ConsumerRecord<String, String> record2 = new ConsumerRecord<>("foo", 1, 1L, "foo", "bar");
+		List<ConsumerRecord<String, String>> records = Arrays.asList(record1, record2);
+		IllegalStateException illegalState = new IllegalStateException();
+		@SuppressWarnings("unchecked")
+		Consumer<String, String> consumer = mock(Consumer.class);
+		processor.process(records, consumer, illegalState, true);
+		processor.process(records, consumer, new DeserializationException("intended", null, false, illegalState), true);
+		verify(template).sendOffsetsToTransaction(anyMap());
+		assertThat(recovered.get()).isSameAs(record1);
+		processor.addNotRetryableException(IllegalStateException.class);
+		recovered.set(null);
+		recovererShouldFail.set(true);
+		processor.process(records, consumer, illegalState, true);
+		verify(template).sendOffsetsToTransaction(anyMap()); // recovery failed
+		processor.process(records, consumer, illegalState, true);
+		verify(template, times(2)).sendOffsetsToTransaction(anyMap());
+		assertThat(recovered.get()).isSameAs(record1);
+		InOrder inOrder = inOrder(consumer);
+		inOrder.verify(consumer).seek(new TopicPartition("foo", 0), 0L); // not recovered so seek
+		inOrder.verify(consumer, times(2)).seek(new TopicPartition("foo", 1), 1L);
+		inOrder.verify(consumer).seek(new TopicPartition("foo", 0), 0L); // recovery failed
+		inOrder.verify(consumer, times(2)).seek(new TopicPartition("foo", 1), 1L);
+		inOrder.verifyNoMoreInteractions();
+	}
+
+}

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -3644,6 +3644,34 @@ To enable this feature, set the `commitRecovered` and `kafkaTemplate` properties
 
 IMPORTANT: If the recoverer fails (throws an exception), the record will be included in the seeks and recovery will be attempted again during the next delivery.
 
+Starting with version 2.3.1, similar to the `SeekToCurrentErrorHandler`, the `DefaultAfterRollbackProcessor` considers certain exceptions to be fatal, and retries are skipped for such exceptions; the recoverer is invoked on the first failure.
+The exceptions that are considered fatal, by default, are:
+
+* `DeserializationException`
+* `MessageConversionException`
+* `MethodArgumentResolutionException`
+* `NoSuchMethodException`
+* `ClassCastException`
+
+since these exceptions are unlikely to be resolved on a retried delivery.
+
+You can add more exception types to the not-retryable category, or completely replace the `BinaryExceptionClassifier` with your own configured classifier.
+See the Javadocs for `DefaultAfterRollbackProcessor` for more information, as well as those for the `spring-retry` `BinaryExceptionClassifier`.
+
+Here is an example that adds `IllegalArgumentException` to the not-retryable exceptions:
+
+====
+[source, java]
+----
+@Bean
+public DefaultAfterRollbackProcessor errorHandler(BiConsumer<ConsumerRecord<?, ?>, Exception> recoverer) {
+    DefaultAfterRollbackProcessor processor = new DefaultAfterRollbackProcessor(recoverer);
+    processor.addNotRetryableException(IllegalArgumentException.class);
+    return processor;
+}
+----
+====
+
 [[dead-letters]]
 ===== Publishing Dead-letter Records
 


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1260

Refactor common code with `SeekToCurrentErrorHandler` into
`FailedRecordProcessor` super class.