### PR TITLE
Fix typo around NRCEvent properties

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
@@ -450,6 +450,8 @@ public class ContainerProperties extends ConsumerProperties {
 	/**
 	 * If the time since the last poll / {@link #getPollTimeout() poll timeout}
 	 * exceeds this value, a NonResponsiveConsumerEvent is published.
+	 * This value should be more than 1.0 to avoid a race condition that can cause
+	 * spurious events to be published.
 	 * Default {@value #DEFAULT_NO_POLL_THRESHOLD}.
 	 * @param noPollThreshold the threshold
 	 * @since 1.3.1

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -1879,9 +1879,10 @@ public ConcurrentKafkaListenerContainerFactory kafkaListenerContainerFactory() {
 In each of these cases, an event is published once per minute while the container is idle.
 
 In addition, if the broker is unreachable, the consumer `poll()` method does not exit, so no messages are received and idle events cannot be generated.
-To solve this issue, the container publishes a `NonResponsiveConsumerEvent` if a poll does not return within 3x the `pollInterval` property.
+To solve this issue, the container publishes a `NonResponsiveConsumerEvent` if a poll does not return within `3x` the `pollTimeout` property.
 By default, this check is performed once every 30 seconds in each container.
-You can modify this behavior by setting the `monitorInterval` and `noPollThreshold` properties in the `ContainerProperties` when configuring the listener container.
+You can modify this behavior by setting the `monitorInterval` (default 30 seconds) and `noPollThreshold` (default 3.0) properties in the `ContainerProperties` when configuring the listener container.
+The `noPollThreshold` should be greater than `1.0` to avoid getting spurious events due to a race condition.
 Receiving such an event lets you stop the containers, thus waking the consumer so that it can terminate.
 
 ====== Event Consumption


### PR DESCRIPTION
- was `pollInterval` instead of `pollTimeout`

**cherry-pick to 2.2.x**