### PR TITLE
GH-1273: Fix offset commit after recovery

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/GenericErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/GenericErrorHandler.java
@@ -56,4 +56,15 @@ public interface GenericErrorHandler<T> {
 		// NOSONAR
 	}
 
+	/**
+	 * Return true if the offset should be committed for a handled error (no exception
+	 * thrown).
+	 * @return true to commit.
+	 * @since 2.3.2
+	 */
+	default boolean isAckAfterHandle() {
+		// TODO: Default true in the next release.
+		return false;
+	}
+
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/SeekToCurrentErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/SeekToCurrentErrorHandler.java
@@ -54,7 +54,7 @@ public class SeekToCurrentErrorHandler extends FailedRecordProcessor implements 
 
 	private static final LoggingCommitCallback LOGGING_COMMIT_CALLBACK = new LoggingCommitCallback();
 
-	private boolean ackAfterHandle;
+	private boolean ackAfterHandle = true;
 
 	/**
 	 * Construct an instance with the default recoverer which simply logs the record after

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/SeekToCurrentErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/SeekToCurrentErrorHandler.java
@@ -54,6 +54,8 @@ public class SeekToCurrentErrorHandler extends FailedRecordProcessor implements 
 
 	private static final LoggingCommitCallback LOGGING_COMMIT_CALLBACK = new LoggingCommitCallback();
 
+	private boolean ackAfterHandle;
+
 	/**
 	 * Construct an instance with the default recoverer which simply logs the record after
 	 * {@value SeekUtils#DEFAULT_MAX_FAILURES} (maxFailures) have occurred for a
@@ -166,6 +168,7 @@ public class SeekToCurrentErrorHandler extends FailedRecordProcessor implements 
 	 * @since 2.3
 	 * @deprecated in favor of {@link #setClassifications(Map, boolean)}.
 	 */
+	@Override
 	@Deprecated
 	public void setClassifier(BinaryExceptionClassifier classifier) {
 		Assert.notNull(classifier, "'classifier' + cannot be null");
@@ -203,6 +206,20 @@ public class SeekToCurrentErrorHandler extends FailedRecordProcessor implements 
 						+ container.getContainerProperties().getAckMode());
 			}
 		}
+	}
+
+	@Override
+	public boolean isAckAfterHandle() {
+		return this.ackAfterHandle;
+	}
+
+	/**
+	 * Set to false to tell the container to NOT commit the offset for a recovered record.
+	 * @param ackAfterHandle false to suppress committing the offset.
+	 * @since 2.3.2
+	 */
+	public void setAckAfterHandle(boolean ackAfterHandle) {
+		this.ackAfterHandle = ackAfterHandle;
 	}
 
 }

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -1736,11 +1736,9 @@ IMPORTANT: The `FilteringBatchMessageListenerAdapter` is ignored if your `@Kafka
 [[retrying-deliveries]]
 ===== Retrying Deliveries
 
-If your listener throws an exception, the default behavior is to invoke the `ErrorHandler`, if configured, or logged otherwise.
+If your listener throws an exception, the default behavior is to invoke the <<error-handlers>>, if configured, or logged otherwise.
 
-NOTE: Two error handler interfaces (`ErrorHandler` and `BatchErrorHandler`) are provided.
-You must configure the appropriate type to match the <<message-listeners,message listener>>.
-
+NOTE:
 To retry deliveries, a convenient listener adapter `RetryingMessageListenerAdapter`  is provided.
 
 You can configure it with a `RetryTemplate` and `RecoveryCallback<Void>` - see the https://github.com/spring-projects/spring-retry[spring-retry] project for information about these components.
@@ -3400,7 +3398,21 @@ This resets each topic/partition in the batch to the lowest offset in the batch.
 
 NOTE: The preceding two examples are simplistic implementations, and you would probably want more checking in the error handler.
 
+[[error-handlers]]
 ===== Container Error Handlers
+
+Two error handler interfaces (`ErrorHandler` and `BatchErrorHandler`) are provided.
+You must configure the appropriate type to match the <<message-listeners,message listener>>.
+
+By default, errors are simply logged when transactions are not being used.
+When transactions are being used, no error handlers are configured, by default, so that the exception will roll back the transaction.
+If you provide a custom error handler when using transactions, it must throw an exception if you want the transaction rolled back.
+
+Starting with version 2.3.2, these interfaces have a default method `isAckAfterHandle()` which is called by the container to determine whether the offset(s) should be committed if the error handler returns without throwing an exception.
+This returns false by default, for backwards compatibility.
+In most cases, however, we expect that the offset should be committed.
+For example, the <<seek-to-current, `SeekToCurrentErrorHandler`>> returns `true` if a record is recovered (after any retries, if so configured).
+In a future release, we expect to change this default to `true`.
 
 You can specify a global error handler to be used for all listeners in the container factory.
 The following example shows how to do so:
@@ -3440,6 +3452,8 @@ public KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<Integer,
 ====
 
 By default, if an annotated listener method throws an exception, it is thrown to the container, and the message is handled according to the container configuration.
+
+If you are using Spring Boot, you simply need to add the error handler as a `@Bean` and boot will add it to the auto-configured factory.
 
 ===== Consumer-Aware Container Error Handlers
 
@@ -3592,6 +3606,9 @@ However, since this error handler has no mechanism to "recover" after retries ar
 Again, the maximum delay must be less than the `max.poll.interval.ms` consumer property.
 
 IMPORTANT: If the recoverer fails (throws an exception), the record will be included in the seeks and recovery will be attempted again during the next delivery.
+
+Starting with version 2.3.2, after a record has been recovered, its offset will be committed (if one of the container `AckMode` s is configured).
+To revert to the previous behavior, set the error handler's `ackAfterHandle` property to false.
 
 ===== Container Stopping Error Handlers
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -70,6 +70,8 @@ The `SeekToCurrentErrorHandler` now treats certain exceptions as fatal and disab
 
 The `SeekToCurrentErrorHandler` and `SeekToCurrentBatchErrorHandler` can now be configured to apply a `BackOff` (thread sleep) between delivery attempts.
 
+Starting with version 2.3.2, recovered records' offsets will be committed when the error handler returns after recovering a failed record.
+
 See <<seek-to-current>> for more information.
 
 The `DeadLetterPublishingRecoverer`, when used in conjunction with an `ErrorHandlingDeserializer2`, now sets the payload of the message sent to the dead-letter topic, to the original value that could not be deserialized.


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1273

Previously, offsets were only committed if an error handler "handled" an
error (did not throw an exception), when transactions are being used.

Now, if an error handler successfully recovers, the offset will automatically
be committed.

Since this is a behavior change, a new boolean `ackAfterHandle()` is added to
the `GenericErrorHandler`, default `false` and the `SeekToCurrentErrorHandler`
returns `true`; it is the only framwork handler that can recover from failures.

In a future release, this boolean will be `true` by default.