### PR TITLE
GH-1278: Zombie Fencing with Batch Listener

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
@@ -599,8 +599,8 @@ public class ContainerProperties extends ConsumerProperties {
 	/**
 	 * When using a batch message listener whether to dispatch records by partition (with
 	 * a transaction for each sub batch if transactions are in use) or the complete batch
-	 * received by the {@code poll(}. Useful when using transactions to enable zombie
-	 * fencing, by using a {code transactional.id} that is unique for the
+	 * received by the {@code poll()}. Useful when using transactions to enable zombie
+	 * fencing, by using a {code transactional.id} that is unique for each
 	 * group/topic/partition.
 	 * @param subBatchPerPartition true for a separate transaction for each partition.
 	 * @since 2.3.2

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
@@ -180,6 +180,8 @@ public class ContainerProperties extends ConsumerProperties {
 
 	private Duration consumerStartTimout = DEFAULT_CONSUMER_START_TIMEOUT;
 
+	private boolean subBatchPerPartition;
+
 	/**
 	 * Create properties for a container that will subscribe to the specified topics.
 	 * @param topics the topics.
@@ -590,6 +592,23 @@ public class ContainerProperties extends ConsumerProperties {
 		this.consumerStartTimout = consumerStartTimout;
 	}
 
+	public boolean isSubBatchPerPartition() {
+		return this.subBatchPerPartition;
+	}
+
+	/**
+	 * When using a batch message listener whether to dispatch records by partition (with
+	 * a transaction for each sub batch if transactions are in use) or the complete batch
+	 * received by the {@code poll(}. Useful when using transactions to enable zombie
+	 * fencing, by using a {code transactional.id} that is unique for the
+	 * group/topic/partition.
+	 * @param subBatchPerPartition true for a separate transaction for each partition.
+	 * @since 2.3.2
+	 */
+	public void setSubBatchPerPartition(boolean subBatchPerPartition) {
+		this.subBatchPerPartition = subBatchPerPartition;
+	}
+
 	@Override
 	public String toString() {
 		return "ContainerProperties ["
@@ -611,6 +630,7 @@ public class ContainerProperties extends ConsumerProperties {
 				+ ", monitorInterval=" + this.monitorInterval
 				+ (this.scheduler != null ? ", scheduler=" + this.scheduler : "")
 				+ ", noPollThreshold=" + this.noPollThreshold
+				+ ", subBatchPerPartition=" + this.subBatchPerPartition
 				+ "]";
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -37,7 +38,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.clients.consumer.Consumer;
@@ -555,13 +555,11 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 
 		private final MicrometerHolder micrometerHolder;
 
-		private Map<TopicPartition, OffsetMetadata> definedPartitions;
-
 		private final AtomicBoolean polling = new AtomicBoolean();
 
-		private volatile Collection<TopicPartition> assignedPartitions;
+		private final boolean subBatchPerPartition = this.containerProperties.isSubBatchPerPartition();
 
-		private volatile Thread consumerThread;
+		private Map<TopicPartition, OffsetMetadata> definedPartitions;
 
 		private int count;
 
@@ -579,7 +577,15 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 
 		private int nackIndex;
 
+		private Iterator<TopicPartition> batchIterator;
+
+		private ConsumerRecords<K, V> lastBatch;
+
 		private volatile boolean consumerPaused;
+
+		private volatile Collection<TopicPartition> assignedPartitions;
+
+		private volatile Thread consumerThread;
 
 		private volatile long lastPoll = System.currentTimeMillis();
 
@@ -929,7 +935,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			checkPaused();
 			this.lastPoll = System.currentTimeMillis();
 			this.polling.set(true);
-			ConsumerRecords<K, V> records = this.consumer.poll(this.pollTimeout);
+			ConsumerRecords<K, V> records = doPoll();
 			if (!this.polling.compareAndSet(true, false)) {
 				/*
 				 * There is a small race condition where wakeIfNecessary was called between
@@ -951,6 +957,31 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			else {
 				checkIdle();
 			}
+		}
+
+		private ConsumerRecords<K, V> doPoll() {
+			ConsumerRecords<K, V> records;
+			if (this.isBatchListener && this.subBatchPerPartition) {
+				if (this.batchIterator == null) {
+					this.lastBatch = this.consumer.poll(this.pollTimeout);
+					if (this.lastBatch.count() == 0) {
+						return this.lastBatch;
+					}
+					else {
+						this.batchIterator = this.lastBatch.partitions().iterator();
+					}
+				}
+				TopicPartition next = this.batchIterator.next();
+				List<ConsumerRecord<K, V>> subBatch = this.lastBatch.records(next);
+				records = new ConsumerRecords<>(Collections.singletonMap(next, subBatch));
+				if (!this.batchIterator.hasNext()) {
+					this.batchIterator = null;
+				}
+			}
+			else {
+				records = this.consumer.poll(this.pollTimeout);
+			}
+			return records;
 		}
 
 		void wakeIfNecessary() {
@@ -1186,6 +1217,10 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 				final List<ConsumerRecord<K, V>> recordList) {
 
 			try {
+				if (this.subBatchPerPartition) {
+					ConsumerRecord<K, V> record = recordList.get(0);
+					TransactionSupport.setTransactionIdSuffix(zombieFenceTxIdSuffix(record.topic(), record.partition()));
+				}
 				this.transactionTemplate.execute(new TransactionCallbackWithoutResult() {
 
 					@Override
@@ -1221,6 +1256,11 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 					batchAfterRollback(records, recordList, e, afterRollbackProcessorToUse);
 				}
 			}
+			finally {
+				if (this.subBatchPerPartition) {
+					TransactionSupport.clearTransactionIdSuffix();
+				}
+			}
 		}
 
 		private void batchAfterRollback(final ConsumerRecords<K, V> records,
@@ -1241,8 +1281,12 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		}
 
 		private List<ConsumerRecord<K, V>> createRecordList(final ConsumerRecords<K, V> records) {
-			return StreamSupport.stream(records.spliterator(), false)
-					.collect(Collectors.toList());
+			Iterator<ConsumerRecord<K, V>> iterator = records.iterator();
+			List<ConsumerRecord<K, V>> list = new LinkedList<>();
+			while (iterator.hasNext()) {
+				list.add(iterator.next());
+			}
+			return list;
 		}
 
 		/**

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/SubBatchPerPartitionTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/SubBatchPerPartitionTests.java
@@ -18,11 +18,13 @@ package org.springframework.kafka.listener;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -40,8 +42,6 @@ import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.clients.consumer.OffsetAndMetadata;
-import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.record.TimestampType;
 import org.junit.jupiter.api.Test;
@@ -55,31 +55,24 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
 import org.springframework.kafka.core.ConsumerFactory;
-import org.springframework.kafka.core.ProducerFactory;
-import org.springframework.kafka.listener.ContainerProperties.AckMode;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
-import org.springframework.kafka.transaction.KafkaTransactionManager;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 /**
  * @author Gary Russell
- * @since 2.0.1
+ * @since 2.3.2
  *
  */
 @SpringJUnitConfig
 @DirtiesContext
-public class SeekToCurrentOnErrorBatchModeTXTests {
+public class SubBatchPerPartitionTests {
 
 	private static final String CONTAINER_ID = "container";
 
 	@SuppressWarnings("rawtypes")
 	@Autowired
 	private Consumer consumer;
-
-	@SuppressWarnings("rawtypes")
-	@Autowired
-	private Producer producer;
 
 	@Autowired
 	private Config config;
@@ -89,58 +82,22 @@ public class SeekToCurrentOnErrorBatchModeTXTests {
 
 	/*
 	 * Deliver 6 records from three partitions, fail on the second record second
-	 * partition, first attempt; verify partition 0,1 committed and a total of 7 records
-	 * handled after seek.
+	 * partition.
 	 */
 	@SuppressWarnings("unchecked")
 	@Test
 	public void discardRemainingRecordsFromPollAndSeek() throws Exception {
 		assertThat(this.config.deliveryLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(this.config.commitLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(this.config.pollLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		this.registry.stop();
 		assertThat(this.config.closeLatch.await(10, TimeUnit.SECONDS)).isTrue();
-		InOrder inOrder = inOrder(this.consumer, this.producer);
+		InOrder inOrder = inOrder(this.consumer);
 		inOrder.verify(this.consumer).subscribe(any(Collection.class), any(ConsumerRebalanceListener.class));
 		inOrder.verify(this.consumer).poll(Duration.ofMillis(ContainerProperties.DEFAULT_POLL_TIMEOUT));
-		inOrder.verify(this.producer).beginTransaction();
-		Map<TopicPartition, OffsetAndMetadata> offsets = new LinkedHashMap<>();
-		offsets.put(new TopicPartition("foo", 0), new OffsetAndMetadata(1L));
-		inOrder.verify(this.producer).sendOffsetsToTransaction(offsets, CONTAINER_ID);
-		inOrder.verify(this.producer).commitTransaction();
-		offsets.clear();
-		offsets.put(new TopicPartition("foo", 0), new OffsetAndMetadata(2L));
-		inOrder.verify(this.producer).beginTransaction();
-		inOrder.verify(this.producer).sendOffsetsToTransaction(offsets, CONTAINER_ID);
-		inOrder.verify(this.producer).commitTransaction();
-		offsets.clear();
-		offsets.put(new TopicPartition("foo", 1), new OffsetAndMetadata(1L));
-		inOrder.verify(this.producer).beginTransaction();
-		inOrder.verify(this.producer).sendOffsetsToTransaction(offsets, CONTAINER_ID);
-		inOrder.verify(this.producer).commitTransaction();
-		inOrder.verify(this.producer).beginTransaction();
-		inOrder.verify(this.consumer).seek(new TopicPartition("foo", 1), 1L);
-		inOrder.verify(this.consumer).seek(new TopicPartition("foo", 2), 0L);
-		inOrder.verify(this.producer).abortTransaction();
+		inOrder.verify(this.consumer, times(3)).commitSync(any(), eq(Duration.ofSeconds(60)));
 		inOrder.verify(this.consumer).poll(Duration.ofMillis(ContainerProperties.DEFAULT_POLL_TIMEOUT));
-		offsets.clear();
-		offsets.put(new TopicPartition("foo", 1), new OffsetAndMetadata(2L));
-		inOrder.verify(this.producer).beginTransaction();
-		inOrder.verify(this.producer).sendOffsetsToTransaction(offsets, CONTAINER_ID);
-		inOrder.verify(this.producer).commitTransaction();
-		offsets.clear();
-		offsets.put(new TopicPartition("foo", 2), new OffsetAndMetadata(1L));
-		inOrder.verify(this.producer).beginTransaction();
-		inOrder.verify(this.producer).sendOffsetsToTransaction(offsets, CONTAINER_ID);
-		inOrder.verify(this.producer).commitTransaction();
-		offsets.clear();
-		offsets.put(new TopicPartition("foo", 2), new OffsetAndMetadata(2L));
-		inOrder.verify(this.producer).beginTransaction();
-		inOrder.verify(this.producer).sendOffsetsToTransaction(offsets, CONTAINER_ID);
-		inOrder.verify(this.producer).commitTransaction();
-		inOrder.verify(this.consumer).poll(Duration.ofMillis(ContainerProperties.DEFAULT_POLL_TIMEOUT));
-		assertThat(this.config.count).isEqualTo(7);
-		assertThat(this.config.contents.toArray()).isEqualTo(new String[]
-				{ "foo", "bar", "baz", "qux", "qux", "fiz", "buz" });
+		assertThat(this.config.contents).contains("foo", "bar", "baz", "qux", "fiz", "buz");
 	}
 
 	@Configuration
@@ -149,21 +106,18 @@ public class SeekToCurrentOnErrorBatchModeTXTests {
 
 		private final List<String> contents = new ArrayList<>();
 
-		private final CountDownLatch pollLatch = new CountDownLatch(3);
+		private final CountDownLatch pollLatch = new CountDownLatch(2);
 
-		private final CountDownLatch deliveryLatch = new CountDownLatch(7);
+		private final CountDownLatch deliveryLatch = new CountDownLatch(3);
+
+		private final CountDownLatch commitLatch = new CountDownLatch(3);
 
 		private final CountDownLatch closeLatch = new CountDownLatch(1);
 
-		private int count;
-
 		@KafkaListener(id = CONTAINER_ID, topics = "foo")
-		public void foo(String in) {
-			this.contents.add(in);
+		public void foo(List<String> in) {
+			contents.addAll(in);
 			this.deliveryLatch.countDown();
-			if (++this.count == 4) { // part 1, offset 1, first time
-				throw new RuntimeException("foo");
-			}
 		}
 
 		@SuppressWarnings({ "rawtypes" })
@@ -185,7 +139,7 @@ public class SeekToCurrentOnErrorBatchModeTXTests {
 			final TopicPartition topicPartition2 = new TopicPartition("foo", 2);
 			willAnswer(i -> {
 				((ConsumerRebalanceListener) i.getArgument(1)).onPartitionsAssigned(
-						Collections.singletonList(topicPartition1));
+						Arrays.asList(topicPartition0, topicPartition1, topicPartition2));
 				return null;
 			}).given(consumer).subscribe(any(Collection.class), any(ConsumerRebalanceListener.class));
 			Map<TopicPartition, List<ConsumerRecord>> records1 = new LinkedHashMap<>();
@@ -198,28 +152,26 @@ public class SeekToCurrentOnErrorBatchModeTXTests {
 			records1.put(topicPartition2, Arrays.asList(
 					new ConsumerRecord("foo", 2, 0L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "fiz"),
 					new ConsumerRecord("foo", 2, 1L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "buz")));
-			Map<TopicPartition, List<ConsumerRecord>> records2 = new LinkedHashMap<>(records1);
-			records2.remove(topicPartition0);
-			records2.put(topicPartition1, Arrays.asList(
-					new ConsumerRecord("foo", 1, 1L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "qux")));
 			final AtomicInteger which = new AtomicInteger();
 			willAnswer(i -> {
 				this.pollLatch.countDown();
 				switch (which.getAndIncrement()) {
 					case 0:
 						return new ConsumerRecords(records1);
-					case 1:
-						return new ConsumerRecords(records2);
 					default:
 						try {
-							Thread.sleep(1000);
+							Thread.sleep(100);
 						}
-						catch (InterruptedException e) {
+						catch (@SuppressWarnings("unused") InterruptedException e) {
 							Thread.currentThread().interrupt();
 						}
 						return new ConsumerRecords(Collections.emptyMap());
 				}
 			}).given(consumer).poll(Duration.ofMillis(ContainerProperties.DEFAULT_POLL_TIMEOUT));
+			willAnswer(i -> {
+				this.commitLatch.countDown();
+				return null;
+			}).given(consumer).commitSync(anyMap(), any());
 			willAnswer(i -> {
 				this.closeLatch.countDown();
 				return null;
@@ -233,31 +185,10 @@ public class SeekToCurrentOnErrorBatchModeTXTests {
 			ConcurrentKafkaListenerContainerFactory factory = new ConcurrentKafkaListenerContainerFactory();
 			factory.setConsumerFactory(consumerFactory());
 			factory.getContainerProperties().setAckOnError(false);
-			factory.setErrorHandler(new SeekToCurrentErrorHandler());
-			factory.getContainerProperties().setAckMode(AckMode.BATCH);
-			factory.getContainerProperties().setTransactionManager(tm());
+			factory.setBatchListener(true);
+			factory.getContainerProperties().setMissingTopicsFatal(false);
+			factory.getContainerProperties().setSubBatchPerPartition(true);
 			return factory;
-		}
-
-		@SuppressWarnings({ "unchecked", "rawtypes" })
-		@Bean
-		public KafkaTransactionManager tm() {
-			return new KafkaTransactionManager<>(producerFactory());
-		}
-
-		@SuppressWarnings("rawtypes")
-		@Bean
-		public ProducerFactory producerFactory() {
-			ProducerFactory pf = mock(ProducerFactory.class);
-			given(pf.createProducer(isNull())).willReturn(producer());
-			given(pf.transactionCapable()).willReturn(true);
-			return pf;
-		}
-
-		@SuppressWarnings("rawtypes")
-		@Bean
-		public Producer producer() {
-			return mock(Producer.class);
 		}
 
 	}

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -2217,7 +2217,9 @@ This is to properly support fencing zombies, https://www.confluent.io/blog/trans
 This new behavior was added in versions 1.3.7, 2.0.6, 2.1.10, and 2.2.0.
 If you wish to revert to the previous behavior, you can set the `producerPerConsumerPartition` property on the `DefaultKafkaProducerFactory` to `false`.
 
-NOTE: While transactions are supported with batch listeners, zombie fencing cannot be supported because a batch may contain records from multiple topics or partitions.
+NOTE: While transactions are supported with batch listeners, by default, zombie fencing is not supported because a batch may contain records from multiple topics or partitions.
+However, starting with version 2.3.2, zombie fencing is supported if you set the container property `subBatchPerPartition` to true.
+In that case, the batch listener is invoked once per partition received from the last poll, as if each poll only returned records for a single partition.
 
 Also see <<transaction-id-prefix>>.
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -64,6 +64,9 @@ See <<micrometer>> for more information.
 The containers now publish additional consumer lifecyle events relating to startup.
 See <<events>> for more information.
 
+Transactional batch listeners can now support zombie fencing.
+See <<transactions>> for more information.
+
 ==== ErrorHandler Changes
 
 The `SeekToCurrentErrorHandler` now treats certain exceptions as fatal and disables retry for those, invoking the recoverer on first failure.


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1278

Support transaction per partition with Batch Listeners so the `transactional.id`
is tied to the group/topic/partition.