### PR TITLE
Remove unnecessary implements statement

### DIFF
--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/rule/EmbeddedKafkaRule.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/rule/EmbeddedKafkaRule.java
@@ -32,7 +32,7 @@ import org.springframework.kafka.test.EmbeddedKafkaBroker;
  *
  * @see EmbeddedKafkaBroker
  */
-public class EmbeddedKafkaRule extends ExternalResource implements TestRule {
+public class EmbeddedKafkaRule extends ExternalResource {
 
 	private final EmbeddedKafkaBroker embeddedKafka;
 


### PR DESCRIPTION
`ExternalResource` already implements `TestRule` which makes the explicit implementation of `TestRule` obsolete.