### PR TITLE
Proposal: Support Kafka Streams Topology customizer

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/config/CompositeKafkaStreamsTopologyCustomizer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/CompositeKafkaStreamsTopologyCustomizer.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.config;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.kafka.streams.Topology;
+
+/**
+ * Composite {@link KafkaStreamsTopologyCustomizer} customizes {@link Topology} by delegating
+ * to a list of provided {@link KafkaStreamsTopologyCustomizer}.
+ *
+ * @author Renato Mefi
+ *
+ * @since 2.4.0
+ */
+public class CompositeKafkaStreamsTopologyCustomizer implements KafkaStreamsTopologyCustomizer {
+
+	private final List<KafkaStreamsTopologyCustomizer> KafkaStreamsTopologyCustomizers = new ArrayList<>();
+
+	public CompositeKafkaStreamsTopologyCustomizer() {
+	}
+
+	public CompositeKafkaStreamsTopologyCustomizer(List<KafkaStreamsTopologyCustomizer> KafkaStreamsTopologyCustomizers) {
+		this.KafkaStreamsTopologyCustomizers.addAll(KafkaStreamsTopologyCustomizers);
+	}
+
+	@Override
+	public void customize(Topology topology) {
+		this.KafkaStreamsTopologyCustomizers.forEach(KafkaStreamsTopologyCustomizer -> KafkaStreamsTopologyCustomizer.customize(topology));
+	}
+
+	public void addKafkaStreamsTopologyCustomizers(List<KafkaStreamsTopologyCustomizer> customizers) {
+		this.KafkaStreamsTopologyCustomizers.addAll(customizers);
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaStreamsTopologyCustomizer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaStreamsTopologyCustomizer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.config;
+
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.Topology;
+
+/**
+ * Callback interface that can be used to configure {@link KafkaStreams} directly.
+ *
+ * @author Renato Mefi
+ *
+ * @since 2.4.0
+ *
+ * @see StreamsBuilderFactoryBean
+ */
+@FunctionalInterface
+public interface KafkaStreamsTopologyCustomizer {
+
+	void customize(Topology topology);
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/config/KafkaStreamsCustomizerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/config/KafkaStreamsCustomizerTests.java
@@ -89,6 +89,7 @@ public class KafkaStreamsCustomizerTests {
 			StreamsBuilderFactoryBean streamsBuilderFactoryBean =
 					new StreamsBuilderFactoryBean(kStreamsConfigs());
 			streamsBuilderFactoryBean.setKafkaStreamsCustomizer(customizer());
+			streamsBuilderFactoryBean.setKafkaStreamsTopologyCustomizer(topologyCustomizer());
 			return streamsBuilderFactoryBean;
 		}
 
@@ -105,6 +106,10 @@ public class KafkaStreamsCustomizerTests {
 
 		private KafkaStreamsCustomizer customizer() {
 			return kafkaStreams -> kafkaStreams.setStateListener(STATE_LISTENER);
+		}
+
+		private KafkaStreamsTopologyCustomizer topologyCustomizer() {
+			return topology -> topology.addSource("fake-source", "fake-source-topic");
 		}
 
 	}


### PR DESCRIPTION
The streams Topology is current in a limited scope, there are use cases where the user might want to customize it, by adding processors that influence GlobalKTables which is my case.

I think it can possibly assist on use cases like https://github.com/spring-projects/spring-kafka/issues/1236

Please let me know if it's a valid idea so I can proceed with documentation and more tests, the current test is very simple and actually doesn't represent the power of the Topology customization, but it's the fastest functional example I can write while the idea is evaluated!

I'm glad to hear your thoughts, thanks you!