### PR TITLE
ConsumerSeekAware Improvement

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerSeekAware.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerSeekAware.java
@@ -96,12 +96,34 @@ public interface ConsumerSeekAware {
 		void seekToBeginning(String topic, int partition);
 
 		/**
+		 * Queue a seekToBeginning operation to the consumer for each
+		 * {@link TopicPartition}. The seek will occur after any pending offset commits.
+		 * The consumer must be currently assigned the specified partition(s).
+		 * @param partitions the {@link TopicPartition}s.
+		 * @since 2.3.4
+		 */
+		default void seekToBeginning(Collection<TopicPartition> partitions) {
+			throw new UnsupportedOperationException();
+		}
+
+		/**
 		 * Queue a seekToEnd operation to the consumer. The seek will occur after any pending
 		 * offset commits. The consumer must be currently assigned the specified partition.
 		 * @param topic the topic.
 		 * @param partition the partition.
 		 */
 		void seekToEnd(String topic, int partition);
+
+		/**
+		 * Queue a seekToEnd operation to the consumer for each {@link TopicPartition}.
+		 * The seek will occur after any pending offset commits. The consumer must be
+		 * currently assigned the specified partition(s).
+		 * @param partitions the {@link TopicPartition}s.
+		 * @since 2.3.4
+		 */
+		default void seekToEnd(Collection<TopicPartition> partitions) {
+			throw new UnsupportedOperationException();
+		}
 
 		/**
 		 * Queue a seek to a position relative to the start or end of the current position.

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -1981,8 +1981,22 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		}
 
 		@Override
+		public void seekToBeginning(Collection<TopicPartition> partitions) {
+			this.seeks.addAll(partitions.stream()
+					.map(tp -> new TopicPartitionOffset(tp.topic(), tp.partition(), SeekPosition.BEGINNING))
+					.collect(Collectors.toList()));
+		}
+
+		@Override
 		public void seekToEnd(String topic, int partition) {
 			this.seeks.add(new TopicPartitionOffset(topic, partition, SeekPosition.END));
+		}
+
+		@Override
+		public void seekToEnd(Collection<TopicPartition> partitions) {
+			this.seeks.addAll(partitions.stream()
+					.map(tp -> new TopicPartitionOffset(tp.topic(), tp.partition(), SeekPosition.END))
+					.collect(Collectors.toList()));
 		}
 
 		@Override
@@ -2243,9 +2257,19 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			}
 
 			@Override
+			public void seekToBeginning(Collection<TopicPartition> partitions) {
+				ListenerConsumer.this.consumer.seekToBeginning(partitions);
+			}
+
+			@Override
 			public void seekToEnd(String topic, int partition) {
 				ListenerConsumer.this.consumer.seekToEnd(
 						Collections.singletonList(new TopicPartition(topic, partition)));
+			}
+
+			@Override
+			public void seekToEnd(Collection<TopicPartition> partitions) {
+				ListenerConsumer.this.consumer.seekToEnd(partitions);
 			}
 
 			@Override

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -2031,7 +2031,11 @@ void seek(String topic, int partition, long offset);
 
 void seekToBeginning(String topic, int partition);
 
+void seekToBeginning(Collection=<TopicPartitions> partitions);
+
 void seekToEnd(String topic, int partition);
+
+void seekToEnd(Collection=<TopicPartitions> partitions);
 
 void seekRelative(String topic, int partition, long offset, boolean toCurrent);
 
@@ -2055,6 +2059,24 @@ When called from other locations, the container will gather all timestamp seek r
 
 You can also perform seek operations from `onIdleContainer()` when an idle container is detected.
 See <<idle-containers>> for how to enable idle container detection.
+
+NOTE: The `seekToBeginning` method that accepts a collection is useful, for example, when processing a compacted topic and you wish to seek to the beginning every time the application is started:
+
+====
+[source, java]
+----
+public class MyListener extends AbstractConsumerSeekAware {
+
+...
+
+    @Override
+	public void onPartitionsAssigned(Map<TopicPartition, Long> assignments, ConsumerSeekCallback callback) {
+		callback.seekToBeginning(assignments.keySet());
+	}
+
+}
+----
+====
 
 To arbitrarily seek at runtime, use the callback reference from the `registerSeekCallback` for the appropriate thread.
 


### PR DESCRIPTION
Add seek to beginning/end variants that take a collection to make
resetting all assigned partitions easier, and more efficient.