### PR TITLE
GH-1309: Fix NPE when no syncCommitTimeout set

### DIFF
--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
 import java.lang.reflect.Type;
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -341,8 +342,16 @@ public class EnableKafkaIntegrationTests {
 		MessageListenerContainer listenerContainer = registry.getListenerContainer("manualStart");
 		assertThat(listenerContainer).isNotNull();
 		assertThat(listenerContainer.isRunning()).isFalse();
+		assertThat(listenerContainer.getContainerProperties().getSyncCommitTimeout()).isNull();
 		this.registry.start();
 		assertThat(listenerContainer.isRunning()).isTrue();
+		assertThat(((ConcurrentMessageListenerContainer<?, ?>) listenerContainer)
+				.getContainers()
+				.get(0)
+				.getContainerProperties().getSyncCommitTimeout())
+				.isEqualTo(Duration.ofSeconds(60));
+		assertThat(listenerContainer.getContainerProperties().getSyncCommitTimeout())
+				.isEqualTo(Duration.ofSeconds(60));
 		listenerContainer.stop();
 		assertThat(KafkaTestUtils.getPropertyValue(listenerContainer, "containerProperties.syncCommits", Boolean.class))
 				.isFalse();


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1309

When no commit timeout is provided we update the properties in the local
container properties.

The parent container's properties must also be updated because the parent
is passed into the error handler (e.g. for stopping the entire container
when an error occurs).

Also, fix a problem where the child container instead of the parent was
passed into the batch error handler.