### PR TITLE
Add parameter names to default object mapper

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/JacksonUtils.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/JacksonUtils.java
@@ -76,6 +76,15 @@ public final class JacksonUtils {
 		}
 
 		try {
+			Class<? extends Module> parameterNamesModule = (Class<? extends Module>)
+					ClassUtils.forName("com.fasterxml.jackson.module.paramnames.ParameterNamesModule", classLoader);
+			objectMapper.registerModule(BeanUtils.instantiateClass(parameterNamesModule));
+		}
+		catch (@SuppressWarnings(UNUSED) ClassNotFoundException ex) {
+			// jackson-parameter-names not available
+		}
+
+		try {
 			Class<? extends Module> javaTimeModule = (Class<? extends Module>)
 					ClassUtils.forName("com.fasterxml.jackson.datatype.jsr310.JavaTimeModule", classLoader);
 			objectMapper.registerModule(BeanUtils.instantiateClass(javaTimeModule));


### PR DESCRIPTION
The parameter names module allows to use constructor parameter names during deserialization. This is one of the basic modules that should typically be added to an object mapper to make things work as expected.

The current workaround is to provide a custom object mapper instead.