### PR TITLE
GH-1321: Add intercept before Tx option

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
@@ -95,6 +95,8 @@ public abstract class AbstractMessageListenerContainer<K, V>
 
 	private RecordInterceptor<K, V> recordInterceptor;
 
+	private boolean interceptBeforeTx;
+
 	private volatile boolean running = false;
 
 	private volatile boolean paused;
@@ -303,9 +305,24 @@ public abstract class AbstractMessageListenerContainer<K, V>
 	 * Does not apply to batch listeners.
 	 * @param recordInterceptor the interceptor.
 	 * @since 2.2.7
+	 * @see #setInterceptBeforeTx(boolean)
 	 */
 	public void setRecordInterceptor(RecordInterceptor<K, V> recordInterceptor) {
 		this.recordInterceptor = recordInterceptor;
+	}
+
+	protected boolean isInterceptBeforeTx() {
+		return this.interceptBeforeTx;
+	}
+
+	/**
+	 * When true, invoke the interceptor before the transaction starts.
+	 * @param interceptBeforeTx true to intercept before the transaction.
+	 * @since 2.3.4
+	 * @see #setRecordInterceptor(RecordInterceptor)
+	 */
+	public void setInterceptBeforeTx(boolean interceptBeforeTx) {
+		this.interceptBeforeTx = interceptBeforeTx;
 	}
 
 	@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
@@ -163,6 +163,7 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 				container.setGenericErrorHandler(getGenericErrorHandler());
 				container.setAfterRollbackProcessor(getAfterRollbackProcessor());
 				container.setRecordInterceptor(getRecordInterceptor());
+				container.setInterceptBeforeTx(isInterceptBeforeTx());
 				container.setEmergencyStop(() -> {
 					stop(() -> {
 						// NOSONAR

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -657,6 +657,11 @@ The interceptor is not invoked when the listener is a <<batch-listners, batch li
 
 Starting with version 2.3, the `CompositeRecordInterceptor` can be used to invoke multiple interceptors.
 
+By default, when using transactions, the interceptor is invoked after the transaction has started.
+Startubg with version 2.3.4, you can set the listener container's `interceptBeforeTx` property to invoke the interceptor before the transaction has started instead.
+
+No interceptor is provided for batch listeners because Kafka already provides a `ConsumerInterceptor`.
+
 [[kafka-container]]
 ====== Using `KafkaMessageListenerContainer`
 

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -658,7 +658,7 @@ The interceptor is not invoked when the listener is a <<batch-listners, batch li
 Starting with version 2.3, the `CompositeRecordInterceptor` can be used to invoke multiple interceptors.
 
 By default, when using transactions, the interceptor is invoked after the transaction has started.
-Startubg with version 2.3.4, you can set the listener container's `interceptBeforeTx` property to invoke the interceptor before the transaction has started instead.
+Starting with version 2.3.4, you can set the listener container's `interceptBeforeTx` property to invoke the interceptor before the transaction has started instead.
 
 No interceptor is provided for batch listeners because Kafka already provides a `ConsumerInterceptor`.
 


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1321

Provide an option to invoke `RecordInterceptor` before the transaction starts.