### PR TITLE
Fix wrong method name in docs

### DIFF
--- a/src/reference/asciidoc/testing.adoc
+++ b/src/reference/asciidoc/testing.adoc
@@ -26,7 +26,7 @@ public static Map<String, Object> consumerProps(String group, String autoCommit,
  * @param embeddedKafka a {@link EmbeddedKafkaBroker} instance.
  * @return the properties.
  */
-public static Map<String, Object> senderProps(EmbeddedKafkaBroker embeddedKafka) { ... }
+public static Map<String, Object> producerProps(EmbeddedKafkaBroker embeddedKafka) { ... }
 ----
 ====
 


### PR DESCRIPTION
This is code block for explaining methods to set up producer and consumer properties. So 'consumerProps()' and 'producerProps()' are must be here. But there is 'senderProps()' method instead of 'producerProps().

API ref. `org.springframework.kafka.test.utils.KafkaTestUtils#producerProps`