### PR TITLE
GH-1319: Agg. Replying Template improvement

### DIFF
--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -503,10 +503,14 @@ The template in <<replying-template>> is strictly for a single request/reply sce
 For cases where multiple receivers of a single message return a reply, you can use the `AggregatingReplyingKafkaTemplate`.
 This is an implementation of the client-side of the https://www.enterpriseintegrationpatterns.com/patterns/messaging/BroadcastAggregate.html[Scatter-Gather Enterprise Integration Pattern].
 
-Like the `ReplyingKafkaTemplate`, the `AggregatingReplyingKafkaTemplate` constructor takes a producer factory and a listener container to receive the replies; it has a third parameter `Predicate<Collection<ConsumerRecord<K, R>>> releaseStrategy` which is consulted each time a reply is received; when the predicate returns `true`, the collection of `ConsumerRecord` s is used to complete the `Future` returned by the `sendAndReceive` method.
+Like the `ReplyingKafkaTemplate`, the `AggregatingReplyingKafkaTemplate` constructor takes a producer factory and a listener container to receive the replies; it has a third parameter `BiPredicate<List<ConsumerRecord<K, R>>, Boolean> releaseStrategy` which is consulted each time a reply is received; when the predicate returns `true`, the collection of `ConsumerRecord` s is used to complete the `Future` returned by the `sendAndReceive` method.
 
 There is an additional property `returnPartialOnTimeout` (default false).
 When this is set to `true`, instead of completing the future with a `KafkaReplyTimeoutException`, a partial result completes the future normally (as long as at least one reply record has been received).
+
+Starting with version 2.3.5, the predicate is also called after a timeout (if `returnPartialOnTimeout` is `true`).
+The first argument is the current list of records; the second is `true` if this call is due to a timeout.
+The predicate can modify the list of records.
 
 ====
 [source, java]

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -7,7 +7,7 @@ Also see <<new-in-sik>>.
 [[kafka-client-2.4]]
 ==== Kafka Client Version
 
-This version requires the 2.4.0 `kafka-clients` or higher.
+This version requires the 2.4.0 `kafka-clients` or higher and supports the new incremental rebalancing feature.
 
 [[x24-carl]]
 ==== ConsumerAwareRabalanceListener
@@ -24,6 +24,14 @@ See the IMPORTANT note at the end of <<rebalance-listeners>> for more informatio
 ==== GenericErrorHandler
 
 The `isAckAfterHandle()` default implementation now returns true by default.
+
+[[x24-agg]]
+==== AggregatingReplyingKafkaTemplate
+
+The `releastStrategy` is now a `BiConsumer`.
+It is now called after a timeout (as well as when records arrive); the second parameter is `true` in the case of a call after a timeout.
+
+See <<aggregating-request-reply>> for more information.
 
 === Migration Guide
 


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1319

- change the release strategy to a `BiConsumer`
- call the strategy during normal message delivery as before
- now call the strategy when releasing a partial result after timeout
- allow the strategy to modify the list (change from `Collection` to `List`).

**cherry-pick to 2.3.x**