### PR TITLE
GH-1340: Support returning a collection

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
@@ -244,4 +244,13 @@ public @interface KafkaListener {
 	 */
 	String[] properties() default {};
 
+	/**
+	 * When false and the return type is a {@link Iterable} return the result as the value
+	 * of a single reply record instead of individual records for each element. Default
+	 * true. Ignored if the reply is of type {@code Iterable<Message<?>>}.
+	 * @return false to create a single reply record.
+	 * @since 2.3.5
+	 */
+	boolean splitIterables() default true;
+
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
@@ -437,6 +437,7 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 			endpoint.setAutoStartup(resolveExpressionAsBoolean(autoStartup, "autoStartup"));
 		}
 		resolveKafkaProperties(endpoint, kafkaListener.properties());
+		endpoint.setSplitIterables(kafkaListener.splitIterables());
 
 		KafkaListenerContainerFactory<?> factory = null;
 		String containerFactoryBeanName = resolve(kafkaListener.containerFactory());

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
@@ -114,6 +114,8 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 
 	private Properties consumerProperties;
 
+	private boolean splitIterables = true;
+
 	@Override
 	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
 		this.beanFactory = beanFactory;
@@ -433,6 +435,21 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 	}
 
 	@Override
+	public boolean isSplitIterables() {
+		return this.splitIterables;
+	}
+
+	/**
+	 * Set to false to disable splitting {@link Iterable} reply values into separate
+	 * records.
+	 * @param splitIterables false to disable; default true.
+	 * @since 2.3.5
+	 */
+	public void setSplitIterables(boolean splitIterables) {
+		this.splitIterables = splitIterables;
+	}
+
+	@Override
 	public void afterPropertiesSet() {
 		boolean topicsEmpty = getTopics().isEmpty();
 		boolean topicPartitionsEmpty = ObjectUtils.isEmpty(getTopicPartitionsToAssign());
@@ -470,6 +487,7 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 		if (this.replyHeadersConfigurer != null) {
 			adapter.setReplyHeadersConfigurer(this.replyHeadersConfigurer);
 		}
+		adapter.setSplitIterables(this.splitIterables);
 		Object messageListener = adapter;
 		Assert.state(messageListener != null,
 				() -> "Endpoint [" + this + "] must provide a non null message listener");

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpoint.java
@@ -144,4 +144,11 @@ public interface KafkaListenerEndpoint {
 	 */
 	void setupListenerContainer(MessageListenerContainer listenerContainer, MessageConverter messageConverter);
 
+	/**
+	 * When true, {@link Iterable} return results will be split into discrete records.
+	 * @return true to split.
+	 * @since 2.3.5
+	 */
+	boolean isSplitIterables();
+
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointAdapter.java
@@ -87,4 +87,9 @@ class KafkaListenerEndpointAdapter implements KafkaListenerEndpoint {
 			MessageConverter messageConverter) {
 	}
 
+	@Override
+	public boolean isSplitIterables() {
+		return true;
+	}
+
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
@@ -23,6 +23,7 @@ import java.lang.reflect.WildcardType;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -122,6 +123,8 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 	private boolean messageReturnType;
 
 	private ReplyHeadersConfigurer replyHeadersConfigurer;
+
+	private boolean splitIterables = true;
 
 	public MessagingMessageListenerAdapter(Object bean, Method method) {
 		this.bean = bean;
@@ -250,6 +253,25 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 	 */
 	public void setReplyHeadersConfigurer(ReplyHeadersConfigurer replyHeadersConfigurer) {
 		this.replyHeadersConfigurer = replyHeadersConfigurer;
+	}
+
+	/**
+	 * When true, {@link Iterable} return results will be split into discrete records.
+	 * @return true to split.
+	 * @since 2.3.5
+	 */
+	protected boolean isSplitIterables() {
+		return this.splitIterables;
+	}
+
+	/**
+	 * Set to false to disable splitting {@link Iterable} reply values into separate
+	 * records.
+	 * @param splitIterables false to disable; default true.
+	 * @since 2.3.5
+	 */
+	public void setSplitIterables(boolean splitIterables) {
+		this.splitIterables = splitIterables;
 	}
 
 	@Override
@@ -406,15 +428,25 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 			this.replyTemplate.send((Message<?>) result);
 		}
 		else {
-			if (result instanceof Collection) {
-				((Collection<V>) result).forEach(v -> {
-					if (v instanceof Message) {
-						this.replyTemplate.send((Message<?>) v);
-					}
-					else {
-						this.replyTemplate.send(topic, v);
-					}
-				});
+			if (result instanceof Iterable) {
+				Iterator<?> iterator = ((Iterable<?>) result).iterator();
+				boolean iterableOfMessages = false;
+				if (iterator.hasNext()) {
+					iterableOfMessages = iterator.next() instanceof Message;
+				}
+				if (iterableOfMessages || this.splitIterables) {
+					((Collection<V>) result).forEach(v -> {
+						if (v instanceof Message) {
+							this.replyTemplate.send((Message<?>) v);
+						}
+						else {
+							this.replyTemplate.send(topic, v);
+						}
+					});
+				}
+				else {
+					sendSingleResult(result, topic, source);
+				}
 			}
 			else {
 				sendSingleResult(result, topic, source);

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
@@ -435,7 +435,7 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 					iterableOfMessages = iterator.next() instanceof Message;
 				}
 				if (iterableOfMessages || this.splitIterables) {
-					((Collection<V>) result).forEach(v -> {
+					((Iterable<V>) result).forEach(v -> {
 						if (v instanceof Message) {
 							this.replyTemplate.send((Message<?>) v);
 						}

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -1744,6 +1744,11 @@ public KafkaListenerErrorHandler voidSendToErrorHandler() {
 See <<annotation-error-handling>> for more information.
 ====
 
+NOTE: If a listener method returns an `Iterable`, by default a record for each element as the value is sent.
+Starting with version 2.3.5, set the `splitIterables` property on `@KafkaListener` to `false` and the entire result will be sent as the value of a single `ProducerRecord`.
+This requires a suitable serializer in the reply template's producer configuration.
+However, if the reply is `Iterable<Message<?>>` the property is ignored and each message is sent separately.
+
 ===== Filtering Messages
 
 In certain scenarios, such as rebalancing, a message that has already been processed may be redelivered.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -38,6 +38,12 @@ See <<aggregating-request-reply>> for more information.
 The `ContainerProperties` provides an `authorizationExceptionRetryInterval` option to let the listener container to retry after any `AuthorizationException` is thrown by the `KafkaConsumer`.
 See its JavaDocs and <<kafka-container>> for more information.
 
+==== @KafkaListener
+
+The `@KafkaListener` annotation has a new property `splitIterables`; default true.
+When a replying listener returns an `Iterable` this property controls whether the return result is sent as a single record or a record for each element is sent.
+See <<>> for more information.
+
 === Migration Guide
 
 * This release is essentially the same as the 2.3.x line, except it has been compiled against the 2.4 `kafka-clients` jar, due to a binary incompatibility.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -42,7 +42,7 @@ See its JavaDocs and <<kafka-container>> for more information.
 
 The `@KafkaListener` annotation has a new property `splitIterables`; default true.
 When a replying listener returns an `Iterable` this property controls whether the return result is sent as a single record or a record for each element is sent.
-See <<>> for more information.
+See <<annotation-send-to>> for more information.
 
 === Migration Guide
 


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1340

Previously, a reply type of `Collection` always split the collection
into discrete replies.

There is now an option to send the entire collection in the reply.

**cherry-pick to 2.3.x - there will be a conflict in the what's new**