### PR TITLE
Fix return type in streams docs

### DIFF
--- a/src/reference/asciidoc/streams.adoc
+++ b/src/reference/asciidoc/streams.adoc
@@ -53,7 +53,7 @@ The following example creates such a bean:
 [source, java]
 ----
 @Bean
-public FactoryBean<StreamsBuilderFactoryBean> myKStreamBuilder(KafkaStreamsConfiguration streamsConfig) {
+public FactoryBean<StreamsBuilder> myKStreamBuilder(KafkaStreamsConfiguration streamsConfig) {
     return new StreamsBuilderFactoryBean(streamsConfig);
 }
 ----


### PR DESCRIPTION
There is 2 way that create the StreamsBuilderFactoryBean by `@Bean` method, returning as `StreamsBuilderFactoryBean` type or as `FactoryBean<StreamsBuilder>` type. but document’s code said return `FactoryBean<StreamsBuilderFactoryBean>` type.