### PR TITLE
GH-1344: Enable updateCopyrights onlyIf grgit

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,8 +34,11 @@ ext {
 	linkScmDevConnection = 'git@github.com:spring-projects/spring-kafka.git'
 	docResourcesVersion = '0.1.0.RELEASE'
 
-	modifiedFiles =
+
+	if (grgit != null) {
+		modifiedFiles =
 			files(grgit.status().unstaged.modified).filter{ f -> f.name.endsWith('.java') || f.name.endsWith('.kt') }
+	}
 
 	assertjVersion = '3.14.0'
 	googleJsr305Version = '3.0.2'
@@ -168,8 +171,10 @@ subprojects { subproject ->
 
 
 	task updateCopyrights {
-		onlyIf { !System.getenv('TRAVIS') && !System.getenv('bamboo_buildKey') }
-		inputs.files(modifiedFiles.filter { f -> f.path.contains(subproject.name) })
+		onlyIf { grgit != null && !System.getenv('TRAVIS') && !System.getenv('bamboo_buildKey') }
+		if (grgit != null) {
+			inputs.files(modifiedFiles.filter { f -> f.path.contains(subproject.name) })
+		}
 		outputs.dir('build')
 
 		doLast {

--- a/build.gradle
+++ b/build.gradle
@@ -16,12 +16,18 @@ plugins {
 	id 'idea'
 	id 'org.sonarqube' version '2.7.1'
 	id 'org.asciidoctor.convert' version '1.6.1'
-	id 'org.ajoberstar.grgit' version '3.1.1'
+	id 'org.ajoberstar.grgit' version '3.1.1' apply false
 	id 'io.spring.nohttp' version '0.0.3.RELEASE'
 	id 'io.spring.dependency-management' version '1.0.8.RELEASE' apply false
 }
 
 apply plugin: 'io.spring.nohttp'
+
+def gitPresent = new File('.git').exists()
+
+if(gitPresent) {
+	apply plugin: 'org.ajoberstar.grgit'
+}
 
 description = 'Spring Kafka'
 
@@ -35,7 +41,7 @@ ext {
 	docResourcesVersion = '0.1.0.RELEASE'
 
 
-	if (grgit != null) {
+	if (gitPresent) {
 		modifiedFiles =
 			files(grgit.status().unstaged.modified).filter{ f -> f.name.endsWith('.java') || f.name.endsWith('.kt') }
 	}
@@ -171,8 +177,8 @@ subprojects { subproject ->
 
 
 	task updateCopyrights {
-		onlyIf { grgit != null && !System.getenv('TRAVIS') && !System.getenv('bamboo_buildKey') }
-		if (grgit != null) {
+		onlyIf { gitPresent && !System.getenv('TRAVIS') && !System.getenv('bamboo_buildKey') }
+		if (gitPresent) {
 			inputs.files(modifiedFiles.filter { f -> f.path.contains(subproject.name) })
 		}
 		outputs.dir('build')


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-kafka/issues/1344

Sometimes people build our project outside of Git repository

* Make the `updateCopyrights` Gralde task conditional on
 the presence of `grgit` object initialized by the
 `org.ajoberstar.grgit` when Git repository is present.
 Otherwise it is `null`
* Check for `grgit` presence when we try to gather `modifiedFiles`