### PR TITLE
GH-1347: Fix @EmbeddedKafka with count > 1

### DIFF
--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/condition/EmbeddedKafkaCondition.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/condition/EmbeddedKafkaCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -115,9 +115,13 @@ public class EmbeddedKafkaCondition implements ExecutionCondition, AfterAllCallb
 	@SuppressWarnings("unchecked")
 	private EmbeddedKafkaBroker createBroker(EmbeddedKafka embedded) {
 		EmbeddedKafkaBroker broker;
+		int[] ports = embedded.ports();
+		if (embedded.count() > 1 && ports.length == 1 && ports[0] == 0) {
+			ports = new int[embedded.count()];
+		}
 		broker = new EmbeddedKafkaBroker(embedded.count(), embedded.controlledShutdown(), embedded.topics())
 				.zkPort(embedded.zookeeperPort())
-				.kafkaPorts(embedded.ports());
+				.kafkaPorts(ports);
 		Properties properties = new Properties();
 
 		for (String pair : embedded.brokerProperties()) {

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafka.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafka.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -93,7 +93,7 @@ public @interface EmbeddedKafka {
 	 * @return ports for brokers.
 	 * @since 2.2.4
 	 */
-	int[] ports() default {0};
+	int[] ports() default { 0 };
 
 	/**
 	 * Set the port on which the embedded Zookeeper should listen;

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizer.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -66,11 +66,15 @@ class EmbeddedKafkaContextCustomizer implements ContextCustomizer {
 						.map(environment::resolvePlaceholders)
 						.toArray(String[]::new);
 
+		int[] ports = this.embeddedKafka.ports();
+		if (this.embeddedKafka.count() > 1 && ports.length == 1 && ports[0] == 0) {
+			ports = new int[this.embeddedKafka.count()];
+		}
 		EmbeddedKafkaBroker embeddedKafkaBroker = new EmbeddedKafkaBroker(this.embeddedKafka.count(),
 					this.embeddedKafka.controlledShutdown(),
 					this.embeddedKafka.partitions(),
 					topics)
-				.kafkaPorts(this.embeddedKafka.ports())
+				.kafkaPorts(ports)
 				.zkPort(this.embeddedKafka.zookeeperPort());
 
 		Properties properties = new Properties();

--- a/spring-kafka-test/src/test/java/org/springframework/kafka/test/condition/EmbeddedKafkaConditionTests.java
+++ b/spring-kafka-test/src/test/java/org/springframework/kafka/test/condition/EmbeddedKafkaConditionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.springframework.kafka.test.utils.KafkaTestUtils;
  * @since 2.3
  *
  */
-@EmbeddedKafka(bootstrapServersProperty = "my.bss.property")
+@EmbeddedKafka(bootstrapServersProperty = "my.bss.property", count = 2)
 public class EmbeddedKafkaConditionTests {
 
 	@Test

--- a/spring-kafka-test/src/test/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizerTests.java
+++ b/spring-kafka-test/src/test/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,7 @@ public class EmbeddedKafkaContextCustomizerTests {
 	private EmbeddedKafka annotationFromSecondClass;
 
 	@BeforeEach
-	public void beforeEachTest() {
+	void beforeEachTest() {
 		annotationFromFirstClass = AnnotationUtils.findAnnotation(TestWithEmbeddedKafka.class, EmbeddedKafka.class);
 		annotationFromSecondClass =
 				AnnotationUtils.findAnnotation(SecondTestWithEmbeddedKafka.class, EmbeddedKafka.class);
@@ -56,7 +56,7 @@ public class EmbeddedKafkaContextCustomizerTests {
 
 
 	@Test
-	public void testHashCode() {
+	void testHashCode() {
 		assertThat(new EmbeddedKafkaContextCustomizer(annotationFromFirstClass).hashCode()).isNotEqualTo(0);
 		assertThat(new EmbeddedKafkaContextCustomizer(annotationFromFirstClass).hashCode())
 				.isEqualTo(new EmbeddedKafkaContextCustomizer(annotationFromSecondClass).hashCode());
@@ -64,14 +64,14 @@ public class EmbeddedKafkaContextCustomizerTests {
 
 
 	@Test
-	public void testEquals() {
+	void testEquals() {
 		assertThat(new EmbeddedKafkaContextCustomizer(annotationFromFirstClass))
 				.isEqualTo(new EmbeddedKafkaContextCustomizer(annotationFromSecondClass));
 		assertThat(new EmbeddedKafkaContextCustomizer(annotationFromFirstClass)).isNotEqualTo(new Object());
 	}
 
 	@Test
-	public void testPorts() {
+	void testPorts() {
 		EmbeddedKafka annotationWithPorts =
 				AnnotationUtils.findAnnotation(TestWithEmbeddedKafkaPorts.class, EmbeddedKafka.class);
 		EmbeddedKafkaContextCustomizer customizer = new EmbeddedKafkaContextCustomizer(annotationWithPorts);
@@ -85,6 +85,21 @@ public class EmbeddedKafkaContextCustomizerTests {
 				.isEqualTo("127.0.0.1:" + annotationWithPorts.ports()[0]);
 		assertThat(KafkaTestUtils.getPropertyValue(factoryStub.getBroker(), "brokerListProperty"))
 				.isEqualTo("my.bss.prop");
+	}
+
+	@Test
+	void testMulti() {
+		EmbeddedKafka annotationWithPorts =
+				AnnotationUtils.findAnnotation(TestWithEmbeddedKafkaMulti.class, EmbeddedKafka.class);
+		EmbeddedKafkaContextCustomizer customizer = new EmbeddedKafkaContextCustomizer(annotationWithPorts);
+		ConfigurableApplicationContext context = mock(ConfigurableApplicationContext.class);
+		BeanFactoryStub factoryStub = new BeanFactoryStub();
+		given(context.getBeanFactory()).willReturn(factoryStub);
+		given(context.getEnvironment()).willReturn(mock(ConfigurableEnvironment.class));
+		customizer.customizeContext(context, null);
+
+		assertThat(factoryStub.getBroker().getBrokersAsString())
+			.matches("127.0.0.1:[0-9]+,127.0.0.1:[0-9]+");
 	}
 
 
@@ -103,6 +118,10 @@ public class EmbeddedKafkaContextCustomizerTests {
 
 	}
 
+	@EmbeddedKafka(count = 2)
+	private class TestWithEmbeddedKafkaMulti {
+
+	}
 	@SuppressWarnings("serial")
 	private class BeanFactoryStub extends DefaultListableBeanFactory {
 


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1347

When count > 1 with no port specification (default random port)
tests failed because not enough ports were provided,

**cherry-pick to 2.3.x**