### PR TITLE
GH-1236: Add Streams infrastructure customizer

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/config/CompositeKafkaStreamsInfrastructireCustomizer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/CompositeKafkaStreamsInfrastructireCustomizer.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.config;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.Topology;
+
+/**
+ * Composite {@link KafkaStreamsCustomizer} customizes {@link KafkaStreams} by delegating
+ * to a list of provided {@link KafkaStreamsCustomizer}.
+ *
+ * @author Gary Russell
+ *
+ * @since 2.4.1
+ */
+public class CompositeKafkaStreamsInfrastructireCustomizer implements KafkaStreamsInfrastructureCustomizer {
+
+	private final List<KafkaStreamsInfrastructureCustomizer> kafkaStreamsCustomizers = new ArrayList<>();
+
+	/**
+	 * Construct an instance with the provided customizers.
+	 * @param customizers the customizers;
+	 */
+	public CompositeKafkaStreamsInfrastructireCustomizer(KafkaStreamsInfrastructureCustomizer... customizers) {
+
+		this.kafkaStreamsCustomizers.addAll(Arrays.asList(customizers));
+	}
+
+	/**
+	 * Add customizers.
+	 * @param customizers the customizers.
+	 */
+	public void addKafkaStreamsCustomizers(KafkaStreamsInfrastructureCustomizer... customizers) {
+		this.kafkaStreamsCustomizers.addAll(Arrays.asList(customizers));
+	}
+
+	@Override
+	public void configureBuilder(StreamsBuilder builder) {
+		this.kafkaStreamsCustomizers.forEach(cust -> cust.configureBuilder(builder));
+	}
+
+	@Override
+	public void configureTopology(Topology topology) {
+		this.kafkaStreamsCustomizers.forEach(cust -> cust.configureTopology(topology));
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/CompositeKafkaStreamsInfrastructureCustomizer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/CompositeKafkaStreamsInfrastructureCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,24 +25,23 @@ import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.Topology;
 
 /**
- * Composite {@link KafkaStreamsCustomizer} customizes {@link KafkaStreams} by delegating
- * to a list of provided {@link KafkaStreamsCustomizer}.
+ * Composite {@link KafkaStreamsInfrastructureCustomizer} customizes {@link KafkaStreams}
+ * by delegating to a list of provided {@link KafkaStreamsInfrastructureCustomizer}.
  *
  * @author Gary Russell
  *
  * @since 2.4.1
  */
-public class CompositeKafkaStreamsInfrastructireCustomizer implements KafkaStreamsInfrastructureCustomizer {
+public class CompositeKafkaStreamsInfrastructureCustomizer implements KafkaStreamsInfrastructureCustomizer {
 
-	private final List<KafkaStreamsInfrastructureCustomizer> kafkaStreamsCustomizers = new ArrayList<>();
+	private final List<KafkaStreamsInfrastructureCustomizer> infrastructureCustomizers = new ArrayList<>();
 
 	/**
 	 * Construct an instance with the provided customizers.
 	 * @param customizers the customizers;
 	 */
-	public CompositeKafkaStreamsInfrastructireCustomizer(KafkaStreamsInfrastructureCustomizer... customizers) {
-
-		this.kafkaStreamsCustomizers.addAll(Arrays.asList(customizers));
+	public CompositeKafkaStreamsInfrastructureCustomizer(KafkaStreamsInfrastructureCustomizer... customizers) {
+		this.infrastructureCustomizers.addAll(Arrays.asList(customizers));
 	}
 
 	/**
@@ -50,17 +49,17 @@ public class CompositeKafkaStreamsInfrastructireCustomizer implements KafkaStrea
 	 * @param customizers the customizers.
 	 */
 	public void addKafkaStreamsCustomizers(KafkaStreamsInfrastructureCustomizer... customizers) {
-		this.kafkaStreamsCustomizers.addAll(Arrays.asList(customizers));
+		this.infrastructureCustomizers.addAll(Arrays.asList(customizers));
 	}
 
 	@Override
 	public void configureBuilder(StreamsBuilder builder) {
-		this.kafkaStreamsCustomizers.forEach(cust -> cust.configureBuilder(builder));
+		this.infrastructureCustomizers.forEach(cust -> cust.configureBuilder(builder));
 	}
 
 	@Override
 	public void configureTopology(Topology topology) {
-		this.kafkaStreamsCustomizers.forEach(cust -> cust.configureTopology(topology));
+		this.infrastructureCustomizers.forEach(cust -> cust.configureTopology(topology));
 	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaStreamsInfrastructureCustomizer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaStreamsInfrastructureCustomizer.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.config;
+
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.Topology;
+
+/**
+ * A customizer for infrastructure components such as the builder and topology.
+ *
+ * @author Gary Russell
+ * @since 2.4.1
+ *
+ */
+public interface KafkaStreamsInfrastructureCustomizer {
+
+	/**
+	 * Configure the builder.
+	 * @param builder the builder.
+	 */
+	default void configureBuilder(StreamsBuilder builder) {
+		// no-op
+	}
+
+	/**
+	 * Configure the topology.
+	 * @param topology the topology
+	 */
+	default void configureTopology(Topology topology) {
+		// no-op
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaStreamsInfrastructureCustomizer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaStreamsInfrastructureCustomizer.java
@@ -20,7 +20,9 @@ import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.Topology;
 
 /**
- * A customizer for infrastructure components such as the builder and topology.
+ * A customizer for infrastructure components such as the {@code StreamsBuilder} and
+ * {@code Topology}. It can be provided to the {@link StreamsBuilderFactoryBean} which
+ * will apply the changes before creating the stream.
  *
  * @author Gary Russell
  * @since 2.4.1

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/StreamsBuilderFactoryBeanCustomizer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/StreamsBuilderFactoryBeanCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/reference/asciidoc/streams.adoc
+++ b/src/reference/asciidoc/streams.adoc
@@ -139,7 +139,7 @@ public interface KafkaStreamsInfrastructureCustomizer {
 
 Default no-op implementations are provided to avoid having to implement both methods if one is not required.
 
-A `CompositeKafkaStreamsInfrastructureCustomizer` if you need multiple customizers.
+A `CompositeKafkaStreamsInfrastructureCustomizer` is provided, for when you need to apply multiple customizers.
 
 [[serde]]
 ==== Streams JSON Serialization and Deserialization

--- a/src/reference/asciidoc/streams.adoc
+++ b/src/reference/asciidoc/streams.adoc
@@ -43,6 +43,7 @@ In other words, all streams defined by a `StreamsBuilder` are tied with a single
 Once a `KafkaStreams` instance has been closed by `streams.close()`, it cannot be restarted.
 Instead, a new `KafkaStreams` instance to restart stream processing must be created.
 
+[[streams-spring]]
 ==== Spring Management
 
 To simplify using Kafka Streams from the Spring application context perspective and use the lifecycle management through a container, the Spring for Apache Kafka introduces `StreamsBuilderFactoryBean`.
@@ -120,6 +121,25 @@ public FactoryBean<StreamsBuilder> myKStreamBuilder(KafkaStreamsConfiguration st
 private StreamsBuilderFactoryBean myKStreamBuilderFactoryBean;
 ----
 ====
+
+Starting with version 2.4.1, the factory bean has a new property `infrastructureCustomizer` with type `KafkaStreamsInfrastructureCustomizer`; this allows customization of the `StreamsBuilder` (e.g. to add a state store) and/or the `Topology` before the stream is created.
+
+====
+[source, java]
+----
+public interface KafkaStreamsInfrastructureCustomizer {
+
+	void configureBuilder(StreamsBuilder builder);
+
+	void configureTopology(Topology topology);
+
+}
+----
+====
+
+Default no-op implementations are provided to avoid having to implement both methods if one is not required.
+
+A `CompositeKafkaStreamsInfrastructureCustomizer` if you need multiple customizers.
 
 [[serde]]
 ==== Streams JSON Serialization and Deserialization

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -44,6 +44,12 @@ The `@KafkaListener` annotation has a new property `splitIterables`; default tru
 When a replying listener returns an `Iterable` this property controls whether the return result is sent as a single record or a record for each element is sent.
 See <<annotation-send-to>> for more information.
 
+==== Kafka Streams
+
+The `StreamsBuilderFactoryBean` accepts a new property `KafkaStreamsInfrastructureCustomizer`.
+This allows configuration of the builder and/or topology before the stream is created.
+See <<streams-spring>> for more information.
+
 === Migration Guide
 
 * This release is essentially the same as the 2.3.x line, except it has been compiled against the 2.4 `kafka-clients` jar, due to a binary incompatibility.


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1236

Allow modification of the builder and/or topolgy before the stream is
created.