### PR TITLE
Document more explicitly that (de)serialization config properties have no effect when instances are provided

### DIFF
--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -2745,7 +2745,8 @@ A `JacksonMimeTypeModule` can be registered as a bean in the application context
 Also starting with version 2.3, the `JsonDeserializer` provides `TypeReference`-based constructors for better handling of target generic container types.
 
 Starting with version 2.1, you can convey type information in record `Headers`, allowing the handling of multiple types.
-In addition, you can configure the serializer and deserializer by using the following Kafka properties:
+In addition, you can configure the serializer and deserializer by using the following Kafka properties.
+They have no effect if you have provided `Serializer` and `Deserializer` instances for `KafkaConsumer` and `KafkaProducer`, respectively.
 
 * `JsonSerializer.ADD_TYPE_INFO_HEADERS` (default `true`): You can set it to `false` to disable this feature on the `JsonSerializer` (sets the `addTypeInfo` property).
 * `JsonSerializer.TYPE_MAPPINGS` (default `empty`): See <<serdes-mapping-types>>.


### PR DESCRIPTION
When reading the reference manual, it is likely that one would encounter the "Introduction" and start with the "consumer properties map" approach to configuring deserialization. However, in the course of troubleshooting consumer failures  (eg. deserialization errors), one might read further into the manual and encounter the "Serialization, Deserialization, and Message Conversion" section, and pass instances of deserializers to the consumer factory in an attempt to fix the failures, and might miss out that in fact consumer properties map now has no effect.

Mention this in the documentation, and add a test case illustrating this is the expected behaviour.