### PR TITLE
GH-681: Fix docs/deprecations for ProducerListener

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/ProducerListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/ProducerListener.java
@@ -55,7 +55,9 @@ public interface ProducerListener<K, V> {
 	 * @param key the key of the outbound message
 	 * @param value the payload of the outbound message
 	 * @param recordMetadata the result of the successful send operation
+	 * @deprecated in favor of {@link #onSuccess(ProducerRecord, RecordMetadata)}.
 	 */
+	@Deprecated
 	default void onSuccess(String topic, Integer partition, K key, V value, RecordMetadata recordMetadata) {
 	}
 
@@ -77,7 +79,9 @@ public interface ProducerListener<K, V> {
 	 * @param key the key of the outbound message
 	 * @param value the payload of the outbound message
 	 * @param exception the exception thrown
+	 * @deprecated in favor of {@link #onError(ProducerRecord, Exception)}.
 	 */
+	@Deprecated
 	default void onError(String topic, Integer partition, K key, V value, Exception exception) {
 	}
 

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -194,11 +194,9 @@ The following listing shows the definition of the `ProducerListener` interface:
 ----
 public interface ProducerListener<K, V> {
 
-    void onSuccess(String topic, Integer partition, K key, V value, RecordMetadata recordMetadata);
+    void onSuccess(ProducerRecord<K, V> producerRecord, RecordMetadata recordMetadata);
 
-    void onError(String topic, Integer partition, K key, V value, Exception exception);
-
-    boolean isInterestedInSuccess();
+    void onError(ProducerRecord<K, V> producerRecord, Exception exception)
 
 }
 ----
@@ -206,10 +204,7 @@ public interface ProducerListener<K, V> {
 
 By default, the template is configured with a `LoggingProducerListener`, which logs errors and does nothing when the send is successful.
 
-`onSuccess` is called only if `isInterestedInSuccess` returns `true`.
-
-For convenience, the abstract `ProducerListenerAdapter` is provided in case you want to implement only one of the methods.
-It returns `false` for `isInterestedInSuccess`.
+For convenience, default method implementations are provided in case you want to implement only one of the methods.
 
 Notice that the send methods return a `ListenableFuture<SendResult>`.
 You can register a callback with the listener to receive the result of the send asynchronously.


### PR DESCRIPTION
See https://github.com/spring-projects/spring-kafka/pull/681#issuecomment-577203808

Deprecate the legacy methods since all the information is available in the
variants that get the full `ProducerRecord`.