### PR TITLE
GH-1354: Fix default BackOff with deprecated CTOR

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordProcessor.java
@@ -73,7 +73,7 @@ public abstract class FailedRecordProcessor {
 
 	private static FixedBackOff maxFailuresToBackOff(int maxFailures) {
 		if (maxFailures < 0) {
-			return new FixedBackOff();
+			return new FixedBackOff(0L, FixedBackOff.UNLIMITED_ATTEMPTS);
 		}
 		return new FixedBackOff(0L, maxFailures == 0 ? 0 : maxFailures - 1);
 	}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/FailedRecordProcessorTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/FailedRecordProcessorTests.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+
+/**
+ * @author Gary Russell
+ * @since 2.3.6
+ *
+ */
+public class FailedRecordProcessorTests {
+
+	@Test
+	void testDefaultBackOff() {
+		FailedRecordProcessor frp = new FailedRecordProcessor(null, 1) {
+		};
+		assertThat(KafkaTestUtils.getPropertyValue(frp, "failureTracker.backOff.interval", Long.class)).isEqualTo(0L);
+		assertThat(KafkaTestUtils.getPropertyValue(frp, "failureTracker.backOff.maxAttempts", Long.class))
+				.isEqualTo(0L);
+		frp = new FailedRecordProcessor(null, 0) {
+		};
+		assertThat(KafkaTestUtils.getPropertyValue(frp, "failureTracker.backOff.interval", Long.class)).isEqualTo(0L);
+		assertThat(KafkaTestUtils.getPropertyValue(frp, "failureTracker.backOff.maxAttempts", Long.class))
+				.isEqualTo(0L);
+		frp = new FailedRecordProcessor(null, -1) {
+		};
+		assertThat(KafkaTestUtils.getPropertyValue(frp, "failureTracker.backOff.interval", Long.class)).isEqualTo(0L);
+		assertThat(KafkaTestUtils.getPropertyValue(frp, "failureTracker.backOff.maxAttempts", Long.class))
+				.isEqualTo(Long.MAX_VALUE);
+	}
+
+}


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1354

When a negative `maxAttempts` was used, the default backOff interval was
5s instead of 0.

**cherry-pick to 2.3.x**