### PR TITLE
GH-1376: Fix ContainerCustomizer

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
@@ -355,7 +355,7 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 
 		endpoint.setupListenerContainer(instance, this.messageConverter);
 		initializeContainer(instance, endpoint);
-
+		customizeContainer(instance);
 		return instance;
 	}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ContainerStoppingBatchErrorHandlerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ContainerStoppingBatchErrorHandlerTests.java
@@ -107,6 +107,7 @@ public class ContainerStoppingBatchErrorHandlerTests {
 		assertThat(two).isSameAs(this.config.springManagedContainer());
 		assertThat(one.getListenerId()).isEqualTo(CONTAINER_ID);
 		assertThat(two.getListenerId()).isEqualTo("springManagedContainer");
+		assertThat(this.config.customized).isEqualTo(2);
 	}
 
 	@Configuration
@@ -122,6 +123,8 @@ public class ContainerStoppingBatchErrorHandlerTests {
 		private final CountDownLatch closeLatch = new CountDownLatch(1);
 
 		private final CountDownLatch commitLatch = new CountDownLatch(3);
+
+		private volatile int customized;
 
 		@KafkaListener(id = CONTAINER_ID, topics = "foo")
 		public void foo(List<String> in) {
@@ -212,6 +215,7 @@ public class ContainerStoppingBatchErrorHandlerTests {
 
 			});
 			factory.setBatchListener(true);
+			factory.setContainerCustomizer(container -> this.customized++);
 			return factory;
 		}
 


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1376

The customizer was not called for containers created for `@KafkaListener`,
only for containers created manually via the factory.

**cherry-pick to 2.3.x**