### PR TITLE
GH-1369: Fix Fenced Consumer-based Producers

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -54,6 +54,7 @@ import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.AuthorizationException;
+import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.errors.WakeupException;
 
 import org.springframework.context.ApplicationContext;
@@ -1299,6 +1300,9 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 					}
 				});
 			}
+			catch (ProducerFencedException e) {
+				this.logger.error(e, "Producer fenced during transaction");
+			}
 			catch (RuntimeException e) {
 				this.logger.error(e, "Transaction rolled back");
 				AfterRollbackProcessor<K, V> afterRollbackProcessorToUse =
@@ -1541,6 +1545,9 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 						}
 
 					});
+				}
+				catch (ProducerFencedException e) {
+					this.logger.error(e, "Producer fenced during transaction");
 				}
 				catch (RuntimeException e) {
 					this.logger.error(e, "Transaction rolled back");

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Queue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -363,9 +364,9 @@ public class DefaultKafkaConsumerFactoryTests {
 		try {
 			ListenableFuture<SendResult<Integer, String>> future = template.send("txCache2", "foo");
 			future.get(10, TimeUnit.SECONDS);
-			assertThat(KafkaTestUtils.getPropertyValue(pf, "cache", Map.class)).hasSize(0);
 			assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
-			assertThat(KafkaTestUtils.getPropertyValue(pfTx, "cache", Map.class)).hasSize(0);
+			assertThat(KafkaTestUtils.getPropertyValue(pfTx, "cache", Map.class)).hasSize(1);
+			assertThat((Queue) KafkaTestUtils.getPropertyValue(pfTx, "cache", Map.class).get("fooTx.")).hasSize(0);
 		}
 		finally {
 			container.stop();


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1369

1. `CloseSafeProducer.cache` was incorrectly null
   (direct access to `this.cache` instead of `getCache()`
   Prevented closure of a fenced `consumerProducer`

2. Don't call the `AfterRollbackProcessor` when a producer is fenced -
   the partitions will have already been revoked so seeking is inappropriate
   and starting a new transaction will fence the new (current) producer.

**cherry-pick to 2.3.x if clean**