### PR TITLE
Make ZK client timeouts configurable

### DIFF
--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaBroker.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaBroker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 the original author or authors.
+ * Copyright 2018-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,9 +100,9 @@ public class EmbeddedKafkaBroker implements InitializingBean, DisposableBean {
 
 	private static final Duration DEFAULT_ADMIN_TIMEOUT = Duration.ofSeconds(10);
 
-	private static final int ZK_CONNECTION_TIMEOUT = 6000;
+	private static final int DEFAULT_ZK_CONNECTION_TIMEOUT = 6000;
 
-	private static final int ZK_SESSION_TIMEOUT = 6000;
+	private static final int DEFAULT_ZK_SESSION_TIMEOUT = 6000;
 
 	private final int count;
 
@@ -125,6 +125,10 @@ public class EmbeddedKafkaBroker implements InitializingBean, DisposableBean {
 	private int[] kafkaPorts;
 
 	private Duration adminTimeout = DEFAULT_ADMIN_TIMEOUT;
+
+	private int zkConnectionTimeout = DEFAULT_ZK_CONNECTION_TIMEOUT;
+
+	private int zkSessionTimeout = DEFAULT_ZK_SESSION_TIMEOUT;
 
 	private String brokerListProperty;
 
@@ -249,6 +253,16 @@ public class EmbeddedKafkaBroker implements InitializingBean, DisposableBean {
 		this.zkPort = zkPort;
 	}
 
+	/**
+	 * Set timeouts for the client to the embedded Zookeeper.
+	 * @param zkConnectionTimeout the connection timeout,
+	 * @param zkSessionTimeout the session timeout.
+	 */
+	public void setZkClientTimeouts(int zkConnectionTimeout, int zkSessionTimeout) {
+		this.zkConnectionTimeout = zkConnectionTimeout;
+		this.zkSessionTimeout = zkSessionTimeout;
+	}
+
 	@Override
 	public void afterPropertiesSet() {
 		try {
@@ -336,8 +350,8 @@ public class EmbeddedKafkaBroker implements InitializingBean, DisposableBean {
 		doWithAdmin(admin -> {
 			createTopics(admin,
 					topicsToCreate.stream()
-							.map(t -> new NewTopic(t, this.partitionsPerTopic, (short) this.count))
-							.collect(Collectors.toList()));
+						.map(t -> new NewTopic(t, this.partitionsPerTopic, (short) this.count))
+						.collect(Collectors.toList()));
 		});
 	}
 
@@ -428,7 +442,7 @@ public class EmbeddedKafkaBroker implements InitializingBean, DisposableBean {
 	 */
 	public synchronized ZooKeeperClient getZooKeeperClient() {
 		if (this.zooKeeperClient == null) {
-			this.zooKeeperClient = new ZooKeeperClient(this.zkConnect, ZK_SESSION_TIMEOUT, ZK_CONNECTION_TIMEOUT,
+			this.zooKeeperClient = new ZooKeeperClient(this.zkConnect, zkSessionTimeout, zkConnectionTimeout,
 					1, Time.SYSTEM, "embeddedKafkaZK", "embeddedKafkaZK");
 		}
 		return this.zooKeeperClient;


### PR DESCRIPTION
For build servers with high load, it may happen that the build hangs for couple of seconds. This causes the internal ZK client session of embedded Kafka broker to timeout and fail the build.

It would be good if these were configurable.