### PR TITLE
Make ZK client timeouts configurable

### DIFF
--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaBroker.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaBroker.java
@@ -258,6 +258,7 @@ public class EmbeddedKafkaBroker implements InitializingBean, DisposableBean {
 	 * Set connection timeout for the client to the embedded Zookeeper.
 	 * @param zkConnectionTimeout the connection timeout,
 	 * @return the {@link EmbeddedKafkaBroker}.
+	 * @since 2.4
 	 */
 	public EmbeddedKafkaBroker zkConnectionTimeout(int zkConnectionTimeout) {
 		this.zkConnectionTimeout = zkConnectionTimeout;
@@ -268,6 +269,7 @@ public class EmbeddedKafkaBroker implements InitializingBean, DisposableBean {
 	 * Set session timeout for the client to the embedded Zookeeper.
 	 * @param zkSessionTimeout the session timeout.
 	 * @return the {@link EmbeddedKafkaBroker}.
+	 * @since 2.4
 	 */
 	public EmbeddedKafkaBroker zkSessionTimeout(int zkSessionTimeout) {
 		this.zkSessionTimeout = zkSessionTimeout;

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaBroker.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaBroker.java
@@ -100,9 +100,9 @@ public class EmbeddedKafkaBroker implements InitializingBean, DisposableBean {
 
 	private static final Duration DEFAULT_ADMIN_TIMEOUT = Duration.ofSeconds(10);
 
-	private static final int DEFAULT_ZK_CONNECTION_TIMEOUT = 6000;
+	public static final int DEFAULT_ZK_CONNECTION_TIMEOUT = 6000;
 
-	private static final int DEFAULT_ZK_SESSION_TIMEOUT = 6000;
+	public static final int DEFAULT_ZK_SESSION_TIMEOUT = 6000;
 
 	private final int count;
 
@@ -257,10 +257,12 @@ public class EmbeddedKafkaBroker implements InitializingBean, DisposableBean {
 	 * Set timeouts for the client to the embedded Zookeeper.
 	 * @param zkConnectionTimeout the connection timeout,
 	 * @param zkSessionTimeout the session timeout.
+	 * @return the {@link EmbeddedKafkaBroker}.
 	 */
-	public void setZkClientTimeouts(int zkConnectionTimeout, int zkSessionTimeout) {
+	public EmbeddedKafkaBroker setZkClientTimeouts(int zkConnectionTimeout, int zkSessionTimeout) {
 		this.zkConnectionTimeout = zkConnectionTimeout;
 		this.zkSessionTimeout = zkSessionTimeout;
+		return this;
 	}
 
 	@Override

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaBroker.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaBroker.java
@@ -77,6 +77,7 @@ import kafka.zookeeper.ZooKeeperClient;
  * @author Kamill Sokol
  * @author Elliot Kennedy
  * @author Nakul Mishra
+ * @author Pawel Lozinski
  *
  * @since 2.2
  */
@@ -254,13 +255,21 @@ public class EmbeddedKafkaBroker implements InitializingBean, DisposableBean {
 	}
 
 	/**
-	 * Set timeouts for the client to the embedded Zookeeper.
+	 * Set connection timeout for the client to the embedded Zookeeper.
 	 * @param zkConnectionTimeout the connection timeout,
+	 * @return the {@link EmbeddedKafkaBroker}.
+	 */
+	public EmbeddedKafkaBroker zkConnectionTimeout(int zkConnectionTimeout) {
+		this.zkConnectionTimeout = zkConnectionTimeout;
+		return this;
+	}
+
+	/**
+	 * Set session timeout for the client to the embedded Zookeeper.
 	 * @param zkSessionTimeout the session timeout.
 	 * @return the {@link EmbeddedKafkaBroker}.
 	 */
-	public EmbeddedKafkaBroker setZkClientTimeouts(int zkConnectionTimeout, int zkSessionTimeout) {
-		this.zkConnectionTimeout = zkConnectionTimeout;
+	public EmbeddedKafkaBroker zkSessionTimeout(int zkSessionTimeout) {
 		this.zkSessionTimeout = zkSessionTimeout;
 		return this;
 	}

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaBroker.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaBroker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 the original author or authors.
+ * Copyright 2018-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,9 +100,9 @@ public class EmbeddedKafkaBroker implements InitializingBean, DisposableBean {
 
 	private static final Duration DEFAULT_ADMIN_TIMEOUT = Duration.ofSeconds(10);
 
-	private static final int ZK_CONNECTION_TIMEOUT = 6000;
+	private static final int DEFAULT_ZK_CONNECTION_TIMEOUT = 6000;
 
-	private static final int ZK_SESSION_TIMEOUT = 6000;
+	private static final int DEFAULT_ZK_SESSION_TIMEOUT = 6000;
 
 	private final int count;
 
@@ -125,6 +125,10 @@ public class EmbeddedKafkaBroker implements InitializingBean, DisposableBean {
 	private int[] kafkaPorts;
 
 	private Duration adminTimeout = DEFAULT_ADMIN_TIMEOUT;
+
+	private int zkConnectionTimeout = DEFAULT_ZK_CONNECTION_TIMEOUT;
+
+	private int zkSessionTimeout = DEFAULT_ZK_SESSION_TIMEOUT;
 
 	private String brokerListProperty;
 
@@ -249,6 +253,16 @@ public class EmbeddedKafkaBroker implements InitializingBean, DisposableBean {
 		this.zkPort = zkPort;
 	}
 
+	/**
+	 * Set timeouts for the client to the embedded Zookeeper.
+	 * @param zkConnectionTimeout the connection timeout,
+	 * @param zkSessionTimeout the session timeout.
+	 */
+	public void setZkClientTimeouts(int zkConnectionTimeout, int zkSessionTimeout) {
+		this.zkConnectionTimeout = zkConnectionTimeout;
+		this.zkSessionTimeout = zkSessionTimeout;
+	}
+
 	@Override
 	public void afterPropertiesSet() {
 		try {
@@ -336,8 +350,8 @@ public class EmbeddedKafkaBroker implements InitializingBean, DisposableBean {
 		doWithAdmin(admin -> {
 			createTopics(admin,
 					topicsToCreate.stream()
-							.map(t -> new NewTopic(t, this.partitionsPerTopic, (short) this.count))
-							.collect(Collectors.toList()));
+						.map(t -> new NewTopic(t, this.partitionsPerTopic, (short) this.count))
+						.collect(Collectors.toList()));
 		});
 	}
 
@@ -428,7 +442,7 @@ public class EmbeddedKafkaBroker implements InitializingBean, DisposableBean {
 	 */
 	public synchronized ZooKeeperClient getZooKeeperClient() {
 		if (this.zooKeeperClient == null) {
-			this.zooKeeperClient = new ZooKeeperClient(this.zkConnect, ZK_SESSION_TIMEOUT, ZK_CONNECTION_TIMEOUT,
+			this.zooKeeperClient = new ZooKeeperClient(this.zkConnect, zkSessionTimeout, zkConnectionTimeout,
 					1, Time.SYSTEM, "embeddedKafkaZK", "embeddedKafkaZK");
 		}
 		return this.zooKeeperClient;

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/condition/EmbeddedKafkaCondition.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/condition/EmbeddedKafkaCondition.java
@@ -50,6 +50,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Pawel Lozinski
  *
  * @since 2.3
  *
@@ -119,7 +120,8 @@ public class EmbeddedKafkaCondition implements ExecutionCondition, AfterAllCallb
 		broker = new EmbeddedKafkaBroker(embedded.count(), embedded.controlledShutdown(), embedded.topics())
 				.zkPort(embedded.zookeeperPort())
 				.kafkaPorts(ports)
-				.setZkClientTimeouts(embedded.zkConnectionTimeout(), embedded.zkSessionTimeout());
+				.zkConnectionTimeout(embedded.zkConnectionTimeout())
+				.zkSessionTimeout(embedded.zkSessionTimeout());
 		Properties properties = new Properties();
 
 		for (String pair : embedded.brokerProperties()) {

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/condition/EmbeddedKafkaCondition.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/condition/EmbeddedKafkaCondition.java
@@ -118,7 +118,8 @@ public class EmbeddedKafkaCondition implements ExecutionCondition, AfterAllCallb
 		int[] ports = setupPorts(embedded);
 		broker = new EmbeddedKafkaBroker(embedded.count(), embedded.controlledShutdown(), embedded.topics())
 				.zkPort(embedded.zookeeperPort())
-				.kafkaPorts(ports);
+				.kafkaPorts(ports)
+				.setZkClientTimeouts(embedded.zkConnectionTimeout(), embedded.zkSessionTimeout());
 		Properties properties = new Properties();
 
 		for (String pair : embedded.brokerProperties()) {

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafka.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafka.java
@@ -26,6 +26,7 @@ import java.lang.annotation.Target;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.core.annotation.AliasFor;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.condition.EmbeddedKafkaCondition;
 
 /**
@@ -154,6 +155,18 @@ public @interface EmbeddedKafka {
 	 * @see org.springframework.kafka.test.EmbeddedKafkaBroker#brokerListProperty(String)
 	 */
 	String bootstrapServersProperty() default "";
+
+	/**
+	 * Timeout for internal ZK client connection.
+	 * @return default {@link EmbeddedKafkaBroker#DEFAULT_ZK_CONNECTION_TIMEOUT}.
+	 */
+	int zkConnectionTimeout() default EmbeddedKafkaBroker.DEFAULT_ZK_CONNECTION_TIMEOUT;
+
+	/**
+	 * Timeout for internal ZK client session.
+	 * @return default {@link EmbeddedKafkaBroker#DEFAULT_ZK_SESSION_TIMEOUT}.
+	 */
+	int zkSessionTimeout() default EmbeddedKafkaBroker.DEFAULT_ZK_SESSION_TIMEOUT;
 
 }
 

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafka.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafka.java
@@ -160,12 +160,14 @@ public @interface EmbeddedKafka {
 	/**
 	 * Timeout for internal ZK client connection.
 	 * @return default {@link EmbeddedKafkaBroker#DEFAULT_ZK_CONNECTION_TIMEOUT}.
+	 * @since 2.4
 	 */
 	int zkConnectionTimeout() default EmbeddedKafkaBroker.DEFAULT_ZK_CONNECTION_TIMEOUT;
 
 	/**
 	 * Timeout for internal ZK client session.
 	 * @return default {@link EmbeddedKafkaBroker#DEFAULT_ZK_SESSION_TIMEOUT}.
+	 * @since 2.4
 	 */
 	int zkSessionTimeout() default EmbeddedKafkaBroker.DEFAULT_ZK_SESSION_TIMEOUT;
 

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafka.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafka.java
@@ -58,6 +58,7 @@ import org.springframework.kafka.test.condition.EmbeddedKafkaCondition;
  * @author Zach Olauson
  * @author Gary Russell
  * @author Sergio Lourenco
+ * @author Pawel Lozinski
  *
  * @since 1.3
  *

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizer.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizer.java
@@ -72,7 +72,8 @@ class EmbeddedKafkaContextCustomizer implements ContextCustomizer {
 					this.embeddedKafka.partitions(),
 					topics)
 				.kafkaPorts(ports)
-				.zkPort(this.embeddedKafka.zookeeperPort());
+				.zkPort(this.embeddedKafka.zookeeperPort())
+				.setZkClientTimeouts(this.embeddedKafka.zkConnectionTimeout(), this.embeddedKafka.zkSessionTimeout());
 
 		Properties properties = new Properties();
 

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizer.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizer.java
@@ -42,6 +42,7 @@ import org.springframework.util.StringUtils;
  * @author Zach Olauson
  * @author Oleg Artyomov
  * @author Sergio Lourenco
+ * @author Pawel Lozinski
  *
  * @since 1.3
  */
@@ -73,7 +74,8 @@ class EmbeddedKafkaContextCustomizer implements ContextCustomizer {
 					topics)
 				.kafkaPorts(ports)
 				.zkPort(this.embeddedKafka.zookeeperPort())
-				.setZkClientTimeouts(this.embeddedKafka.zkConnectionTimeout(), this.embeddedKafka.zkSessionTimeout());
+				.zkConnectionTimeout(this.embeddedKafka.zkConnectionTimeout())
+				.zkSessionTimeout(this.embeddedKafka.zkSessionTimeout());
 
 		Properties properties = new Properties();
 


### PR DESCRIPTION
For build servers with high load, it may happen that the build hangs for couple of seconds. This causes the internal ZK client session of embedded Kafka broker to timeout and fail the build.

It would be good if these were configurable.