### PR TITLE
Fix BatchToRecordAdapter

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/BatchToRecordAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/BatchToRecordAdapter.java
@@ -61,12 +61,12 @@ public interface BatchToRecordAdapter<K, V> {
 
 		/**
 		 * Handle each message.
-		 * @param records the records.
+		 * @param record the record.
 		 * @param ack the acknowledgment.
 		 * @param consumer the consumer.
 		 * @param message the message.
 		 */
-		void invoke(List<ConsumerRecord<K, V>> records, Acknowledgment ack, Consumer<?, ?> consumer,
+		void invoke(ConsumerRecord<K, V> record, Acknowledgment ack, Consumer<?, ?> consumer,
 				Message<?> message);
 
 	}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/DefaultBatchToRecordAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/DefaultBatchToRecordAdapter.java
@@ -68,7 +68,7 @@ public class DefaultBatchToRecordAdapter<K, V> implements BatchToRecordAdapter<K
 		for (int i = 0; i < messages.size(); i++) {
 			Message<?> message = messages.get(i);
 			try {
-				callback.invoke(records, ack, consumer, message);
+				callback.invoke(records.get(i), ack, consumer, message);
 			}
 			catch (Exception e) {
 				this.recoverer.accept(records.get(i), e);

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
@@ -318,6 +318,7 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 	 */
 	protected final Object invokeHandler(Object data, Acknowledgment acknowledgment, Message<?> message,
 			Consumer<?, ?> consumer) {
+
 		try {
 			if (data instanceof List && !this.isConsumerRecordList) {
 				return this.handlerMethod.invoke(message, acknowledgment, consumer);


### PR DESCRIPTION
Incorrectly passed the whole message list to the callback, which
caused listeners with a `ConsumerRecord<?, ?>` argument to fail.

Changes a public API but there is no choice and it was only added a couple of
weeks ago.