### PR TITLE
GH-1386: Fix StreamsBuilder customization

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/config/StreamsBuilderFactoryBean.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/StreamsBuilderFactoryBean.java
@@ -224,7 +224,9 @@ public class StreamsBuilderFactoryBean extends AbstractFactoryBean<StreamsBuilde
 			Assert.state(this.properties != null,
 					"streams configuration properties must not be null");
 		}
-		return new StreamsBuilder();
+		StreamsBuilder builder = new StreamsBuilder();
+		this.infrastructureCustomizer.configureBuilder(builder);
+		return builder;
 	}
 
 	@Override
@@ -246,9 +248,7 @@ public class StreamsBuilderFactoryBean extends AbstractFactoryBean<StreamsBuilde
 			try {
 				Assert.state(this.properties != null,
 						"streams configuration properties must not be null");
-				StreamsBuilder builder = getObject();
-				this.infrastructureCustomizer.configureBuilder(builder);
-				Topology topology = builder.build(this.properties); // NOSONAR: getObject() cannot return null
+				Topology topology = getObject().build(this.properties); // NOSONAR: getObject() cannot return null
 				this.infrastructureCustomizer.configureTopology(topology);
 				LOGGER.debug(() -> topology.describe().toString());
 				this.kafkaStreams = new KafkaStreams(topology, this.properties, this.clientSupplier);


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1386

The builder was incorrectly customized in `start()`. It needs to be
customized after creation so that when it is used to create `KStream`s
elsewhere, it is already customized.