### PR TITLE
Replace JIRA ticket with GitHub issue in the contribution guidelines

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -250,8 +250,11 @@ Add a comment to the associated GitHub issue(s) linking to your new pull request
 
 == Provide a Link to the GitHub issue in the Associated Pull Request
 
-Add a GitHub issue link to your first commit comment of the pull request on the last line, so your commit message
-may look like this:
+There are multiple ways to link a Pull Request to a GitHub issue as described
+https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue[here].
+
+One way would be to add a GitHub issue link to your first commit comment of the pull request on the second line,
+so your commit message may look like this:
 
 ----
     GH-1: Add Contribution Guidelines
@@ -262,3 +265,8 @@ may look like this:
     * mention Contribution Guidelines in the `README.md`
     * mention CODE_OF_CONDUCT in the `README.md`
 ----
+
+Also by using specific
+https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword[keywords]
+you can link to a GitHub issue like so:
+    Closes #10

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -269,4 +269,5 @@ so your commit message may look like this:
 Also by using specific
 https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword[keywords]
 you can link to a GitHub issue like so:
+
     Closes #10

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -52,7 +52,7 @@ _you should see branches on origin as well as upstream, including 'master' and '
 
 == A Day in the Life of a Contributor
 
-* _Always_ work on topic branches (Typically use the Jira ticket ID as the branch name).
+* _Always_ work on topic branches (Typically use the GitHub issue ID as the branch name).
   - For example, to create and switch to a new branch for issue GH-123: `git checkout -b GH-123`
 * You might be working on several different topic branches at any given time, but when at a stopping point for one of those branches, commit (a local operation).
 * Please follow the "Commit Guidelines" described in
@@ -246,11 +246,11 @@ Make sure that all tests pass prior to submitting your pull request.
 
 == Mention your pull request on the associated GitHub issue
 
-Add a comment to the associated JIRA issue(s) linking to your new pull request.
+Add a comment to the associated GitHub issue(s) linking to your new pull request.
 
-== Provide a Link to the JIRA issue in the Associated Pull Request
+== Provide a Link to the GitHub issue in the Associated Pull Request
 
-Add a JIRA issue link to your first commit comment of the pull request on the last line, so your commit message
+Add a GitHub issue link to your first commit comment of the pull request on the last line, so your commit message
 may look like this:
 
 ----

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Here are some ways for you to get involved in the community:
 
 * Get involved with the Spring community on the Spring Community Forums.  Please help out on the [StackOverflow](https://stackoverflow.com/questions/tagged/spring-kafka) by responding to questions and joining the debate.
 * Create [GitHub issues](https://github.com/spring-projects/spring-kafka/issues) for bugs and new features and comment and vote on the ones that you are interested in.
-* Github is for social coding: if you want to write code, we encourage contributions through pull requests from [forks of this repository](https://help.github.com/forking/).  If you want to contribute code this way, please reference a JIRA ticket as well covering the specific issue you are addressing.
+* Github is for social coding: if you want to write code, we encourage contributions through pull requests from [forks of this repository](https://help.github.com/forking/).  If you want to contribute code this way, please reference a GitHub issue as well covering the specific issue you are addressing.
 * Watch for upcoming articles on Spring by [subscribing](https://www.springsource.org/node/feed) to springframework.org
 
 Before we accept a non-trivial patch or pull request we will need you to sign the [contributor's agreement](https://support.springsource.com/spring_committer_signup).


### PR DESCRIPTION
It seems the contribution guidelines are still referencing JIRA and this can lead to confusion for future contributors.
Fixed it by changing it to GitHub issues