### PR TITLE
GH-1400: Expose topology from StreamsBuilder

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/config/StreamsBuilderFactoryBean.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/StreamsBuilderFactoryBean.java
@@ -93,6 +93,8 @@ public class StreamsBuilderFactoryBean extends AbstractFactoryBean<StreamsBuilde
 
 	private volatile boolean running;
 
+	private Topology topology;
+
 	/**
 	 * Default constructor that creates the factory without configuration
 	 * {@link Properties}. It is the factory user's responsibility to properly set
@@ -190,6 +192,15 @@ public class StreamsBuilderFactoryBean extends AbstractFactoryBean<StreamsBuilde
 		this.closeTimeout = Duration.ofSeconds(closeTimeout); // NOSONAR (sync)
 	}
 
+	/**
+	 * Providing access to the associated {@link Topology} of this {@link StreamsBuilderFactoryBean}.
+	 * @return {@link Topology} object
+	 * @since 2.4.4
+	 */
+	public Topology getTopology() {
+		return this.topology;
+	}
+
 	@Override
 	public Class<?> getObjectType() {
 		return StreamsBuilder.class;
@@ -250,6 +261,7 @@ public class StreamsBuilderFactoryBean extends AbstractFactoryBean<StreamsBuilde
 						"streams configuration properties must not be null");
 				Topology topology = getObject().build(this.properties); // NOSONAR: getObject() cannot return null
 				this.infrastructureCustomizer.configureTopology(topology);
+				this.topology = topology;
 				LOGGER.debug(() -> topology.describe().toString());
 				this.kafkaStreams = new KafkaStreams(topology, this.properties, this.clientSupplier);
 				this.kafkaStreams.setStateListener(this.stateListener);

--- a/spring-kafka/src/test/java/org/springframework/kafka/config/StreamsBuilderFactoryBeanTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/config/StreamsBuilderFactoryBeanTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 the original author or authors.
+ * Copyright 2018-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,6 +51,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
  * @author Artem Bilan
  * @author Gary Russell
  * @author Denis Washington
+ * @author Soby Chacko
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -99,6 +100,7 @@ public class StreamsBuilderFactoryBeanTests {
 		streamsBuilderFactoryBean.start();
 		StreamsBuilder streamsBuilder = streamsBuilderFactoryBean.getObject();
 		verify(streamsBuilder).build(kafkaStreamsConfiguration.asProperties());
+		assertThat(streamsBuilderFactoryBean.getTopology()).isNotNull();
 	}
 
 	@Configuration


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1400

Currently, StreamsBuilderFacotryBean does not give direct access to the toplogy object.
It will be beneficial for downstream clients such as the Kafka Strems binder in
Spring Cloud Stream to get access to the topology object directly.