### PR TITLE
DeadLetterPublishingRecoverer improvements

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaOperations.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaOperations.java
@@ -227,6 +227,16 @@ public interface KafkaOperations<K, V> {
 	}
 
 	/**
+	 * Return true if the template is currently running in a transaction on the calling
+	 * thread.
+	 * @return true if a transaction is running.
+	 * @since 2.5
+	 */
+	default boolean inTransaction() {
+		return false;
+	}
+
+	/**
 	 * A callback for executing arbitrary operations on the {@link Producer}.
 	 * @param <K> the key type.
 	 * @param <V> the value type.

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
@@ -446,11 +446,12 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V> {
 
 
 	/**
-	 * Return true if the template is currently running in a transaction on the
-	 * calling thread.
+	 * Return true if the template is currently running in a transaction on the calling
+	 * thread.
 	 * @return true if a transaction is running.
 	 * @since 2.2.1
 	 */
+	@Override
 	public boolean inTransaction() {
 		return this.transactional && (this.producers.get() != null
 				|| TransactionSynchronizationManager.getResource(this.producerFactory) != null

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
@@ -138,7 +138,7 @@ public class DeadLetterPublishingRecoverer implements ConsumerRecordRecoverer {
 	}
 
 	/**
-	 * Set to true to retain a Java serialized Deserialization exception header. By
+	 * Set to true to retain a Java serialized {@link DeserializationException} header. By
 	 * default, such headers are removed from the published record, unless both key and
 	 * value deserialization exceptions occur, in which case, the DLT_* headers are
 	 * created from the value exception and the key exception header is retained.

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
@@ -29,15 +29,15 @@ import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 
 import org.springframework.core.log.LogAccessor;
 import org.springframework.kafka.core.KafkaOperations;
-import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.support.serializer.DeserializationException;
-import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer2;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ObjectUtils;
@@ -58,22 +58,24 @@ public class DeadLetterPublishingRecoverer implements ConsumerRecordRecoverer {
 	private static final BiFunction<ConsumerRecord<?, ?>, Exception, TopicPartition>
 		DEFAULT_DESTINATION_RESOLVER = (cr, e) -> new TopicPartition(cr.topic() + ".DLT", cr.partition());
 
-	private final KafkaTemplate<Object, Object> template;
+	private final KafkaOperations<Object, Object> template;
 
-	private final Map<Class<?>, KafkaTemplate<?, ?>> templates;
+	private final Map<Class<?>, KafkaOperations<?, ?>> templates;
 
 	private final boolean transactional;
 
 	private final BiFunction<ConsumerRecord<?, ?>, Exception, TopicPartition> destinationResolver;
+
+	private boolean retainExceptionHeader;
 
 	/**
 	 * Create an instance with the provided template and a default destination resolving
 	 * function that returns a TopicPartition based on the original topic (appended with ".DLT")
 	 * from the failed record, and the same partition as the failed record. Therefore the
 	 * dead-letter topic must have at least as many partitions as the original topic.
-	 * @param template the {@link KafkaTemplate} to use for publishing.
+	 * @param template the {@link KafkaOperations} to use for publishing.
 	 */
-	public DeadLetterPublishingRecoverer(KafkaTemplate<? extends Object, ? extends Object> template) {
+	public DeadLetterPublishingRecoverer(KafkaOperations<? extends Object, ? extends Object> template) {
 		this(template, DEFAULT_DESTINATION_RESOLVER);
 	}
 
@@ -82,10 +84,10 @@ public class DeadLetterPublishingRecoverer implements ConsumerRecordRecoverer {
 	 * that receives the failed consumer record and the exception and returns a
 	 * {@link TopicPartition}. If the partition in the {@link TopicPartition} is less than
 	 * 0, no partition is set when publishing to the topic.
-	 * @param template the {@link KafkaTemplate} to use for publishing.
+	 * @param template the {@link KafkaOperations} to use for publishing.
 	 * @param destinationResolver the resolving function.
 	 */
-	public DeadLetterPublishingRecoverer(KafkaTemplate<? extends Object, ? extends Object> template,
+	public DeadLetterPublishingRecoverer(KafkaOperations<? extends Object, ? extends Object> template,
 			BiFunction<ConsumerRecord<?, ?>, Exception, TopicPartition> destinationResolver) {
 		this(Collections.singletonMap(Object.class, template), destinationResolver);
 	}
@@ -99,9 +101,9 @@ public class DeadLetterPublishingRecoverer implements ConsumerRecordRecoverer {
 	 * template to use for objects (producer record values) of that type. A
 	 * {@link java.util.LinkedHashMap} is recommended when there is more than one
 	 * template, to ensure the map is traversed in order.
-	 * @param templates the {@link KafkaTemplate}s to use for publishing.
+	 * @param templates the {@link KafkaOperations}s to use for publishing.
 	 */
-	public DeadLetterPublishingRecoverer(Map<Class<?>, KafkaTemplate<? extends Object, ? extends Object>> templates) {
+	public DeadLetterPublishingRecoverer(Map<Class<?>, KafkaOperations<? extends Object, ? extends Object>> templates) {
 		this(templates, DEFAULT_DESTINATION_RESOLVER);
 	}
 
@@ -113,16 +115,18 @@ public class DeadLetterPublishingRecoverer implements ConsumerRecordRecoverer {
 	 * classes and the value the corresponding template to use for objects (producer
 	 * record values) of that type. A {@link java.util.LinkedHashMap} is recommended when
 	 * there is more than one template, to ensure the map is traversed in order.
-	 * @param templates the {@link KafkaTemplate}s to use for publishing.
+	 * @param templates the {@link KafkaOperations}s to use for publishing.
 	 * @param destinationResolver the resolving function.
 	 */
 	@SuppressWarnings("unchecked")
-	public DeadLetterPublishingRecoverer(Map<Class<?>, KafkaTemplate<? extends Object, ? extends Object>> templates,
+	public DeadLetterPublishingRecoverer(Map<Class<?>, KafkaOperations<? extends Object, ? extends Object>> templates,
 			BiFunction<ConsumerRecord<?, ?>, Exception, TopicPartition> destinationResolver) {
 
 		Assert.isTrue(!ObjectUtils.isEmpty(templates), "At least one template is required");
 		Assert.notNull(destinationResolver, "The destinationResolver cannot be null");
-		this.template = templates.size() == 1 ? (KafkaTemplate<Object, Object>) templates.values().iterator().next() : null;
+		this.template = templates.size() == 1
+				? (KafkaOperations<Object, Object>) templates.values().iterator().next()
+				: null;
 		this.templates = templates;
 		this.transactional = templates.values().iterator().next().isTransactional();
 		Boolean tx = this.transactional;
@@ -133,22 +137,40 @@ public class DeadLetterPublishingRecoverer implements ConsumerRecordRecoverer {
 		this.destinationResolver = destinationResolver;
 	}
 
+	/**
+	 * Set to true to retain a Java serialized Deserialization exception header. By
+	 * default, such headers are removed from the published record, unless both key and
+	 * value deserialization exceptions occur, in which case, the DLT_* headers are
+	 * created from the value exception and the key exception header is retained.
+	 * @param retainExceptionHeader true to retain the
+	 * @since 2.5
+	 */
+	public void setRetainExceptionHeader(boolean retainExceptionHeader) {
+		this.retainExceptionHeader = retainExceptionHeader;
+	}
+
 	@Override
 	public void accept(ConsumerRecord<?, ?> record, Exception exception) {
 		TopicPartition tp = this.destinationResolver.apply(record, exception);
-		RecordHeaders headers = new RecordHeaders(record.headers().toArray());
-		enhanceHeaders(headers, record, exception);
 		boolean isKey = false;
 		DeserializationException deserEx = ListenerUtils.getExceptionFromHeader(record,
-				ErrorHandlingDeserializer2.VALUE_DESERIALIZER_EXCEPTION_HEADER, LOGGER);
+				ErrorHandlingDeserializer.VALUE_DESERIALIZER_EXCEPTION_HEADER, LOGGER);
 		if (deserEx == null) {
 			deserEx = ListenerUtils.getExceptionFromHeader(record,
-					ErrorHandlingDeserializer2.KEY_DESERIALIZER_EXCEPTION_HEADER, LOGGER);
+					ErrorHandlingDeserializer.KEY_DESERIALIZER_EXCEPTION_HEADER, LOGGER);
 			isKey = true;
 		}
+		Headers headers;
+		if (deserEx == null || this.retainExceptionHeader) {
+			headers = new RecordHeaders(record.headers().toArray());
+		}
+		else {
+			headers = deserEx.getHeaders();
+		}
+		enhanceHeaders(headers, record, exception);
 		ProducerRecord<Object, Object> outRecord = createProducerRecord(record, tp, headers,
 				deserEx == null ? null : deserEx.getData(), isKey);
-		KafkaTemplate<Object, Object> kafkaTemplate = findTemplateForValue(outRecord.value());
+		KafkaOperations<Object, Object> kafkaTemplate = findTemplateForValue(outRecord.value());
 		if (this.transactional && !kafkaTemplate.inTransaction() && !kafkaTemplate.isAllowNonTransactional()) {
 			kafkaTemplate.executeInTransaction(t -> {
 				publish(outRecord, t);
@@ -161,7 +183,7 @@ public class DeadLetterPublishingRecoverer implements ConsumerRecordRecoverer {
 	}
 
 	@SuppressWarnings("unchecked")
-	private KafkaTemplate<Object, Object> findTemplateForValue(Object value) {
+	private KafkaOperations<Object, Object> findTemplateForValue(Object value) {
 		if (this.template != null) {
 			return this.template;
 		}
@@ -170,10 +192,10 @@ public class DeadLetterPublishingRecoverer implements ConsumerRecordRecoverer {
 			.filter((k) -> k.isAssignableFrom(value.getClass()))
 			.findFirst();
 		if (key.isPresent()) {
-			return (KafkaTemplate<Object, Object>) this.templates.get(key.get());
+			return (KafkaOperations<Object, Object>) this.templates.get(key.get());
 		}
 		LOGGER.warn(() -> "Failed to find a template for " + value.getClass() + " attempting to use the last entry");
-		return (KafkaTemplate<Object, Object>) this.templates.values()
+		return (KafkaOperations<Object, Object>) this.templates.values()
 				.stream()
 				.reduce((first,  second) -> second)
 				.get();
@@ -195,7 +217,7 @@ public class DeadLetterPublishingRecoverer implements ConsumerRecordRecoverer {
 	 * @see KafkaHeaders
 	 */
 	protected ProducerRecord<Object, Object> createProducerRecord(ConsumerRecord<?, ?> record,
-			TopicPartition topicPartition, RecordHeaders headers, @Nullable byte[] data, boolean isKey) {
+			TopicPartition topicPartition, Headers headers, @Nullable byte[] data, boolean isKey) {
 
 		return new ProducerRecord<>(topicPartition.topic(),
 				topicPartition.partition() < 0 ? null : topicPartition.partition(),
@@ -222,7 +244,7 @@ public class DeadLetterPublishingRecoverer implements ConsumerRecordRecoverer {
 		}
 	}
 
-	private void enhanceHeaders(RecordHeaders kafkaHeaders, ConsumerRecord<?, ?> record, Exception exception) {
+	private void enhanceHeaders(Headers kafkaHeaders, ConsumerRecord<?, ?> record, Exception exception) {
 		kafkaHeaders.add(
 				new RecordHeader(KafkaHeaders.DLT_ORIGINAL_TOPIC, record.topic().getBytes(StandardCharsets.UTF_8)));
 		kafkaHeaders.add(new RecordHeader(KafkaHeaders.DLT_ORIGINAL_PARTITION,

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -87,7 +87,7 @@ import org.springframework.kafka.support.TopicPartitionOffset;
 import org.springframework.kafka.support.TopicPartitionOffset.SeekPosition;
 import org.springframework.kafka.support.TransactionSupport;
 import org.springframework.kafka.support.serializer.DeserializationException;
-import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer2;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
 import org.springframework.kafka.transaction.KafkaAwareTransactionManager;
 import org.springframework.lang.Nullable;
 import org.springframework.scheduling.SchedulingAwareRunnable;
@@ -864,8 +864,8 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 
 		private boolean checkDeserializer(Object deser) {
 			return deser instanceof Class
-					? ErrorHandlingDeserializer2.class.isAssignableFrom((Class<?>) deser)
-					: deser instanceof String && deser.equals(ErrorHandlingDeserializer2.class.getName());
+					? ErrorHandlingDeserializer.class.isAssignableFrom((Class<?>) deser)
+					: deser instanceof String && deser.equals(ErrorHandlingDeserializer.class.getName());
 		}
 
 		protected void checkConsumer() {
@@ -1732,10 +1732,10 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 				throw (DeserializationException) record.key();
 			}
 			if (record.value() == null && this.checkNullValueForExceptions) {
-				checkDeser(record, ErrorHandlingDeserializer2.VALUE_DESERIALIZER_EXCEPTION_HEADER);
+				checkDeser(record, ErrorHandlingDeserializer.VALUE_DESERIALIZER_EXCEPTION_HEADER);
 			}
 			if (record.key() == null && this.checkNullKeyForExceptions) {
-				checkDeser(record, ErrorHandlingDeserializer2.KEY_DESERIALIZER_EXCEPTION_HEADER);
+				checkDeser(record, ErrorHandlingDeserializer.KEY_DESERIALIZER_EXCEPTION_HEADER);
 			}
 			if (this.deliveryAttemptAware != null) {
 				byte[] buff = new byte[4]; // NOSONAR (magic #)

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ListenerUtils.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ListenerUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,6 @@ package org.springframework.kafka.listener;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
-import java.util.Arrays;
-import java.util.stream.Collectors;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Header;
@@ -29,7 +27,6 @@ import org.apache.kafka.common.header.internals.RecordHeaders;
 
 import org.springframework.core.log.LogAccessor;
 import org.springframework.kafka.support.serializer.DeserializationException;
-import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer2;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
@@ -87,10 +84,8 @@ public final class ListenerUtils {
 			try {
 				DeserializationException ex = (DeserializationException) new ObjectInputStream(
 						new ByteArrayInputStream(header.value())).readObject();
-				Headers headers = new RecordHeaders(Arrays.stream(record.headers().toArray())
-						.filter(h -> !h.key()
-								.startsWith(ErrorHandlingDeserializer2.KEY_DESERIALIZER_EXCEPTION_HEADER_PREFIX))
-						.collect(Collectors.toList()));
+				Headers headers = new RecordHeaders(record.headers().toArray());
+				headers.remove(headerName);
 				ex.setHeaders(headers);
 				return ex;
 			}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DeserializationException.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DeserializationException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 the original author or authors.
+ * Copyright 2018-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,10 +41,29 @@ public class DeserializationException extends KafkaException {
 
 	private final boolean isKey;
 
-	public DeserializationException(String message, byte[] data, boolean isKey, Throwable cause) {
-		this(message, null, data, isKey, cause);
+	/**
+	 * Construct an instance with the provided properties.
+	 * @param message the message.
+	 * @param data the data (value or key).
+	 * @param isKey true if the exception occurred while deserializing the key.
+	 * @param cause the cause.
+	 */
+	public DeserializationException(String message, byte[] data, boolean isKey, Throwable cause) { // NOSONAR array reference
+		super(message, cause);
+		this.data = data; // NOSONAR array reference
+		this.isKey = isKey;
 	}
 
+	/**
+	 * Construct an instance with the provided properties.
+	 * @param message the message.
+	 * @param headers the headers.
+	 * @param data the data (value or key).
+	 * @param isKey true if the exception occurred while deserializing the key.
+	 * @param cause the cause.
+	 * @deprecated Headers are not set during construction.
+	 */
+	@Deprecated
 	public DeserializationException(String message, @Nullable Headers headers, byte[] data, // NOSONAR array reference
 			boolean isKey, Throwable cause) {
 
@@ -54,19 +73,36 @@ public class DeserializationException extends KafkaException {
 		this.isKey = isKey;
 	}
 
+	/**
+	 * Get the headers.
+	 * @return the headers.
+	 */
 	@Nullable
 	public Headers getHeaders() {
 		return this.headers;
 	}
 
+	/**
+	 * Set the headers.
+	 * @param headers the headers.
+	 */
 	public void setHeaders(@Nullable Headers headers) {
 		this.headers = headers;
 	}
 
+	/**
+	 * Get the data that failed deserialization (value or key).
+	 * @return the data.
+	 */
 	public byte[] getData() {
 		return this.data; // NOSONAR array reference
 	}
 
+	/**
+	 * True if deserialization of the key failed, otherwise deserialization of the value
+	 * failed.
+	 * @return true for the key.
+	 */
 	public boolean isKey() {
 		return this.isKey;
 	}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ErrorHandlingDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ErrorHandlingDeserializer.java
@@ -16,10 +16,15 @@
 
 package org.springframework.kafka.support.serializer;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.serialization.Deserializer;
 
 import org.springframework.util.Assert;
@@ -27,19 +32,43 @@ import org.springframework.util.ClassUtils;
 
 /**
  * Delegating key/value deserializer that catches exceptions, returning them
- * in the consumer record.
+ * in the headers as serialized java objects.
  *
  * @param <T> class of the entity, representing messages
  *
  * @author Gary Russell
  * @author Artem Bilan
- * @deprecated in favor of {@link ErrorHandlingDeserializer2}.
+ * @author Victor Perez Rey
  *
  * @since 2.2
  *
  */
-@Deprecated
 public class ErrorHandlingDeserializer<T> implements Deserializer<T> {
+
+	/**
+	 * Header name for deserialization exceptions.
+	 */
+	public static final String KEY_DESERIALIZER_EXCEPTION_HEADER_PREFIX = "springDeserializerException";
+
+	/**
+	 * Header name for deserialization exceptions.
+	 */
+	public static final String KEY_DESERIALIZER_EXCEPTION_HEADER = KEY_DESERIALIZER_EXCEPTION_HEADER_PREFIX + "Key";
+
+	/**
+	 * Header name for deserialization exceptions.
+	 */
+	public static final String VALUE_DESERIALIZER_EXCEPTION_HEADER = KEY_DESERIALIZER_EXCEPTION_HEADER_PREFIX + "Value";
+
+	/**
+	 * Supplier for a T when deserialization fails.
+	 */
+	public static final String KEY_FUNCTION = "spring.deserializer.key.function";
+
+	/**
+	 * Supplier for a T when deserialization fails.
+	 */
+	public static final String VALUE_FUNCTION = "spring.deserializer.value.function";
 
 	/**
 	 * Property name for the delegate key deserializer.
@@ -55,6 +84,8 @@ public class ErrorHandlingDeserializer<T> implements Deserializer<T> {
 
 	private boolean isForKey;
 
+	private Function<FailedDeserializationInfo, T> failedDeserializationFunction;
+
 	public ErrorHandlingDeserializer() {
 	}
 
@@ -62,31 +93,72 @@ public class ErrorHandlingDeserializer<T> implements Deserializer<T> {
 		this.delegate = setupDelegate(delegate);
 	}
 
+	/**
+	 * Provide an alternative supplying mechanism when deserialization fails.
+	 * @param failedDeserializationFunction the {@link BiFunction} to use.
+	 * @deprecated since 2.2.8 in favor of {@link #setFailedDeserializationFunction(Function)}.
+	 */
+	@Deprecated
+	public void setFailedDeserializationFunction(BiFunction<byte[], Headers, T> failedDeserializationFunction) {
+		setFailedDeserializationFunction((failed) ->
+				failedDeserializationFunction.apply(failed.getData(), failed.getHeaders()));
+	}
+
+	/**
+	 * Provide an alternative supplying mechanism when deserialization fails.
+	 * @param failedDeserializationFunction the {@link Function} to use.
+	 * @since 2.2.8
+	 */
+	public void setFailedDeserializationFunction(Function<FailedDeserializationInfo, T> failedDeserializationFunction) {
+		this.failedDeserializationFunction = failedDeserializationFunction;
+	}
+
+	public boolean isForKey() {
+		return this.isForKey;
+	}
+
+	/**
+	 * Set to true if this deserializer is to be used as a key deserializer when
+	 * configuring outside of Kafka.
+	 * @param isKey true for a key deserializer, false otherwise.
+	 * @since 2.2.3
+	 */
+	public void setForKey(boolean isKey) {
+		this.isForKey = isKey;
+	}
+
+	/**
+	 * Set to true if this deserializer is to be used as a key deserializer when
+	 * configuring outside of Kafka.
+	 * @param isKey true for a key deserializer, false otherwise.
+	 * @return this
+	 * @since 2.2.3
+	 */
+	public ErrorHandlingDeserializer<T> keyDeserializer(boolean isKey) {
+		this.isForKey = isKey;
+		return this;
+	}
+
 	@Override
 	public void configure(Map<String, ?> configs, boolean isKey) {
-		if (isKey && configs.containsKey(KEY_DESERIALIZER_CLASS)) {
-			try {
-				Object value = configs.get(KEY_DESERIALIZER_CLASS);
-				Class<?> clazz = value instanceof Class ? (Class<?>) value : ClassUtils.forName((String) value, null);
-				this.delegate = setupDelegate(clazz.newInstance());
-			}
-			catch (ClassNotFoundException | LinkageError | InstantiationException | IllegalAccessException e) {
-				throw new IllegalStateException(e);
-			}
-		}
-		else if (!isKey && configs.containsKey(VALUE_DESERIALIZER_CLASS)) {
-			try {
-				Object value = configs.get(VALUE_DESERIALIZER_CLASS);
-				Class<?> clazz = value instanceof Class ? (Class<?>) value : ClassUtils.forName((String) value, null);
-				this.delegate = setupDelegate(clazz.newInstance());
-			}
-			catch (ClassNotFoundException | LinkageError | InstantiationException | IllegalAccessException e) {
-				throw new IllegalStateException(e);
-			}
-		}
+		setupDelegate(configs, isKey ? KEY_DESERIALIZER_CLASS : VALUE_DESERIALIZER_CLASS);
 		Assert.state(this.delegate != null, "No delegate deserializer configured");
 		this.delegate.configure(configs, isKey);
 		this.isForKey = isKey;
+		setupFunction(configs, isKey ? KEY_FUNCTION : VALUE_FUNCTION);
+	}
+
+	public void setupDelegate(Map<String, ?> configs, String configKey) {
+		if (configs.containsKey(configKey)) {
+			try {
+				Object value = configs.get(configKey);
+				Class<?> clazz = value instanceof Class ? (Class<?>) value : ClassUtils.forName((String) value, null);
+				this.delegate = setupDelegate(clazz.newInstance());
+			}
+			catch (ClassNotFoundException | LinkageError | InstantiationException | IllegalAccessException e) {
+				throw new IllegalStateException(e);
+			}
+		}
 	}
 
 	@SuppressWarnings("unchecked")
@@ -95,13 +167,29 @@ public class ErrorHandlingDeserializer<T> implements Deserializer<T> {
 		return (Deserializer<T>) delegate;
 	}
 
+	@SuppressWarnings("unchecked")
+	private void setupFunction(Map<String, ?> configs, String configKey) {
+		if (configs.containsKey(configKey)) {
+			try {
+				Object value = configs.get(configKey);
+				Class<?> clazz = value instanceof Class ? (Class<?>) value : ClassUtils.forName((String) value, null);
+				Assert.isTrue(Function.class.isAssignableFrom(clazz), "'function' must be a 'Function ', not a "
+						+ clazz.getName());
+				this.failedDeserializationFunction = (Function<FailedDeserializationInfo, T>) clazz.newInstance();
+			}
+			catch (ClassNotFoundException | LinkageError | InstantiationException | IllegalAccessException e) {
+				throw new IllegalStateException(e);
+			}
+		}
+	}
+
 	@Override
 	public T deserialize(String topic, byte[] data) {
 		try {
 			return this.delegate.deserialize(topic, data);
 		}
 		catch (Exception e) {
-			return deserializationException(null, data, e);
+			return recoverFromSupplier(topic, null, data, e);
 		}
 	}
 
@@ -111,22 +199,54 @@ public class ErrorHandlingDeserializer<T> implements Deserializer<T> {
 			return this.delegate.deserialize(topic, headers, data);
 		}
 		catch (Exception e) {
-			return deserializationException(headers, data, e);
+			deserializationException(headers, data, e);
+			return recoverFromSupplier(topic, headers, data, e);
+		}
+	}
+
+	private T recoverFromSupplier(String topic, Headers headers, byte[] data, Exception exception) {
+		if (this.failedDeserializationFunction != null) {
+			FailedDeserializationInfo failedDeserializationInfo =
+					new FailedDeserializationInfo(topic, headers, data, this.isForKey, exception);
+			return this.failedDeserializationFunction.apply(failedDeserializationInfo);
+		}
+		else {
+			return null;
 		}
 	}
 
 	@Override
 	public void close() {
-		this.delegate.close();
+		if (this.delegate != null) {
+			this.delegate.close();
+		}
 	}
 
-	@SuppressWarnings("unchecked")
-	private T deserializationException(Headers headers, byte[] data, Exception e) {
-		// We need this container to trick a generic type. It doesn't matter at runtime anyway.
-		AtomicReference<T> reference =
-				(AtomicReference<T>) new AtomicReference<>(
-						new DeserializationException("Failed to deserialize", headers, data, this.isForKey, e));
-		return reference.get();
+	private void deserializationException(Headers headers, byte[] data, Exception e) {
+		ByteArrayOutputStream stream = new ByteArrayOutputStream();
+		DeserializationException exception =
+				new DeserializationException("failed to deserialize", data, this.isForKey, e);
+		try (ObjectOutputStream oos = new ObjectOutputStream(stream)) {
+			oos.writeObject(exception);
+		}
+		catch (IOException ex) {
+			stream = new ByteArrayOutputStream();
+			try (ObjectOutputStream oos = new ObjectOutputStream(stream)) {
+				exception = new DeserializationException("failed to deserialize",
+						data, this.isForKey, new RuntimeException("Could not deserialize type "
+						+ e.getClass().getName() + " with message " + e.getMessage()
+						+ " failure: " + ex.getMessage()));
+				oos.writeObject(exception);
+			}
+			catch (IOException ex2) {
+				throw new IllegalStateException("Could not serialize a DeserializationException", ex2); // NOSONAR
+			}
+		}
+		headers.add(
+				new RecordHeader(this.isForKey
+						? KEY_DESERIALIZER_EXCEPTION_HEADER
+						: VALUE_DESERIALIZER_EXCEPTION_HEADER,
+						stream.toByteArray()));
 	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ErrorHandlingDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ErrorHandlingDeserializer.java
@@ -20,7 +20,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.util.Map;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.apache.kafka.common.header.Headers;
@@ -91,17 +90,6 @@ public class ErrorHandlingDeserializer<T> implements Deserializer<T> {
 
 	public ErrorHandlingDeserializer(Deserializer<T> delegate) {
 		this.delegate = setupDelegate(delegate);
-	}
-
-	/**
-	 * Provide an alternative supplying mechanism when deserialization fails.
-	 * @param failedDeserializationFunction the {@link BiFunction} to use.
-	 * @deprecated since 2.2.8 in favor of {@link #setFailedDeserializationFunction(Function)}.
-	 */
-	@Deprecated
-	public void setFailedDeserializationFunction(BiFunction<byte[], Headers, T> failedDeserializationFunction) {
-		setFailedDeserializationFunction((failed) ->
-				failedDeserializationFunction.apply(failed.getData(), failed.getHeaders()));
 	}
 
 	/**

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/BatchListenerConversion2Tests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/BatchListenerConversion2Tests.java
@@ -39,7 +39,7 @@ import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.support.converter.BytesJsonMessageConverter;
-import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer2;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
 import org.springframework.kafka.support.serializer.FailedDeserializationInfo;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 import org.springframework.kafka.test.EmbeddedKafkaBroker;
@@ -106,9 +106,9 @@ public class BatchListenerConversion2Tests {
 		public Map<String, Object> consumerConfigs() {
 			Map<String, Object> consumerProps =
 					KafkaTestUtils.consumerProps(DEFAULT_TEST_GROUP_ID, "false", this.embeddedKafka);
-			consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer2.class);
-			consumerProps.put(ErrorHandlingDeserializer2.VALUE_DESERIALIZER_CLASS, JsonDeserializer.class);
-			consumerProps.put(ErrorHandlingDeserializer2.VALUE_FUNCTION, FailedFooProvider.class);
+			consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+			consumerProps.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, JsonDeserializer.class);
+			consumerProps.put(ErrorHandlingDeserializer.VALUE_FUNCTION, FailedFooProvider.class);
 			consumerProps.put(JsonDeserializer.VALUE_DEFAULT_TYPE, Foo.class.getName());
 			consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 			return consumerProps;

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ErrorHandlingDeserializerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ErrorHandlingDeserializerTests.java
@@ -48,7 +48,7 @@ import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.support.serializer.DeserializationException;
-import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer2;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
 import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.test.annotation.DirtiesContext;
@@ -82,10 +82,10 @@ public class ErrorHandlingDeserializerTests {
 
 	@Test
 	public void unitTests() throws Exception {
-		ErrorHandlingDeserializer2<String> ehd = new ErrorHandlingDeserializer2<>(new StringDeserializer());
+		ErrorHandlingDeserializer<String> ehd = new ErrorHandlingDeserializer<>(new StringDeserializer());
 		assertThat(ehd.deserialize("topic", "foo".getBytes())).isEqualTo("foo");
 		ehd.close();
-		ehd = new ErrorHandlingDeserializer2<>(new Deserializer<String>() {
+		ehd = new ErrorHandlingDeserializer<>(new Deserializer<String>() {
 
 			@Override
 			public void configure(Map<String, ?> configs, boolean isKey) {
@@ -104,7 +104,7 @@ public class ErrorHandlingDeserializerTests {
 		Headers headers = new RecordHeaders();
 		Object result = ehd.deserialize("topic", headers, "foo".getBytes());
 		assertThat(result).isNull();
-		Header deser = headers.lastHeader(ErrorHandlingDeserializer2.VALUE_DESERIALIZER_EXCEPTION_HEADER);
+		Header deser = headers.lastHeader(ErrorHandlingDeserializer.VALUE_DESERIALIZER_EXCEPTION_HEADER);
 		assertThat(new ObjectInputStream(new ByteArrayInputStream(deser.value())).readObject()).isInstanceOf(DeserializationException.class);
 		ehd.close();
 	}
@@ -171,10 +171,10 @@ public class ErrorHandlingDeserializerTests {
 		public ConsumerFactory<String, String> cf() {
 			Map<String, Object> props = KafkaTestUtils.consumerProps(TOPIC + ".g1", "false", embeddedKafka());
 			props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-			props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer2.class.getName());
-			props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer2.class);
-			props.put(ErrorHandlingDeserializer2.KEY_DESERIALIZER_CLASS, FailSometimesDeserializer.class);
-			props.put(ErrorHandlingDeserializer2.VALUE_DESERIALIZER_CLASS, FailSometimesDeserializer.class.getName());
+			props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class.getName());
+			props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+			props.put(ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS, FailSometimesDeserializer.class);
+			props.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, FailSometimesDeserializer.class.getName());
 			return new DefaultKafkaConsumerFactory<>(props);
 		}
 
@@ -183,8 +183,8 @@ public class ErrorHandlingDeserializerTests {
 			Map<String, Object> props = KafkaTestUtils.consumerProps(TOPIC + ".g2", "false", embeddedKafka());
 			props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 			return new DefaultKafkaConsumerFactory<>(props,
-					new ErrorHandlingDeserializer2<String>(new FailSometimesDeserializer()).keyDeserializer(true),
-					new ErrorHandlingDeserializer2<String>(new FailSometimesDeserializer()));
+					new ErrorHandlingDeserializer<String>(new FailSometimesDeserializer()).keyDeserializer(true),
+					new ErrorHandlingDeserializer<String>(new FailSometimesDeserializer()));
 		}
 
 		@Bean

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
@@ -94,7 +94,7 @@ import org.springframework.kafka.listener.adapter.FilteringMessageListenerAdapte
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.kafka.support.TopicPartitionOffset;
 import org.springframework.kafka.support.TopicPartitionOffset.SeekPosition;
-import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer2;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 import org.springframework.kafka.support.serializer.JsonSerializer;
 import org.springframework.kafka.test.EmbeddedKafkaBroker;
@@ -2029,8 +2029,8 @@ public class KafkaMessageListenerContainerTests {
 		Map<String, Object> props = KafkaTestUtils.consumerProps("testJson", "false", embeddedKafka);
 		props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 
-		ErrorHandlingDeserializer2<Foo1> errorHandlingDeserializer =
-				new ErrorHandlingDeserializer2<>(new JsonDeserializer<>(Foo1.class, false));
+		ErrorHandlingDeserializer<Foo1> errorHandlingDeserializer =
+				new ErrorHandlingDeserializer<>(new JsonDeserializer<>(Foo1.class, false));
 
 		DefaultKafkaConsumerFactory<Integer, Foo1> cf = new DefaultKafkaConsumerFactory<>(props,
 				new IntegerDeserializer(), errorHandlingDeserializer);

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentRecovererTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentRecovererTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 the original author or authors.
+ * Copyright 2018-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,10 +54,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.kafka.KafkaException;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaOperations;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.event.ConsumerStoppedEvent;
 import org.springframework.kafka.listener.ContainerProperties.AckMode;
-import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer2;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.condition.EmbeddedKafkaCondition;
@@ -90,7 +91,7 @@ public class SeekToCurrentRecovererTests {
 		props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 		props.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
 		DefaultKafkaConsumerFactory<Integer, String> cf = new DefaultKafkaConsumerFactory<>(props, null,
-				new ErrorHandlingDeserializer2<>(new JsonDeserializer<>(String.class)));
+				new ErrorHandlingDeserializer<>(new JsonDeserializer<>(String.class)));
 		ContainerProperties containerProps = new ContainerProperties(topic1);
 		containerProps.setPollTimeout(10_000);
 
@@ -117,7 +118,7 @@ public class SeekToCurrentRecovererTests {
 		container.setBeanName("testSeekMaxFailures");
 		final CountDownLatch recoverLatch = new CountDownLatch(1);
 		final AtomicReference<String> failedGroupId = new AtomicReference<>();
-		Map<Class<?>, KafkaTemplate<?, ?>> templates = new LinkedHashMap<>();
+		Map<Class<?>, KafkaOperations<?, ?>> templates = new LinkedHashMap<>();
 		templates.put(String.class, template);
 		templates.put(byte[].class, new KafkaTemplate<>(dltPf));
 		DeadLetterPublishingRecoverer recoverer =

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -3122,24 +3122,24 @@ When used as the parameter to a `@KafkaListener` method, the interface type is a
 ===== Using `ErrorHandlingDeserializer`
 
 When a deserializer fails to deserialize a message, Spring has no way to handle the problem, because it occurs before the `poll()` returns.
-To solve this problem, version 2.2 introduced the `ErrorHandlingDeserializer2`.
+To solve this problem, the `ErrorHandlingDeserializer` has been introduced.
 This deserializer delegates to a real deserializer (key or value).
-If the delegate fails to deserialize the record content, the `ErrorHandlingDeserializer2` returns a `null` value and a `DeserializationException` in a header that contains the cause and the raw bytes.
+If the delegate fails to deserialize the record content, the `ErrorHandlingDeserializer` returns a `null` value and a `DeserializationException` in a header that contains the cause and the raw bytes.
 When you use a record-level `MessageListener`, if the `ConsumerRecord` contains a `DeserializationException` header for either the key or value, the container's `ErrorHandler` is called with the failed `ConsumerRecord`.
 The record is not passed to the listener.
 
-Alternatively, you can configure the `ErrorHandlingDeserializer2` to create a custom value by providing a `failedDeserializationFunction`, which is a `Function<FailedDeserializationInfo, T>`.
+Alternatively, you can configure the `ErrorHandlingDeserializer` to create a custom value by providing a `failedDeserializationFunction`, which is a `Function<FailedDeserializationInfo, T>`.
 This function is invoked to create an instance of `T`, which is passed to the listener in the usual fashion.
 An object of type `FailedDeserializationInfo`, which contains all the contextual information is provided to the function.
 You can find the `DeserializationException` (as a serialized Java object) in headers.
-See the https://docs.spring.io/spring-kafka/api/org/springframework/kafka/support/serializer/ErrorHandlingDeserializer2.html[Javadoc] for the `ErrorHandlingDeserializer2` for more information.
+See the https://docs.spring.io/spring-kafka/api/org/springframework/kafka/support/serializer/ErrorHandlingDeserializer.html[Javadoc] for the `ErrorHandlingDeserializer` for more information.
 
 CAUTION: When you use a `BatchMessageListener`, you must provide a `failedDeserializationFunction`.
 Otherwise, the batch of records are not type safe.
 
-You can use the `DefaultKafkaConsumerFactory` constructor that takes key and value `Deserializer` objects and wire in appropriate `ErrorHandlingDeserializer2` instances that you have configured with the proper delegates.
+You can use the `DefaultKafkaConsumerFactory` constructor that takes key and value `Deserializer` objects and wire in appropriate `ErrorHandlingDeserializer` instances that you have configured with the proper delegates.
 Alternatively, you can use consumer configuration properties (which are used by the `ErrorHandlingDeserializer`) to instantiate the delegates.
-The property names are `ErrorHandlingDeserializer2.KEY_DESERIALIZER_CLASS` and `ErrorHandlingDeserializer2.VALUE_DESERIALIZER_CLASS`.
+The property names are `ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS` and `ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS`.
 The property value can be a class or class name.
 The following example shows how to set these properties:
 
@@ -3147,8 +3147,8 @@ The following example shows how to set these properties:
 [source, java]
 ----
 ... // other props
-props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer2.class);
-props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer2.class);
+props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
 props.put(ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS, JsonDeserializer.class);
 props.put(JsonDeserializer.KEY_DEFAULT_TYPE, "com.example.MyKey")
 props.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, JsonDeserializer.class.getName());
@@ -3194,9 +3194,9 @@ The preceding example uses the following configuration:
 [source, java]
 ----
 ...
-consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer2.class);
-consumerProps.put(ErrorHandlingDeserializer2.VALUE_DESERIALIZER_CLASS, JsonDeserializer.class);
-consumerProps.put(ErrorHandlingDeserializer2.VALUE_FUNCTION, FailedFooProvider.class);
+consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+consumerProps.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, JsonDeserializer.class);
+consumerProps.put(ErrorHandlingDeserializer.VALUE_FUNCTION, FailedFooProvider.class);
 ...
 ----
 ====
@@ -3983,7 +3983,7 @@ The record sent to the dead-letter topic is enhanced with the following headers:
 * `KafkaHeaders.DLT_ORIGINAL_TIMESTAMP_TYPE`: The original timestamp type.
 
 
-Starting with version 2.3, when used in conjunction with an `ErrorHandlingDeserializer2`, the publisher will restore the record `value()`, in the dead-letter producer record, to the original value that failed to be deserialized.
+Starting with version 2.3, when used in conjunction with an `ErrorHandlingDeserializer`, the publisher will restore the record `value()`, in the dead-letter producer record, to the original value that failed to be deserialized.
 Previously, the `value()` was null and user code had to decode the `DeserializationException` from the message headers.
 In addition, you can provide multiple `KafkaTemplate` s to the publisher; this might be needed, for example, if you want to publish the `byte[]` from a `DeserializationException`, as well as values using a different serializer from records that were deserialized successfully.
 Here is an example of configuring the publisher with `KafkaTemplate` s that use a `String` and `byte[]` serializer:
@@ -4009,6 +4009,10 @@ A `LinkedHashMap` is recommended so that the keys are examined in order.
 IMPORTANT: If the recoverer fails (throws an exception), the record will be included in the seeks and recovery will be attempted again during the next delivery.
 
 Starting with version 2.3, the recoverer can also be used with Kafka Streams - see <<streams-deser-recovery>> for more information.
+
+The `ErrorHandlingDeserializer` adds the deserialization exception(s) in headers `ErrorHandlingDeserializer.VALUE_DESERIALIZER_EXCEPTION_HEADER` and `ErrorHandlingDeserializer.KEY_DESERIALIZER_EXCEPTION_HEADER` (using java serialization).
+By default, these headers are not retained in the message published to the dead letter topic, unless both the key and value fail deserialization.
+In that case, the `DLT_*` headers are based on the value deserialization and the key `DeserializationException` is retained in the header.
 
 [[kerberos]]
 ==== Kerberos


### PR DESCRIPTION
- strip exception header from record published to DLT
- remove deprecated `ErrorHandlingDeserializer`
- rename `ErrorHandlingDeserializer2` to `ErrorHandlingDeserializer`
- add deprecated `ErrorHandlingDeserializer2`