### PR TITLE
GH-1414: ConcurrentMLC Fix ConcurrentModification

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,7 +76,7 @@ public abstract class AbstractMessageListenerContainer<K, V>
 
 	private final ContainerProperties containerProperties;
 
-	private final Object lifecycleMonitor = new Object();
+	protected final Object lifecycleMonitor = new Object(); // NOSONAR
 
 	private String beanName;
 


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1414

- synchronize all access to `this.containers`
- don't return an indirect reference to the field in `getContainers()`

**cherry-pick to all supported (1.3.x will require a back port)**