### PR TITLE
FEATURE: ToStringSerializer

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ParseStringDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ParseStringDeserializer.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2016-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support.serializer;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.serialization.Deserializer;
+
+import org.springframework.util.Assert;
+
+/**
+ * Generic {@link org.apache.kafka.common.serialization.Deserializer Deserializer} for deserialization of entity from
+ * its {@link String} representation received from Kafka (a.k.a parsing).
+ *
+ * @param <T> class of the entity, representing messages
+ *
+ * @author Alexei Klenin
+ * @since 2.5
+ */
+public class ParseStringDeserializer<T> implements Deserializer<T> {
+
+	private final BiFunction<String, Headers, T> parser;
+	protected Charset charset = StandardCharsets.UTF_8;
+
+	public ParseStringDeserializer(Function<String, T> parser) {
+		this.parser = (message, ignoredHeaders) -> parser.apply(message);
+	}
+
+	public ParseStringDeserializer(BiFunction<String, Headers, T> parser) {
+		this.parser = parser;
+	}
+
+	@Override
+	public T deserialize(String topic, byte[] data) {
+		return deserialize(topic, null, data);
+	}
+
+	@Override
+	public T deserialize(String topic, Headers headers, byte[] data) {
+		return this.parser.apply(new String(data, this.charset), headers);
+	}
+
+	/**
+	 * Set a charset to use when converting byte[] to {@link String}. Default UTF-8.
+	 * @param charset  the charset.
+	 */
+	public void setCharset(Charset charset) {
+		Assert.notNull(charset, "'charset' cannot be null");
+		this.charset = charset;
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ToStringSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ToStringSerializer.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2016-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support.serializer;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.serialization.Serializer;
+
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * Generic {@link org.apache.kafka.common.serialization.Serializer Serializer} that relies on
+ * {@link Object#toString()} to get serialized representation of the entity.
+ *
+ * @param <T> class of the entity, representing messages
+ *
+ * @author Alexei Klenin
+ * @since 2.5
+ */
+public class ToStringSerializer<T> implements Serializer<T> {
+
+	/**
+	 * Kafka config property for enabling/disabling adding type headers.
+	 */
+	public static final String ADD_TYPE_INFO_HEADERS = "spring.message.add.type.headers";
+
+
+	/**
+	 * Header for the type of key.
+	 */
+	public static final String KEY_TYPE = "spring.message.key.type";
+
+	/**
+	 * Header for the type of value.
+	 */
+	public static final String VALUE_TYPE = "spring.message.value.type";
+
+	protected boolean addTypeInfo = true;
+	protected Charset charset = StandardCharsets.UTF_8;
+	private String typeInfoHeader = VALUE_TYPE;
+
+	@Override
+	public void configure(Map<String, ?> configs, boolean isKey) {
+		if (isKey) {
+			this.typeInfoHeader = KEY_TYPE;
+		}
+
+		if (configs.containsKey(ADD_TYPE_INFO_HEADERS)) {
+			Object config = configs.get(ADD_TYPE_INFO_HEADERS);
+			if (config instanceof Boolean) {
+				this.addTypeInfo = (Boolean) config;
+			}
+			else if (config instanceof String) {
+				this.addTypeInfo = Boolean.parseBoolean((String) config);
+			}
+			else {
+				throw new IllegalStateException(
+						ADD_TYPE_INFO_HEADERS + " must be Boolean or String");
+			}
+		}
+	}
+
+	@Override
+	public byte[] serialize(String topic, @Nullable T data) {
+		return serialize(topic, null, data);
+	}
+
+	@Override
+	@Nullable
+	public byte[] serialize(String topic, @Nullable Headers headers, @Nullable T data) {
+		if (data == null) {
+			return null;
+		}
+
+		if (this.addTypeInfo && headers != null) {
+			headers.add(this.typeInfoHeader, data.getClass().getName().getBytes());
+		}
+
+		return data.toString().getBytes(this.charset);
+	}
+
+	@Override
+	public void close() {
+		// No-op
+	}
+
+	public boolean isAddTypeInfo() {
+		return this.addTypeInfo;
+	}
+
+	/**
+	 * Set to false to disable adding type info headers.
+	 * @param addTypeInfo  true to add headers
+	 */
+	public void setAddTypeInfo(boolean addTypeInfo) {
+		this.addTypeInfo = addTypeInfo;
+	}
+
+	/**
+	 * Set a charset to use when converting {@link String} to byte[]. Default UTF-8.
+	 * @param charset  the charset.
+	 */
+	public void setCharset(Charset charset) {
+		Assert.notNull(charset, "'charset' cannot be null");
+		this.charset = charset;
+	}
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/ToStringSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/ToStringSerializationTests.java
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2016-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support.serializer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.kafka.support.serializer.testentities.DummyEntity;
+
+public class ToStringSerializationTests {
+
+	@Test
+	@DisplayName("Test serialization of key with headers")
+	public void testToStringSerializer_keySerializationWithHeaders() {
+
+		/* Given */
+		ToStringSerializer<TestEntity> serializer = new ToStringSerializer<>();
+		serializer.configure(Collections.emptyMap(), true);
+		serializer.setAddTypeInfo(true);
+
+		Headers headers = new RecordHeaders();
+
+		TestEntity entity = new TestEntity("toto", 123, true);
+
+		/* When */
+		byte[] serialized = serializer.serialize("my-topic", headers, entity);
+
+		/* Then */
+		assertThat(serialized)
+				.isNotNull()
+				.isNotEmpty();
+		assertThat(new String(serialized))
+				.isEqualTo("toto:123:true");
+		assertThat(headers)
+				.isNotEmpty()
+				.hasSize(1);
+		assertThat(headers.lastHeader(ToStringSerializer.KEY_TYPE))
+				.hasFieldOrPropertyWithValue("key", ToStringSerializer.KEY_TYPE)
+				.hasFieldOrPropertyWithValue("value", TestEntity.class.getName().getBytes());
+	}
+
+	@Test
+	@DisplayName("Test serialization of key without headers")
+	public void testToStringSerializer_keySerializationWithoutHeaders() {
+
+		/* Given */
+		ToStringSerializer<TestEntity> serializer = new ToStringSerializer<>();
+		serializer.configure(Collections.emptyMap(), true);
+		serializer.setAddTypeInfo(false);
+
+		Headers headers = new RecordHeaders();
+
+		TestEntity entity = new TestEntity("toto", 123, true);
+
+		/* When */
+		byte[] serialized = serializer.serialize("my-topic", headers, entity);
+
+		/* Then */
+		assertThat(serialized)
+				.isNotNull()
+				.isNotEmpty();
+		assertThat(new String(serialized))
+				.isEqualTo("toto:123:true");
+		assertThat(headers)
+				.isEmpty();
+	}
+
+	@Test
+	@DisplayName("Test serialization of value with headers")
+	public void testToStringSerializer_valueSerializationWithHeaders() {
+
+		/* Given */
+		ToStringSerializer<TestEntity> serializer = new ToStringSerializer<>();
+		serializer.configure(Collections.emptyMap(), false);
+		serializer.setAddTypeInfo(true);
+
+		Headers headers = new RecordHeaders();
+
+		TestEntity entity = new TestEntity("toto", 123, true);
+
+		/* When */
+		byte[] serialized = serializer.serialize("my-topic", headers, entity);
+
+		/* Then */
+		assertThat(serialized)
+				.isNotNull()
+				.isNotEmpty();
+		assertThat(new String(serialized))
+				.isEqualTo("toto:123:true");
+		assertThat(headers)
+				.isNotEmpty()
+				.hasSize(1);
+		assertThat(headers.lastHeader(ToStringSerializer.VALUE_TYPE))
+				.hasFieldOrPropertyWithValue("key", ToStringSerializer.VALUE_TYPE)
+				.hasFieldOrPropertyWithValue("value", TestEntity.class.getName().getBytes());
+	}
+
+	@Test
+	@DisplayName("Test serialization of value without headers")
+	public void testToStringSerializer_valueSerializationWithoutHeaders() {
+
+		/* Given */
+		ToStringSerializer<TestEntity> serializer = new ToStringSerializer<>();
+		serializer.configure(Collections.emptyMap(), false);
+		serializer.setAddTypeInfo(false);
+
+		Headers headers = new RecordHeaders();
+
+		TestEntity entity = new TestEntity("toto", 123, true);
+
+		/* When */
+		byte[] serialized = serializer.serialize("my-topic", headers, entity);
+
+		/* Then */
+		assertThat(serialized)
+				.isNotNull()
+				.isNotEmpty();
+		assertThat(new String(serialized))
+				.isEqualTo("toto:123:true");
+		assertThat(headers)
+				.isEmpty();
+	}
+
+	@Test
+	@DisplayName("Test simple deserialization without headers")
+	public void testSimpleDeserialization() {
+
+		/* Given */
+		ParseStringDeserializer<TestEntity> deserializer = new ParseStringDeserializer<>(TestEntity::parse);
+		byte[] data = "toto:123:true".getBytes();
+
+		/* When */
+		TestEntity entity = deserializer.deserialize("my-topic", data);
+
+		/* Then */
+		assertThat(entity)
+				.hasFieldOrPropertyWithValue("first", "toto")
+				.hasFieldOrPropertyWithValue("second", 123)
+				.hasFieldOrPropertyWithValue("third", true);
+	}
+
+	@Test
+	@DisplayName("Test deserialization using headers")
+	public void testSerialization_usingHeaders() {
+
+		/* Given */
+		ParseStringDeserializer<Object> deserializer = new ParseStringDeserializer<>((str, headers) -> {
+			byte[] header = headers.lastHeader(ToStringSerializer.VALUE_TYPE).value();
+			String entityType = new String(header);
+
+			if (entityType.contains("TestEntity")) {
+				return TestEntity.parse(str);
+			}
+			else if (entityType.contains("DummyEntity")) {
+				DummyEntity dummyEntity = new DummyEntity();
+				String[] tokens = str.split(":");
+				dummyEntity.stringValue = tokens[0];
+				dummyEntity.intValue = Integer.parseInt(tokens[1]);
+				return dummyEntity;
+			}
+
+			return null;
+		});
+
+		byte[] data = "toto:123:true".getBytes();
+		Headers headers = new RecordHeaders();
+		headers.add(ToStringSerializer.VALUE_TYPE, DummyEntity.class.getName().getBytes());
+
+		/* When */
+		Object entity = deserializer.deserialize("my-topic", headers, data);
+
+		/* Then */
+		assertThat(entity)
+				.isNotNull()
+				.isInstanceOf(DummyEntity.class)
+				.hasFieldOrPropertyWithValue("stringValue", "toto")
+				.hasFieldOrPropertyWithValue("intValue", 123);
+	}
+
+	@Test
+	@DisplayName("Test serialization/deserialization with provided charset")
+	public void testSerializationDeserializationWithCharset() {
+
+		/* Given */
+		ToStringSerializer<TestEntity> serializer = new ToStringSerializer<>();
+		serializer.setCharset(StandardCharsets.ISO_8859_1);
+
+		TestEntity entity = new TestEntity("tôtô", 123, true);
+
+		ParseStringDeserializer<TestEntity> deserializerLatin1 = new ParseStringDeserializer<>(TestEntity::parse);
+		deserializerLatin1.setCharset(StandardCharsets.ISO_8859_1);
+
+		ParseStringDeserializer<TestEntity> deserializerUtf8 = new ParseStringDeserializer<>(TestEntity::parse);
+
+		/* When */
+		byte[] serialized = serializer.serialize("my-topic", entity);
+
+		TestEntity deserializedWithLatin1 = deserializerLatin1.deserialize("my-topic", serialized);
+		TestEntity deserializedWithUtf8 = deserializerUtf8.deserialize("my-topic", serialized);
+
+		/* Then */
+		assertThat(deserializedWithLatin1)
+				.hasFieldOrPropertyWithValue("first", "tôtô")
+				.hasFieldOrPropertyWithValue("second", 123)
+				.hasFieldOrPropertyWithValue("third", true);
+
+		assertThat(deserializedWithUtf8)
+				.hasFieldOrPropertyWithValue("second", 123)
+				.hasFieldOrPropertyWithValue("third", true);
+		assertThat(deserializedWithUtf8.first)
+				.isNotEqualTo("tôtô");
+	}
+
+	private static final class TestEntity {
+		String first;
+		int second;
+		boolean third;
+
+		TestEntity(String first, int second, boolean third) {
+			this.first = first;
+			this.second = second;
+			this.third = third;
+		}
+
+		@Override
+		public String toString() {
+			return String.join(":", first, Integer.toString(second), Boolean.toString(third));
+		}
+
+		public static TestEntity parse(String str) {
+			String[] tokens = str.split(":");
+			String first = tokens[0];
+			int second = Integer.parseInt(tokens[1]);
+			boolean third = Boolean.parseBoolean(tokens[2]);
+			return new TestEntity(first, second, third);
+		}
+	}
+}

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -2844,6 +2844,42 @@ constructors to accept `Serializer` and `Deserializer` instances for `keys` and 
 When you use this API, the `DefaultKafkaProducerFactory` and `DefaultKafkaConsumerFactory` also provide properties (through constructors or setter methods) to inject custom `Serializer` and `Deserializer` instances into the target `Producer` or `Consumer`.
 Also, you can pass in `Supplier<Serializer>` or `Supplier<Deserializer>` instances through constructors - these `Supplier` s are called on creation of each `Producer` or `Consumer`.
 
+===== String serialization
+
+Since version 2.5, Spring Kafka provides `ToStringSerializer` and `ParseStringDeserializer` classes that uses String representation of entities. They relies on methods `toString` and `parse`:
+
+====
+[source, java]
+----
+ToStringSerializer<Thing> thingSerializer = new ToStringSerializer<>();
+//...
+ParseStringDeserializer<Thing> deserializer = new ParseStringDeserializer<>(Thing::parse);
+----
+====
+
+By default `ToStringSerializer` is configured to convey type information about serialized entity in record `Headers`. This information can be used by `ParseStringDeserializer` on the receiving side.
+
+* `ToStringSerializer.ADD_TYPE_INFO_HEADERS` (default `true`): You can set it to `false` to disable this feature on the `ToStringSerializer` (sets the `addTypeInfo` property).
+
+====
+[source, java]
+----
+ParseStringDeserializer<Object> deserializer = new ParseStringDeserializer<>((str, headers) -> {
+	byte[] header = headers.lastHeader(ToStringSerializer.VALUE_TYPE).value();
+	String entityType = new String(header);
+
+	if (entityType.contains("Thing")) {
+		return Thing.parse(str);
+	}
+	else {
+		// ...parsing logic
+	}
+});
+----
+====
+
+You can configure which encoding serializer/deserializer uses by `setCharset`. By default it is `UTF-8`.
+
 ===== JSON
 
 Spring for Apache Kafka also provides `JsonSerializer` and `JsonDeserializer` implementations that are based on the


### PR DESCRIPTION
This pull request adds two convenient classes for serialization/deserialisation. Sometimes, we don't need Jackson or any other library to do serialization/deserialization, and plain `toString` and `parse` method can suffice. So:
```java
ToStringSerializer<TestEntity> serializer = new ToStringSerializer<>();
serializer.configure(Collections.emptyMap(), false);
serializer.setAddTypeInfo(false);
//...
ParseStringDeserializer<TestEntity> deserializer = new ParseStringDeserializer<>(TestEntity::parse);
```