### PR TITLE
Support `flush()` with send(Message<?>)

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/KafkaHeaders.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/KafkaHeaders.java
@@ -201,4 +201,11 @@ public abstract class KafkaHeaders {
 	 */
 	public static final String DELIVERY_ATTEMPT = PREFIX + "deliveryAttempt";
 
+	/**
+	 * For outbound messages, flush the producer after the send. Set to
+	 * {@link Boolean#TRUE} or {@link Boolean#FALSE}.
+	 * @since 2.5
+	 */
+	public static final String FLUSH = PREFIX + "flush";
+
 }

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -78,9 +78,9 @@ private KafkaAdmin admin;
 ----
 ====
 
-==== Sending Messages
+==== Sending Records
 
-This section covers how to send messages.
+This section covers how to send records.
 
 [[kafka-template]]
 ===== Using `KafkaTemplate`
@@ -3094,6 +3094,16 @@ Again, using `byte[]` or `Bytes` is more efficient because they avoid a `String`
 
 For convenience, starting with version 2.3, the framework also provides a `StringOrBytesSerializer` which can serialize all three value types so it can be used with any of the message converters.
 ====
+
+When using the `KafkaTemplate.send(Message<?> message)` variant of the `send` method, the destination topic must be configured as a default on the template or it must be provided in the `KafkaHeaders.TOPIC` header.
+The following headers are used for outbound messages:
+
+* `KafkaHeaders.TOPIC` - the destination topic.
+* `KafkaHeaders.PARTITION` - the destination partition.
+* `KafkaHeaders.MESSAGE_KEY` - the `key` property of the `ProducerRecord`.
+* `KafkaHeaders.FLUSH` - flush the producer after the `send()`.
+
+Flushing after sending several messages might be useful if you are using the `linger.ms` and `batch.size` Kafka producer properties; just set the header to `Boolean.TRUE` on the last message and an incomplete batch will be sent immediately.
 
 [[data-projection]]
 ====== Using Spring Data Projection Interfaces

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -21,3 +21,6 @@ See <<reply-message>> for more information.
 
 The `KafkaTemplate` can now maintain micrometer timers.
 See <<micrometer>> for more information.
+
+The `send()` method variant that takes a `spring-messaging` `Message<?>` can now optionally flush the producer after sending.
+See <<messaging-message-conversion>> for more information.


### PR DESCRIPTION
- add a header that will tell the template to flush after sending.