### PR TITLE
Don't populate a null RECEIVED_MESSAGE_KEY

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/converter/MessageConverter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/converter/MessageConverter.java
@@ -35,22 +35,38 @@ import org.springframework.lang.Nullable;
  */
 public interface MessageConverter {
 
+	/**
+	 * Get the thread bound group id.
+	 * @return the group id.
+	 */
 	@Nullable
 	static String getGroupId() {
 		return KafkaUtils.getConsumerGroupId();
 	}
 
+	/**
+	 * Set up the common headers.
+	 * @param acknowledgment the acknowledgment.
+	 * @param consumer the consumer.
+	 * @param rawHeaders the raw headers map.
+	 * @param theKey the key.
+	 * @param topic the topic.
+	 * @param partition the partition.
+	 * @param offset the offfset.
+	 * @param timestampType the timestamp type.
+	 * @param timestamp the timestamp.
+	 */
 	default void commonHeaders(Acknowledgment acknowledgment, Consumer<?, ?> consumer, Map<String, Object> rawHeaders,
-			Object theKey, Object topic, Object partition, Object offset,
+			@Nullable Object theKey, Object topic, Object partition, Object offset,
 			@Nullable Object timestampType, Object timestamp) {
 
-		rawHeaders.put(KafkaHeaders.RECEIVED_MESSAGE_KEY, theKey);
 		rawHeaders.put(KafkaHeaders.RECEIVED_TOPIC, topic);
 		rawHeaders.put(KafkaHeaders.RECEIVED_PARTITION_ID, partition);
 		rawHeaders.put(KafkaHeaders.OFFSET, offset);
 		rawHeaders.put(KafkaHeaders.TIMESTAMP_TYPE, timestampType);
 		rawHeaders.put(KafkaHeaders.RECEIVED_TIMESTAMP, timestamp);
 		JavaUtils.INSTANCE
+			.acceptIfNotNull(KafkaHeaders.RECEIVED_MESSAGE_KEY, theKey, (key, val) -> rawHeaders.put(key, val))
 			.acceptIfNotNull(KafkaHeaders.GROUP_ID, MessageConverter.getGroupId(),
 					(key, val) -> rawHeaders.put(key, val))
 			.acceptIfNotNull(KafkaHeaders.ACKNOWLEDGMENT, acknowledgment, (key, val) -> rawHeaders.put(key, val))

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/converter/MessagingMessageConverterTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/converter/MessagingMessageConverterTests.java
@@ -43,4 +43,14 @@ public class MessagingMessageConverterTests {
 		assertThat(message.getHeaders().get(KafkaHeaders.RECEIVED_MESSAGE_KEY)).isEqualTo("bar");
 	}
 
+	@Test
+	void dontMapNullKey() {
+		MessagingMessageConverter converter = new MessagingMessageConverter();
+		ConsumerRecord<String, String> record = new ConsumerRecord<>("foo", 1, 42, -1L, null, 0L, 0, 0, null, "baz");
+		Message<?> message = converter.toMessage(record, null, null, null);
+		assertThat(message.getPayload()).isEqualTo("baz");
+		assertThat(message.getHeaders().get(KafkaHeaders.RECEIVED_TOPIC)).isEqualTo("foo");
+		assertThat(message.getHeaders().containsKey(KafkaHeaders.RECEIVED_MESSAGE_KEY)).isFalse();
+	}
+
 }

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -1068,6 +1068,9 @@ You can use the following header names to retrieve the headers of the message:
 * `KafkaHeaders.RECEIVED_TIMESTAMP`
 * `KafkaHeaders.TIMESTAMP_TYPE`
 
+Starting with version 2.5 the `RECEIVED_MESSAGE_KEY` is not present if the incoming record has a `null` key; previously the header was populated with a `null` value.
+This change is to make the framework consistent with `spring-messaging` conventions where `null` valued headers are not present.
+
 The following example shows how to use the headers:
 
 ====
@@ -1075,7 +1078,7 @@ The following example shows how to use the headers:
 ----
 @KafkaListener(id = "qux", topicPattern = "myTopic1")
 public void listen(@Payload String foo,
-        @Header(KafkaHeaders.RECEIVED_MESSAGE_KEY) Integer key,
+        @Header(name = KafkaHeaders.RECEIVED_MESSAGE_KEY, required = false) Integer key,
         @Header(KafkaHeaders.RECEIVED_PARTITION_ID) int partition,
         @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
         @Header(KafkaHeaders.RECEIVED_TIMESTAMP) long ts

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -11,10 +11,12 @@ There is now an option to to add a header which tracks delivery attempts when us
 See <<>> for more information.
 
 [[x25-message-return]]
-==== @KafkaListener Improvements
+==== @KafkaListener Changes
 
 Default reply headers will now be populated automatically if needed when a `@KafkaListener` return type is `Message<?>`.
 See <<reply-message>> for more information.
+
+The `KafkaHeaders.RECEIVED_MESSAGE_KEY` is no longer populated with a `null` value when the incoming record has a `null` key; the header is omitted altogether.
 
 [[x25-template]]
 ==== KafkaTemplate Changes


### PR DESCRIPTION
The message converter builds a simple `Map` from the record properties;
it does not use a `MessageBuilder`; a `null` key was incorrectly mapped
with a `null` value instead of omitting the header altogether.