### PR TITLE
GH-1424: Abort delivery on ProducerFencedException

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -1525,6 +1525,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 				}
 				catch (ProducerFencedException e) {
 					this.logger.error(e, "Producer fenced during transaction");
+					break;
 				}
 				catch (RuntimeException e) {
 					this.logger.error(e, "Transaction rolled back");


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1424

Do not deliver remaining records after a `ProducerFencedException` - the
partitions will have been reassigned to another instance.

**cherry-pick to 2.4.x, 2.3.x**