### PR TITLE
GH-1370: Container props: Polish, Defaults, Docs

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
@@ -389,13 +389,15 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 	protected void initializeContainer(C instance, KafkaListenerEndpoint endpoint) {
 		ContainerProperties properties = instance.getContainerProperties();
 		BeanUtils.copyProperties(this.containerProperties, properties, "topics", "topicPartitions", "topicPattern",
-				"messageListener", "ackCount", "ackTime");
+				"messageListener", "ackCount", "ackTime", "subBatchPerPartition");
 		JavaUtils.INSTANCE
 				.acceptIfNotNull(this.afterRollbackProcessor, instance::setAfterRollbackProcessor)
 				.acceptIfCondition(this.containerProperties.getAckCount() > 0, this.containerProperties.getAckCount(),
 						properties::setAckCount)
 				.acceptIfCondition(this.containerProperties.getAckTime() > 0, this.containerProperties.getAckTime(),
 						properties::setAckTime)
+				.acceptIfNotNull(this.containerProperties.getSubBatchPerPartition(),
+						properties::setSubBatchPerPartition)
 				.acceptIfNotNull(this.errorHandler, instance::setGenericErrorHandler)
 				.acceptIfNotNull(this.missingTopicsFatal, instance.getContainerProperties()::setMissingTopicsFatal);
 		if (endpoint.getAutoStartup() != null) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
@@ -120,21 +120,24 @@ public abstract class AbstractMessageListenerContainer<K, V>
 		else if (containerProperties.getTopicPattern() != null) {
 			this.containerProperties = new ContainerProperties(containerProperties.getTopicPattern());
 		}
-		else if (containerProperties.getTopicPartitionsToAssign() != null) {
-			this.containerProperties = new ContainerProperties(containerProperties.getTopicPartitionsToAssign());
+		else if (containerProperties.getTopicPartitions() != null) {
+			this.containerProperties = new ContainerProperties(containerProperties.getTopicPartitions());
 		}
 		else {
 			throw new IllegalStateException("topics, topicPattern, or topicPartitions must be provided");
 		}
 
 		BeanUtils.copyProperties(containerProperties, this.containerProperties,
-				"topics", "topicPartitions", "topicPattern", "ackCount", "ackTime");
+				"topics", "topicPartitions", "topicPattern", "ackCount", "ackTime", "subBatchPerPartition");
 
 		if (containerProperties.getAckCount() > 0) {
 			this.containerProperties.setAckCount(containerProperties.getAckCount());
 		}
 		if (containerProperties.getAckTime() > 0) {
 			this.containerProperties.setAckTime(containerProperties.getAckTime());
+		}
+		if (containerProperties.getSubBatchPerPartition() != null) {
+			this.containerProperties.setSubBatchPerPartition(containerProperties.getSubBatchPerPartition());
 		}
 		if (this.containerProperties.getConsumerRebalanceListener() == null) {
 			this.containerProperties.setConsumerRebalanceListener(createSimpleLoggingConsumerRebalanceListener());
@@ -343,7 +346,7 @@ public abstract class AbstractMessageListenerContainer<K, V>
 				if (client != null) {
 					String[] topics = this.containerProperties.getTopics();
 					if (topics == null) {
-						topics = Arrays.stream(this.containerProperties.getTopicPartitionsToAssign())
+						topics = Arrays.stream(this.containerProperties.getTopicPartitions())
 								.map(TopicPartitionOffset::getTopic)
 								.toArray(String[]::new);
 					}
@@ -377,7 +380,7 @@ public abstract class AbstractMessageListenerContainer<K, V>
 	}
 
 	public void checkGroupId() {
-		if (this.containerProperties.getTopicPartitionsToAssign() == null) {
+		if (this.containerProperties.getTopicPartitions() == null) {
 			boolean hasGroupIdConsumerConfig = true; // assume true for non-standard containers
 			if (this.consumerFactory != null) { // we always have one for standard containers
 				Object groupIdConfig = this.consumerFactory.getConfigurationProperties()

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
@@ -143,7 +143,7 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 		if (!isRunning()) {
 			checkTopics();
 			ContainerProperties containerProperties = getContainerProperties();
-			TopicPartitionOffset[] topicPartitions = containerProperties.getTopicPartitionsToAssign();
+			TopicPartitionOffset[] topicPartitions = containerProperties.getTopicPartitions();
 			if (topicPartitions != null && this.concurrency > topicPartitions.length) {
 				this.logger.warn(() -> "When specific partitions are provided, the concurrency must be less than or "
 						+ "equal to the number of partitions; reduced from " + this.concurrency + " to "
@@ -188,7 +188,7 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 	}
 
 	private TopicPartitionOffset[] partitionSubset(ContainerProperties containerProperties, int i) {
-		TopicPartitionOffset[] topicPartitions = containerProperties.getTopicPartitionsToAssign();
+		TopicPartitionOffset[] topicPartitions = containerProperties.getTopicPartitions();
 		if (this.concurrency == 1) {
 			return topicPartitions;
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ public class ConsumerProperties {
 	/**
 	 * Topics/partitions/initial offsets.
 	 */
-	private final TopicPartitionOffset[] topicPartitionsToAssign;
+	private final TopicPartitionOffset[] topicPartitions;
 
 	/**
 	 * The max time to block in the consumer waiting for records.
@@ -107,7 +107,7 @@ public class ConsumerProperties {
 		Assert.notEmpty(topics, "An array of topics must be provided");
 		this.topics = topics.clone();
 		this.topicPattern = null;
-		this.topicPartitionsToAssign = null;
+		this.topicPartitions = null;
 	}
 
 	/**
@@ -122,7 +122,7 @@ public class ConsumerProperties {
 	public ConsumerProperties(Pattern topicPattern) {
 		this.topics = null;
 		this.topicPattern = topicPattern;
-		this.topicPartitionsToAssign = null;
+		this.topicPartitions = null;
 	}
 
 	/**
@@ -134,9 +134,13 @@ public class ConsumerProperties {
 		this.topics = null;
 		this.topicPattern = null;
 		Assert.notEmpty(topicPartitions, "An array of topicPartitions must be provided");
-		this.topicPartitionsToAssign = Arrays.copyOf(topicPartitions, topicPartitions.length);
+		this.topicPartitions = Arrays.copyOf(topicPartitions, topicPartitions.length);
 	}
 
+	/**
+	 * Return the configured topics.
+	 * @return the topics.
+	 */
 	@Nullable
 	public String[] getTopics() {
 		return this.topics != null
@@ -144,15 +148,35 @@ public class ConsumerProperties {
 				: null;
 	}
 
+	/**
+	 * Return the configured topic pattern.
+	 * @return the topic pattern.
+	 */
 	@Nullable
 	public Pattern getTopicPattern() {
 		return this.topicPattern;
 	}
 
+	/**
+	 * Return the configured {@link TopicPartitionOffset}s.
+	 * @deprecated in favor of {@link #getTopicPartitions()}.
+	 * @return the topics/partitions.
+	 */
+	@Deprecated
 	@Nullable
 	public TopicPartitionOffset[] getTopicPartitionsToAssign() {
-		return this.topicPartitionsToAssign != null
-				? Arrays.copyOf(this.topicPartitionsToAssign, this.topicPartitionsToAssign.length)
+		return getTopicPartitions();
+	}
+
+	/**
+	 * Return the configured {@link TopicPartitionOffset}s.
+	 * @return the topics/partitions.
+	 * @since 2.5
+	 */
+	@Nullable
+	public TopicPartitionOffset[] getTopicPartitions() {
+		return this.topicPartitions != null
+				? Arrays.copyOf(this.topicPartitions, this.topicPartitions.length)
 				: null;
 	}
 
@@ -349,8 +373,8 @@ public class ConsumerProperties {
 	private String renderTopics() {
 		return (this.topics != null ? "topics=" + Arrays.toString(this.topics) : "")
 				+ (this.topicPattern != null ? ", topicPattern=" + this.topicPattern : "")
-				+ (this.topicPartitionsToAssign != null
-						? ", topicPartitions=" + Arrays.toString(this.topicPartitionsToAssign)
+				+ (this.topicPartitions != null
+						? ", topicPartitions=" + Arrays.toString(this.topicPartitions)
 						: "");
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -189,7 +189,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			this.topicPartitions = Arrays.copyOf(topicPartitions, topicPartitions.length);
 		}
 		else {
-			this.topicPartitions = containerProperties.getTopicPartitionsToAssign();
+			this.topicPartitions = containerProperties.getTopicPartitions();
 		}
 	}
 
@@ -517,7 +517,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 
 		private final AtomicBoolean polling = new AtomicBoolean();
 
-		private final boolean subBatchPerPartition = this.containerProperties.isSubBatchPerPartition();
+		private final boolean subBatchPerPartition;
 
 		private final Duration authorizationExceptionRetryInterval =
 				this.containerProperties.getAuthorizationExceptionRetryInterval();
@@ -640,6 +640,12 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			this.maxPollInterval = obtainMaxPollInterval(consumerProperties);
 			this.micrometerHolder = obtainMicrometerHolder();
 			this.deliveryAttemptAware = setupDeliveryAttemptAware();
+			this.subBatchPerPartition = setupSubBatchPerPartition();
+		}
+
+		private boolean setupSubBatchPerPartition() {
+			Boolean subBatching = this.containerProperties.getSubBatchPerPartition();
+			return subBatching == null ? this.transactionManager != null : subBatching;
 		}
 
 		private DeliveryAttemptAware setupDeliveryAttemptAware() {

--- a/spring-kafka/src/main/java/org/springframework/kafka/requestreply/ReplyingKafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/requestreply/ReplyingKafkaTemplate.java
@@ -121,7 +121,7 @@ public class ReplyingKafkaTemplate<K, V, R> extends KafkaTemplate<K, V> implemen
 		ContainerProperties properties = this.replyContainer.getContainerProperties();
 		String tempReplyTopic = null;
 		byte[] tempReplyPartition = null;
-		TopicPartitionOffset[] topicPartitionsToAssign = properties.getTopicPartitionsToAssign();
+		TopicPartitionOffset[] topicPartitionsToAssign = properties.getTopicPartitions();
 		String[] topics = properties.getTopics();
 		if (topics != null && topics.length == 1) {
 			tempReplyTopic = topics[0];

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -1159,6 +1159,7 @@ public class EnableKafkaIntegrationTests {
 			return factory;
 		}
 
+		@SuppressWarnings("deprecation")
 		@Bean
 		public KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<Integer, String>>
 				recordAckListenerContainerFactory() {

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
@@ -612,7 +612,6 @@ public class ConcurrentMessageListenerContainerTests {
 		});
 		containerProps.setSyncCommits(true);
 		containerProps.setAckMode(ContainerProperties.AckMode.RECORD);
-		containerProps.setAckOnError(false);
 		ConcurrentMessageListenerContainer<Integer, String> container = new ConcurrentMessageListenerContainer<>(cf,
 				containerProps);
 		container.setConcurrency(2);
@@ -682,6 +681,7 @@ public class ConcurrentMessageListenerContainerTests {
 		testAckOnErrorWithManualImmediateGuts(topic11, false);
 	}
 
+	@SuppressWarnings("deprecation")
 	private void testAckOnErrorWithManualImmediateGuts(String topic, boolean ackOnError) throws Exception {
 		logger.info("Start ack on error with ManualImmediate ack mode");
 		Map<String, Object> props = KafkaTestUtils.consumerProps("testMan" + ackOnError, "false", embeddedKafka);

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ContainerStoppingBatchErrorHandlerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ContainerStoppingBatchErrorHandlerTests.java
@@ -196,7 +196,6 @@ public class ContainerStoppingBatchErrorHandlerTests {
 		public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
 			ConcurrentKafkaListenerContainerFactory factory = new ConcurrentKafkaListenerContainerFactory();
 			factory.setConsumerFactory(consumerFactory());
-			factory.getContainerProperties().setAckOnError(false);
 			factory.setBatchErrorHandler(new ContainerStoppingBatchErrorHandler() {
 
 				@Override

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ContainerStoppingErrorHandlerBatchModeTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ContainerStoppingErrorHandlerBatchModeTests.java
@@ -186,7 +186,6 @@ public class ContainerStoppingErrorHandlerBatchModeTests {
 		public ConcurrentKafkaListenerContainerFactory kafkaListenerContainerFactory() {
 			ConcurrentKafkaListenerContainerFactory factory = new ConcurrentKafkaListenerContainerFactory();
 			factory.setConsumerFactory(consumerFactory());
-			factory.getContainerProperties().setAckOnError(false);
 			factory.setErrorHandler(new ContainerStoppingErrorHandler() {
 
 				@Override

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ContainerStoppingErrorHandlerRecordModeTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ContainerStoppingErrorHandlerRecordModeTests.java
@@ -204,7 +204,6 @@ public class ContainerStoppingErrorHandlerRecordModeTests {
 		public ConcurrentKafkaListenerContainerFactory kafkaListenerContainerFactory() {
 			ConcurrentKafkaListenerContainerFactory factory = new ConcurrentKafkaListenerContainerFactory();
 			factory.setConsumerFactory(consumerFactory());
-			factory.getContainerProperties().setAckOnError(false);
 			factory.setErrorHandler(new ContainerStoppingErrorHandler() {
 
 				@Override

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
@@ -515,7 +515,6 @@ public class KafkaMessageListenerContainerTests {
 		});
 		containerProps.setSyncCommits(true);
 		containerProps.setAckMode(AckMode.RECORD);
-		containerProps.setAckOnError(false);
 		containerProps.setIdleBetweenPolls(1000L);
 		//		containerProps.setCommitLogLevel(LogIfLevelEnabled.Level.WARN);
 
@@ -930,7 +929,6 @@ public class KafkaMessageListenerContainerTests {
 		containerProps.setSyncCommits(true);
 		containerProps.setAckMode(AckMode.BATCH);
 		containerProps.setPollTimeout(100);
-		containerProps.setAckOnError(false);
 
 		CountDownLatch stubbingComplete = new CountDownLatch(1);
 		KafkaMessageListenerContainer<Integer, String> container = spyOnContainer(
@@ -999,7 +997,6 @@ public class KafkaMessageListenerContainerTests {
 		containerProps.setSyncCommits(true);
 		containerProps.setAckMode(AckMode.BATCH);
 		containerProps.setPollTimeout(100);
-		containerProps.setAckOnError(false);
 
 		CountDownLatch stubbingComplete = new CountDownLatch(1);
 		KafkaMessageListenerContainer<Integer, String> container = spyOnContainer(
@@ -1083,7 +1080,6 @@ public class KafkaMessageListenerContainerTests {
 		containerProps.setSyncCommits(true);
 		containerProps.setAckMode(AckMode.MANUAL_IMMEDIATE);
 		containerProps.setPollTimeout(100);
-		containerProps.setAckOnError(false);
 
 		CountDownLatch stubbingComplete = new CountDownLatch(1);
 		KafkaMessageListenerContainer<Integer, String> container = spyOnContainer(
@@ -1126,6 +1122,7 @@ public class KafkaMessageListenerContainerTests {
 		logger.info("Stop batch listener manual");
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testBatchListenerErrors() throws Exception {
 		logger.info("Start batch listener errors");
@@ -1319,7 +1316,6 @@ public class KafkaMessageListenerContainerTests {
 		Listener messageListener = new Listener();
 		containerProps.setMessageListener(messageListener);
 		containerProps.setSyncCommits(true);
-		containerProps.setAckOnError(false);
 		containerProps.setIdleEventInterval(10L);
 		KafkaMessageListenerContainer<Integer, String> container = new KafkaMessageListenerContainer<>(cf,
 				containerProps);
@@ -1389,7 +1385,6 @@ public class KafkaMessageListenerContainerTests {
 		containerProps.setMessageListener(messageListener);
 		containerProps.setSyncCommits(true);
 		containerProps.setAckMode(AckMode.RECORD);
-		containerProps.setAckOnError(false);
 		containerProps.setIdleEventInterval(60000L);
 
 		KafkaMessageListenerContainer<Integer, String> container = new KafkaMessageListenerContainer<>(cf,
@@ -2530,7 +2525,6 @@ public class KafkaMessageListenerContainerTests {
 		containerProps.setSyncCommits(true);
 		containerProps.setAckMode(AckMode.BATCH);
 		containerProps.setPollTimeout(100);
-		containerProps.setAckOnError(false);
 
 		Map<String, Object> senderProps = KafkaTestUtils.producerProps(embeddedKafka);
 		ProducerFactory<Integer, String> pf = new DefaultKafkaProducerFactory<>(senderProps);

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ManualNackBatchTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ManualNackBatchTests.java
@@ -215,9 +215,7 @@ public class ManualNackBatchTests {
 		public ConcurrentKafkaListenerContainerFactory kafkaListenerContainerFactory() {
 			ConcurrentKafkaListenerContainerFactory factory = new ConcurrentKafkaListenerContainerFactory();
 			factory.setConsumerFactory(consumerFactory());
-			factory.getContainerProperties().setAckOnError(false);
 			factory.setBatchListener(true);
-			factory.getContainerProperties().setMissingTopicsFatal(false);
 			factory.getContainerProperties().setAckMode(AckMode.MANUAL);
 			return factory;
 		}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ManualNackRecordTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ManualNackRecordTests.java
@@ -209,7 +209,6 @@ public class ManualNackRecordTests {
 		public ConcurrentKafkaListenerContainerFactory kafkaListenerContainerFactory() {
 			ConcurrentKafkaListenerContainerFactory factory = new ConcurrentKafkaListenerContainerFactory();
 			factory.setConsumerFactory(consumerFactory());
-			factory.getContainerProperties().setAckOnError(false);
 			factory.setErrorHandler(new SeekToCurrentErrorHandler());
 			factory.getContainerProperties().setAckMode(AckMode.MANUAL);
 			factory.getContainerProperties().setMissingTopicsFatal(false);

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/RemainingRecordsErrorHandlerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/RemainingRecordsErrorHandlerTests.java
@@ -191,7 +191,6 @@ public class RemainingRecordsErrorHandlerTests {
 		public ConcurrentKafkaListenerContainerFactory kafkaListenerContainerFactory() {
 			ConcurrentKafkaListenerContainerFactory factory = new ConcurrentKafkaListenerContainerFactory();
 			factory.setConsumerFactory(consumerFactory());
-			factory.getContainerProperties().setAckOnError(false);
 			factory.setErrorHandler(new RemainingRecordsErrorHandler() {
 
 				@Override

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentBatchErrorHandlerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentBatchErrorHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -262,7 +262,6 @@ public class SeekToCurrentBatchErrorHandlerTests {
 		public ConcurrentKafkaListenerContainerFactory kafkaListenerContainerFactory() {
 			ConcurrentKafkaListenerContainerFactory factory = new ConcurrentKafkaListenerContainerFactory();
 			factory.setConsumerFactory(consumerFactory());
-			factory.getContainerProperties().setAckOnError(false);
 			factory.setBatchErrorHandler(new SeekToCurrentBatchErrorHandler() {
 
 				@Override
@@ -276,6 +275,7 @@ public class SeekToCurrentBatchErrorHandlerTests {
 			});
 			factory.setBatchListener(true);
 			factory.getContainerProperties().setTransactionManager(tm());
+			factory.getContainerProperties().setSubBatchPerPartition(false);
 			factory.setMissingTopicsFatal(false);
 			return factory;
 		}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentOnErrorBatchModeTXTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentOnErrorBatchModeTXTests.java
@@ -232,7 +232,6 @@ public class SeekToCurrentOnErrorBatchModeTXTests {
 		public ConcurrentKafkaListenerContainerFactory kafkaListenerContainerFactory() {
 			ConcurrentKafkaListenerContainerFactory factory = new ConcurrentKafkaListenerContainerFactory();
 			factory.setConsumerFactory(consumerFactory());
-			factory.getContainerProperties().setAckOnError(false);
 			factory.setErrorHandler(new SeekToCurrentErrorHandler());
 			factory.getContainerProperties().setAckMode(AckMode.BATCH);
 			factory.getContainerProperties().setTransactionManager(tm());

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentOnErrorBatchModeTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentOnErrorBatchModeTests.java
@@ -206,7 +206,6 @@ public class SeekToCurrentOnErrorBatchModeTests {
 		public ConcurrentKafkaListenerContainerFactory kafkaListenerContainerFactory() {
 			ConcurrentKafkaListenerContainerFactory factory = new ConcurrentKafkaListenerContainerFactory();
 			factory.setConsumerFactory(consumerFactory());
-			factory.getContainerProperties().setAckOnError(false);
 			factory.setErrorHandler(new SeekToCurrentErrorHandler());
 			factory.getContainerProperties().setAckMode(AckMode.BATCH);
 			return factory;

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentOnErrorRecordModeTXTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentOnErrorRecordModeTXTests.java
@@ -233,7 +233,6 @@ public class SeekToCurrentOnErrorRecordModeTXTests {
 		public ConcurrentKafkaListenerContainerFactory kafkaListenerContainerFactory() {
 			ConcurrentKafkaListenerContainerFactory factory = new ConcurrentKafkaListenerContainerFactory();
 			factory.setConsumerFactory(consumerFactory());
-			factory.getContainerProperties().setAckOnError(false);
 			factory.setErrorHandler(new SeekToCurrentErrorHandler());
 			factory.getContainerProperties().setAckMode(AckMode.RECORD);
 			factory.getContainerProperties().setTransactionManager(tm());

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentOnErrorRecordModeTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentOnErrorRecordModeTests.java
@@ -222,7 +222,6 @@ public class SeekToCurrentOnErrorRecordModeTests {
 		public ConcurrentKafkaListenerContainerFactory kafkaListenerContainerFactory() {
 			ConcurrentKafkaListenerContainerFactory factory = new ConcurrentKafkaListenerContainerFactory();
 			factory.setConsumerFactory(consumerFactory());
-			factory.getContainerProperties().setAckOnError(false);
 			factory.setErrorHandler(new SeekToCurrentErrorHandler());
 			factory.getContainerProperties().setAckMode(AckMode.RECORD);
 			factory.getContainerProperties().setDeliveryAttemptHeader(true);

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/SubBatchPerPartitionTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/SubBatchPerPartitionTests.java
@@ -218,7 +218,6 @@ public class SubBatchPerPartitionTests {
 		public ConcurrentKafkaListenerContainerFactory kafkaListenerContainerFactory() {
 			ConcurrentKafkaListenerContainerFactory factory = new ConcurrentKafkaListenerContainerFactory();
 			factory.setConsumerFactory(consumerFactory());
-			factory.getContainerProperties().setAckOnError(false);
 			factory.setBatchListener(true);
 			factory.getContainerProperties().setMissingTopicsFatal(false);
 			factory.getContainerProperties().setSubBatchPerPartition(true);
@@ -230,7 +229,6 @@ public class SubBatchPerPartitionTests {
 		public ConcurrentKafkaListenerContainerFactory filteredFactory() {
 			ConcurrentKafkaListenerContainerFactory factory = new ConcurrentKafkaListenerContainerFactory();
 			factory.setConsumerFactory(consumerFactory());
-			factory.getContainerProperties().setAckOnError(false);
 			factory.setBatchListener(true);
 			factory.getContainerProperties().setMissingTopicsFatal(false);
 			factory.getContainerProperties().setSubBatchPerPartition(true);

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/SubBatchPerPartitionTxTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/SubBatchPerPartitionTxTests.java
@@ -201,7 +201,8 @@ public class SubBatchPerPartitionTxTests {
 			factory.getContainerProperties().setAckMode(AckMode.BATCH);
 			factory.getContainerProperties().setTransactionManager(tm());
 			factory.setBatchListener(true);
-			factory.getContainerProperties().setSubBatchPerPartition(true);
+			// true by default for a transactional container since 2.5
+//			factory.getContainerProperties().setSubBatchPerPartition(true);
 			return factory;
 		}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/SubBatchPerPartitionTxTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/SubBatchPerPartitionTxTests.java
@@ -90,7 +90,7 @@ public class SubBatchPerPartitionTxTests {
 
 	@SuppressWarnings("unchecked")
 	@Test
-	public void threeTransactions() throws Exception {
+	public void threeTransactionsForThreeSubBatches() throws Exception {
 		assertThat(this.config.deliveryLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(this.config.pollLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		this.registry.stop();
@@ -201,8 +201,6 @@ public class SubBatchPerPartitionTxTests {
 			factory.getContainerProperties().setAckMode(AckMode.BATCH);
 			factory.getContainerProperties().setTransactionManager(tm());
 			factory.setBatchListener(true);
-			// true by default for a transactional container since 2.5
-//			factory.getContainerProperties().setSubBatchPerPartition(true);
 			return factory;
 		}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/TransactionalContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/TransactionalContainerTests.java
@@ -80,6 +80,7 @@ import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.core.ProducerFactoryUtils;
 import org.springframework.kafka.event.ConsumerStoppedEvent;
 import org.springframework.kafka.listener.ContainerProperties.AckMode;
+import org.springframework.kafka.listener.ContainerProperties.AssignmentCommitOption;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.kafka.support.DefaultKafkaHeaderMapper;
 import org.springframework.kafka.support.KafkaHeaders;
@@ -198,6 +199,7 @@ public class TransactionalContainerTests {
 		props.setAckMode(ackMode);
 		props.setGroupId("group");
 		props.setTransactionManager(ptm);
+		props.setAssignmentCommitOption(AssignmentCommitOption.ALWAYS);
 		final KafkaTemplate template = new KafkaTemplate(pf);
 		if (AckMode.MANUAL_IMMEDIATE.equals(ackMode)) {
 			class AckListener implements AcknowledgingMessageListener {
@@ -367,6 +369,7 @@ public class TransactionalContainerTests {
 				new TopicPartitionOffset("foo", 1));
 		props.setGroupId("group");
 		props.setTransactionManager(tm);
+		props.setSubBatchPerPartition(false);
 		final KafkaTemplate template = new KafkaTemplate(pf);
 		props.setMessageListener((BatchMessageListener) recordlist -> {
 			template.send("bar", "baz");

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -1920,7 +1920,6 @@ CommitOption
 |LATEST_ONLY _NO_TX
 |Whether or not to commit the initial position on assignment; by default, the initial offset will only be committed if the `ConsumerConfig.AUTO_OFFSET_RESET_CONFIG` is `latest` and it won't run in a transaction even if there is a transaction manager present.
 See the javadocs for `ContainerProperties.AssignmentCommitOption` for more information about the available options.
-In 2.3 and 2.4, the default was `ALWAYS` to retain the previous default before it was configurable.
 
 |authorizationException
 RetryInterval

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -1889,6 +1889,272 @@ However, see the note at the beginning of this section; you can avoid using the 
 
 IMPORTANT: If the recoverer fails (throws an exception), the record will be included in the seeks and recovery will be attempted again during the next delivery.
 
+[[container-props]]
+==== Listener Container Properties
+
+.`ContainerProperties` Properties
+[cols="6l,3,16", options="header"]
+|===
+| Property
+| Default
+| Description
+
+|ackCount
+|1
+|The number of records before committing pending offsets when the `ackMode` is `COUNT` or `COUNT_TIME`.
+
+|ackMode
+|BATCH
+|Controls how often offsets are committed - see <<committing-offsets>>.
+
+|ackOnError
+|`false`
+|[DEPRECATED in favor of `ErrorHandler.isAckAfterHandle()`]
+
+|ackTime
+|5000
+|The time in milliseconds after which pending offsets are committed when the `ackMode` is `TIME` or `COUNT_TIME`.
+
+|assignment
+CommitOption
+|LATEST_ONLY _NO_TX
+|Whether or not to commit the initial position on assignment; by default, the initial offset will only be committed if the `ConsumerConfig.AUTO_OFFSET_RESET_CONFIG` is `latest` and it won't run in a transaction even if there is a transaction manager present.
+See the javadocs for `ContainerProperties.AssignmentCommitOption` for more information about the available options.
+In 2.3 and 2.4, the default was `ALWAYS` to retain the previous default before it was configurable.
+
+|authorizationException
+RetryInterval
+|`null`
+|When not null, a `Duration` to sleep between polls when an `AuthorizationException` is thrown by the Kafka client.
+When null, such exceptions are considered fatal and the container will stop.
+
+|clientId
+|(empty string)
+|A prefix for the `client.id` consumer property.
+Overrides the consumer factory `client.id` property; in a concurrent container, `-n` is added as a suffix for each consumer instance.
+
+|commitCallback
+|`null`
+|When present and `syncCommits` is `false` a callback invoked after the commit completes.
+
+|commitLogLevel
+|DEBUG
+|The logging level for logs pertaining to committing offsets.
+
+|consumerRebalanceListener
+|`null`
+|A rebalance listener; see <<rebalance-listeners>>.
+
+|consumerStartTimout
+|30s
+|The time to wait for the consumer to start before logging an error; this might happen if, say, you use a task executor with insufficient threads.
+
+|consumerTaskExecutor
+|`SimpleAsync` `TaskExecutor`
+|A task executor to run the consumer threads.
+The default executor creates threads named `<name>-C-n`; with the `KafkaMessageListenerContainer`, the name is the bean name; with the `ConcurrentMessageListenerContainer` the name is the bean name suffixed with `-n` where n is incremented for each child container.
+
+|deliveryAttemptHeader
+|`false`
+|See <<delivery-header>>.
+
+|groupId
+|`null`
+|Overrides the consumer `group.id` property; automatically set by the `@KafkaListener` `id` or `groupId` property.
+
+|idleBetweenPolls
+|0
+|Used to slow down deliveries by sleeping the thread between polls.
+The time to process a batch of records plus this value must be less than the `max.poll.interval.ms` consumer property.
+
+|idleEventInterval
+|`null`
+|When set, enables publication of `ListenerContainerIdleEvent` s, see <<events>> and <<idle-containers>>.
+
+|kafkaConsumerProperties
+|None
+|Used to override any arbitrary consumer properties configured on the consumer factory.
+
+|logContainerConfig
+|`false`
+|Set to true to log at INFO level all container properties.
+
+|messageListener
+|`null`
+|The message listener.
+
+|micrometerEnabled
+|`true`
+|Whether or not to maintain Micrometer timers for the consumer threads.
+
+|missingTopicsFatal
+|`false`
+|When true prevents the container from starting if the confifgured topic(s) are not present on the broker.
+
+|monitorInterval
+|30s
+|How often to check the state of the consumer threads for `NonResponsiveConsumerEvent` s.
+See `noPollThreshold` and `pollTimeout`.
+
+|noPollThreshold
+|3.0
+|Multiplied by `pollTimeOut` to determine whether to publish a `NonResponsiveConsumerEvent`.
+See `monitorInterval`.
+
+|pollTimeout
+|5000
+|The timeout passed into `Consumer.poll()`.
+
+|scheduler
+|`ThreadPool` `TaskScheduler`
+|A scheduler on which to run the consumer monitor task.
+
+|shutdownTimeout
+|10000
+|The maximum time in ms to block the `stop()` method until all consumers stop and before publishing the container stopped event.
+
+|subBatchPerPartition
+|See desc.
+|When using a batch listener, if this is `true`, the listener is called with the results of the poll split into sub batches, one per partition.
+Default `false` except when using transactions - see <<transactions>>.
+
+|syncCommitTimeout
+|`null`
+|The timeout to use when `syncCommits` is `true`.
+When not set, the container will attempt to determine the `default.api.timeout.ms` consumer property and use that; otherwise it will use 60 seconds.
+
+|syncCommits
+|`true`
+|Whether to use sync or async commits for offsets; see `commitCallback`.
+
+|topics
+topicPattern
+topicPartitions
+|n/a
+|The configured topics, topic pattern or explicitly assigned topics/partitions.
+Mutually exclusive; at least one must be provided; enforced by `ContainerProperties` constructors.
+
+|transactionManager
+|`null`
+|See <<transactions>>.
+|===
+
+.`AbstractListenerContainer` Properties
+[cols="6l,3,16", options="header"]
+|===
+| Property
+| Default
+| Description
+
+|afterRollback
+Processor
+|`DefaultAfter`
+`Rollback`
+`Processor`
+|An `AfterRollbackProcessor` to invoke after a transaction is rolled back.
+
+|applicationEventPublisher
+|application context
+|The event publisher.
+
+|batchError
+Handler
+|See desc.
+|An error handler for a batch listener; defaults to a `BatchLoggingErrorHandler` or `null` if transactions are being used (errors are handled by the `AfterRollbackProcessor`).
+
+|beanName
+|bean name
+|The bean name of the container; suffixed with `-n` for child containers.
+
+|containerProperties
+|`Container`
+`Properties`
+|The container properties instance.
+
+|errorHandler
+|See desc.
+|An error handler for a record listener; defaults to a `LoggingErrorHandler` or `null` if transactions are being used (errors are handled by the `AfterRollbackProcessor`).
+
+|genericErrorHandler
+|See desc.
+|Either a batch or record error handler - see `batchErrorHandler` and `errorHandler`.
+
+|groupId
+|See desc.
+|The `containerProperties.groupId`, if present, otherwise the `group.id` property from the consumer factory.
+
+|intercept
+BeforeTx
+|`false`
+|Determines whether the `recordInterceptor` is called before or after a transaction starts.
+
+|listenerId
+|See desc.
+|The bean name for user-configured containers or the `id` attribute of `@KafkaListener` s.
+
+|pause
+Requested
+|n/a
+|True if a consumer pause has been requested (read only).
+
+|record
+Interceptor
+|`null`
+|Set a `RecordInterceptor` to call before invoking the listener; does not apply to batch listeners.
+Also see `interceptBeforeTx`.
+
+|topicCheck
+Timeout
+|30s
+|When the `missingTopicsFatal` container property is `true`, how long to wait, in seconds, for the `describeTopics` operation to complete.
+|===
+
+.`KafkaMessageListenerContainer` Properties
+[cols="6l,3,16", options="header"]
+|===
+| Property
+| Default
+| Description
+
+|assigned
+Partitions
+|n/a
+|The partitions currently assigned to this container (explicitly or not) (read only).
+
+|clientId
+Suffix
+|`null`
+|Used by the concurrent container to give each child container's consumer a unique `client.id`.
+
+|containerPaused
+|n/a
+|True if pause has been requested and the consumer has actually paused.
+|===
+
+.`ConcurrentMessageListenerContainer` Properties
+[cols="6l,3,16", options="header"]
+|===
+| Property
+| Default
+| Description
+
+|assigned
+Partitions
+|n/a
+|The aggregate of partitions currently assigned to this container's child `KafkaMessageListenerContainer` s (explicitly or not) (read only).
+
+|concurrency
+|1
+|The number of child `KafkaMessageListenerContainer` s to manage.
+
+|containerPaused
+|n/a
+|True if pause has been requested and all child containers' consumer has actually paused.
+
+|containers
+|n/a
+|A reference to all child `KafkaMessageListenerContainer` s.
+|===
 [[events]]
 ==== Application Events
 
@@ -2392,6 +2658,7 @@ If you wish to revert to the previous behavior, you can set the `producerPerCons
 NOTE: While transactions are supported with batch listeners, by default, zombie fencing is not supported because a batch may contain records from multiple topics or partitions.
 However, starting with version 2.3.2, zombie fencing is supported if you set the container property `subBatchPerPartition` to true.
 In that case, the batch listener is invoked once per partition received from the last poll, as if each poll only returned records for a single partition.
+This is `true` by default since version 2.5 when transactions are enabled; set it to `false` if you are using transactions but are not concerned about zombie fencing.
 
 Also see <<transaction-id-prefix>>.
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -18,6 +18,15 @@ See <<reply-message>> for more information.
 
 The `KafkaHeaders.RECEIVED_MESSAGE_KEY` is no longer populated with a `null` value when the incoming record has a `null` key; the header is omitted altogether.
 
+[[x25-container]]
+==== Listener Container Changes
+
+The `assignmentCommitOption` container property is now `LATEST_ONLY_NO_TX` by default.
+See <<container-props>> for more information.
+
+The `subBatchPerPartition` container property is now `true` by default when using transactions.
+See <<transactions>> for more information.
+
 [[x25-template]]
 ==== KafkaTemplate Changes
 


### PR DESCRIPTION
See GH-1370

- deprecate `ContainerProperties.getTopicPartitionsToAssign()`
- defaults for `ackCount`, `ackTime`
- `subBatchPerPartition` default `true` for transactions
- `assignmentCommitOption` default to `LATEST_ONLY_NO_TX`
- deprecate `ackOnError`