### PR TITLE
GH-1446: Support Static Group Membership

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
@@ -415,7 +415,6 @@ public abstract class AbstractMessageListenerContainer<K, V>
 					doStop(latch::countDown);
 					try {
 						latch.await(this.containerProperties.getShutdownTimeout(), TimeUnit.MILLISECONDS); // NOSONAR
-						publishContainerStoppedEvent();
 					}
 					catch (@SuppressWarnings("unused") InterruptedException e) {
 						Thread.currentThread().interrupt();
@@ -424,6 +423,7 @@ public abstract class AbstractMessageListenerContainer<K, V>
 				else {
 					doStop(() -> { });
 				}
+				publishContainerStoppedEvent();
 			}
 		}
 	}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
@@ -415,10 +415,10 @@ public abstract class AbstractMessageListenerContainer<K, V>
 					doStop(latch::countDown);
 					try {
 						latch.await(this.containerProperties.getShutdownTimeout(), TimeUnit.MILLISECONDS); // NOSONAR
+						publishContainerStoppedEvent();
 					}
 					catch (@SuppressWarnings("unused") InterruptedException e) {
 						Thread.currentThread().interrupt();
-						publishContainerStoppedEvent();
 					}
 				}
 				else {

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
@@ -399,16 +399,30 @@ public abstract class AbstractMessageListenerContainer<K, V>
 
 	@Override
 	public final void stop() {
+		stop(true);
+	}
+
+	/**
+	 * Stop the container.
+	 * @param wait wait for the listener to terminate.
+	 * @since 2.3.8
+	 */
+	public final void stop(boolean wait) {
 		synchronized (this.lifecycleMonitor) {
 			if (isRunning()) {
-				final CountDownLatch latch = new CountDownLatch(1);
-				doStop(latch::countDown);
-				try {
-					latch.await(this.containerProperties.getShutdownTimeout(), TimeUnit.MILLISECONDS); // NOSONAR
-					publishContainerStoppedEvent();
+				if (wait) {
+					final CountDownLatch latch = new CountDownLatch(1);
+					doStop(latch::countDown);
+					try {
+						latch.await(this.containerProperties.getShutdownTimeout(), TimeUnit.MILLISECONDS); // NOSONAR
+						publishContainerStoppedEvent();
+					}
+					catch (@SuppressWarnings("unused") InterruptedException e) {
+						Thread.currentThread().interrupt();
+					}
 				}
-				catch (@SuppressWarnings("unused") InterruptedException e) {
-					Thread.currentThread().interrupt();
+				else {
+					doStop(() -> { });
 				}
 			}
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
@@ -418,12 +418,14 @@ public abstract class AbstractMessageListenerContainer<K, V>
 					}
 					catch (@SuppressWarnings("unused") InterruptedException e) {
 						Thread.currentThread().interrupt();
+						publishContainerStoppedEvent();
 					}
 				}
 				else {
-					doStop(() -> { });
+					doStop(() -> {
+						publishContainerStoppedEvent();
+					});
 				}
-				publishContainerStoppedEvent();
 			}
 		}
 	}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
@@ -68,6 +68,7 @@ import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.AuthorizationException;
+import org.apache.kafka.common.errors.FencedInstanceIdException;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
@@ -2701,16 +2702,16 @@ public class KafkaMessageListenerContainerTests {
 		KafkaMessageListenerContainer<Integer, String> container =
 				new KafkaMessageListenerContainer<>(cf, containerProps);
 
-		CountDownLatch stopping = new CountDownLatch(1);
+		CountDownLatch stopped = new CountDownLatch(1);
 
 		container.setApplicationEventPublisher(e -> {
-			if (e instanceof ConsumerStoppingEvent) {
-				stopping.countDown();
+			if (e instanceof ConsumerStoppedEvent) {
+				stopped.countDown();
 			}
 		});
 
 		container.start();
-		assertThat(stopping.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(stopped.await(10, TimeUnit.SECONDS)).isTrue();
 		container.stop();
 	}
 
@@ -2736,6 +2737,37 @@ public class KafkaMessageListenerContainerTests {
 				new KafkaMessageListenerContainer<>(cf, containerProps);
 		container.start();
 		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+		container.stop();
+	}
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Test
+	void testFatalErrorOnFencedInstanceException() throws Exception {
+		ConsumerFactory<Integer, String> cf = mock(ConsumerFactory.class);
+		Consumer<Integer, String> consumer = mock(Consumer.class);
+		given(cf.createConsumer(eq("grp"), eq("clientId"), isNull(), any())).willReturn(consumer);
+		given(cf.getConfigurationProperties()).willReturn(new HashMap<>());
+
+		willThrow(FencedInstanceIdException.class)
+				.given(consumer).poll(any());
+
+		ContainerProperties containerProps = new ContainerProperties(topic1);
+		containerProps.setGroupId("grp");
+		containerProps.setClientId("clientId");
+		containerProps.setMessageListener((MessageListener) r -> { });
+		KafkaMessageListenerContainer<Integer, String> container =
+				new KafkaMessageListenerContainer<>(cf, containerProps);
+
+		CountDownLatch stopped = new CountDownLatch(1);
+
+		container.setApplicationEventPublisher(e -> {
+			if (e instanceof ConsumerStoppedEvent) {
+				stopped.countDown();
+			}
+		});
+
+		container.start();
+		assertThat(stopped.await(10, TimeUnit.SECONDS)).isTrue();
 		container.stop();
 	}
 

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -776,6 +776,10 @@ Starting with version 2.3.4, you can set the listener container's `interceptBefo
 
 No interceptor is provided for batch listeners because Kafka already provides a `ConsumerInterceptor`.
 
+Starting with versions 2.3.8, 2.4.6, the `ConcurrentMessageListenerContainer` now supports https://kafka.apache.org/documentation/#static_membership[Static Membership] when the concurrency is greater than one.
+The `group.instance.id` is suffixed with `-n` with `n` starting at `1`.
+This, together with an increased `session.timeout.ms`, can be used to reduce rebalance events, for example, when application instances are restarted.
+
 [[kafka-container]]
 ====== Using `KafkaMessageListenerContainer`
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -31,6 +31,9 @@ See <<transactions>> for more information.
 A new `RecoveringBatchErrorHandler` is now provided.
 See <<recovering-batch-eh>> for more information.
 
+Static group membership is now supported.
+See <<message-listener-container>> for more information.
+
 [[x25-template]]
 ==== KafkaTemplate Changes
 


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1446

See https://kafka.apache.org/documentation/#static_membership

Add a qualifier to `group.instance.id` for each child container.

Catch `FencedInstanceIdException` and stop the container.

Fix delay on self-stopping containers.

Treat `FencedInstanceIdException` the same as `ProducerFencedException` when
using transactions (do not call `AfterRollbackProcessor`.

**cherry-pick to 2.4.x, 2.3.x**