### PR TITLE
Fix commits on partition revocation

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -2294,8 +2294,14 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 					else {
 						this.userListener.onPartitionsRevoked(partitions);
 					}
-					// Wait until now to commit, in case the user listener added acks
-					commitPendingAcks();
+					try {
+						// Wait until now to commit, in case the user listener added acks
+						commitPendingAcks();
+					}
+					catch (Exception e) {
+						ListenerConsumer.this.logger.error(e, () -> "Fatal commit error after revocation "
+								+ partitions);
+					}
 					if (this.consumerAwareListener != null) {
 						this.consumerAwareListener.onPartitionsRevokedAfterCommit(ListenerConsumer.this.consumer,
 								partitions);


### PR DESCRIPTION
Complete the remainder of `onPartitionsRevoked()` if the commits fail
fatally.

It is possible that commits might fail when using manual acks; we must
complete the remainder of the method if the commits fail.

**I will backport as needed**