### PR TITLE
Producer/Consumer Factory Listeners and Micrometer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,7 +57,7 @@ ext {
 	junitJupiterVersion = '5.5.2'
 	kafkaVersion = '2.5.0'
 	log4jVersion = '2.12.1'
-	micrometerVersion = '1.3.6'
+	micrometerVersion = '1.5.0-SNAPSHOT'
 	mockitoVersion = '3.0.0'
 	reactorVersion = 'Dysprosium-SR6'
 	scalaVersion = '2.12'

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/ConsumerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/ConsumerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -134,6 +134,37 @@ public interface ConsumerFactory<K, V> {
 	@Nullable
 	default Deserializer<V> getValueDeserializer() {
 		return null;
+	}
+
+	/**
+	 * Called whenever a consumer is added or removed.
+	 *
+	 * @param <K> the key type.
+	 * @param <V> the value type.
+	 *
+	 * @since 2.5
+	 *
+	 */
+	interface Listener<K, V> {
+
+		/**
+		 * A new consumer was created.
+		 * @param id the consumer id (factory bean name and client.id separated by a
+		 * period).
+		 * @param consumer the consumer.
+		 */
+		default void consumerAdded(String id, Consumer<K, V> consumer) {
+		}
+
+		/**
+		 * An existing consumer was removed.
+		 * @param id the consumer id (factory bean name and client.id separated by a
+		 * period).
+		 * @param consumer the consumer.
+		 */
+		default void consumerRemoved(String id, Consumer<K, V> consumer) {
+		}
+
 	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,18 +18,28 @@ package org.springframework.kafka.core;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
 import java.util.function.Supplier;
 
+import org.aopalliance.aop.Advice;
+import org.aopalliance.intercept.MethodInterceptor;
+import org.aopalliance.intercept.MethodInvocation;
 import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.serialization.Deserializer;
 
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.aop.support.NameMatchMethodPointcutAdvisor;
+import org.springframework.beans.factory.BeanNameAware;
 import org.springframework.core.log.LogAccessor;
 import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 /**
@@ -57,7 +67,7 @@ import org.springframework.util.StringUtils;
  * @author Artem Bilan
  * @author Chris Gilbert
  */
-public class DefaultKafkaConsumerFactory<K, V> implements ConsumerFactory<K, V> {
+public class DefaultKafkaConsumerFactory<K, V> implements ConsumerFactory<K, V>, BeanNameAware {
 
 	private static final LogAccessor LOGGER = new LogAccessor(LogFactory.getLog(DefaultKafkaConsumerFactory.class));
 
@@ -66,6 +76,11 @@ public class DefaultKafkaConsumerFactory<K, V> implements ConsumerFactory<K, V> 
 	private Supplier<Deserializer<K>> keyDeserializerSupplier;
 
 	private Supplier<Deserializer<V>> valueDeserializerSupplier;
+
+	private String beanName = "not.managed.by.Spring";
+
+	private Listener<K, V> listener;
+
 
 	/**
 	 * Construct a factory with the provided configuration.
@@ -104,12 +119,37 @@ public class DefaultKafkaConsumerFactory<K, V> implements ConsumerFactory<K, V> 
 		this.valueDeserializerSupplier = valueDeserializerSupplier == null ? () -> null : valueDeserializerSupplier;
 	}
 
+	@Override
+	public void setBeanName(String name) {
+		this.beanName = name;
+	}
+
+	/**
+	 * Set the key deserializer.
+	 * @param keyDeserializer the deserializer.
+	 * @since 2.5
+	 */
 	public void setKeyDeserializer(@Nullable Deserializer<K> keyDeserializer) {
 		this.keyDeserializerSupplier = () -> keyDeserializer;
 	}
 
+	/**
+	 * Set the value deserializer.
+	 * @param valueDeserializer the valuee deserializer.
+	 * @since 2.5
+	 */
 	public void setValueDeserializer(@Nullable Deserializer<V> valueDeserializer) {
 		this.valueDeserializerSupplier = () -> valueDeserializer;
+	}
+
+	/**
+	 * Set a listener.
+	 * @param listener the listener.
+	 * @since 2.5
+	 */
+	public void setListener(Listener<K, V> listener) {
+		Assert.notNull(listener, "'listener' cannot be null");
+		this.listener = listener;
 	}
 
 	@Override
@@ -142,13 +182,13 @@ public class DefaultKafkaConsumerFactory<K, V> implements ConsumerFactory<K, V> 
 	}
 
 	@Deprecated
-	protected KafkaConsumer<K, V> createKafkaConsumer(@Nullable String groupId, @Nullable String clientIdPrefix,
+	protected Consumer<K, V> createKafkaConsumer(@Nullable String groupId, @Nullable String clientIdPrefix,
 			@Nullable String clientIdSuffixArg) {
 
 		return createKafkaConsumer(groupId, clientIdPrefix, clientIdSuffixArg, null);
 	}
 
-	protected KafkaConsumer<K, V> createKafkaConsumer(@Nullable String groupId, @Nullable String clientIdPrefix,
+	protected Consumer<K, V> createKafkaConsumer(@Nullable String groupId, @Nullable String clientIdPrefix,
 			@Nullable String clientIdSuffixArg, @Nullable Properties properties) {
 
 		boolean overrideClientIdPrefix = StringUtils.hasText(clientIdPrefix);
@@ -169,7 +209,7 @@ public class DefaultKafkaConsumerFactory<K, V> implements ConsumerFactory<K, V> 
 		}
 	}
 
-	private KafkaConsumer<K, V> createConsumerWithAdjustedProperties(String groupId, String clientIdPrefix,
+	private Consumer<K, V> createConsumerWithAdjustedProperties(String groupId, String clientIdPrefix,
 			Properties properties, boolean overrideClientIdPrefix, String clientIdSuffix,
 			boolean shouldModifyClientId) {
 
@@ -202,9 +242,49 @@ public class DefaultKafkaConsumerFactory<K, V> implements ConsumerFactory<K, V> 
 		});
 	}
 
-	protected KafkaConsumer<K, V> createKafkaConsumer(Map<String, Object> configProps) {
-		return new KafkaConsumer<>(configProps, this.keyDeserializerSupplier.get(),
+	@SuppressWarnings("resource")
+	protected Consumer<K, V> createKafkaConsumer(Map<String, Object> configProps) {
+		Consumer<K, V> kafkaConsumer = createRawConsumer(configProps);
+
+		if (this.listener != null) {
+			Map<MetricName, ? extends Metric> metrics = kafkaConsumer.metrics();
+			Iterator<MetricName> metricIterator = metrics.keySet().iterator();
+			String clientId;
+			if (metricIterator.hasNext()) {
+				clientId = metricIterator.next().tags().get("client-id");
+			}
+			else {
+				clientId = "unknown";
+			}
+			String id = this.beanName + "." + clientId;
+			kafkaConsumer = createProxy(kafkaConsumer, id);
+			this.listener.consumerAdded(id, kafkaConsumer);
+		}
+		return kafkaConsumer;
+	}
+
+	protected Consumer<K, V> createRawConsumer(Map<String, Object> configProps) {
+		Consumer<K, V> kafkaConsumer = new KafkaConsumer<>(configProps, this.keyDeserializerSupplier.get(),
 				this.valueDeserializerSupplier.get());
+		return kafkaConsumer;
+	}
+
+	@SuppressWarnings("unchecked")
+	private Consumer<K, V> createProxy(Consumer<K, V> kafkaConsumer, String id) {
+		ProxyFactory pf = new ProxyFactory(kafkaConsumer);
+		Advice advice = new MethodInterceptor() {
+
+			@Override
+			public Object invoke(MethodInvocation invocation) throws Throwable {
+				DefaultKafkaConsumerFactory.this.listener.consumerRemoved(id, kafkaConsumer);
+				return invocation.proceed();
+			}
+
+		};
+		NameMatchMethodPointcutAdvisor advisor = new NameMatchMethodPointcutAdvisor(advice);
+		advisor.addMethodName("close");
+		pf.addAdvisor(advisor);
+		return (Consumer<K, V>) pf.getProxy();
 	}
 
 	@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
@@ -127,7 +127,6 @@ public class DefaultKafkaConsumerFactory<K, V> implements ConsumerFactory<K, V>,
 	/**
 	 * Set the key deserializer.
 	 * @param keyDeserializer the deserializer.
-	 * @since 2.5
 	 */
 	public void setKeyDeserializer(@Nullable Deserializer<K> keyDeserializer) {
 		this.keyDeserializerSupplier = () -> keyDeserializer;
@@ -136,7 +135,6 @@ public class DefaultKafkaConsumerFactory<K, V> implements ConsumerFactory<K, V>,
 	/**
 	 * Set the value deserializer.
 	 * @param valueDeserializer the valuee deserializer.
-	 * @since 2.5
 	 */
 	public void setValueDeserializer(@Nullable Deserializer<V> valueDeserializer) {
 		this.valueDeserializerSupplier = () -> valueDeserializer;

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/MicrometerConsumerListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/MicrometerConsumerListener.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.core;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.consumer.Consumer;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.kafka.KafkaClientMetrics;
+
+/**
+ * A consumer factory listener that manages {@link KafkaClientMetrics}.
+ *
+ * @param <K> the key type.
+ * @param <V> the value type.
+ *
+ * @author Gary Russell
+ * @since 2.5
+ *
+ */
+public class MicrometerConsumerListener<K, V> implements ConsumerFactory.Listener<K, V> {
+
+	private final MeterRegistry meterRegistry;
+
+	private final Iterable<Tag> tags;
+
+	private final Map<String, KafkaClientMetrics> metrics = new HashMap<>();
+
+	/**
+	 * Construct an instance with the provided registry.
+	 * @param meterRegistry the registry.
+	 */
+	public MicrometerConsumerListener(MeterRegistry meterRegistry) {
+		this(meterRegistry, Collections.emptyList());
+	}
+
+	/**
+	 * Construct an instance with the provided registry and tags.
+	 * @param meterRegistry the registry.
+	 * @param tags the tags.
+	 */
+	public MicrometerConsumerListener(MeterRegistry meterRegistry, Iterable<Tag> tags) {
+		this.meterRegistry = meterRegistry;
+		this.tags = tags;
+	}
+
+	@Override
+	public synchronized void consumerAdded(String id, Consumer<K, V> consumer) {
+		if (!this.metrics.containsKey(id)) {
+			this.metrics.put(id, new KafkaClientMetrics(consumer, this.tags));
+			this.metrics.get(id).bindTo(this.meterRegistry);
+		}
+	}
+
+	@Override
+	public synchronized void consumerRemoved(String id, Consumer<K, V> consumer) {
+		KafkaClientMetrics removed = this.metrics.remove(id);
+		if (removed != null) {
+			removed.close();
+		}
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/MicrometerProducerListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/MicrometerProducerListener.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.core;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.producer.Producer;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.kafka.KafkaClientMetrics;
+
+/**
+ * A producer factory listener that manages {@link KafkaClientMetrics}.
+ *
+ * @param <K> the key type.
+ * @param <V> the value type.
+ *
+ * @author Gary Russell
+ * @since 2.5
+ *
+ */
+public class MicrometerProducerListener<K, V> implements ProducerFactory.Listener<K, V> {
+
+	private final MeterRegistry meterRegistry;
+
+	private final Iterable<Tag> tags;
+
+	private final Map<String, KafkaClientMetrics> metrics = new HashMap<>();
+
+	/**
+	 * Construct an instance with the provided registry.
+	 * @param meterRegistry the registry.
+	 */
+	public MicrometerProducerListener(MeterRegistry meterRegistry) {
+		this(meterRegistry, Collections.emptyList());
+	}
+
+	/**
+	 * Construct an instance with the provided registry and tags.
+	 * @param meterRegistry the registry.
+	 * @param tags the tags.
+	 */
+	public MicrometerProducerListener(MeterRegistry meterRegistry, Iterable<Tag> tags) {
+		this.meterRegistry = meterRegistry;
+		this.tags = tags;
+	}
+
+
+	@Override
+	public synchronized void producerAdded(String id, Producer<K, V> producer) {
+		if (!this.metrics.containsKey(id)) {
+			this.metrics.put(id, new KafkaClientMetrics(producer, this.tags));
+			this.metrics.get(id).bindTo(this.meterRegistry);
+		}
+	}
+
+	@Override
+	public synchronized void producerRemoved(String id, Producer<K, V> producer) {
+		KafkaClientMetrics removed = this.metrics.remove(id);
+		if (removed != null) {
+			removed.close();
+		}
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/ProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/ProducerFactory.java
@@ -168,4 +168,35 @@ public interface ProducerFactory<K, V> {
 		return DEFAULT_PHYSICAL_CLOSE_TIMEOUT;
 	}
 
+	/**
+	 * Called whenever a producer is added or removed.
+	 *
+	 * @param <K> the key type.
+	 * @param <V> the value type.
+	 *
+	 * @since 2.5
+	 *
+	 */
+	interface Listener<K, V> {
+
+		/**
+		 * A new producer was created.
+		 * @param id the producer id (factory bean name and client.id separated by a
+		 * period).
+		 * @param producer the producer.
+		 */
+		default void producerAdded(String id, Producer<K, V> producer) {
+		}
+
+		/**
+		 * An exsting producer was removed.
+		 * @param id the producer id (factory bean name and client.id separated by a
+		 * period).
+		 * @param producer the producer.
+		 */
+		default void producerRemoved(String id, Producer<K, V> producer) {
+		}
+
+	}
+
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -796,12 +796,14 @@ public class EnableKafkaIntegrationTests {
 		assertThat(this.config.intercepted).isTrue();
 		assertThat(this.meterRegistry.get("kafka.consumer.coordinator.join.total")
 				.tag("consumerTag", "bytesString")
+				.tag("spring.id", "bytesStringConsumerFactory.tag-0")
 				.functionCounter()
 				.count())
 					.isGreaterThan(0);
 
 		assertThat(this.meterRegistry.get("kafka.producer.node.incoming.byte.total")
 				.tag("producerTag", "bytesString")
+				.tag("spring.id", "bytesStringProducerFactory.bsPF-1")
 				.functionCounter()
 				.count())
 					.isGreaterThan(0);
@@ -1274,6 +1276,7 @@ public class EnableKafkaIntegrationTests {
 		public ProducerFactory<byte[], String> bytesStringProducerFactory() {
 			Map<String, Object> configs = producerConfigs();
 			configs.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
+			configs.put(ProducerConfig.CLIENT_ID_CONFIG, "bsPF");
 			DefaultKafkaProducerFactory<byte[], String> pf = new DefaultKafkaProducerFactory<>(configs);
 			pf.setListener(new MicrometerProducerListener<byte[], String>(meterRegistry(),
 					Collections.singletonList(new ImmutableTag("producerTag", "bytesString"))));
@@ -1910,7 +1913,7 @@ public class EnableKafkaIntegrationTests {
 			// empty
 		}
 
-		@KafkaListener(id = "bytesKey", topics = "annotated36",
+		@KafkaListener(id = "bytesKey", topics = "annotated36", clientIdPrefix = "tag",
 				containerFactory = "bytesStringListenerContainerFactory")
 		public void bytesKey(String in, @Header(KafkaHeaders.RECEIVED_MESSAGE_KEY) String key) {
 			this.convertedKey = key;

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -80,6 +80,8 @@ import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.MicrometerConsumerListener;
+import org.springframework.kafka.core.MicrometerProducerListener;
 import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.event.ListenerContainerIdleEvent;
 import org.springframework.kafka.listener.AbstractConsumerSeekAware;
@@ -137,6 +139,7 @@ import org.springframework.util.concurrent.ListenableFuture;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 
+import io.micrometer.core.instrument.ImmutableTag;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
@@ -791,6 +794,17 @@ public class EnableKafkaIntegrationTests {
 		assertThat(this.listener.keyLatch.await(30, TimeUnit.SECONDS)).isTrue();
 		assertThat(this.listener.convertedKey).isEqualTo("foo");
 		assertThat(this.config.intercepted).isTrue();
+		assertThat(this.meterRegistry.get("kafka.consumer.coordinator.join.total")
+				.tag("consumerTag", "bytesString")
+				.functionCounter()
+				.count())
+					.isGreaterThan(0);
+
+		assertThat(this.meterRegistry.get("kafka.producer.node.incoming.byte.total")
+				.tag("producerTag", "bytesString")
+				.functionCounter()
+				.count())
+					.isGreaterThan(0);
 	}
 
 	@Test
@@ -1186,7 +1200,10 @@ public class EnableKafkaIntegrationTests {
 		public DefaultKafkaConsumerFactory<byte[], String> bytesStringConsumerFactory() {
 			Map<String, Object> configs = consumerConfigs();
 			configs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
-			return new DefaultKafkaConsumerFactory<>(configs);
+			DefaultKafkaConsumerFactory<byte[], String> cf = new DefaultKafkaConsumerFactory<>(configs);
+			cf.setListener(new MicrometerConsumerListener<byte[], String>(meterRegistry(),
+					Collections.singletonList(new ImmutableTag("consumerTag", "bytesString"))));
+			return cf;
 		}
 
 		private ConsumerFactory<Integer, String> configuredConsumerFactory(String clientAndGroupId) {
@@ -1257,7 +1274,10 @@ public class EnableKafkaIntegrationTests {
 		public ProducerFactory<byte[], String> bytesStringProducerFactory() {
 			Map<String, Object> configs = producerConfigs();
 			configs.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
-			return new DefaultKafkaProducerFactory<>(configs);
+			DefaultKafkaProducerFactory<byte[], String> pf = new DefaultKafkaProducerFactory<>(configs);
+			pf.setListener(new MicrometerProducerListener<byte[], String>(meterRegistry(),
+					Collections.singletonList(new ImmutableTag("producerTag", "bytesString"))));
+			return pf;
 		}
 
 		@Bean

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
@@ -17,26 +17,34 @@
 package org.springframework.kafka.core;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 import java.util.AbstractMap;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Queue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.ConsumerFactory.Listener;
 import org.springframework.kafka.listener.ContainerProperties;
 import org.springframework.kafka.listener.KafkaMessageListenerContainer;
 import org.springframework.kafka.listener.MessageListener;
@@ -363,14 +371,60 @@ public class DefaultKafkaConsumerFactoryTests {
 			ListenableFuture<SendResult<Integer, String>> future = template.send("txCache2", "foo");
 			future.get(10, TimeUnit.SECONDS);
 			assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
-			assertThat(KafkaTestUtils.getPropertyValue(pfTx, "cache", Map.class)).hasSize(1);
-			assertThat((Queue) KafkaTestUtils.getPropertyValue(pfTx, "cache", Map.class).get("fooTx.")).hasSize(0);
+			assertThat(KafkaTestUtils.getPropertyValue(pfTx, "cache", Map.class)).hasSize(0);
 		}
 		finally {
 			container.stop();
 			pf.destroy();
 			pfTx.destroy();
 		}
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Test
+	void listener() {
+		Consumer consumer = mock(Consumer.class);
+		Map<MetricName, ? extends Metric> metrics = new HashMap<>();
+		metrics.put(new MetricName("test", "group", "desc", Collections.singletonMap("client-id", "foo-0")), null);
+		given(consumer.metrics()).willReturn(metrics);
+		DefaultKafkaConsumerFactory cf = new DefaultKafkaConsumerFactory(Collections.emptyMap()) {
+
+			@Override
+			protected Consumer createRawConsumer(Map configProps) {
+				return consumer;
+			}
+
+		};
+		List<String> adds = new ArrayList<>();
+		List<String> removals = new ArrayList<>();
+
+		Consumer consum = cf.createConsumer();
+		assertThat(AopUtils.isAopProxy(consum)).isFalse();
+		assertThat(adds).hasSize(0);
+
+		cf.setListener(new Listener() {
+
+			@Override
+			public void consumerAdded(String id, Consumer consumer) {
+				adds.add(id);
+			}
+
+			@Override
+			public void consumerRemoved(String id, Consumer consumer) {
+				removals.add(id);
+			}
+
+		});
+		cf.setBeanName("cf");
+
+		consum = cf.createConsumer();
+		assertThat(AopUtils.isAopProxy(consum)).isTrue();
+		assertThat(AopUtils.isJdkDynamicProxy(consum)).isTrue();
+		assertThat(adds).hasSize(1);
+		assertThat(adds.get(0)).isEqualTo("cf.foo-0");
+		assertThat(removals).hasSize(0);
+		consum.close();
+		assertThat(removals).hasSize(1);
 	}
 
 	@Configuration

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTransactionTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTransactionTests.java
@@ -377,12 +377,18 @@ public class KafkaTemplateTransactionTests {
 		@SuppressWarnings("unchecked")
 		Producer<String, String> producer = mock(Producer.class);
 
-		DefaultKafkaProducerFactory<String, String> pf = new DefaultKafkaProducerFactory<String, String>(Collections.emptyMap()) {
+		DefaultKafkaProducerFactory<String, String> pf =
+				new DefaultKafkaProducerFactory<String, String>(Collections.emptyMap()) {
 
+			@SuppressWarnings({ "rawtypes", "unchecked" })
 			@Override
 			public Producer<String, String> createProducer(String txIdPrefixArg) {
-				CloseSafeProducer<String, String> closeSafeProducer = new CloseSafeProducer<>(producer, getCache(),
-						Duration.ofSeconds(1));
+				CloseSafeProducer<String, String> closeSafeProducer = new CloseSafeProducer<>(producer,
+						(prod, timeout) -> {
+							prod.closeDelegate(timeout, new Listener() { });
+							return true;
+						},
+						Duration.ofSeconds(1), "factory");
 				return closeSafeProducer;
 			}
 
@@ -403,7 +409,7 @@ public class KafkaTemplateTransactionTests {
 	}
 
 	@Test
-	public void testNormalCloseAfterCommitCacheFull() {
+	void testNormalCloseAfterCommitCacheFull() {
 		@SuppressWarnings("unchecked")
 		Producer<String, String> producer = mock(Producer.class);
 
@@ -416,13 +422,14 @@ public class KafkaTemplateTransactionTests {
 				BlockingQueue<CloseSafeProducer<String, String>> cache = new LinkedBlockingDeque<>(1);
 				try {
 					cache.put(new CloseSafeProducer<>(mock(Producer.class), this::removeProducer,
-							Duration.ofSeconds(1)));
+							Duration.ofSeconds(1), "factory"));
 				}
 				catch (@SuppressWarnings("unused") InterruptedException e) {
 					Thread.currentThread().interrupt();
 				}
-				CloseSafeProducer<String, String> closeSafeProducer = new CloseSafeProducer<>(producer, cache,
-						Duration.ofSeconds(1));
+				KafkaTestUtils.getPropertyValue(this, "cache", Map.class).put("foo", cache);
+				CloseSafeProducer<String, String> closeSafeProducer = new CloseSafeProducer<>(producer,
+						this::cacheReturner, "foo", Duration.ofSeconds(1), "factory");
 				return closeSafeProducer;
 			}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
@@ -44,7 +44,6 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.TopicPartition;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -123,7 +122,7 @@ public class ConcurrentMessageListenerContainerTests {
 		DefaultKafkaConsumerFactory<Integer, String> cf = new DefaultKafkaConsumerFactory<Integer, String>(props) {
 
 			@Override
-			protected KafkaConsumer<Integer, String> createKafkaConsumer(String groupId, String clientIdPrefix,
+			protected Consumer<Integer, String> createKafkaConsumer(String groupId, String clientIdPrefix,
 					String clientIdSuffixArg, Properties properties) {
 
 				overrides.set(properties);
@@ -218,7 +217,7 @@ public class ConcurrentMessageListenerContainerTests {
 		DefaultKafkaConsumerFactory<Integer, String> cf = new DefaultKafkaConsumerFactory<Integer, String>(props) {
 
 			@Override
-			protected KafkaConsumer<Integer, String> createKafkaConsumer(String groupId, String clientIdPrefix,
+			protected Consumer<Integer, String> createKafkaConsumer(String groupId, String clientIdPrefix,
 					String clientIdSuffixArg, Properties properties) {
 
 				overrides.set(properties);
@@ -290,7 +289,7 @@ public class ConcurrentMessageListenerContainerTests {
 		DefaultKafkaConsumerFactory<Integer, String> cf = new DefaultKafkaConsumerFactory<Integer, String>(props) {
 
 			@Override
-			protected KafkaConsumer<Integer, String> createKafkaConsumer(String groupId, String clientIdPrefix,
+			protected Consumer<Integer, String> createKafkaConsumer(String groupId, String clientIdPrefix,
 					String clientIdSuffixArg, Properties properties) {
 
 				overrides.set(properties);

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -2810,6 +2810,7 @@ public ConsumerFactory<String, String> myConsumerFactory() {
 @Bean
 public ProducerFactory<String, String> myProducerFactory() {
     Map<String, Object> configs = producerConfigs();
+    configs.put(ProducerConfig.CLIENT_ID_CONFIG, "myClientId");
     ...
     DefaultKafkaProducerFactory<byte[], String> pf = new DefaultKafkaProducerFactory<>(configs);
     ...
@@ -2818,6 +2819,20 @@ public ProducerFactory<String, String> myProducerFactory() {
     ...
     return pf;
 }
+----
+====
+
+The consumer/producer `id` passed to the listener is added to the meter's tags with tag name `spring.id`.
+
+====
+.An example of obtaining one of the Kafka metrics
+[source, java]
+----
+double count =this.meterRegistry.get("kafka.producer.node.incoming.byte.total")
+				.tag("customTag", "customTagValue")
+				.tag("spring.id", "myProducerFactory.myClientId-1")
+				.functionCounter()
+				.count()
 ----
 ====
 

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -4,6 +4,56 @@
 This section offers detailed explanations of the various concerns that impact using Spring for Apache Kafka.
 For a quick but less detailed introduction, see <<quick-tour>>.
 
+[[connecting]]
+==== Connecting to Kafka
+
+* `KafkaAdmin` - see <<configuring-topics>>
+* `ProducerFactory` - see <<sending-messages>>
+* `ConsumerFactory` - see <<receiving-messages>>
+
+[[factory-listeners]]
+===== Factory Listeners
+
+Starting with version 2.5, the `DefaultKafkaProducerFactory` and `DefaultKafkaConsumerFactory` can be configured with a `Listener` to receive notifications whenever a producer or consumer is created or closed.
+
+====
+.Producer Factory Listener
+[source, java]
+----
+interface Listener<K, V> {
+
+    default void producerAdded(String id, Producer<K, V> producer) {
+    }
+
+    default void producerRemoved(String id, Producer<K, V> producer) {
+    }
+
+}
+----
+====
+
+====
+.Consumer Factory Listener
+[source, java]
+----
+interface Listener<K, V> {
+
+    default void consumerAdded(String id, Consumer<K, V> consumer) {
+    }
+
+    default void consumerRemoved(String id, Consumer<K, V> consumer) {
+    }
+
+}
+----
+====
+
+In each case, the `id` is created by appending the `client-id` property (obtained from the `metrics()` after creation) to the factory `beanName` property, separated by `.`.
+
+These listeners can be used, for example, to create and bind a Micrometer `KafkaClientMetrics` instance when a new client is created (and close it when the client is closed).
+
+The framework provides listeners that do exactly that; see <<micrometer-native>>.
+
 [[configuring-topics]]
 ==== Configuring Topics
 
@@ -2418,7 +2468,7 @@ You should stop the concurrent container instead.
 Note that you can obtain the current positions when idle is detected by implementing `ConsumerSeekAware` in your listener.
 See `onIdleContainer()` in <<seek>>.
 
-===== Topic/Partition Initial Offset
+==== Topic/Partition Initial Offset
 
 There are several ways to set the initial offset for a partition.
 
@@ -2432,7 +2482,7 @@ When you use group management where the broker assigns partitions:
 You can, however, seek to a specific offset during initialization (or at any time thereafter).
 
 [[seek]]
-===== Seeking to a Specific Offset
+==== Seeking to a Specific Offset
 
 In order to seek, your listener must implement `ConsumerSeekAware`, which has the following methods:
 
@@ -2638,7 +2688,7 @@ public class SeekToLastOnIdleListener extends AbstractConsumerSeekAware {
 ====
 
 [[container-factory]]
-===== Container factory
+==== Container factory
 
 As discussed in <<kafka-listener-annotation>>, a `ConcurrentKafkaListenerContainerFactory` is used to create containers for annotated methods.
 
@@ -2682,7 +2732,7 @@ public KafkaListenerContainerFactory<?, ?> kafkaListenerContainerFactory() {
 ====
 
 [[thread-safety]]
-===== Thread Safety
+==== Thread Safety
 
 When using a concurrent message listener container, a single listener instance is invoked on all consumer threads.
 Listeners, therefore, need to be thread-safe, and it is preferable to use stateless listeners.
@@ -2700,6 +2750,9 @@ IMPORTANT: By default, the application context's event multicaster invokes event
 If you change the multicaster to use an async executor, thread cleanup is not effective.
 
 [[micrometer]]
+
+==== Monitoring
+
 ===== Monitoring Listener Performance
 
 Starting with version 2.3, the listener container will automatically create and update Micrometer `Timer` s for the listener, if `Micrometer` is detected on the class path, and a single `MeterRegistry` is present in the application context.
@@ -2731,6 +2784,42 @@ The timers are named `spring.kafka.template` and have the following tags:
 * `exception` : `none` or the exception class name for failures
 
 You can add additional tags using the template's `micrometerTags` property.
+
+[[micrometer-native]]
+===== Micrometer Native Metrics
+
+Starting with version 2.5, the framework provides <<factory-listeners>> to manage Micrometer `KafkaClientMetric` s whenever producers and consumers are created and closed.
+
+To enable this feature, simply add the listeners to your producer and consumer factories:
+
+====
+[source, java]
+----
+@Bean
+public ConsumerFactory<String, String> myConsumerFactory() {
+    Map<String, Object> configs = consumerConfigs();
+    ...
+    DefaultKafkaConsumerFactory<byte[], String> cf = new DefaultKafkaConsumerFactory<>(configs);
+    ...
+    cf.setListener(new MicrometerConsumerListener<String, String>(meterRegistry(),
+            Collections.singletonList(new ImmutableTag("customTag", "customTagValue"))));
+    ...
+    return cf;
+}
+
+@Bean
+public ProducerFactory<String, String> myProducerFactory() {
+    Map<String, Object> configs = producerConfigs();
+    ...
+    DefaultKafkaProducerFactory<byte[], String> pf = new DefaultKafkaProducerFactory<>(configs);
+    ...
+    pf.setListener(new MicrometerProducerListener<byte[], String>(meterRegistry(),
+            Collections.singletonList(new ImmutableTag("customTag", "customTagValue"))));
+    ...
+    return pf;
+}
+----
+====
 
 [[transactions]]
 ==== Transactions

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -2788,7 +2788,7 @@ You can add additional tags using the template's `micrometerTags` property.
 [[micrometer-native]]
 ===== Micrometer Native Metrics
 
-Starting with version 2.5, the framework provides <<factory-listeners>> to manage Micrometer `KafkaClientMetric` s whenever producers and consumers are created and closed.
+Starting with version 2.5, the framework provides <<factory-listeners>> to manage a Micrometer `KafkaClientMetrics` instance whenever producers and consumers are created and closed.
 
 To enable this feature, simply add the listeners to your producer and consumer factories:
 

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -5,6 +5,13 @@ For changes in earlier version, see <<history>>.
 
 Also see <<new-in-sik>>.
 
+[[x25-factory-listeners]]
+==== Consumer/Producer Factory Changes
+
+The default consumer and producer factories can now invoke a callback whenever a consumer or producer is created or closed.
+Implementations for native Micrometer metrics are provided.
+See <<factory-listeners>> for more information.
+
 [[x25-kafka-client]]
 ==== Kafka Client Version
 


### PR DESCRIPTION
- Refactor `DKPF` so that `CloseSafeProducer` is not aware of whether it is cached
- Add producer and consumer factory listeners
- Add listener implementations for Micrometer