### PR TITLE
Fix commit on assignment for earliest setting

### DIFF
--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -56,6 +56,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetCommitCallback;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -142,7 +143,6 @@ import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 
 import io.micrometer.core.instrument.ImmutableTag;
-import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
@@ -910,12 +910,12 @@ public class EnableKafkaIntegrationTests {
 		@Bean
 		public MeterRegistry meterRegistry() {
 			SimpleMeterRegistry reg = new SimpleMeterRegistry();
-			List<java.util.function.Consumer<Meter>> al =
-					KafkaTestUtils.getPropertyValue(reg, "meterAddedListeners", List.class);
-			List<java.util.function.Consumer<Meter>> rl =
-					KafkaTestUtils.getPropertyValue(reg, "meterRemovedListeners", List.class);
-			al.add(meter -> logger.warn("Added:   " + meter.getId()));
-			rl.add(meter -> logger.warn("Removed: " + meter.getId()));
+//			List<java.util.function.Consumer<Meter>> al =
+//					KafkaTestUtils.getPropertyValue(reg, "meterAddedListeners", List.class);
+//			List<java.util.function.Consumer<Meter>> rl =
+//					KafkaTestUtils.getPropertyValue(reg, "meterRemovedListeners", List.class);
+//			al.add(meter -> logger.warn("Added:   " + meter.getId()));
+//			rl.add(meter -> logger.warn("Removed: " + meter.getId()));
 			return reg;
 		}
 
@@ -1910,21 +1910,24 @@ public class EnableKafkaIntegrationTests {
 			for (int i = 0; i < topicsHeader.size(); i++) {
 				this.latch17.countDown();
 				String inTopic = topicsHeader.get(i);
-				if ("annotated26".equals(inTopic) && consumer.committed(Collections.singleton(
-						new org.apache.kafka.common.TopicPartition(inTopic, partitionsHeader.get(i))))
-							.values()
-							.iterator()
-							.next()
-							.offset() == 1) {
-					this.latch18.countDown();
-				}
-				else if ("annotated27".equals(inTopic) && consumer.committed(Collections.singleton(
-						new org.apache.kafka.common.TopicPartition(inTopic, partitionsHeader.get(i))))
-							.values()
-							.iterator()
-							.next()
-							.offset() == 3) {
-					this.latch18.countDown();
+				Map<org.apache.kafka.common.TopicPartition, OffsetAndMetadata> committed = consumer.committed(
+						Collections.singleton(
+								new org.apache.kafka.common.TopicPartition(inTopic, partitionsHeader.get(i))));
+				if (committed.values().iterator().next() != null) {
+					if ("annotated26".equals(inTopic) && committed
+								.values()
+								.iterator()
+								.next()
+								.offset() == 1) {
+						this.latch18.countDown();
+					}
+					else if ("annotated27".equals(inTopic) && committed
+								.values()
+								.iterator()
+								.next()
+								.offset() == 3) {
+						this.latch18.countDown();
+					}
 				}
 			}
 		}

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -143,6 +143,7 @@ import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 
 import io.micrometer.core.instrument.ImmutableTag;
+import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
@@ -910,12 +911,12 @@ public class EnableKafkaIntegrationTests {
 		@Bean
 		public MeterRegistry meterRegistry() {
 			SimpleMeterRegistry reg = new SimpleMeterRegistry();
-//			List<java.util.function.Consumer<Meter>> al =
-//					KafkaTestUtils.getPropertyValue(reg, "meterAddedListeners", List.class);
-//			List<java.util.function.Consumer<Meter>> rl =
-//					KafkaTestUtils.getPropertyValue(reg, "meterRemovedListeners", List.class);
-//			al.add(meter -> logger.warn("Added:   " + meter.getId()));
-//			rl.add(meter -> logger.warn("Removed: " + meter.getId()));
+			List<java.util.function.Consumer<Meter>> al =
+					KafkaTestUtils.getPropertyValue(reg, "meterAddedListeners", List.class);
+			List<java.util.function.Consumer<Meter>> rl =
+					KafkaTestUtils.getPropertyValue(reg, "meterRemovedListeners", List.class);
+			al.add(meter -> logger.warn("Added:   " + meter.getId()));
+			rl.add(meter -> logger.warn("Removed: " + meter.getId()));
 			return reg;
 		}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerMockTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerMockTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.withSettings;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -497,7 +496,7 @@ public class ConcurrentMessageListenerContainerMockTests {
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
 	void testNoCommitOnAssignmentWithEarliest() throws InterruptedException {
-		Consumer consumer = mock(Consumer.class, withSettings().verboseLogging());
+		Consumer consumer = mock(Consumer.class);
 		ConsumerRecords records = new ConsumerRecords<>(Collections.emptyMap());
 		CountDownLatch latch = new CountDownLatch(1);
 		willAnswer(inv -> {

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerMockTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerMockTests.java
@@ -23,7 +23,9 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.withSettings;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -42,6 +44,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -489,6 +492,40 @@ public class ConcurrentMessageListenerContainerMockTests {
 		finally {
 			container.stop();
 		}
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Test
+	void testNoCommitOnAssignmentWithEarliest() throws InterruptedException {
+		Consumer consumer = mock(Consumer.class, withSettings().verboseLogging());
+		ConsumerRecords records = new ConsumerRecords<>(Collections.emptyMap());
+		CountDownLatch latch = new CountDownLatch(1);
+		willAnswer(inv -> {
+			latch.countDown();
+			Thread.sleep(50);
+			return records;
+		}).given(consumer).poll(any());
+		TopicPartition tp0 = new TopicPartition("foo", 0);
+		List<TopicPartition> assignments = Arrays.asList(tp0);
+		willAnswer(invocation -> {
+			((ConsumerRebalanceListener) invocation.getArgument(1))
+				.onPartitionsAssigned(assignments);
+			return null;
+		}).given(consumer).subscribe(any(Collection.class), any());
+		ConsumerFactory cf = mock(ConsumerFactory.class);
+		given(cf.createConsumer(any(), any(), any(), any())).willReturn(consumer);
+		given(cf.getConfigurationProperties())
+				.willReturn(Collections.singletonMap(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest"));
+		ContainerProperties containerProperties = new ContainerProperties("foo");
+		containerProperties.setGroupId("grp");
+		containerProperties.setMessageListener((MessageListener) rec -> { });
+		containerProperties.setMissingTopicsFatal(false);
+		containerProperties.setAssignmentCommitOption(AssignmentCommitOption.LATEST_ONLY);
+		ConcurrentMessageListenerContainer container = new ConcurrentMessageListenerContainer(cf,
+				containerProperties);
+		container.start();
+		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+		verify(consumer, never()).commitSync(any(), any());
 	}
 
 	public static class TestMessageListener1 implements MessageListener<String, String>, ConsumerSeekAware {


### PR DESCRIPTION
Commit on assignment should not occur when `auto.offset.reset` is `earliest`
when assigment option is not `ALWAYS`.

The code did not consult the factory configuration, just the container
properties.

Work around is to set it on the container properties.

**cherry-pick to 2.4.x, 2.3.x**