### PR TITLE
GH-1475: Add KafkaSendCallback

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaFailureCallback.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaFailureCallback.java
@@ -26,8 +26,10 @@ import org.springframework.util.concurrent.FailureCallback;
  * @param <V> the value type.
  *
  * @author Gary Russell
+ * @since 2.5
  *
  */
+@FunctionalInterface
 public interface KafkaFailureCallback<K, V> extends FailureCallback {
 
 	@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaFailureCallback.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaFailureCallback.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.core;
+
+import org.springframework.util.concurrent.FailureCallback;
+
+/**
+ * An enhanced {@link FailureCallback} for reporting
+ * {@link KafkaProducerException}s.
+ *
+ * @param <K> the key type.
+ * @param <V> the value type.
+ *
+ * @author Gary Russell
+ *
+ */
+public interface KafkaFailureCallback<K, V> extends FailureCallback {
+
+	@Override
+	default void onFailure(Throwable ex) {
+		onFailure((KafkaProducerException) ex);
+	}
+
+	/**
+	 * Called when the send fails.
+	 * @param ex the exception.
+	 */
+	void onFailure(KafkaProducerException ex);
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaProducerException.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaProducerException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,13 +31,37 @@ public class KafkaProducerException extends KafkaException {
 
 	private final ProducerRecord<?, ?> producerRecord;
 
+	/**
+	 * Construct an instance with the provided properties.
+	 * @param failedProducerRecord the producer record.
+	 * @param message the message.
+	 * @param cause the cause.
+	 */
 	public KafkaProducerException(ProducerRecord<?, ?> failedProducerRecord, String message, Throwable cause) {
 		super(message, cause);
 		this.producerRecord = failedProducerRecord;
 	}
 
+	/**
+	 * Return the failed producer record.
+	 * @return the record.
+	 * @deprecated in favor of {@link #getFailedProducerRecord()}
+	 */
+	@Deprecated
 	public ProducerRecord<?, ?> getProducerRecord() {
 		return this.producerRecord;
+	}
+
+	/**
+	 * Return the failed producer record.
+	 * @param <K> the key type.
+	 * @param <V> the value type.
+	 * @return the record.
+	 * @since 2.5
+	 */
+	@SuppressWarnings("unchecked")
+	public <K, V> ProducerRecord<K, V> getFailedProducerRecord() {
+		return (ProducerRecord<K, V>) producerRecord;
 	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaSendCallback.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaSendCallback.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.core;
+
+import org.springframework.kafka.support.SendResult;
+import org.springframework.util.concurrent.ListenableFutureCallback;
+
+/**
+ * An enhanced {@link ListenableFutureCallback} for reporting
+ * {@link KafkaProducerException}s.
+ *
+ * @param <K> the key type.
+ * @param <V> the value type.
+ *
+ * @author Gary Russell
+ * @since 2.5
+ *
+ */
+public interface KafkaSendCallback<K, V> extends ListenableFutureCallback<SendResult<K, V>>, KafkaFailureCallback<K, V> {
+
+}

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -315,9 +315,47 @@ future.addCallback(new ListenableFutureCallback<SendResult<Integer, String>>() {
 `SendResult` has two properties, a `ProducerRecord` and `RecordMetadata`.
 See the Kafka API documentation for information about those objects.
 
-The `Throwable` in `onFailure` can be cast to a `KafkaProducerException`; its `producerRecord` property contains the failed record.
+The `Throwable` in `onFailure` can be cast to a `KafkaProducerException`; its `failedProducerRecord` property contains the failed record.
 
-If you wish to block the sending thread to await the result, you can invoke the future's `get()` method.
+Starting with version 2.5, you can use a `KafkaSendCallback` instead of a `ListenableFutureCallback`, making it easier to extract the failed `ProducerRecord`, avoiding the need to cast the `Throwable`:
+
+====
+[source, java]
+----
+ListenableFuture<SendResult<Integer, String>> future = template.send("topic", 1, "thing");
+future.addCallback(new KafkaSendCallback<Integer, String>() {
+
+    @Override
+    public void onSuccess(SendResult<Integer, String> result) {
+        ...
+    }
+
+    @Override
+    public void onFailure(KafkaProducerException ex) {
+        ProducerRecord<Integer, String> failed = ex.getFailedProducerRecord();
+        ...
+    }
+
+});
+----
+====
+
+You can also use a pair of lambdas:
+
+====
+[source, java]
+----
+ListenableFuture<SendResult<Integer, String>> future = template.send("topic", 1, "thing");
+future.addCallback(result -> {
+        ...
+    }, (KafkaFailureCallback<Integer, String>) ex -> {
+            ProducerRecord<Integer, String> failed = ex.getFailedProducerRecord();
+            ...
+    });
+----
+====
+
+If you wish to block the sending thread to await the result, you can invoke the future's `get()` method; using the method with a timeout is recommended.
 You may wish to invoke `flush()` before waiting or, for convenience, the template has a constructor with an `autoFlush` parameter that causes the template to `flush()` on each send.
 Flushing is only needed if you have set the `linger.ms` producer property and want to immediately send a partial batch.
 
@@ -333,7 +371,7 @@ public void sendToKafka(final MyOutputData data) {
     final ProducerRecord<String, String> record = createRecord(data);
 
     ListenableFuture<SendResult<Integer, String>> future = template.send(record);
-    future.addCallback(new ListenableFutureCallback<SendResult<Integer, String>>() {
+    future.addCallback(new KafkaSendCallback<SendResult<Integer, String>>() {
 
         @Override
         public void onSuccess(SendResult<Integer, String> result) {
@@ -341,7 +379,7 @@ public void sendToKafka(final MyOutputData data) {
         }
 
         @Override
-        public void onFailure(Throwable ex) {
+        public void onFailure(KafkaProducerException ex) {
             handleFailure(data, record, ex);
         }
 
@@ -369,6 +407,8 @@ public void sendToKafka(final MyOutputData data) {
 ----
 ====
 
+Note that the cause of the `ExecutionException` is `KafkaProducerException` with the `failedProducerRecord` property.
+
 [[routing-template]]
 ===== Using `RoutingKafkaTemplate`
 
@@ -387,33 +427,33 @@ The following simple Spring Boot application provides an example of how to use t
 @SpringBootApplication
 public class Application {
 
-	public static void main(String[] args) {
-		SpringApplication.run(Application.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+    }
 
-	@Bean
-	public RoutingKafkaTemplate routingTemplate(GenericApplicationContext context,
-			ProducerFactory<Object, Object> pf) {
+    @Bean
+    public RoutingKafkaTemplate routingTemplate(GenericApplicationContext context,
+            ProducerFactory<Object, Object> pf) {
 
-		// Clone the PF with a different Serializer, register with Spring for shutdown
-		Map<String, Object> configs = new HashMap<>(pf.getConfigurationProperties());
-		configs.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
-		DefaultKafkaProducerFactory<Object, Object> bytesPF = new DefaultKafkaProducerFactory<>(configs);
-		context.registerBean(DefaultKafkaProducerFactory.class, "bytesPF", bytesPF);
+        // Clone the PF with a different Serializer, register with Spring for shutdown
+        Map<String, Object> configs = new HashMap<>(pf.getConfigurationProperties());
+        configs.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class);
+        DefaultKafkaProducerFactory<Object, Object> bytesPF = new DefaultKafkaProducerFactory<>(configs);
+        context.registerBean(DefaultKafkaProducerFactory.class, "bytesPF", bytesPF);
 
-		Map<Pattern, ProducerFactory<Object, Object>> map = new LinkedHashMap<>();
-		map.put(Pattern.compile("two"), bytesPF);
-		map.put(Pattern.compile(".+"), pf); // Default PF with StringSerializer
-		return new RoutingKafkaTemplate(map);
-	}
+        Map<Pattern, ProducerFactory<Object, Object>> map = new LinkedHashMap<>();
+        map.put(Pattern.compile("two"), bytesPF);
+        map.put(Pattern.compile(".+"), pf); // Default PF with StringSerializer
+        return new RoutingKafkaTemplate(map);
+    }
 
-	@Bean
-	public ApplicationRunner runner(RoutingKafkaTemplate routingTemplate) {
-		return args -> {
-			routingTemplate.send("one", "thing1");
-			routingTemplate.send("two", "thing2".getBytes());
-		};
-	}
+    @Bean
+    public ApplicationRunner runner(RoutingKafkaTemplate routingTemplate) {
+        return args -> {
+            routingTemplate.send("one", "thing1");
+            routingTemplate.send("two", "thing2".getBytes());
+        };
+    }
 
 }
 ----
@@ -2577,9 +2617,9 @@ public class MyListener extends AbstractConsumerSeekAware {
 ...
 
     @Override
-	public void onPartitionsAssigned(Map<TopicPartition, Long> assignments, ConsumerSeekCallback callback) {
-		callback.seekToBeginning(assignments.keySet());
-	}
+    public void onPartitionsAssigned(Map<TopicPartition, Long> assignments, ConsumerSeekCallback callback) {
+        callback.seekToBeginning(assignments.keySet());
+    }
 
 }
 ----
@@ -2638,10 +2678,10 @@ class Listener implements ConsumerSeekAware {
     }
 
     @Override
-	public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
-		partitions.forEach(tp -> this.callbacks.remove(tp));
-		this.callbackForThread.remove();
-	}
+    public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
+        partitions.forEach(tp -> this.callbacks.remove(tp));
+        this.callbackForThread.remove();
+    }
 
     @Override
     public void onIdleContainer(Map<TopicPartition, Long> assignments, ConsumerSeekCallback callback) {
@@ -2844,10 +2884,10 @@ The consumer/producer `id` passed to the listener is added to the meter's tags w
 [source, java]
 ----
 double count =this.meterRegistry.get("kafka.producer.node.incoming.byte.total")
-				.tag("customTag", "customTagValue")
-				.tag("spring.id", "myProducerFactory.myClientId-1")
-				.functionCounter()
-				.count()
+                .tag("customTag", "customTagValue")
+                .tag("spring.id", "myProducerFactory.myClientId-1")
+                .functionCounter()
+                .count()
 ----
 ====
 
@@ -3392,15 +3432,15 @@ This information can be used by `ParseStringDeserializer` on the receiving side.
 [source, java]
 ----
 ParseStringDeserializer<Object> deserializer = new ParseStringDeserializer<>((str, headers) -> {
-	byte[] header = headers.lastHeader(ToStringSerializer.VALUE_TYPE).value();
-	String entityType = new String(header);
+    byte[] header = headers.lastHeader(ToStringSerializer.VALUE_TYPE).value();
+    String entityType = new String(header);
 
-	if (entityType.contains("Thing")) {
-		return Thing.parse(str);
-	}
-	else {
-		// ...parsing logic
-	}
+    if (entityType.contains("Thing")) {
+        return Thing.parse(str);
+    }
+    else {
+        // ...parsing logic
+    }
 });
 ----
 ====

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -73,6 +73,9 @@ See <<kafka-template>> for more information.
 A `RoutingKafkaTemplate` has now been provided.
 See <<routing-template>> for more information.
 
+You can now use `KafkaSendCallback` instead of `ListenerFutureCallback` to get a narrower exception, making it easier to extract the failed `ProducerRecord`.
+See <<kafka-template>> for more information.
+
 [[x25-string-serializer]]
 ==== Kafka String Serializer/Deserializer
 


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1475

Add `onFailure` with a narrowed `Throwable` to make it easier to access
the failed producer record.