### PR TITLE
GH-1479: ConsumerRecordMetadata

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/AdapterUtils.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/AdapterUtils.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener.adapter;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.TopicPartition;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Utilities for listener adapters.
+ *
+ * @author Gary Russell
+ * @since 2.5
+ *
+ */
+public final class AdapterUtils {
+
+	private AdapterUtils() {
+	}
+
+	/**
+	 * Build a {@link ConsumerRecordMetadata} from the first {@link ConsumerRecord} in data, if any.
+	 * @param data the data array.
+	 * @return the metadata or null if data does not contain a {@link ConsumerRecord}.
+	 */
+	@Nullable
+	public static Object buildConsumerRecordMetadataFromArray(Object... data) {
+		for (Object object : data) {
+			ConsumerRecordMetadata metadata = buildConsumerRecordMetadata(object);
+			if (metadata != null) {
+				return metadata;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Build a {@link ConsumerRecordMetadata} from data which must be a
+	 * {@link ConsumerRecord}.
+	 * @param data the record.
+	 * @return the metadata or null if data is not a {@link ConsumerRecord}.
+	 */
+	@Nullable
+	public static ConsumerRecordMetadata buildConsumerRecordMetadata(Object data) {
+		if (!(data instanceof ConsumerRecord)) {
+			return null;
+		}
+		ConsumerRecord<?, ?> record = (ConsumerRecord<?, ?>) data;
+		return new ConsumerRecordMetadata(new RecordMetadata(new TopicPartition(record.topic(), record.partition()),
+				0, record.offset(), record.timestamp(), null, record.serializedKeySize(),
+				record.serializedValueSize()), record.timestampType());
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/ConsumerRecordMetadata.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/ConsumerRecordMetadata.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener.adapter;
+
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.record.TimestampType;
+
+/**
+ * Used to provide a listener method argument when the user supplies such a parameter.
+ * Delegates to {@link RecordMetadata} (which is final, hence no subclass) for all except
+ * timestamp type.
+ *
+ * @author Gary Russell
+ * @since 2.5
+ *
+ */
+public class ConsumerRecordMetadata {
+
+	private final RecordMetadata delegate;
+
+	private final TimestampType timestampType;
+
+	public ConsumerRecordMetadata(RecordMetadata delegate, TimestampType timestampType) {
+		this.delegate = delegate;
+		this.timestampType = timestampType;
+	}
+
+	public boolean hasOffset() {
+		return this.delegate.hasOffset();
+	}
+
+	public long offset() {
+		return this.delegate.offset();
+	}
+
+	public boolean hasTimestamp() {
+		return this.delegate.hasTimestamp();
+	}
+
+	public long timestamp() {
+		return this.delegate.timestamp();
+	}
+
+	public int serializedKeySize() {
+		return this.delegate.serializedKeySize();
+	}
+
+	public int serializedValueSize() {
+		return this.delegate.serializedValueSize();
+	}
+
+	public String topic() {
+		return this.delegate.topic();
+	}
+
+	public int partition() {
+		return this.delegate.partition();
+	}
+
+	public TimestampType timestampType() {
+		return this.timestampType;
+	}
+
+	@Override
+	public int hashCode() {
+		return this.delegate.hashCode() + this.timestampType.name().hashCode();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof ConsumerRecordMetadata)) {
+			return false;
+		}
+		return this.delegate.equals(obj)
+				&& this.timestampType.equals(((ConsumerRecordMetadata) obj).timestampType());
+	}
+
+	@Override
+	public String toString() {
+		return this.delegate.toString();
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/DelegatingInvocableHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/DelegatingInvocableHandler.java
@@ -126,7 +126,9 @@ public class DelegatingInvocableHandler {
 			@Nullable BeanFactory beanFactory) {
 
 		this.handlers = new ArrayList<>();
-		checkMetadata(handlers);
+		for (InvocableHandlerMethod handler : handlers) {
+			this.handlers.add(wrapIfNecessary(handler));
+		}
 		this.defaultHandler = wrapIfNecessary(defaultHandler);
 		this.bean = bean;
 		this.resolver = beanExpressionResolver;
@@ -134,12 +136,6 @@ public class DelegatingInvocableHandler {
 		this.beanFactory = beanFactory instanceof ConfigurableListableBeanFactory
 				? (ConfigurableListableBeanFactory) beanFactory
 				: null;
-	}
-
-	private void checkMetadata(List<InvocableHandlerMethod> methodHandlers) {
-		for (InvocableHandlerMethod handler : methodHandlers) {
-			this.handlers.add(wrapIfNecessary(handler));
-		}
 	}
 
 	private InvocableHandlerMethod wrapIfNecessary(InvocableHandlerMethod handler) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/DelegatingInvocableHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/DelegatingInvocableHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.kafka.listener.adapter;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -40,6 +41,7 @@ import org.springframework.kafka.KafkaException;
 import org.springframework.kafka.support.KafkaUtils;
 import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.HandlerMethod;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
@@ -123,14 +125,34 @@ public class DelegatingInvocableHandler {
 			Object bean, BeanExpressionResolver beanExpressionResolver, BeanExpressionContext beanExpressionContext,
 			@Nullable BeanFactory beanFactory) {
 
-		this.handlers = new ArrayList<>(handlers);
-		this.defaultHandler = defaultHandler;
+		this.handlers = new ArrayList<>();
+		checkMetadata(handlers);
+		this.defaultHandler = wrapIfNecessary(defaultHandler);
 		this.bean = bean;
 		this.resolver = beanExpressionResolver;
 		this.beanExpressionContext = beanExpressionContext;
 		this.beanFactory = beanFactory instanceof ConfigurableListableBeanFactory
 				? (ConfigurableListableBeanFactory) beanFactory
 				: null;
+	}
+
+	private void checkMetadata(List<InvocableHandlerMethod> methodHandlers) {
+		for (InvocableHandlerMethod handler : methodHandlers) {
+			this.handlers.add(wrapIfNecessary(handler));
+		}
+	}
+
+	private InvocableHandlerMethod wrapIfNecessary(InvocableHandlerMethod handler) {
+		if (handler == null) {
+			return null;
+		}
+		Parameter[] parameters = handler.getMethod().getParameters();
+		for (Parameter parameter : parameters) {
+			if (parameter.getType().equals(ConsumerRecordMetadata.class)) {
+				return new DelegatingInvocableHandler.MetadataAwareInvocableHandlerMethod(handler);
+			}
+		}
+		return handler;
 	}
 
 	/**
@@ -152,7 +174,16 @@ public class DelegatingInvocableHandler {
 	public Object invoke(Message<?> message, Object... providedArgs) throws Exception { //NOSONAR
 		Class<? extends Object> payloadClass = message.getPayload().getClass();
 		InvocableHandlerMethod handler = getHandlerForPayload(payloadClass);
-		Object result = handler.invoke(message, providedArgs);
+		Object result;
+		if (handler instanceof MetadataAwareInvocableHandlerMethod) {
+			Object[] args = new Object[providedArgs.length + 1];
+			args[0] = AdapterUtils.buildConsumerRecordMetadataFromArray(providedArgs);
+			System.arraycopy(providedArgs, 0, args, 1, providedArgs.length);
+			result = handler.invoke(message, args);
+		}
+		else {
+			result = handler.invoke(message, providedArgs);
+		}
 		Expression replyTo = this.handlerSendTo.get(handler);
 		return new InvocationResult(result, replyTo, this.handlerReturnsMessage.get(handler));
 	}
@@ -282,6 +313,19 @@ public class DelegatingInvocableHandler {
 
 	public boolean hasDefaultHandler() {
 		return this.defaultHandler != null;
+	}
+
+	/**
+	 * A handler method that is aware of {@link ConsumerRecordMetadata}.
+	 *
+	 * @since 2.5
+	 */
+	private static final class MetadataAwareInvocableHandlerMethod extends InvocableHandlerMethod {
+
+		MetadataAwareInvocableHandlerMethod(HandlerMethod handlerMethod) {
+			super(handlerMethod);
+		}
+
 	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
@@ -120,6 +120,8 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 
 	private boolean hasAckParameter;
 
+	private boolean hasMetadataParameter;
+
 	private boolean messageReturnType;
 
 	private ReplyHeadersConfigurer replyHeadersConfigurer;
@@ -324,7 +326,13 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 				return this.handlerMethod.invoke(message, acknowledgment, consumer);
 			}
 			else {
-				return this.handlerMethod.invoke(message, data, acknowledgment, consumer);
+				if (this.hasMetadataParameter) {
+					return this.handlerMethod.invoke(message, data, acknowledgment, consumer,
+							AdapterUtils.buildConsumerRecordMetadata(data));
+				}
+				else {
+					return this.handlerMethod.invoke(message, data, acknowledgment, consumer);
+				}
 			}
 		}
 		catch (org.springframework.messaging.converter.MessageConversionException ex) {
@@ -562,6 +570,9 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 			isNotConvertible |= isAck;
 			boolean isConsumer = parameterIsType(parameterType, Consumer.class);
 			isNotConvertible |= isConsumer;
+			boolean isMeta = parameterIsType(parameterType, ConsumerRecordMetadata.class);
+			this.hasMetadataParameter |= isMeta;
+			isNotConvertible |= isMeta;
 			if (isNotConvertible) {
 				notConvertibleParameters++;
 			}

--- a/spring-kafka/src/test/java/org/springframework/kafka/config/RecordMessagingMessageListenerAdapterTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/config/RecordMessagingMessageListenerAdapterTests.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.record.TimestampType;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.format.support.DefaultFormattingConversionService;
+import org.springframework.kafka.listener.adapter.ConsumerRecordMetadata;
+import org.springframework.kafka.listener.adapter.RecordMessagingMessageListenerAdapter;
+import org.springframework.messaging.converter.GenericMessageConverter;
+import org.springframework.messaging.handler.annotation.support.DefaultMessageHandlerMethodFactory;
+import org.springframework.messaging.handler.annotation.support.MessageHandlerMethodFactory;
+
+/**
+ * @author Gary Russell
+ * @since 2.5
+ *
+ */
+public class RecordMessagingMessageListenerAdapterTests {
+
+	@Test
+	void testMetaString() throws Exception {
+		Method method = TestClass.class.getDeclaredMethod("listen", String.class, ConsumerRecordMetadata.class);
+		TestClass bean = new TestClass();
+		MethodKafkaListenerEndpoint<Object, Object> endpoint = new MethodKafkaListenerEndpoint<>();
+		endpoint.setBean(bean);
+		endpoint.setMethod(method);
+		endpoint.setMessageHandlerMethodFactory(messageHandlerFactory());
+		RecordMessagingMessageListenerAdapter<Object, Object> adapter =
+				(RecordMessagingMessageListenerAdapter<Object, Object>) endpoint.createMessageListener(null, null);
+		ConsumerRecord<Object, Object> record = new ConsumerRecord<>("topic", 0, 42L, 43L, TimestampType.CREATE_TIME,
+				0L, 44, 45, null, "foo");
+		adapter.onMessage(record, null, null);
+		assertThat(bean.string).isEqualTo("foo");
+		assertThat(bean.metadata.topic()).isEqualTo(record.topic());
+		assertThat(bean.metadata.partition()).isEqualTo(record.partition());
+		assertThat(bean.metadata.offset()).isEqualTo(record.offset());
+		assertThat(bean.metadata.serializedKeySize()).isEqualTo(record.serializedKeySize());
+		assertThat(bean.metadata.serializedValueSize()).isEqualTo(record.serializedValueSize());
+		assertThat(bean.metadata.timestamp()).isEqualTo(record.timestamp());
+		assertThat(bean.metadata.timestampType()).isEqualTo(record.timestampType());
+	}
+
+	@Test
+	void testMultiMetaString() {
+		Method[] declaredMethods = TestMultiClass.class.getDeclaredMethods();
+		Method defMethod = null;
+		List<Method> methods = new ArrayList<>();
+		for (Method method : declaredMethods) {
+			if (method.getName().equals("defListen")) {
+				defMethod = method;
+			}
+			methods.add(method);
+		}
+		TestMultiClass bean = new TestMultiClass();
+		MultiMethodKafkaListenerEndpoint<Object, Object> endpoint = new MultiMethodKafkaListenerEndpoint<>(methods,
+				defMethod, bean);
+		endpoint.setMessageHandlerMethodFactory(messageHandlerFactory());
+		RecordMessagingMessageListenerAdapter<Object, Object> adapter =
+				(RecordMessagingMessageListenerAdapter<Object, Object>) endpoint.createMessageListener(null, null);
+		adapter.onMessage(new ConsumerRecord<>("topic", 0, 0L, null, 42), null, null);
+		assertThat(bean.value).isEqualTo(42);
+		ConsumerRecord<Object, Object> record = new ConsumerRecord<>("topic", 0, 42L, 43L, TimestampType.CREATE_TIME,
+				0L, 44, 45, null, "foo");
+		adapter.onMessage(record, null, null);
+		assertThat(bean.string).isEqualTo("foo");
+		assertThat(bean.metadata.topic()).isEqualTo(record.topic());
+		assertThat(bean.metadata.partition()).isEqualTo(record.partition());
+		assertThat(bean.metadata.offset()).isEqualTo(record.offset());
+		assertThat(bean.metadata.serializedKeySize()).isEqualTo(record.serializedKeySize());
+		assertThat(bean.metadata.serializedValueSize()).isEqualTo(record.serializedValueSize());
+		assertThat(bean.metadata.timestamp()).isEqualTo(record.timestamp());
+		assertThat(bean.metadata.timestampType()).isEqualTo(record.timestampType());
+	}
+
+	private MessageHandlerMethodFactory messageHandlerFactory() {
+		DefaultMessageHandlerMethodFactory defaultFactory = new DefaultMessageHandlerMethodFactory();
+		DefaultFormattingConversionService cs = new DefaultFormattingConversionService();
+		defaultFactory.setConversionService(cs);
+		GenericMessageConverter messageConverter = new GenericMessageConverter(cs);
+		defaultFactory.setMessageConverter(messageConverter);
+		defaultFactory.afterPropertiesSet();
+		return defaultFactory;
+	}
+
+	public static class TestClass {
+
+		String string;
+
+		ConsumerRecordMetadata metadata;
+
+		public void listen(String str, ConsumerRecordMetadata meta) {
+			this.string = str;
+			this.metadata = meta;
+		}
+
+	}
+
+	public static class TestMultiClass {
+
+		int value;
+
+		String string;
+
+		ConsumerRecordMetadata metadata;
+
+		public void listen(Integer value) {
+			this.value = value;
+		}
+
+		public void defListen(String str, ConsumerRecordMetadata meta) {
+			this.string = str;
+			this.metadata = meta;
+		}
+
+	}
+
+}

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -1241,7 +1241,10 @@ public void listen(String data, Acknowledgment ack) {
 ----
 ====
 
-Finally, metadata about the message is available from message headers.
+[[consumer-record-metadata]]
+====== Consumer Record Metadata
+
+Finally, metadata about the record is available from message headers.
 You can use the following header names to retrieve the headers of the message:
 
 * `KafkaHeaders.OFFSET`
@@ -1270,6 +1273,20 @@ public void listen(@Payload String foo,
 }
 ----
 ====
+
+Starting with version 2.5, instead of using discrete headers, you can receive record metadata in a `ConsumerRecordMetadata` parameter.
+
+====
+[source, java]
+----
+@KafkaListener(...)
+public void listen(String str, ConsumerRecordMetadata meta) {
+    ...
+}
+----
+====
+
+This contains all the data from the `ConsumerRecord` except the key and value.
 
 [[batch-listeners]]
 ====== Batch listeners
@@ -1606,6 +1623,24 @@ At most, one method can be so designated.
 When using `@KafkaHandler` methods, the payload must have already been converted to the domain object (so the match can be performed).
 Use a custom deserializer, the `JsonDeserializer`, or the `JsonMessageConverter` with its `TypePrecedence` set to `TYPE_ID`.
 See <<serdes>> for more information.
+
+IMPORTANT: Due to some limitations in the way Spring resolves method arguments, a default `@KafkaHandler` cannot receive discrete headers; it must use the `ConsumerRecordMetadata` as discussed in <<consumer-record-metadata>>.
+
+For example:
+
+====
+[source, java]
+----
+@KafkaHandler(isDefault = true)
+public void listenDefault(Object object, @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
+    ...
+}
+----
+====
+
+This won't work if the object is a `String`; the `topic` parameter will also get a reference to `object`.
+
+If you need metadata about the record in a default method, use this
 
 [[kafkalistener-lifecycle]]
 ===== `@KafkaListener` Lifecycle Management

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -38,6 +38,9 @@ See <<reply-message>> for more information.
 
 The `KafkaHeaders.RECEIVED_MESSAGE_KEY` is no longer populated with a `null` value when the incoming record has a `null` key; the header is omitted altogether.
 
+`@KafkaListener` methods can now specify a `ConsumerRecordMetadata` parameter instead of using discrete headers for metadata such as topic, partition, etc.
+See <<consumer-record-metadata>> for more information.
+
 [[x25-container]]
 ==== Listener Container Changes
 


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1479

Because we pass the payload in as a discrete argument, standard headers
such as `RECEIVED_TOPIC` will get the payload value if it's a String.
See https://github.com/spring-projects/spring-framework/issues/25033

Provide a mechanism to get the record metadata as a parameter instead.
Make this available in all listeners for consistency.