### PR TITLE
let the suffix "" when concurrency is 1

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
@@ -181,7 +181,11 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 				if (getApplicationEventPublisher() != null) {
 					container.setApplicationEventPublisher(getApplicationEventPublisher());
 				}
-				container.setClientIdSuffix("-" + i);
+				if(this.concurrency == 1){
+				    container.setClientIdSuffix("");
+				} else {
+				    container.setClientIdSuffix("-" + i);
+				}
 				container.setGenericErrorHandler(getGenericErrorHandler());
 				container.setAfterRollbackProcessor(getAfterRollbackProcessor());
 				container.setRecordInterceptor(getRecordInterceptor());


### PR DESCRIPTION
when concurrency=1, do not  add suffix to clientId in a container.
the situation is that,when enable the  kafka's ACL and the clientId  produced by app automatic  and  only one partition in kafka topic，
add the suffix can result the wrong clientid,so when concurrency=1, just let the suffix "".