### PR TITLE
GH-1487: @KafkaListener Meta-Annotation on Class

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
@@ -313,7 +313,7 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 	 */
 	private Collection<KafkaListener> findListenerAnnotations(Class<?> clazz) {
 		Set<KafkaListener> listeners = new HashSet<>();
-		KafkaListener ann = AnnotationUtils.findAnnotation(clazz, KafkaListener.class);
+		KafkaListener ann = AnnotatedElementUtils.findMergedAnnotation(clazz, KafkaListener.class);
 		if (ann != null) {
 			listeners.add(ann);
 		}

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/AliasPropertiesTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/AliasPropertiesTests.java
@@ -32,6 +32,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.AliasFor;
+import org.springframework.kafka.annotation.AliasPropertiesTests.Config.ClassLevelListener;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.config.KafkaListenerConfigUtils;
 import org.springframework.kafka.config.KafkaListenerContainerFactory;
@@ -42,6 +43,7 @@ import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.stereotype.Component;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
@@ -65,11 +67,15 @@ public class AliasPropertiesTests {
 	@Autowired
 	private KafkaListenerEndpointRegistry kafkaListenerEndpointRegistry;
 
+	@Autowired
+	private ClassLevelListener classLevel;
+
 	@Test
 	public void testAliasFor() throws Exception {
 		this.template.send("alias.tests", "foo");
 		assertThat(this.config.latch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(this.config.kafkaListenerEndpointRegistry()).isSameAs(this.kafkaListenerEndpointRegistry);
+		assertThat(this.classLevel.latch.await(10, TimeUnit.SECONDS)).isTrue();
 	}
 
 	@Configuration
@@ -123,17 +129,33 @@ public class AliasPropertiesTests {
 			return KafkaTestUtils.producerProps(embeddedKafka());
 		}
 
-		@MyListener("alias.tests")
+		@MyListener(id = "onMethod", value = "alias.tests")
 		public void listen1(String in) {
-			latch.countDown();
+			this.latch.countDown();
+		}
+
+		@Component
+		@MyListener(id = "onClass", value = "alias.tests")
+		public static class ClassLevelListener {
+
+			private final CountDownLatch latch = new CountDownLatch(1);
+
+			@KafkaHandler
+			void listen(String in) {
+				this.latch.countDown();
+			}
+
 		}
 
 	}
 
-	@Target(ElementType.METHOD)
+	@Target({ ElementType.METHOD, ElementType.TYPE })
 	@Retention(RetentionPolicy.RUNTIME)
 	@KafkaListener
 	public @interface MyListener {
+
+		@AliasFor(annotation = KafkaListener.class, attribute = "id")
+		String id() default "";
 
 		@AliasFor(annotation = KafkaListener.class, attribute = "topics")
 		String[] value();


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1487

A meta-annotated annotation did not work at the class level.

**cherry-pick to 2.4.x, 2.3.x, 2.2.x**