### PR TITLE
Delegating(De)Serializer Improvements

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,10 +18,16 @@ package org.springframework.kafka.support.serializer;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
+import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
 
+import org.springframework.core.log.LogAccessor;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
@@ -29,13 +35,16 @@ import org.springframework.util.StringUtils;
 
 /**
  * A {@link Serializer} that delegates to other serializers based on a serialization
- * selector header.
+ * selector header. If the header is missing, and the type is supported by {@link Serdes}
+ * we will delegate to that serializer type.
  *
  * @author Gary Russell
  * @since 2.3
  *
  */
 public class DelegatingSerializer implements Serializer<Object> {
+
+	private static final LogAccessor LOGGER = new LogAccessor(DelegatingDeserializer.class);
 
 	/**
 	 * Name of the header containing the serialization selector.
@@ -48,7 +57,11 @@ public class DelegatingSerializer implements Serializer<Object> {
 	 */
 	public static final String SERIALIZATION_SELECTOR_CONFIG = "spring.kafka.serialization.selector.config";
 
-	private final Map<String, Serializer<?>> delegates = new HashMap<>();
+	private final Map<String, Serializer<?>> delegates = new ConcurrentHashMap<>();
+
+	private final Map<String, Object> autoConfigs = new HashMap<>();
+
+	private boolean forKeys;
 
 	/**
 	 * Construct an instance that will be configured in {@link #configure(Map, boolean)}
@@ -61,7 +74,8 @@ public class DelegatingSerializer implements Serializer<Object> {
 	/**
 	 * Construct an instance with the supplied mapping of selectors to delegate
 	 * serializers. The selector must be supplied in the
-	 * {@link DelegatingSerializer#SERIALIZATION_SELECTOR} header.
+	 * {@link DelegatingSerializer#SERIALIZATION_SELECTOR} header. It is not necessary to
+	 * configure standard serializers supported by {@link Serdes}.
 	 * @param delegates the map of delegates.
 	 */
 	public DelegatingSerializer(Map<String, Serializer<?>> delegates) {
@@ -71,6 +85,8 @@ public class DelegatingSerializer implements Serializer<Object> {
 	@SuppressWarnings("unchecked")
 	@Override
 	public void configure(Map<String, ?> configs, boolean isKey) {
+		this.autoConfigs.putAll(configs);
+		this.forKeys = isKey;
 		Object value = configs.get(SERIALIZATION_SELECTOR_CONFIG);
 		if (value == null) {
 			return;
@@ -156,9 +172,24 @@ public class DelegatingSerializer implements Serializer<Object> {
 
 	@Override
 	public byte[] serialize(String topic, Headers headers, Object data) {
-		byte[] value = headers.lastHeader(SERIALIZATION_SELECTOR).value();
+		byte[] value = null;
+		Header header = headers.lastHeader(SERIALIZATION_SELECTOR);
+		if (header != null) {
+			value = header.value();
+		}
 		if (value == null) {
-			throw new IllegalStateException("No '" + SERIALIZATION_SELECTOR + "' header present");
+			value = trySerdes(data);
+			if (value == null) {
+				throw new IllegalStateException("No '" + SERIALIZATION_SELECTOR
+						+ "' header present and type (" + data.getClass().getName()
+						+ ") is not supported by Serdes");
+			}
+			try {
+				headers.add(new RecordHeader(SERIALIZATION_SELECTOR, value));
+			}
+			catch (IllegalStateException e) {
+				LOGGER.debug(e, () -> "Could not set header for type " + data.getClass());
+			}
 		}
 		String selector = new String(value).replaceAll("\"", "");
 		@SuppressWarnings("unchecked")
@@ -168,6 +199,24 @@ public class DelegatingSerializer implements Serializer<Object> {
 					"No serializer found for '" + SERIALIZATION_SELECTOR + "' header with value '" + selector + "'");
 		}
 		return serializer.serialize(topic, headers, data);
+	}
+
+	/*
+	 * Package for testing.
+	 */
+	@Nullable
+	byte[] trySerdes(Object data) {
+		try {
+			Serde<? extends Object> serdeFrom = Serdes.serdeFrom(data.getClass());
+			Serializer<?> serializer = serdeFrom.serializer();
+			serializer.configure(this.autoConfigs, this.forKeys);
+			String key = data.getClass().getName();
+			this.delegates.put(key, serializer);
+			return key.getBytes();
+		}
+		catch (IllegalStateException e) {
+			return null;
+		}
 	}
 
 	@Override

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -3748,6 +3748,10 @@ Producers would then set the `DelegatingSerializer.SERIALIZATION_SELECTOR` heade
 
 This technique supports sending different types to the same topic (or different topics).
 
+NOTE: Starting with version 2.5.1, it is not necessary to set the header if the type (key or value) is one of the standard types supported by `Serdes` (`Long`, `Integer`, etc).
+Instead, the serializer will set the header to the class name of the type.
+It is not necessary to configure serializers or deserializers for these types, they will be created (once) dynamically.
+
 For another technique to send different types to different topics, see <<routing-template>>.
 
 [[retrying-deserialization]]

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -94,6 +94,12 @@ See <<string-serde>> for more information.
 The `JsonDeserializer` now has more flexibility to determine the deserialization type.
 See <<serdes-type-methods>> for more information.
 
+[[x25-delegate-serde]]
+==== Delegating Serializer/Deserializer
+
+The `DelegatingSerializer` can now handle "standard" types, when the outbound record has no header.
+See <<delegating-serialization>> for more information.
+
 [[x25-testing]]
 ==== Testing Changes
 


### PR DESCRIPTION
Automatically handle "standard" types supported by the `Serdes`.