### PR TITLE
Support keys in Delegating(De)Serializer

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingDeserializer.java
@@ -62,7 +62,7 @@ public class DelegatingDeserializer implements Deserializer<Object> {
 	 * Construct an instance that will be configured in {@link #configure(Map, boolean)}
 	 * with consumer properties
 	 * {@link DelegatingSerializer#KEY_SERIALIZATION_SELECTOR_CONFIG} and
-	 * {@link DelegatingSerializer#VALUE_SERIALIZATION_SELECTOR_CONFIG}
+	 * {@link DelegatingSerializer#VALUE_SERIALIZATION_SELECTOR_CONFIG}.
 	 */
 	public DelegatingDeserializer() {
 	}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingDeserializer.java
@@ -26,7 +26,6 @@ import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 
-import org.springframework.core.log.LogAccessor;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
@@ -43,12 +42,13 @@ import org.springframework.util.StringUtils;
  */
 public class DelegatingDeserializer implements Deserializer<Object> {
 
-	private static final LogAccessor LOGGER = new LogAccessor(DelegatingDeserializer.class);
-
 	/**
 	 * Name of the configuration property containing the serialization selector map with
 	 * format {@code selector:class,...}.
+	 * @deprecated Use {@link DelegatingSerializer#VALUE_SERIALIZATION_SELECTOR} or
+	 * {@link DelegatingSerializer#KEY_SERIALIZATION_SELECTOR}.
 	 */
+	@Deprecated
 	public static final String SERIALIZATION_SELECTOR_CONFIG = DelegatingSerializer.SERIALIZATION_SELECTOR_CONFIG;
 
 
@@ -60,8 +60,9 @@ public class DelegatingDeserializer implements Deserializer<Object> {
 
 	/**
 	 * Construct an instance that will be configured in {@link #configure(Map, boolean)}
-	 * with a consumer property
-	 * {@link #SERIALIZATION_SELECTOR_CONFIG}.
+	 * with consumer properties
+	 * {@link DelegatingSerializer#KEY_SERIALIZATION_SELECTOR_CONFIG} and
+	 * {@link DelegatingSerializer#VALUE_SERIALIZATION_SELECTOR_CONFIG}
 	 */
 	public DelegatingDeserializer() {
 	}
@@ -82,7 +83,8 @@ public class DelegatingDeserializer implements Deserializer<Object> {
 	public void configure(Map<String, ?> configs, boolean isKey) {
 		this.autoConfigs.putAll(configs);
 		this.forKeys = isKey;
-		Object value = configs.get(SERIALIZATION_SELECTOR_CONFIG);
+		String configKey = configKey();
+		Object value = configs.get(configKey);
 		if (value == null) {
 			return;
 		}
@@ -98,7 +100,7 @@ public class DelegatingDeserializer implements Deserializer<Object> {
 					createInstanceAndConfigure(configs, isKey, this.delegates, selector, (String) deser);
 				}
 				else {
-					throw new IllegalStateException(SERIALIZATION_SELECTOR_CONFIG
+					throw new IllegalStateException(configKey
 							+ " map entries must be Serializers or class names, not " + value.getClass());
 				}
 			});
@@ -107,9 +109,14 @@ public class DelegatingDeserializer implements Deserializer<Object> {
 			this.delegates.putAll(createDelegates((String) value, configs, isKey));
 		}
 		else {
-			throw new IllegalStateException(
-					SERIALIZATION_SELECTOR_CONFIG + " must be a map or String, not " + value.getClass());
+			throw new IllegalStateException(configKey + " must be a map or String, not " + value.getClass());
 		}
+	}
+
+	private String configKey() {
+		return this.forKeys
+				? DelegatingSerializer.KEY_SERIALIZATION_SELECTOR_CONFIG
+				: DelegatingSerializer.VALUE_SERIALIZATION_SELECTOR_CONFIG;
 	}
 
 	protected static Map<String, Deserializer<?>> createDelegates(String mappings, Map<String, ?> configs,
@@ -167,12 +174,13 @@ public class DelegatingDeserializer implements Deserializer<Object> {
 	@Override
 	public Object deserialize(String topic, Headers headers, byte[] data) {
 		byte[] value = null;
-		Header header = headers.lastHeader(DelegatingSerializer.SERIALIZATION_SELECTOR);
+		String selectorKey = selectorKey();
+		Header header = headers.lastHeader(selectorKey);
 		if (header != null) {
 			value = header.value();
 		}
 		if (value == null) {
-			throw new IllegalStateException("No '" + DelegatingSerializer.SERIALIZATION_SELECTOR + "' header present");
+			throw new IllegalStateException("No '" + selectorKey + "' header present");
 		}
 		String selector = new String(value).replaceAll("\"", "");
 		Deserializer<? extends Object> deserializer = this.delegates.get(selector);
@@ -185,6 +193,12 @@ public class DelegatingDeserializer implements Deserializer<Object> {
 		else {
 			return deserializer.deserialize(topic, headers, data);
 		}
+	}
+
+	private String selectorKey() {
+		return this.forKeys
+				? DelegatingSerializer.KEY_SERIALIZATION_SELECTOR
+				: DelegatingSerializer.VALUE_SERIALIZATION_SELECTOR;
 	}
 
 	/*

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingSerializer.java
@@ -47,15 +47,40 @@ public class DelegatingSerializer implements Serializer<Object> {
 	private static final LogAccessor LOGGER = new LogAccessor(DelegatingDeserializer.class);
 
 	/**
-	 * Name of the header containing the serialization selector.
+	 * Synonym for {@link #VALUE_SERIALIZATION_SELECTOR}.
+	 * @deprecated in favor of {@link #VALUE_SERIALIZATION_SELECTOR}.
 	 */
+	@Deprecated
 	public static final String SERIALIZATION_SELECTOR = "spring.kafka.serialization.selector";
 
 	/**
-	 * Name of the configuration property containing the serialization selector map with
-	 * format {@code selector:class,...}.
+	 * Name of the header containing the serialization selector for values.
 	 */
+	public static final String VALUE_SERIALIZATION_SELECTOR = "spring.kafka.serialization.selector";
+
+	/**
+	 * Name of the header containing the serialization selector for keys.
+	 */
+	public static final String KEY_SERIALIZATION_SELECTOR = "spring.kafka.key.serialization.selector";
+
+	/**
+	 * Synonym for {@link #VALUE_SERIALIZATION_SELECTOR_CONFIG}.
+	 * @deprecated in favor of {@link #VALUE_SERIALIZATION_SELECTOR_CONFIG}.
+	 */
+	@Deprecated
 	public static final String SERIALIZATION_SELECTOR_CONFIG = "spring.kafka.serialization.selector.config";
+
+	/**
+	 * Name of the configuration property containing the serialization selector map for
+	 * values with format {@code selector:class,...}.
+	 */
+	public static final String VALUE_SERIALIZATION_SELECTOR_CONFIG = "spring.kafka.serialization.selector.config";
+
+	/**
+	 * Name of the configuration property containing the serialization selector map for
+	 * keys with format {@code selector:class,...}.
+	 */
+	public static final String KEY_SERIALIZATION_SELECTOR_CONFIG = "spring.kafka.key.serialization.selector.config";
 
 	private final Map<String, Serializer<?>> delegates = new ConcurrentHashMap<>();
 
@@ -65,8 +90,8 @@ public class DelegatingSerializer implements Serializer<Object> {
 
 	/**
 	 * Construct an instance that will be configured in {@link #configure(Map, boolean)}
-	 * with a producer property
-	 * {@link DelegatingSerializer#SERIALIZATION_SELECTOR_CONFIG}.
+	 * with producer properties {@link #VALUE_SERIALIZATION_SELECTOR_CONFIG} and
+	 * {@link #KEY_SERIALIZATION_SELECTOR_CONFIG}.
 	 */
 	public DelegatingSerializer() {
 	}
@@ -74,8 +99,9 @@ public class DelegatingSerializer implements Serializer<Object> {
 	/**
 	 * Construct an instance with the supplied mapping of selectors to delegate
 	 * serializers. The selector must be supplied in the
-	 * {@link DelegatingSerializer#SERIALIZATION_SELECTOR} header. It is not necessary to
-	 * configure standard serializers supported by {@link Serdes}.
+	 * {@link #KEY_SERIALIZATION_SELECTOR} and/or {@link #VALUE_SERIALIZATION_SELECTOR}
+	 * headers. It is not necessary to configure standard serializers supported by
+	 * {@link Serdes}.
 	 * @param delegates the map of delegates.
 	 */
 	public DelegatingSerializer(Map<String, Serializer<?>> delegates) {
@@ -87,7 +113,8 @@ public class DelegatingSerializer implements Serializer<Object> {
 	public void configure(Map<String, ?> configs, boolean isKey) {
 		this.autoConfigs.putAll(configs);
 		this.forKeys = isKey;
-		Object value = configs.get(SERIALIZATION_SELECTOR_CONFIG);
+		String configKey = configKey();
+		Object value = configs.get(configKey);
 		if (value == null) {
 			return;
 		}
@@ -103,7 +130,7 @@ public class DelegatingSerializer implements Serializer<Object> {
 					createInstanceAndConfigure(configs, isKey, this.delegates, selector, (String) serializer);
 				}
 				else {
-					throw new IllegalStateException(SERIALIZATION_SELECTOR_CONFIG
+					throw new IllegalStateException(configKey
 							+ " map entries must be Serializers or class names, not " + value.getClass());
 				}
 			});
@@ -113,8 +140,12 @@ public class DelegatingSerializer implements Serializer<Object> {
 		}
 		else {
 			throw new IllegalStateException(
-					SERIALIZATION_SELECTOR_CONFIG + " must be a map or String, not " + value.getClass());
+					configKey + " must be a map or String, not " + value.getClass());
 		}
+	}
+
+	private String configKey() {
+		return this.forKeys ? KEY_SERIALIZATION_SELECTOR_CONFIG : VALUE_SERIALIZATION_SELECTOR_CONFIG;
 	}
 
 	protected static Map<String, Serializer<?>> createDelegates(String mappings, Map<String, ?> configs,
@@ -173,19 +204,20 @@ public class DelegatingSerializer implements Serializer<Object> {
 	@Override
 	public byte[] serialize(String topic, Headers headers, Object data) {
 		byte[] value = null;
-		Header header = headers.lastHeader(SERIALIZATION_SELECTOR);
+		String selectorKey = selectorKey();
+		Header header = headers.lastHeader(selectorKey);
 		if (header != null) {
 			value = header.value();
 		}
 		if (value == null) {
 			value = trySerdes(data);
 			if (value == null) {
-				throw new IllegalStateException("No '" + SERIALIZATION_SELECTOR
+				throw new IllegalStateException("No '" + selectorKey
 						+ "' header present and type (" + data.getClass().getName()
 						+ ") is not supported by Serdes");
 			}
 			try {
-				headers.add(new RecordHeader(SERIALIZATION_SELECTOR, value));
+				headers.add(new RecordHeader(selectorKey, value));
 			}
 			catch (IllegalStateException e) {
 				LOGGER.debug(e, () -> "Could not set header for type " + data.getClass());
@@ -196,9 +228,13 @@ public class DelegatingSerializer implements Serializer<Object> {
 		Serializer<Object> serializer = (Serializer<Object>) this.delegates.get(selector);
 		if (serializer == null) {
 			throw new IllegalStateException(
-					"No serializer found for '" + SERIALIZATION_SELECTOR + "' header with value '" + selector + "'");
+					"No serializer found for '" + selectorKey + "' header with value '" + selector + "'");
 		}
 		return serializer.serialize(topic, headers, data);
+	}
+
+	private String selectorKey() {
+		return this.forKeys ? KEY_SERIALIZATION_SELECTOR : VALUE_SERIALIZATION_SELECTOR;
 	}
 
 	/*

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/DelegatingSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/DelegatingSerializationTests.java
@@ -55,14 +55,14 @@ public class DelegatingSerializationTests {
 		serializers.put("bytes", new BytesSerializer());
 		serializers.put("int", IntegerSerializer.class);
 		serializers.put("string", StringSerializer.class.getName());
-		configs.put(DelegatingSerializer.SERIALIZATION_SELECTOR_CONFIG, serializers);
+		configs.put(DelegatingSerializer.VALUE_SERIALIZATION_SELECTOR_CONFIG, serializers);
 		serializer.configure(configs, false);
 		DelegatingDeserializer deserializer = new DelegatingDeserializer();
 		Map<String, Object> deserializers = new HashMap<>();
 		deserializers.put("bytes", new BytesDeserializer());
 		deserializers.put("int", IntegerDeserializer.class);
 		deserializers.put("string", StringDeserializer.class.getName());
-		configs.put(DelegatingSerializer.SERIALIZATION_SELECTOR_CONFIG, deserializers);
+		configs.put(DelegatingSerializer.VALUE_SERIALIZATION_SELECTOR_CONFIG, deserializers);
 		deserializer.configure(configs, false);
 		doTest(serializer, deserializer);
 	}
@@ -71,38 +71,72 @@ public class DelegatingSerializationTests {
 	void testWithPropertyConfig() {
 		DelegatingSerializer serializer = new DelegatingSerializer();
 		Map<String, Object> configs = new HashMap<>();
-		configs.put(DelegatingSerializer.SERIALIZATION_SELECTOR_CONFIG, "bytes:" + BytesSerializer.class.getName()
+		configs.put(DelegatingSerializer.VALUE_SERIALIZATION_SELECTOR_CONFIG, "bytes:" + BytesSerializer.class.getName()
 				+ ", int:" + IntegerSerializer.class.getName() + ", string: " + StringSerializer.class.getName());
 		serializer.configure(configs, false);
 		DelegatingDeserializer deserializer = new DelegatingDeserializer();
-		configs.put(DelegatingSerializer.SERIALIZATION_SELECTOR_CONFIG, "bytes:" + BytesDeserializer.class.getName()
+		configs.put(DelegatingSerializer.VALUE_SERIALIZATION_SELECTOR_CONFIG, "bytes:" + BytesDeserializer.class.getName()
 				+ ", int:" + IntegerDeserializer.class.getName() + ", string: " + StringDeserializer.class.getName());
 		deserializer.configure(configs, false);
 		doTest(serializer, deserializer);
 	}
 
+	@Test
+	void testWithMapConfigKeys() {
+		DelegatingSerializer serializer = new DelegatingSerializer();
+		Map<String, Object> configs = new HashMap<>();
+		Map<String, Object> serializers = new HashMap<>();
+		serializers.put("bytes", new BytesSerializer());
+		serializers.put("int", IntegerSerializer.class);
+		serializers.put("string", StringSerializer.class.getName());
+		configs.put(DelegatingSerializer.KEY_SERIALIZATION_SELECTOR_CONFIG, serializers);
+		serializer.configure(configs, true);
+		DelegatingDeserializer deserializer = new DelegatingDeserializer();
+		Map<String, Object> deserializers = new HashMap<>();
+		deserializers.put("bytes", new BytesDeserializer());
+		deserializers.put("int", IntegerDeserializer.class);
+		deserializers.put("string", StringDeserializer.class.getName());
+		configs.put(DelegatingSerializer.KEY_SERIALIZATION_SELECTOR_CONFIG, deserializers);
+		deserializer.configure(configs, true);
+		doTestKeys(serializer, deserializer);
+	}
+
+	@Test
+	void testWithPropertyConfigKeys() {
+		DelegatingSerializer serializer = new DelegatingSerializer();
+		Map<String, Object> configs = new HashMap<>();
+		configs.put(DelegatingSerializer.KEY_SERIALIZATION_SELECTOR_CONFIG, "bytes:" + BytesSerializer.class.getName()
+				+ ", int:" + IntegerSerializer.class.getName() + ", string: " + StringSerializer.class.getName());
+		serializer.configure(configs, true);
+		DelegatingDeserializer deserializer = new DelegatingDeserializer();
+		configs.put(DelegatingSerializer.KEY_SERIALIZATION_SELECTOR_CONFIG, "bytes:" + BytesDeserializer.class.getName()
+				+ ", int:" + IntegerDeserializer.class.getName() + ", string: " + StringDeserializer.class.getName());
+		deserializer.configure(configs, true);
+		doTestKeys(serializer, deserializer);
+	}
+
 	private void doTest(DelegatingSerializer serializer, DelegatingDeserializer deserializer) {
 		Headers headers = new RecordHeaders();
-		headers.add(new RecordHeader(DelegatingSerializer.SERIALIZATION_SELECTOR, "bytes".getBytes()));
+		headers.add(new RecordHeader(DelegatingSerializer.VALUE_SERIALIZATION_SELECTOR, "bytes".getBytes()));
 		byte[] bytes = new byte[] { 1, 2, 3, 4 };
 		byte[] serialized = serializer.serialize("foo", headers, new Bytes(bytes));
 		assertThat(serialized).isSameAs(bytes);
-		headers.add(new RecordHeader(DelegatingSerializer.SERIALIZATION_SELECTOR, "int".getBytes()));
+		headers.add(new RecordHeader(DelegatingSerializer.VALUE_SERIALIZATION_SELECTOR, "int".getBytes()));
 		serialized = serializer.serialize("foo", headers, 42);
 		assertThat(serialized).isEqualTo(new byte[] { 0, 0, 0, 42 });
 		assertThat(deserializer.deserialize("foo", headers, serialized)).isEqualTo(42);
-		headers.add(new RecordHeader(DelegatingSerializer.SERIALIZATION_SELECTOR, "string".getBytes()));
+		headers.add(new RecordHeader(DelegatingSerializer.VALUE_SERIALIZATION_SELECTOR, "string".getBytes()));
 		serialized = serializer.serialize("foo", headers, "bar");
 		assertThat(serialized).isEqualTo(new byte[] { 'b', 'a', 'r' });
 		assertThat(deserializer.deserialize("foo", headers, serialized)).isEqualTo("bar");
 
 		// implicit Serdes
-		headers.remove(DelegatingSerializer.SERIALIZATION_SELECTOR);
+		headers.remove(DelegatingSerializer.VALUE_SERIALIZATION_SELECTOR);
 		DelegatingSerializer spySe = spy(serializer);
 		serialized = spySe.serialize("foo", headers, 42L);
 		serialized = spySe.serialize("foo", headers, 42L);
 		verify(spySe, times(1)).trySerdes(42L);
-		assertThat(headers.lastHeader(DelegatingSerializer.SERIALIZATION_SELECTOR).value())
+		assertThat(headers.lastHeader(DelegatingSerializer.VALUE_SERIALIZATION_SELECTOR).value())
 				.isEqualTo(Long.class.getName().getBytes());
 		DelegatingDeserializer spyDe = spy(deserializer);
 		assertThat(spyDe.deserialize("foo", headers, serialized)).isEqualTo(42L);
@@ -111,21 +145,59 @@ public class DelegatingSerializationTests {
 
 		// The DKHM will jsonize the value; test that we ignore the quotes
 		MessageHeaders messageHeaders = new MessageHeaders(
-				Collections.singletonMap(DelegatingSerializer.SERIALIZATION_SELECTOR, "string"));
+				Collections.singletonMap(DelegatingSerializer.VALUE_SERIALIZATION_SELECTOR, "string"));
 		new DefaultKafkaHeaderMapper().fromHeaders(messageHeaders, headers);
-		assertThat(headers.lastHeader(DelegatingSerializer.SERIALIZATION_SELECTOR).value())
+		assertThat(headers.lastHeader(DelegatingSerializer.VALUE_SERIALIZATION_SELECTOR).value())
 				.isEqualTo(new byte[] { 's', 't', 'r', 'i', 'n', 'g' });
 		serialized = serializer.serialize("foo", headers, "bar");
 		assertThat(serialized).isEqualTo(new byte[] { 'b', 'a', 'r' });
 		assertThat(deserializer.deserialize("foo", headers, serialized)).isEqualTo("bar");
+	}
 
+	private void doTestKeys(DelegatingSerializer serializer, DelegatingDeserializer deserializer) {
+		Headers headers = new RecordHeaders();
+		headers.add(new RecordHeader(DelegatingSerializer.KEY_SERIALIZATION_SELECTOR, "bytes".getBytes()));
+		byte[] bytes = new byte[] { 1, 2, 3, 4 };
+		byte[] serialized = serializer.serialize("foo", headers, new Bytes(bytes));
+		assertThat(serialized).isSameAs(bytes);
+		headers.add(new RecordHeader(DelegatingSerializer.KEY_SERIALIZATION_SELECTOR, "int".getBytes()));
+		serialized = serializer.serialize("foo", headers, 42);
+		assertThat(serialized).isEqualTo(new byte[] { 0, 0, 0, 42 });
+		assertThat(deserializer.deserialize("foo", headers, serialized)).isEqualTo(42);
+		headers.add(new RecordHeader(DelegatingSerializer.KEY_SERIALIZATION_SELECTOR, "string".getBytes()));
+		serialized = serializer.serialize("foo", headers, "bar");
+		assertThat(serialized).isEqualTo(new byte[] { 'b', 'a', 'r' });
+		assertThat(deserializer.deserialize("foo", headers, serialized)).isEqualTo("bar");
+
+		// implicit Serdes
+		headers.remove(DelegatingSerializer.KEY_SERIALIZATION_SELECTOR);
+		DelegatingSerializer spySe = spy(serializer);
+		serialized = spySe.serialize("foo", headers, 42L);
+		serialized = spySe.serialize("foo", headers, 42L);
+		verify(spySe, times(1)).trySerdes(42L);
+		assertThat(headers.lastHeader(DelegatingSerializer.KEY_SERIALIZATION_SELECTOR).value())
+				.isEqualTo(Long.class.getName().getBytes());
+		DelegatingDeserializer spyDe = spy(deserializer);
+		assertThat(spyDe.deserialize("foo", headers, serialized)).isEqualTo(42L);
+		spyDe.deserialize("foo", headers, serialized);
+		verify(spyDe, times(1)).trySerdes(Long.class.getName());
+
+		// The DKHM will jsonize the value; test that we ignore the quotes
+		MessageHeaders messageHeaders = new MessageHeaders(
+				Collections.singletonMap(DelegatingSerializer.KEY_SERIALIZATION_SELECTOR, "string"));
+		new DefaultKafkaHeaderMapper().fromHeaders(messageHeaders, headers);
+		assertThat(headers.lastHeader(DelegatingSerializer.KEY_SERIALIZATION_SELECTOR).value())
+				.isEqualTo(new byte[] { 's', 't', 'r', 'i', 'n', 'g' });
+		serialized = serializer.serialize("foo", headers, "bar");
+		assertThat(serialized).isEqualTo(new byte[] { 'b', 'a', 'r' });
+		assertThat(deserializer.deserialize("foo", headers, serialized)).isEqualTo("bar");
 	}
 
 	@Test
 	void testBadIncomingOnlyOnce() {
 		DelegatingDeserializer spy = spy(new DelegatingDeserializer());
 		Headers headers = new RecordHeaders();
-		headers.add(new RecordHeader(DelegatingSerializer.SERIALIZATION_SELECTOR, "junk".getBytes()));
+		headers.add(new RecordHeader(DelegatingSerializer.VALUE_SERIALIZATION_SELECTOR, "junk".getBytes()));
 		byte[] data = "foo".getBytes();
 		assertThat(spy.deserialize("foo", headers, data)).isSameAs(data);
 		spy.deserialize("foo", headers, data);

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -3720,11 +3720,11 @@ JsonDeserializer<Object> deser = new JsonDeserializer<>()
 ===== Delegating Serializer and Deserializer
 
 Version 2.3 introduced the `DelegatingSerializer` and `DelegatingDeserializer`, which allow producing and consuming records with different key and/or value types.
-Producers must set a header `DelegatingSerializer.SERIALIZATION_SELECTOR` to a selector value that is used to select which serializer to use; if a match is not found, an `IllegalStateException` is thrown.
+Producers must set a header `DelegatingSerializer.VALUE_SERIALIZATION_SELECTOR` to a selector value that is used to select which serializer to use for the value and `DelegatingSerializer.KEY_SERIALIZATION_SELECTOR` for the key; if a match is not found, an `IllegalStateException` is thrown.
 
-For incoming records, the deserializer uses the same header to select the deserializer to use; if a match is not found or the header is not present, the raw `byte[]` is returned.
+For incoming records, the deserializer uses the same headers to select the deserializer to use; if a match is not found or the header is not present, the raw `byte[]` is returned.
 
-You can configure the map of selector to `Serializer` / `Deserializer` via a constructor, or you can configure it via Kafka producer/consumer properties with the key `DelegatingSerializer.SERIALIZATION_SELECTOR_CONFIG`.
+You can configure the map of selector to `Serializer` / `Deserializer` via a constructor, or you can configure it via Kafka producer/consumer properties with the keys `DelegatingSerializer.VALUE_SERIALIZATION_SELECTOR_CONFIG` and `DelegatingSerializer.KEY_SERIALIZATION_SELECTOR_CONFIG`.
 For the serializer, the producer property can be a `Map<String, Object>` where the key is the selector and the value is a `Serializer` instance, a serializer `Class` or the class name.
 The property can also be a String of comma-delimited map entries, as shown below.
 
@@ -3736,19 +3736,19 @@ To configure using properties, use the following syntax:
 ====
 [source, java]
 ----
-producerProps.put(DelegatingSerializer.SERIALIZATION_SELECTOR_CONFIG,
+producerProps.put(DelegatingSerializer.VALUE_SERIALIZATION_SELECTOR_CONFIG,
     "thing1:com.example.MyThing1Serializer, thing2:com.example.MyThing2Serializer")
 
-consumerProps.put(DelegatingDeserializer.SERIALIZATION_SELECTOR_CONFIG,
+consumerProps.put(DelegatingDeserializer.VALUE_SERIALIZATION_SELECTOR_CONFIG,
     "thing1:com.example.MyThing1Deserializer, thing2:com.example.MyThing2Deserializer")
 ----
 ====
 
-Producers would then set the `DelegatingSerializer.SERIALIZATION_SELECTOR` header to `thing1` or `thing2`.
+Producers would then set the `DelegatingSerializer.VALUE_SERIALIZATION_SELECTOR` header to `thing1` or `thing2`.
 
 This technique supports sending different types to the same topic (or different topics).
 
-NOTE: Starting with version 2.5.1, it is not necessary to set the header if the type (key or value) is one of the standard types supported by `Serdes` (`Long`, `Integer`, etc).
+NOTE: Starting with version 2.5.1, it is not necessary to set the selector header, if the type (key or value) is one of the standard types supported by `Serdes` (`Long`, `Integer`, etc).
 Instead, the serializer will set the header to the class name of the type.
 It is not necessary to configure serializers or deserializers for these types, they will be created (once) dynamically.
 


### PR DESCRIPTION
Previously, a single config and selector header was available
making it impossible to use these (De)Serializers for both
key and value.

**I will backport after merge as needed due to conflicts**