### PR TITLE
GH-1508: Fix DefaultARProcessor for EOSMode.BETA

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/DefaultAfterRollbackProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/DefaultAfterRollbackProcessor.java
@@ -25,9 +25,12 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.kafka.core.KafkaOperations;
 import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.ContainerProperties.EOSMode;
 import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
 import org.springframework.util.backoff.BackOff;
 
 /**
@@ -46,9 +49,10 @@ import org.springframework.util.backoff.BackOff;
  * @since 1.3.5
  *
  */
-public class DefaultAfterRollbackProcessor<K, V> extends FailedRecordProcessor implements AfterRollbackProcessor<K, V> {
+public class DefaultAfterRollbackProcessor<K, V> extends FailedRecordProcessor
+		implements AfterRollbackProcessor<K, V>, InitializingBean {
 
-	private KafkaOperations<K, V> kafkaTemplate;
+	private KafkaOperations<?, ?> kafkaTemplate;
 
 	/**
 	 * Construct an instance with the default recoverer which simply logs the record after
@@ -91,21 +95,66 @@ public class DefaultAfterRollbackProcessor<K, V> extends FailedRecordProcessor i
 	public DefaultAfterRollbackProcessor(@Nullable BiConsumer<ConsumerRecord<?, ?>, Exception> recoverer,
 			BackOff backOff) {
 
+		this(recoverer, backOff, null, false);
+	}
+
+	/**
+	 * Construct an instance with the provided recoverer which will be called after the
+	 * backOff returns STOP for a topic/partition/offset.
+	 * @param recoverer the recoverer; if null, the default (logging) recoverer is used.
+	 * @param backOff the {@link BackOff}.
+	 * @param kafkaOperations for sending the recovered offset to the transaction.
+	 * @param commitRecovered true to commit the recovered record's offset; requires a
+	 * {@link KafkaOperations}.
+	 * @since 2.5.3
+	 */
+	public DefaultAfterRollbackProcessor(@Nullable BiConsumer<ConsumerRecord<?, ?>, Exception> recoverer,
+			BackOff backOff, @Nullable KafkaOperations<?, ?> kafkaOperations, boolean commitRecovered) {
+
 		super(recoverer, backOff);
+		this.kafkaTemplate = kafkaOperations;
+		super.setCommitRecovered(commitRecovered);
+		checkConfig();
+	}
+
+	@Override
+	public void afterPropertiesSet() {
+		// remove InitializingBean when the deprecated setters are removed.
+		checkConfig();
+	}
+
+	private void checkConfig() {
+		Assert.isTrue(!isCommitRecovered() || this.kafkaTemplate != null,
+				"A KafkaOperations is required when 'commitRecovered' is true");
+	}
+
+	@Override
+	@Deprecated
+	public void process(List<ConsumerRecord<K, V>> records, Consumer<K, V> consumer, Exception exception,
+			boolean recoverable) {
+
+		process(records, consumer, exception, recoverable, EOSMode.ALPHA);
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Override
 	public void process(List<ConsumerRecord<K, V>> records, Consumer<K, V> consumer, Exception exception,
-			boolean recoverable) {
+			boolean recoverable, @Nullable EOSMode eosMode) {
 
 		if (SeekUtils.doSeeks(((List) records), consumer, exception, recoverable,
 				getSkipPredicate((List) records, exception), this.logger)
-					&& isCommitRecovered() && this.kafkaTemplate != null && this.kafkaTemplate.isTransactional()) {
+					&& isCommitRecovered() && this.kafkaTemplate.isTransactional()) {
 			ConsumerRecord<K, V> skipped = records.get(0);
-			this.kafkaTemplate.sendOffsetsToTransaction(
-					Collections.singletonMap(new TopicPartition(skipped.topic(), skipped.partition()),
-							new OffsetAndMetadata(skipped.offset() + 1)));
+			if (EOSMode.ALPHA.equals(eosMode)) {
+				this.kafkaTemplate.sendOffsetsToTransaction(
+						Collections.singletonMap(new TopicPartition(skipped.topic(), skipped.partition()),
+								new OffsetAndMetadata(skipped.offset() + 1)));
+			}
+			else {
+				this.kafkaTemplate.sendOffsetsToTransaction(
+						Collections.singletonMap(new TopicPartition(skipped.topic(), skipped.partition()),
+								new OffsetAndMetadata(skipped.offset() + 1)), consumer.groupMetadata());
+			}
 		}
 	}
 
@@ -115,29 +164,32 @@ public class DefaultAfterRollbackProcessor<K, V> extends FailedRecordProcessor i
 	}
 
 	/**
-	 * {@inheritDoc}
-	 * Set to true and the container will run the
-	 * {@link #process(List, Consumer, Exception, boolean)} method in a transaction and,
-	 * if a record is skipped and recovered, we will send its offset to the transaction.
-	 * Requires a {@link KafkaOperations}.
+	 * {@inheritDoc} Set to true and the container will run the {@link #process(List,
+	 * Consumer, Exception, boolean, EOSMode)} method in a transaction and, if a record
+	 * is skipped and recovered, we will send its offset to the transaction. Requires a
+	 * {@link KafkaOperations}.
 	 * @param commitRecovered true to process in a transaction.
 	 * @since 2.3
+	 * @deprecated in favor of
+	 * {@link #DefaultAfterRollbackProcessor(BiConsumer, BackOff, KafkaOperations, boolean)}.
 	 * @see #isProcessInTransaction()
-	 * @see #process(List, Consumer, Exception, boolean)
-	 * @see #setKafkaOperations(KafkaOperations)
+	 * @see #process(List, Consumer, Exception, boolean, EOSMode)
 	 */
+	@Deprecated
 	@Override
 	public void setCommitRecovered(boolean commitRecovered) { // NOSONAR enhanced javadoc
 		super.setCommitRecovered(commitRecovered);
 	}
 
 	/**
-	 * Set a {@link KafkaTemplate} to use to send the offset of a recovered record
-	 * to a transaction.
+	 * Set a {@link KafkaTemplate} to use to send the offset of a recovered record to a
+	 * transaction.
 	 * @param kafkaTemplate the template.
 	 * @since 2.2.5
+	 * @deprecated in favor of
+	 * {@link #DefaultAfterRollbackProcessor(BiConsumer, BackOff, KafkaOperations,
+	 * boolean)}.
 	 * @see #setCommitRecovered(boolean)
-	 * @deprecated in favor of {@link #setKafkaOperations(KafkaOperations)}.
 	 */
 	@Deprecated
 	public void setKafkaTemplate(KafkaTemplate<K, V> kafkaTemplate) {
@@ -145,12 +197,16 @@ public class DefaultAfterRollbackProcessor<K, V> extends FailedRecordProcessor i
 	}
 
 	/**
-	 * Set a {@link KafkaOperations} to use to send the offset of a recovered record
-	 * to a transaction.
+	 * Set a {@link KafkaOperations} to use to send the offset of a recovered record to a
+	 * transaction.
 	 * @param kafkaOperations the operations.
 	 * @since 2.5.1
+	 * @deprecated in favor of
+	 * {@link #DefaultAfterRollbackProcessor(BiConsumer, BackOff, KafkaOperations,
+	 * boolean)}.
 	 * @see #setCommitRecovered(boolean)
 	 */
+	@Deprecated
 	public void setKafkaOperations(KafkaOperations<K, V> kafkaOperations) {
 		this.kafkaTemplate = kafkaOperations;
 	}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -1430,10 +1430,11 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			try {
 				if (recordList == null) {
 					afterRollbackProcessorToUse.process(createRecordList(records), this.consumer, rollbackException,
-							false);
+							false, this.eosMode);
 				}
 				else {
-					afterRollbackProcessorToUse.process(recordList, this.consumer, rollbackException, false);
+					afterRollbackProcessorToUse.process(recordList, this.consumer, rollbackException, false,
+							this.eosMode);
 				}
 			}
 			catch (KafkaException ke) {
@@ -1690,14 +1691,15 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 
 					@Override
 					protected void doInTransactionWithoutResult(TransactionStatus status) {
-						afterRollbackProcessorToUse.process(unprocessed, ListenerConsumer.this.consumer, e, true);
+						afterRollbackProcessorToUse.process(unprocessed, ListenerConsumer.this.consumer, e, true,
+								ListenerConsumer.this.eosMode);
 					}
 
 				});
 			}
 			else {
 				try {
-					afterRollbackProcessorToUse.process(unprocessed, this.consumer, e, true);
+					afterRollbackProcessorToUse.process(unprocessed, this.consumer, e, true, this.eosMode);
 				}
 				catch (KafkaException ke) {
 					ke.selfLog("AfterRollbackProcessor threw an exception", this.logger);


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1508

- also validate configuration when `commitRecovered` is `true`; deprecate setters.