### PR TITLE
GH-1519: Fix @SendTo on @KafkaHandler

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/AdapterUtils.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/AdapterUtils.java
@@ -20,6 +20,9 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.TopicPartition;
 
+import org.springframework.expression.ParserContext;
+import org.springframework.expression.common.TemplateParserContext;
+import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.lang.Nullable;
 
 /**
@@ -30,6 +33,12 @@ import org.springframework.lang.Nullable;
  *
  */
 public final class AdapterUtils {
+
+	/**
+	 * Parser context for runtime SpEL using ! as the template prefix.
+	 * @since 2.2.15
+	 */
+	public static final ParserContext PARSER_CONTEXT = new TemplateParserContext("!{", "}");
 
 	private AdapterUtils() {
 	}
@@ -65,6 +74,16 @@ public final class AdapterUtils {
 		return new ConsumerRecordMetadata(new RecordMetadata(new TopicPartition(record.topic(), record.partition()),
 				0, record.offset(), record.timestamp(), null, record.serializedKeySize(),
 				record.serializedValueSize()), record.timestampType());
+	}
+
+	/**
+	 * Return the default expression when no SendTo value is present.
+	 * @return the expression.
+	 * @since 2.2.15
+	 */
+	public static String getDefaultReplyTopicExpression() {
+		return PARSER_CONTEXT.getExpressionPrefix() + "source.headers['"
+				+ KafkaHeaders.REPLY_TOPIC + "']" + PARSER_CONTEXT.getExpressionSuffix();
 	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
@@ -39,9 +39,7 @@ import org.springframework.core.MethodParameter;
 import org.springframework.core.log.LogAccessor;
 import org.springframework.expression.BeanResolver;
 import org.springframework.expression.Expression;
-import org.springframework.expression.ParserContext;
 import org.springframework.expression.common.LiteralExpression;
-import org.springframework.expression.common.TemplateParserContext;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.expression.spel.support.StandardTypeConverter;
@@ -83,8 +81,6 @@ import org.springframework.util.StringUtils;
 public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerSeekAware {
 
 	private static final SpelExpressionParser PARSER = new SpelExpressionParser();
-
-	private static final ParserContext PARSER_CONTEXT = new TemplateParserContext("!{", "}");
 
 	/**
 	 * Message used when no conversion is needed.
@@ -201,11 +197,10 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 	public void setReplyTopic(String replyTopicParam) {
 		String replyTopic = replyTopicParam;
 		if (!StringUtils.hasText(replyTopic)) {
-			replyTopic = PARSER_CONTEXT.getExpressionPrefix() + "source.headers['"
-					+ KafkaHeaders.REPLY_TOPIC + "']" + PARSER_CONTEXT.getExpressionSuffix();
+			replyTopic = AdapterUtils.getDefaultReplyTopicExpression();
 		}
-		if (replyTopic.contains(PARSER_CONTEXT.getExpressionPrefix())) {
-			this.replyTopicExpression = PARSER.parseExpression(replyTopic, PARSER_CONTEXT);
+		if (replyTopic.contains(AdapterUtils.PARSER_CONTEXT.getExpressionPrefix())) {
+			this.replyTopicExpression = PARSER.parseExpression(replyTopic, AdapterUtils.PARSER_CONTEXT);
 		}
 		else {
 			this.replyTopicExpression = new LiteralExpression(replyTopic);


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1519

An empty `@SendTo` on a `@KafkaListener` method means send the reply
to the `KafkaHeaders.REPLY_TOPIC` header.

This default was not applied for class-level `@KafkaListener`s.

**backport to 2.4.x, 2.3.x, 2.2.x**

(I will do the back ports, because I expect conflicts).