### PR TITLE
GH-1522: Commit recovered record with MANUAL Acks

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/SeekUtils.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/SeekUtils.java
@@ -174,7 +174,7 @@ public final class SeekUtils {
 				}
 			}
 			else {
-				logger.warn(() -> "'commitRecovered' ignored, container AckMode must be MANUAL_IMMEDIATE, not "
+				logger.debug(() -> "'commitRecovered' ignored, container AckMode must be MANUAL_IMMEDIATE, not "
 						+ container.getContainerProperties().getAckMode());
 			}
 		}


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1522

If the `errorHandler.isAckAfterHandle()` is true and the handler exits
normally, add the offset to the pending `acks`, even when the `AckMode`
is `MANUAL`.