### PR TITLE
GH-1527: Add Support for Transaction Properties

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
@@ -706,7 +706,7 @@ public class ContainerProperties extends ConsumerProperties {
 	 * @since 2.5.4
 	 */
 	public void setTransactionDefinition(TransactionDefinition transactionDefinition) {
- 		this.transactionDefinition = transactionDefinition;
+		this.transactionDefinition = transactionDefinition;
 	}
 
 	@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
@@ -29,6 +29,7 @@ import org.springframework.kafka.support.TopicPartitionOffset;
 import org.springframework.lang.Nullable;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
 import org.springframework.util.Assert;
 
 /**
@@ -239,6 +240,8 @@ public class ContainerProperties extends ConsumerProperties {
 	private boolean deliveryAttemptHeader;
 
 	private EOSMode eosMode;
+
+	private TransactionDefinition transactionDefinition;
 
 	/**
 	 * Create properties for a container that will subscribe to the specified topics.
@@ -680,6 +683,30 @@ public class ContainerProperties extends ConsumerProperties {
 		if (this.eosMode.equals(EOSMode.BETA) && this.subBatchPerPartition == null) {
 			this.subBatchPerPartition = false;
 		}
+	}
+
+	/**
+	 * Get the transaction definition.
+	 * @return the definition.
+	 * @since 2.5.4
+	 */
+	@Nullable
+	public TransactionDefinition getTransactionDefinition() {
+		return this.transactionDefinition;
+	}
+
+	/**
+	 * Set a transaction definition with properties (e.g. timeout) that will be copied to
+	 * the container's transaction template. Note that this is only generally useful when
+	 * used with a
+	 * {@link org.springframework.kafka.transaction.ChainedKafkaTransactionManager}
+	 * configured with a non-Kafka transaction manager. Kafka has no concept of
+	 * transaction timeout, for example.
+	 * @param transactionDefinition the definition.
+	 * @since 2.5.4
+	 */
+	public void setTransactionDefinition(TransactionDefinition transactionDefinition) {
+ 		this.transactionDefinition = transactionDefinition;
 	}
 
 	@Override

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -2279,6 +2279,11 @@ topicPartitions
 |The configured topics, topic pattern or explicitly assigned topics/partitions.
 Mutually exclusive; at least one must be provided; enforced by `ContainerProperties` constructors.
 
+|transaction
+Definition
+|`null`
+|Set transaction properties; see <<chained-transaction-manager>> for more information.
+
 |transactionManager
 |`null`
 |See <<transactions>>.

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -3052,6 +3052,10 @@ You should chain your transaction managers in the desired order and provide the 
 
 See <<ex-jdbc-sync>> for an example application that synchronizes JDBC and Kafka transactions.
 
+Starting with version 2.5.4, you can configure a `TransactionDefinition` in the `ContainerProperties`; its properties will be copied to the container's `TransactionTemplate` used to start transactions.
+This allows, for example, setting a transaction timeout for other transaction managers within the `ChainedKafkaTransactionManager`.
+It does not, however, make sense to set a propagation behavior because the container would always need to start a new transaction; anything other than `REQUIRED` or `REQUIRES_NEW` will be rejected.
+
 ===== `KafkaTemplate` Local Transactions
 
 You can use the `KafkaTemplate` to execute a series of operations within a local transaction.


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1527

For example, to set a timeout for other transaction managers in a
chained transaction manager.