### PR TITLE
Fix idleBetweenPolls max value calculation

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -140,6 +140,8 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 
 	private static final int DEFAULT_ACK_TIME = 5000;
 
+	private static final Map<String, Object> CONSUMER_CONFIG_DEFAULTS = ConsumerConfig.configDef().defaultValues();
+
 	private final AbstractMessageListenerContainer<K, V> thisOrParentContainer;
 
 	private final TopicPartitionOffset[] topicPartitions;
@@ -678,12 +680,13 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 
 		private Properties propertiesFromProperties() {
 			Properties propertyOverrides = this.containerProperties.getKafkaConsumerProperties();
-			Properties props = new Properties(propertyOverrides);
-			Set<String> stringPropertyNames = props.stringPropertyNames();
-			// Copy non-string-valued properties from the default hash table to the new properties object
-			propertyOverrides.forEach((key, value) -> {
-				if (key instanceof String && !stringPropertyNames.contains(key)) {
-					props.put(key, value);
+			Properties props = new Properties();
+			props.putAll(propertyOverrides);
+			Set<String> stringPropertyNames = propertyOverrides.stringPropertyNames();
+			// User might have provided properties as defaults
+			stringPropertyNames.forEach((name) -> {
+				if (!props.contains(name)) {
+					props.setProperty(name, propertyOverrides.getProperty(name));
 				}
 			});
 			return props;
@@ -783,9 +786,9 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 					this.logger.warn(() -> "Unexpected type: " + timeoutToLog.getClass().getName()
 							+ " in property '"
 							+ ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG
-							+ "'; defaulting to 30 seconds.");
+							+ "'; using Kafka default.");
 				}
-				return Duration.ofSeconds(SIXTY / 2).toMillis(); // Default 'max.poll.interval.ms' is 30 seconds
+				return (int) CONSUMER_CONFIG_DEFAULTS.get(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG);
 			}
 		}
 
@@ -868,12 +871,12 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 						this.logger.warn(() -> "Unexpected type: " + timeoutToLog.getClass().getName()
 							+ " in property '"
 							+ ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG
-							+ "'; defaulting to 60 seconds for sync commit timeouts");
+							+ "'; defaulting to Kafka default for sync commit timeouts");
 					}
-					return Duration.ofSeconds(SIXTY);
+					return Duration
+							.ofMillis((int) CONSUMER_CONFIG_DEFAULTS.get(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG));
 				}
 			}
-
 		}
 
 		private Object findDeserializerClass(Map<String, Object> props, boolean isValue) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -435,8 +435,6 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 
 		private static final String ERROR_HANDLER_THREW_AN_EXCEPTION = "Error handler threw an exception";
 
-		private static final int SIXTY = 60;
-
 		private static final String UNCHECKED = "unchecked";
 
 		private static final String RAWTYPES = "rawtypes";

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -98,6 +98,7 @@ import org.springframework.kafka.listener.ConsumerSeekAware;
 import org.springframework.kafka.listener.ContainerProperties;
 import org.springframework.kafka.listener.ContainerProperties.AckMode;
 import org.springframework.kafka.listener.KafkaListenerErrorHandler;
+import org.springframework.kafka.listener.KafkaMessageListenerContainer;
 import org.springframework.kafka.listener.ListenerExecutionFailedException;
 import org.springframework.kafka.listener.MessageListenerContainer;
 import org.springframework.kafka.listener.adapter.FilteringMessageListenerAdapter;
@@ -235,6 +236,10 @@ public class EnableKafkaIntegrationTests {
 		List<?> containers = KafkaTestUtils.getPropertyValue(container, "containers", List.class);
 		assertThat(KafkaTestUtils.getPropertyValue(containers.get(0), "listenerConsumer.consumerGroupId"))
 				.isEqualTo(DEFAULT_TEST_GROUP_ID);
+		assertThat(KafkaTestUtils.getPropertyValue(containers.get(0), "listenerConsumer.maxPollInterval"))
+				.isEqualTo(300000L);
+		assertThat(KafkaTestUtils.getPropertyValue(containers.get(0), "listenerConsumer.syncCommitTimeout"))
+				.isEqualTo(Duration.ofSeconds(60));
 		container.stop();
 	}
 
@@ -370,13 +375,15 @@ public class EnableKafkaIntegrationTests {
 		assertThat(listenerContainer.getContainerProperties().getSyncCommitTimeout()).isNull();
 		this.registry.start();
 		assertThat(listenerContainer.isRunning()).isTrue();
-		assertThat(((ConcurrentMessageListenerContainer<?, ?>) listenerContainer)
+		KafkaMessageListenerContainer<?, ?> kafkaMessageListenerContainer =
+				((ConcurrentMessageListenerContainer<?, ?>) listenerContainer)
 				.getContainers()
-				.get(0)
+				.get(0);
+		assertThat(kafkaMessageListenerContainer
 				.getContainerProperties().getSyncCommitTimeout())
-				.isEqualTo(Duration.ofSeconds(60));
+				.isEqualTo(Duration.ofSeconds(59));
 		assertThat(listenerContainer.getContainerProperties().getSyncCommitTimeout())
-				.isEqualTo(Duration.ofSeconds(60));
+				.isEqualTo(Duration.ofSeconds(59));
 		listenerContainer.stop();
 		assertThat(KafkaTestUtils.getPropertyValue(listenerContainer, "containerProperties.syncCommits", Boolean.class))
 				.isFalse();
@@ -384,6 +391,8 @@ public class EnableKafkaIntegrationTests {
 				.isNotNull();
 		assertThat(KafkaTestUtils.getPropertyValue(listenerContainer, "containerProperties.consumerRebalanceListener"))
 				.isNotNull();
+		assertThat(KafkaTestUtils.getPropertyValue(kafkaMessageListenerContainer, "listenerConsumer.maxPollInterval"))
+				.isEqualTo(301000L);
 	}
 
 	@Test
@@ -1683,7 +1692,9 @@ public class EnableKafkaIntegrationTests {
 		volatile CustomMethodArgument customMethodArgument;
 
 		@KafkaListener(id = "manualStart", topics = "manualStart",
-				containerFactory = "kafkaAutoStartFalseListenerContainerFactory")
+				containerFactory = "kafkaAutoStartFalseListenerContainerFactory",
+				properties = { ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG + ":301000",
+						ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG + ":59000" })
 		public void manualStart(String foo) {
 		}
 


### PR DESCRIPTION
- Wrong default used when `max.poll.interval.ms` is not specified - 30s Vs 300s
- Value set in `@KafkaListener.properties` ignored for this calculatio and default
  used instead
- Also use actual default for `ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG`

**I will back port - expecting conflicts**