### PR TITLE
GH-1565: ErrorHandlingDeserializer Extensions

### DIFF
--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ErrorHandlingDeserializerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ErrorHandlingDeserializerTests.java
@@ -170,7 +170,7 @@ public class ErrorHandlingDeserializerTests {
 		@Bean
 		public ConsumerFactory<String, String> cf() {
 			Map<String, Object> props = KafkaTestUtils.consumerProps(TOPIC + ".g1", "false", embeddedKafka());
-			props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class.getName());
+			props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ExtendedEHD.class.getName());
 			props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
 			props.put(ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS, FailSometimesDeserializer.class);
 			props.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, FailSometimesDeserializer.class.getName());
@@ -228,6 +228,10 @@ public class ErrorHandlingDeserializerTests {
 			}
 			return string;
 		}
+
+	}
+
+	public static class ExtendedEHD<T> extends ErrorHandlingDeserializer<T> {
 
 	}
 


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1565

Previously extended `ErrorHandlingDeserializer` only worked if configured
as a class rather than a class name.

Spring Boot automatically converts the class names to classes but config
outside of such an environment would not work.

**cherry-pick to 2.5.x, 2.4.x, 2.3.x**