### PR TITLE
GH-1569: Add Message Listener Advice Chain

### DIFF
--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -2184,6 +2184,10 @@ If the function returns `null`, the handler's default `BackOff` will be used.
 |1
 |The number of records before committing pending offsets when the `ackMode` is `COUNT` or `COUNT_TIME`.
 
+|adviceChain
+|`null`
+|A chain of `Advice` objects (e.g. `MethodInterceptor` around advice) wrapping the message listener, invoked in order.
+
 |ackMode
 |BATCH
 |Controls how often offsets are committed - see <<committing-offsets>>.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -17,6 +17,9 @@ Various error handlers (that extend `FailedRecordProcessor`) and the `DefaultAft
 In addition, you can now select the `BackOff` to use based on the failed record and/or exception.
 See <<seek-to-current>>, <<recovering-batch-eh>>, <<dead-letters>> and <<after-rollback>> for more information.
 
+You can now configure an `adviceChain` in the container properties.
+See <<container-props>> for more information.
+
 ==== @KafkaLisener Changes
 
 When using manual partition assignment, you can now specify a wildcard for determining which partitions should be reset to the initial offset.


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1569

Allow provision of around advices, for example to set/reset logging MDC.

**cherry-pick to 2.5.x (what's new will need fixing)**