### PR TITLE
Json (de)serialization configuration improvements

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java
@@ -142,7 +142,7 @@ public class JsonDeserializer<T> implements Deserializer<T> {
 	 * {@link ObjectMapper}.
 	 * @param targetType the target type to use if no type info headers are present.
 	 */
-	public JsonDeserializer(Class<? super T> targetType) {
+	public JsonDeserializer(@Nullable Class<? super T> targetType) {
 		this(targetType, true);
 	}
 
@@ -151,7 +151,17 @@ public class JsonDeserializer<T> implements Deserializer<T> {
 	 * @param targetType the target type reference to use if no type info headers are present.
 	 * @since 2.3
 	 */
-	public JsonDeserializer(TypeReference<? super T> targetType) {
+	public JsonDeserializer(@Nullable TypeReference<? super T> targetType) {
+		this(targetType, true);
+	}
+
+
+	/**
+	 * Construct an instance with the provided target type, and a default {@link ObjectMapper}.
+	 * @param targetType the target java type to use if no type info headers are present.
+	 * @since 2.3
+	 */
+	public JsonDeserializer(@Nullable JavaType targetType) {
 		this(targetType, true);
 	}
 
@@ -180,6 +190,18 @@ public class JsonDeserializer<T> implements Deserializer<T> {
 	}
 
 	/**
+	 * Construct an instance with the provided target type, and
+	 * useHeadersIfPresent with a default {@link ObjectMapper}.
+	 * @param targetType the target java type.
+	 * @param useHeadersIfPresent true to use headers if present and fall back to target
+	 * type if not.
+	 * @since 2.3
+	 */
+	public JsonDeserializer(JavaType targetType, boolean useHeadersIfPresent) {
+		this(targetType, JacksonUtils.enhancedObjectMapper(), useHeadersIfPresent);
+	}
+
+	/**
 	 * Construct an instance with the provided target type, and {@link ObjectMapper}.
 	 * @param targetType the target type to use if no type info headers are present.
 	 * @param objectMapper the mapper. type if not.
@@ -194,6 +216,15 @@ public class JsonDeserializer<T> implements Deserializer<T> {
 	 * @param objectMapper the mapper. type if not.
 	 */
 	public JsonDeserializer(TypeReference<? super T> targetType, ObjectMapper objectMapper) {
+		this(targetType, objectMapper, true);
+	}
+
+	/**
+	 * Construct an instance with the provided target type, and {@link ObjectMapper}.
+	 * @param targetType the target java type to use if no type info headers are present.
+	 * @param objectMapper the mapper. type if not.
+	 */
+	public JsonDeserializer(JavaType targetType, ObjectMapper objectMapper) {
 		this(targetType, objectMapper, true);
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java
@@ -548,6 +548,43 @@ public class JsonDeserializer<T> implements Deserializer<T> {
 		// No-op
 	}
 
+	/**
+	 * Copies this deserializer with same configuration, except new target type is used.
+	 * @param newTargetType type used for when type headers are missing, not null
+	 * @param <X> new deserialization result type
+	 * @return new instance of deserializer with type changes
+	 * @since 2.6
+	 */
+	public <X> JsonDeserializer<X> copyWithType(Class<? super X> newTargetType) {
+		return copyWithType(this.objectMapper.constructType(newTargetType));
+	}
+
+	/**
+	 * Copies this deserializer with same configuration, except new target type reference is used.
+	 * @param newTargetType type reference used for when type headers are missing, not null
+	 * @param <X> new deserialization result type
+	 * @return new instance of deserializer with type changes
+	 * @since 2.6
+	 */
+	public <X> JsonDeserializer<X> copyWithType(TypeReference<? super X> newTargetType) {
+		return copyWithType(this.objectMapper.constructType(newTargetType.getType()));
+	}
+
+	/**
+	 * Copies this deserializer with same configuration, except new target java type is used.
+	 * @param newTargetType java type used for when type headers are missing, not null
+	 * @param <X> new deserialization result type
+	 * @return new instance of deserializer with type changes
+	 * @since 2.6
+	 */
+	public <X> JsonDeserializer<X> copyWithType(JavaType newTargetType) {
+		JsonDeserializer<X> result = new JsonDeserializer<>(newTargetType, this.objectMapper, this.useTypeHeaders);
+		result.removeTypeHeaders = this.removeTypeHeaders;
+		result.typeMapper = this.typeMapper;
+		result.typeMapperExplicitlySet = this.typeMapperExplicitlySet;
+		return result;
+	}
+
 	// Fluent API
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerde.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerde.java
@@ -125,6 +125,42 @@ public class JsonSerde<T> implements Serde<T> {
 		return this.jsonDeserializer;
 	}
 
+	/**
+	 * Copies this serde with same configuration, except new target type is used.
+	 * @param newTargetType type reference forced for serialization, and used as default for deserialization, not null
+	 * @param <X> new deserialization result type and serialization source type
+	 * @return new instance of serde with type changes
+	 * @since 2.6
+	 */
+	public <X> JsonSerde<X> copyWithType(Class<? super X> newTargetType) {
+		return new JsonSerde<>(this.jsonSerializer.copyWithType(newTargetType),
+			this.jsonDeserializer.copyWithType(newTargetType));
+	}
+
+	/**
+	 * Copies this serde with same configuration, except new target type reference is used.
+	 * @param newTargetType type reference forced for serialization, and used as default for deserialization, not null
+	 * @param <X> new deserialization result type and serialization source type
+	 * @return new instance of serde with type changes
+	 * @since 2.6
+	 */
+	public <X> JsonSerde<X> copyWithType(TypeReference<? super X> newTargetType) {
+		return new JsonSerde<>(this.jsonSerializer.copyWithType(newTargetType),
+			this.jsonDeserializer.copyWithType(newTargetType));
+	}
+
+	/**
+	 * Copies this serde with same configuration, except new target java type is used.
+	 * @param newTargetType java type forced for serialization, and used as default for deserialization, not null
+	 * @param <X> new deserialization result type and serialization source type
+	 * @return new instance of serde with type changes
+	 * @since 2.6
+	 */
+	public <X> JsonSerde<X> copyWithType(JavaType newTargetType) {
+		return new JsonSerde<>(this.jsonSerializer.copyWithType(newTargetType),
+			this.jsonDeserializer.copyWithType(newTargetType));
+	}
+
 	// Fluent API
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerde.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerde.java
@@ -92,7 +92,7 @@ public class JsonSerde<T> implements Serde<T> {
 			Class<?> resolvedGeneric = ResolvableType.forClass(getClass()).getSuperType().resolveGeneric(0);
 			actualJavaType = resolvedGeneric != null ? objectMapper.constructType(resolvedGeneric) : null;
 		}
-		this.jsonSerializer = new JsonSerializer<>(objectMapper);
+		this.jsonSerializer = new JsonSerializer<>(actualJavaType, objectMapper);
 		this.jsonDeserializer = new JsonDeserializer<>(actualJavaType, objectMapper);
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerializer.java
@@ -204,6 +204,43 @@ public class JsonSerializer<T> implements Serializer<T> {
 		// No-op
 	}
 
+	/**
+	 * Copies this serializer with same configuration, except new target type reference is used.
+	 * @param newTargetType type reference forced for serialization, not null
+	 * @param <X> new serialization source type
+	 * @return new instance of serializer with type changes
+	 * @since 2.6
+	 */
+	public <X> JsonSerializer<X> copyWithType(Class<? super X> newTargetType) {
+		return copyWithType(this.objectMapper.constructType(newTargetType));
+	}
+
+	/**
+	 * Copies this serializer with same configuration, except new target type reference is used.
+	 * @param newTargetType type reference forced for serialization, not null
+	 * @param <X> new serialization source type
+	 * @return new instance of serializer with type changes
+	 * @since 2.6
+	 */
+	public <X> JsonSerializer<X> copyWithType(TypeReference<? super X> newTargetType) {
+		return copyWithType(this.objectMapper.constructType(newTargetType.getType()));
+	}
+
+	/**
+	 * Copies this serializer with same configuration, except new target java type is used.
+	 * @param newTargetType java type forced for serialization, not null
+	 * @param <X> new serialization source type
+	 * @return new instance of serializer with type changes
+	 * @since 2.6
+	 */
+	public <X> JsonSerializer<X> copyWithType(JavaType newTargetType) {
+		JsonSerializer<X> result = new JsonSerializer<>(newTargetType, this.objectMapper);
+		result.addTypeInfo = this.addTypeInfo;
+		result.typeMapper = this.typeMapper;
+		result.typeMapperExplicitlySet = this.typeMapperExplicitlySet;
+		return result;
+	}
+
 	// Fluent API
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,10 @@ import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.StringUtils;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
 
 /**
  * Generic {@link org.apache.kafka.common.serialization.Serializer Serializer} for sending
@@ -63,17 +66,32 @@ public class JsonSerializer<T> implements Serializer<T> {
 
 	protected boolean addTypeInfo = true; // NOSONAR
 
+	private ObjectWriter writer;
+
 	protected Jackson2JavaTypeMapper typeMapper = new DefaultJackson2JavaTypeMapper(); // NOSONAR
 
 	private boolean typeMapperExplicitlySet = false;
 
 	public JsonSerializer() {
-		this(JacksonUtils.enhancedObjectMapper());
+		this((JavaType) null, JacksonUtils.enhancedObjectMapper());
+	}
+
+	public JsonSerializer(TypeReference<? super T> targetType) {
+		this(targetType, JacksonUtils.enhancedObjectMapper());
 	}
 
 	public JsonSerializer(ObjectMapper objectMapper) {
+		this((JavaType) null, objectMapper);
+	}
+
+	public JsonSerializer(TypeReference<? super T> targetType, ObjectMapper objectMapper) {
+		this(targetType == null ? null : objectMapper.constructType(targetType.getType()), objectMapper);
+	}
+
+	public JsonSerializer(JavaType targetType, ObjectMapper objectMapper) {
 		Assert.notNull(objectMapper, "'objectMapper' must not be null.");
 		this.objectMapper = objectMapper;
+		this.writer = objectMapper.writerFor(targetType);
 	}
 
 	public boolean isAddTypeInfo() {
@@ -174,7 +192,7 @@ public class JsonSerializer<T> implements Serializer<T> {
 			return null;
 		}
 		try {
-			return this.objectMapper.writeValueAsBytes(data);
+			return this.writer.writeValueAsBytes(data);
 		}
 		catch (IOException ex) {
 			throw new SerializationException("Can't serialize data [" + data + "] for topic [" + topic + "]", ex);

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/JsonSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/JsonSerializationTests.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.kafka.common.errors.SerializationException;
@@ -42,6 +43,9 @@ import org.springframework.kafka.support.converter.Jackson2JavaTypeMapper.TypePr
 import org.springframework.kafka.support.serializer.testentities.DummyEntity;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JavaType;
@@ -225,6 +229,16 @@ public class JsonSerializationTests {
 	}
 
 	@Test
+	void testDeserializerTypeForcedType() {
+		JsonSerializer<List<Parent>> ser = new JsonSerializer<>(new TypeReference<List<Parent>>() { });
+		JsonDeserializer<List<Parent>> de = new JsonDeserializer<>(new TypeReference<List<Parent>>() { });
+		List<Parent> dummy = Arrays.asList(new Child(1), new Parent(2));
+		assertThat(de.deserialize(this.topic, ser.serialize(this.topic, dummy))).isEqualTo(dummy);
+		ser.close();
+		de.close();
+	}
+
+	@Test
 	void jsonNode() throws IOException {
 		JsonSerializer<Object> ser = new JsonSerializer<>();
 		JsonDeserializer<JsonNode> de = new JsonDeserializer<>();
@@ -380,5 +394,44 @@ public class JsonSerializationTests {
 		public String bar = "bar";
 
 	}
+
+	@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+	@JsonSubTypes({
+		@JsonSubTypes.Type(value = Parent.class, name = "parent"),
+		@JsonSubTypes.Type(value = Child.class, name = "child")
+	})
+	public static class Parent {
+		@JsonProperty
+		private int number;
+
+		Parent() { }
+
+		Parent(int number) {
+			this.number = number;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (o == null || !getClass().equals(o.getClass())) {
+				return false;
+			}
+			Parent parent = (Parent) o;
+			return number == parent.number;
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(number);
+		}
+	}
+
+	public static class Child extends Parent {
+		Child() { }
+
+		Child(int number) {
+			super(number);
+		}
+	}
+
 
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/JsonSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/JsonSerializationTests.java
@@ -349,6 +349,20 @@ public class JsonSerializationTests {
 		deser.close();
 	}
 
+	@Test
+	void testCopyWithType() {
+		JsonDeserializer<Object> deser = new JsonDeserializer<>();
+		JsonSerializer<Object> ser = new JsonSerializer<>();
+		JsonDeserializer<Parent> typedDeser = deser.copyWithType(Parent.class);
+		JsonSerializer<Parent> typedSer = ser.copyWithType(Parent.class);
+		Child serializedValue = new Child(1);
+		assertThat(typedDeser.deserialize("", typedSer.serialize("", serializedValue))).isEqualTo(serializedValue);
+		deser.close();
+		ser.close();
+		typedDeser.close();
+		typedSer.close();
+	}
+
 	public static JavaType fooBarJavaType(byte[] data, Headers headers) {
 		if (data[0] == '{' && data[1] == 'f') {
 			return TypeFactory.defaultInstance().constructType(Foo.class);


### PR DESCRIPTION
This changes improve ability to configure `JsonSerde` as well as `JsonSerializer` and `JsonDeserializer`.

First, allow `TypeReference` and `JavaType` when constructing `JsonSerde`. This can be helpful when using Serde for deserialization, but there are container types involved.

Second, allow forcing type format when serializing. This is actually a problem that cannot be currently solved using `JsonSerializer`: Lets assume theres a serialized type A, which is polymorphic and there is a list of objects of type A, possibly subtypes. Currently, the mechanism finds typed jackson serializer only for raw list, and serializes contents without configuration, so as simple beans, skipping properties that should be added. This can be seen in test `JsonSerializationTests#testDeserializerTypeForcedType` which fails when not providing forced type to `JsonSerializer`.

Lastly, this pull request adds ability to create copies of `JsonSerde`, `JsonSerializer` and `JsonDeserializer` with changed forced and default type. This change allows to create a single bean with `JsonSerde<?>` as actual type, configure its typeMapper, and other behaviors, and use this bean as a base for all the serdes used. Unfortunately, this couldn't be done with the fluent API, because generic parameter of type changes.

There is a backward incompatibility in this changes - previously, when creating `JsonSerde` with specified class or type reference, this was only passed to deserialized as default type, and now is also passed to serializer as a forced type. This means that if user created `JsonSerde` instance with specified target type, but used its serializer to serialize unrelated type, now this will fail, instead of serializing the data without type information. I don't think this is problematic: Either user didn't specify a type and serialized types based on header data or object mapper configuration, or they specified type and serialized objects of this type. 

In any case, I think specifing type for `JsonSerde` and using its serializer to serialize unrelated types could very well be a invalid configuration and probably should produce an error. If you don't agree, I can add backward compatiblity flag.
