### PR TITLE
Fix Request/Reply with ConsumerRecord<?, ?>

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
@@ -605,7 +605,7 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 			}
 		}
 
-		if (notConvertibleParameters == method.getParameterCount()) {
+		if (notConvertibleParameters == method.getParameterCount() && method.getReturnType().equals(void.class)) {
 			this.conversionNeeded = false;
 		}
 		boolean validParametersForBatch = method.getGenericParameterTypes().length <= allowedBatchParameters;

--- a/spring-kafka/src/test/java/org/springframework/kafka/requestreply/ReplyingKafkaTemplateTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/requestreply/ReplyingKafkaTemplateTests.java
@@ -109,7 +109,8 @@ import org.springframework.util.concurrent.SettableListenableFuture;
 		ReplyingKafkaTemplateTests.G_REPLY, ReplyingKafkaTemplateTests.G_REQUEST,
 		ReplyingKafkaTemplateTests.H_REPLY, ReplyingKafkaTemplateTests.H_REQUEST,
 		ReplyingKafkaTemplateTests.I_REPLY, ReplyingKafkaTemplateTests.I_REQUEST,
-		ReplyingKafkaTemplateTests.J_REPLY, ReplyingKafkaTemplateTests.J_REQUEST })
+		ReplyingKafkaTemplateTests.J_REPLY, ReplyingKafkaTemplateTests.J_REQUEST,
+		ReplyingKafkaTemplateTests.K_REPLY, ReplyingKafkaTemplateTests.K_REQUEST })
 public class ReplyingKafkaTemplateTests {
 
 	public static final String A_REPLY = "aReply";
@@ -152,6 +153,10 @@ public class ReplyingKafkaTemplateTests {
 
 	public static final String J_REQUEST = "jRequest";
 
+	public static final String K_REPLY = "kReply";
+
+	public static final String K_REQUEST = "kRequest";
+
 	@Autowired
 	private EmbeddedKafkaBroker embeddedKafka;
 
@@ -191,6 +196,24 @@ public class ReplyingKafkaTemplateTests {
 			assertThatExceptionOfType(ExecutionException.class)
 					.isThrownBy(() -> template.sendAndReceive(record2, Duration.ZERO).get(10, TimeUnit.SECONDS))
 					.withCauseExactlyInstanceOf(KafkaReplyTimeoutException.class);
+		}
+		finally {
+			template.stop();
+			template.destroy();
+		}
+	}
+
+	@Test
+	void testConsumerRecord() throws Exception {
+		ReplyingKafkaTemplate<Integer, String, String> template = createTemplate(K_REPLY);
+		try {
+			template.setDefaultReplyTimeout(Duration.ofSeconds(30));
+			Headers headers = new RecordHeaders();
+			ProducerRecord<Integer, String> record = new ProducerRecord<>(K_REQUEST, null, null, null, "foo", headers);
+			RequestReplyFuture<Integer, String, String> future = template.sendAndReceive(record);
+			future.getSendFuture().get(10, TimeUnit.SECONDS); // send ok
+			ConsumerRecord<Integer, String> consumerRecord = future.get(30, TimeUnit.SECONDS);
+			assertThat(consumerRecord.value()).isEqualTo("FOO");
 		}
 		finally {
 			template.stop();
@@ -728,6 +751,12 @@ public class ReplyingKafkaTemplateTests {
 		@SendTo  // default REPLY_TOPIC header
 		public String handleJ(String in) throws InterruptedException {
 			return in.toUpperCase();
+		}
+
+		@KafkaListener(id = K_REQUEST, topics = { K_REQUEST })
+		@SendTo
+		public String handleK(ConsumerRecord<String, String> in) {
+			return in.value().toUpperCase();
 		}
 
 	}


### PR DESCRIPTION
Message conversion is bypassed when consuming the raw `ConsumerRecord`.
However, the request message is needed when returning a result (for
reply topic determination, correlation, etc).

**I will do the backports; I expect conflicts in the test.**