### PR TITLE
Fix Shutdown Race Causing Test Delays

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -1096,6 +1096,9 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			}
 			pauseConsumerIfNecessary();
 			this.lastPoll = System.currentTimeMillis();
+			if (!isRunning()) {
+				return;
+			}
 			this.polling.set(true);
 			ConsumerRecords<K, V> records = doPoll();
 			if (!this.polling.compareAndSet(true, false) && records != null) {


### PR DESCRIPTION
Don't poll the consumer if the container has already stopped.
This causes excessive test run times.
Local build time reduced from 7 minutes to less than 5.