### PR TITLE
GH-1587: Fix NPE with Foreign TM and fixTxOffsets

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerProperties.java
@@ -410,9 +410,10 @@ public class ConsumerProperties {
 	 * functionally affect the consumer but some users have expressed concern that the
 	 * "lag" is non-zero. Set this to true and the container will correct such
 	 * mis-reported offsets. The check is performed before the next poll to avoid adding
-	 * significant complexity to the commit processing. IMPORTANT: The lag will only be
-	 * corrected if the consumer is configured with
-	 * {@code isolation.level=read_committed}.
+	 * significant complexity to the commit processing. IMPORTANT: At the time of writing,
+	 * the lag will only be corrected if the consumer is configured with
+	 * {@code isolation.level=read_committed} and {@code max.poll.records} is greater than
+	 * 1. See https://issues.apache.org/jira/browse/KAFKA-10683 for more information.
 	 * @param fixTxOffsets true to correct the offset(s).
 	 * @since 2.5.6
 	 */

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -1186,7 +1186,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 					});
 					if (toFix.size() > 0) {
 						this.logger.debug(() -> "Fixing TX offsets: " + toFix);
-						if (this.transactionTemplate == null) {
+						if (this.kafkaTxManager == null) {
 							if (this.syncCommits) {
 								commitSync(toFix);
 							}

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -2300,7 +2300,8 @@ The default executor creates threads named `<name>-C-n`; with the `KafkaMessageL
 This does not functionally affect the consumer but some users have expressed concern that the "lag" is non-zero.
 Set this property to `true` and the container will correct such mis-reported offsets.
 The check is performed before the next poll to avoid adding significant complexity to the commit processing.
-The lag will only be corrected if the consumer is configured with `isolation.level=read_committed`.
+At the time of writing, the lag will only be corrected if the consumer is configured with `isolation.level=read_committed` and `max.poll.records` is greater than 1.
+See https://issues.apache.org/jira/browse/KAFKA-10683[KAFKA-10683] for more information.
 
 |groupId
 |`null`


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1587

Code was using the presence of a transaction template instead of the KTM.

**cherry-pick to 2.5.x**