### PR TITLE
GH-1613: Fix Race in Producer Factory

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
@@ -439,7 +439,6 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 				next = queue.poll();
 			}
 		});
-		this.cache.clear();
 		synchronized (this.consumerProducers) {
 			this.consumerProducers.forEach(
 					(k, v) -> v.closeDelegate(this.physicalCloseTimeout, this.listeners));


### PR DESCRIPTION
Resolves

Do not clear the cache in `destroy()` - just drain the producer queues instead.
Fixes a race condition where a producer could be returned to the cache between draining
the queues and clearing the map.
Just leave the queue(s) in place to accept new returns.

**cherry-pick to 2.5.x, 2.4.x, 2.3.x, 1.3.x**