### PR TITLE
Improve subBatchPerPartition determination

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
@@ -682,20 +682,17 @@ public class ContainerProperties extends ConsumerProperties {
 	 * Set the exactly once semantics mode. When {@link EOSMode#ALPHA} a producer per
 	 * group/topic/partition is used (enabling 'transactional.id fencing`).
 	 * {@link EOSMode#BETA} enables fetch-offset-request fencing, and requires brokers 2.5
-	 * or later. In the 2.6 client, the default will be BETA because the 2.6 client can
+	 * or later. With the 2.6 client, the default is now BETA because the 2.6 client can
 	 * automatically fall back to ALPHA.
 	 * @param eosMode the mode; default ALPHA.
 	 * @since 2.5
 	 */
 	public void setEosMode(EOSMode eosMode) {
 		if (eosMode == null) {
-			this.eosMode = EOSMode.ALPHA;
+			this.eosMode = EOSMode.ALPHA; // TODO change this in 2.7 to an assertion
 		}
 		else {
 			this.eosMode = eosMode;
-		}
-		if (this.eosMode.equals(EOSMode.BETA) && this.subBatchPerPartition == null) {
-			this.subBatchPerPartition = false;
 		}
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -748,7 +748,13 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 
 		private boolean setupSubBatchPerPartition() {
 			Boolean subBatching = this.containerProperties.getSubBatchPerPartition();
-			return subBatching == null ? this.transactionManager != null : subBatching;
+			if (subBatching != null) {
+				return subBatching;
+			}
+			if (this.transactionManager == null) {
+				return false;
+			}
+			return this.eosMode.equals(EOSMode.ALPHA);
 		}
 
 		private DeliveryAttemptAware setupDeliveryAttemptAware() {


### PR DESCRIPTION
Previously, the `subBatchPartition` was coerced when the `EOSMode`
property was set.
This mechanism relied on `BeanUtils.copyProperties` so it was not
obvious how the default was set to false in 2.6.

Remove the coercion and add explicit code in the determination to check
the `EOSMode`.