### PR TITLE
GH-1633: Do not stop parent container when fenced

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -1088,7 +1088,11 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 							+ "' has been fenced");
 					break;
 				}
-				catch (StopAfterFenceException | Error e) { // NOSONAR - rethrown
+				catch (StopAfterFenceException e) {
+					this.logger.error(e, "Stopping container due to fencing");
+					stop();
+				}
+				catch (Error e) { // NOSONAR - rethrown
 					Runnable runnable = KafkaMessageListenerContainer.this.emergencyStop;
 					if (runnable != null) {
 						runnable.run();


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1633

Only the child container instance should be stopped when a producer is
fenced.

Tested with a Boot Application:

```java
@SpringBootApplication
public class Kgh1633Application {

	public static void main(String[] args) {
		SpringApplication.run(Kgh1633Application.class, args);
	}

	@Autowired
	KafkaTemplate<String, String> template;

	@KafkaListener(id = "kgh1633a", topics = "kgh1633")
	public void listen(String in) throws InterruptedException {
		System.out.println(in);
		this.template.send("kgh1633-1", "foo");
		Thread.sleep(10_000);
	}

	@Bean
	public NewTopic topic1() {
		return TopicBuilder.name("kgh1633").partitions(1).replicas(1).build();
	}

	@Bean
	public NewTopic topic2() {
		return TopicBuilder.name("kgh1633-1").partitions(1).replicas(1).build();
	}

//	@EventListener
//	public void started(ConsumerStartedEvent event) {
//		// temporary until GH-1633 is fixed
//		KafkaMessageListenerContainer<?, ?> container = (KafkaMessageListenerContainer<?, ?>) event.getSource();
//		container.setEmergencyStop(() -> container.stop(() -> { }));
//	}

	@EventListener
	public void stopped(ConsumerStoppedEvent event) {
		((KafkaMessageListenerContainer<?, ?>) event.getSource()).start();
	}

}

@Component
class Customizer {

	Customizer(AbstractKafkaListenerContainerFactory<?, ?, ?> factory) {
		factory.getContainerProperties().setStopContainerWhenFenced(true);
	}

}
```
```properties
spring.kafka.producer.transaction-id-prefix=tx-
spring.kafka.producer.acks=all
spring.kafka.producer.properties.transaction.timeout.ms=5000
```