### PR TITLE
GH-1637: Fix TopicPartitionOffset.hashCode()

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/TopicPartitionOffset.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/TopicPartitionOffset.java
@@ -212,7 +212,7 @@ public class TopicPartitionOffset {
 
 	@Override
 	public int hashCode() {
-		return this.topicPartition.hashCode();
+		return this.topicPartition.hashCode() + this.position.hashCode();
 	}
 
 	@Override

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/TopicPartitionOffsetTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/TopicPartitionOffsetTests.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.kafka.support.TopicPartitionOffset.SeekPosition;
+
+/**
+ * @author Gary Russell
+ * @since 2.3.13
+ *
+ */
+public class TopicPartitionOffsetTests {
+
+	@Test
+	void hashCodeTest() {
+		assertThat(new TopicPartitionOffset("foo", 1, SeekPosition.BEGINNING).hashCode())
+				.isNotEqualTo(new TopicPartitionOffset("foo",  1, SeekPosition.END).hashCode());
+	}
+
+}


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1637

**cherry-pick to 2.5.x, 2.4.x, 2.3.x**