### PR TITLE
Clear lastCommits after fixTxOffset

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -1237,7 +1237,11 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 					}
 				}
 				catch (Exception e) {
-					this.logger.error(e, "Failed to correct transactional offset(s)");
+					this.logger.error(e, () -> "Failed to correct transactional offset(s): "
+							+ ListenerConsumer.this.lastCommits);
+				}
+				finally {
+					ListenerConsumer.this.lastCommits.clear();
 				}
 			}
 		}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/TransactionalContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/TransactionalContainerTests.java
@@ -710,6 +710,7 @@ public class TransactionalContainerTests {
 		assertThat(latch.await(60, TimeUnit.SECONDS)).isTrue();
 		TopicPartition partition0 = new TopicPartition(topic, 0);
 		assertThat(committed.get().get(partition0).offset()).isEqualTo(2L);
+		assertThat(KafkaTestUtils.getPropertyValue(container, "listenerConsumer.lastCommits", Map.class)).isEmpty();
 		container.stop();
 		pf.destroy();
 	}


### PR DESCRIPTION
On gitter, a user reported

```
Failed to correct transactional offset(s)
java.lang.IllegalStateException: You can only check the position for partitions assigned to this consumer.
```

It is not clear how this happened since we remove revoked partitions from `lastCommits`.

However, `lastCommits` should be cleared, even if successful, to avoid unnecessary
processing if no records are received by the next poll.

- add the `lastCommits` to the error log
- clear `lastCommits` in a finally block

**cherry-pick to 2.5.x**