### PR TITLE
2.7.0 RC3 Kafka Clients

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,15 +57,15 @@ ext {
 	jaywayJsonPathVersion = '2.4.0'
 	junit4Version = '4.13.1'
 	junitJupiterVersion = '5.7.0'
-	kafkaVersion = '2.6.0'
+	kafkaVersion = '2.7.0'
 	log4jVersion = '2.13.3'
 	micrometerVersion = '1.5.7'
 	mockitoVersion = '3.5.13'
-	reactorVersion = 'Dysprosium-SR13'
+	reactorVersion = '2020.0.1'
 	scalaVersion = '2.13'
-	springDataCommonsVersion = '2.3.5.RELEASE'
+	springDataCommonsVersion = '2.4.1'
 	springRetryVersion = '1.3.0'
-	springVersion = '5.2.11.RELEASE'
+	springVersion = '5.3.1'
 
 	idPrefix = 'kafka'
 }
@@ -103,7 +103,7 @@ allprojects {
 		if (version.endsWith('SNAPSHOT')) {
 			maven { url 'https://repo.spring.io/libs-snapshot' }
 		}
-//		maven { url 'https://repository.apache.org/content/groups/staging/' }
+		maven { url 'https://repository.apache.org/content/groups/staging/' }
 	}
 
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-version=2.6.4-SNAPSHOT
+version=2.7.0-SNAPSHOT
 org.gradle.caching=true
 org.gradle.parallel=true

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/utils/KafkaTestUtils.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/utils/KafkaTestUtils.java
@@ -115,7 +115,6 @@ public final class KafkaTestUtils {
 	public static Map<String, Object> producerProps(String brokers) {
 		Map<String, Object> props = new HashMap<>();
 		props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, brokers);
-		props.put(ProducerConfig.RETRIES_CONFIG, 0);
 		props.put(ProducerConfig.BATCH_SIZE_CONFIG, "16384");
 		props.put(ProducerConfig.LINGER_MS_CONFIG, 1);
 		props.put(ProducerConfig.BUFFER_MEMORY_CONFIG, "33554432");

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/reactive/ReactiveKafkaProducerTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/reactive/ReactiveKafkaProducerTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2020 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -130,7 +130,7 @@ public class ReactiveKafkaProducerTemplate<K, V> implements AutoCloseable, Dispo
 	 * scheduled to avoid a deadlock; see
 	 * https://issues.apache.org/jira/browse/KAFKA-10790
 	 */
-	@Deprecated(since = "2.7")
+	@Deprecated(since = "2.7", forRemoval = true)
 	public Mono<?> flush() {
 		return doOnProducer(producer -> {
 			producer.flush();

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/reactive/ReactiveKafkaProducerTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/reactive/ReactiveKafkaProducerTemplate.java
@@ -121,10 +121,20 @@ public class ReactiveKafkaProducerTemplate<K, V> implements AutoCloseable, Dispo
 		return this.sender.send(records);
 	}
 
-	public Mono<Void> flush() {
+	/**
+	 * Flush the producer.
+	 * @return {@link Mono#empty()}.
+	 * @deprecated - flush does not make sense in the context of a reactive flow since,
+	 * the send completion signal is a send result, which implies that a flush is
+	 * redundant. If you use this method with reactor-kafka 1.3 or later, it must be
+	 * scheduled to avoid a deadlock; see
+	 * https://issues.apache.org/jira/browse/KAFKA-10790
+	 */
+	@Deprecated(since = "2.7")
+	public Mono<?> flush() {
 		return doOnProducer(producer -> {
 			producer.flush();
-			return null;
+			return Mono.empty();
 		});
 	}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/config/StreamsBuilderFactoryBeanTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/config/StreamsBuilderFactoryBeanTests.java
@@ -125,7 +125,7 @@ public class StreamsBuilderFactoryBeanTests {
 			Map<String, Object> props = new HashMap<>();
 			props.put(StreamsConfig.APPLICATION_ID_CONFIG, APPLICATION_ID);
 			props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, this.brokerAddresses);
-			props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION, StreamsConfig.OPTIMIZE);
+			props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE);
 			props.put(StreamsConfig.STATE_DIR_CONFIG, stateStoreDir.toString());
 			return new KafkaStreamsConfiguration(props);
 		}

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
@@ -36,7 +36,6 @@ import java.util.stream.Stream;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.serialization.StringDeserializer;
@@ -327,7 +326,6 @@ public class DefaultKafkaConsumerFactoryTests {
 	@Test
 	public void testNestedTxProducerIsCached() throws Exception {
 		Map<String, Object> producerProps = KafkaTestUtils.producerProps(this.embeddedKafka);
-		producerProps.put(ProducerConfig.RETRIES_CONFIG, 1);
 		DefaultKafkaProducerFactory<Integer, String> pf = new DefaultKafkaProducerFactory<>(producerProps);
 		KafkaTemplate<Integer, String> template = new KafkaTemplate<>(pf);
 		DefaultKafkaProducerFactory<Integer, String> pfTx = new DefaultKafkaProducerFactory<>(producerProps);
@@ -373,7 +371,6 @@ public class DefaultKafkaConsumerFactoryTests {
 	@Test
 	public void testContainerTxProducerIsNotCached() throws Exception {
 		Map<String, Object> producerProps = KafkaTestUtils.producerProps(this.embeddedKafka);
-		producerProps.put(ProducerConfig.RETRIES_CONFIG, 1);
 		DefaultKafkaProducerFactory<Integer, String> pf = new DefaultKafkaProducerFactory<>(producerProps);
 		KafkaTemplate<Integer, String> template = new KafkaTemplate<>(pf);
 		DefaultKafkaProducerFactory<Integer, String> pfTx = new DefaultKafkaProducerFactory<>(producerProps);

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTransactionTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTransactionTests.java
@@ -101,7 +101,6 @@ public class KafkaTemplateTransactionTests {
 	@Test
 	public void testLocalTransaction() {
 		Map<String, Object> senderProps = KafkaTestUtils.producerProps(embeddedKafka);
-		senderProps.put(ProducerConfig.RETRIES_CONFIG, 1);
 		senderProps.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "my.transaction.");
 		senderProps.put(ProducerConfig.CLIENT_ID_CONFIG, "customClientId");
 		DefaultKafkaProducerFactory<String, String> pf = new DefaultKafkaProducerFactory<>(senderProps);
@@ -157,7 +156,6 @@ public class KafkaTemplateTransactionTests {
 	@Test
 	public void testGlobalTransaction() {
 		Map<String, Object> senderProps = KafkaTestUtils.producerProps(embeddedKafka);
-		senderProps.put(ProducerConfig.RETRIES_CONFIG, 1);
 		DefaultKafkaProducerFactory<String, String> pf = new DefaultKafkaProducerFactory<>(senderProps);
 		pf.setKeySerializer(new StringSerializer());
 		pf.setTransactionIdPrefix("my.transaction.");
@@ -236,7 +234,6 @@ public class KafkaTemplateTransactionTests {
 	@Test
 	public void testNoTx() {
 		Map<String, Object> senderProps = KafkaTestUtils.producerProps(embeddedKafka);
-		senderProps.put(ProducerConfig.RETRIES_CONFIG, 1);
 		DefaultKafkaProducerFactory<String, String> pf = new DefaultKafkaProducerFactory<>(senderProps);
 		pf.setKeySerializer(new StringSerializer());
 		pf.setTransactionIdPrefix("my.transaction.");
@@ -249,7 +246,8 @@ public class KafkaTemplateTransactionTests {
 
 	@Test
 	public void testTransactionSynchronization() {
-		MockProducer<String, String> producer = spy(new MockProducer<>());
+		StringSerializer ss = new StringSerializer();
+		MockProducer<String, String> producer = spy(new MockProducer<>(false, ss, ss));
 		producer.initTransactions();
 
 		@SuppressWarnings("unchecked")
@@ -283,7 +281,8 @@ public class KafkaTemplateTransactionTests {
 
 	@Test
 	public void testTransactionSynchronizationExceptionOnCommit() {
-		MockProducer<String, String> producer = new MockProducer<>();
+		StringSerializer ss = new StringSerializer();
+		MockProducer<String, String> producer = new MockProducer<>(false, ss, ss);
 		producer.initTransactions();
 
 		@SuppressWarnings("unchecked")
@@ -553,7 +552,6 @@ public class KafkaTemplateTransactionTests {
 	void testNonTxWithTx() {
 		Map<String, Object> senderProps = KafkaTestUtils.producerProps(this.embeddedKafka);
 		senderProps.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "tx.");
-		senderProps.put(ProducerConfig.RETRIES_CONFIG, 2);
 		DefaultKafkaProducerFactory<String, String> pf = new DefaultKafkaProducerFactory<>(senderProps);
 		pf.setKeySerializer(new StringSerializer());
 		KafkaTemplate<String, String> template = new KafkaTemplate<>(pf, true);

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/reactive/ReactiveKafkaProducerTemplateIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/reactive/ReactiveKafkaProducerTemplateIntegrationTests.java
@@ -404,27 +404,6 @@ public class ReactiveKafkaProducerTemplateIntegrationTests {
 	}
 
 	@Test
-	public void shouldFlushRecordsOnDemand() {
-		Mono<Void> sendWithFlushMono = reactiveKafkaProducerTemplate
-				.send(Mono.just(SenderRecord
-						.create(new ProducerRecord<>(REACTIVE_INT_KEY_TOPIC, DEFAULT_KEY, DEFAULT_VALUE), null)))
-				.then(reactiveKafkaProducerTemplate.flush())
-				.then();
-
-		StepVerifier.create(sendWithFlushMono)
-				.expectComplete()
-				.verify(DEFAULT_VERIFY_TIMEOUT);
-
-		StepVerifier.create(reactiveKafkaConsumerTemplate.receive().doOnNext(rr -> rr.receiverOffset().acknowledge()))
-				.assertNext(receiverRecord -> {
-					assertThat(receiverRecord.key()).isEqualTo(DEFAULT_KEY);
-					assertThat(receiverRecord.value()).isEqualTo(DEFAULT_VALUE);
-				})
-				.thenCancel()
-				.verify(DEFAULT_VERIFY_TIMEOUT);
-	}
-
-	@Test
 	public void shouldReturnPartitionsForTopic() {
 		Flux<PartitionInfo> topicPartitionsMono = reactiveKafkaProducerTemplate
 				.partitionsFromProducerFor(REACTIVE_INT_KEY_TOPIC);

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/reactive/ReactiveKafkaProducerTemplateTransactionIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/reactive/ReactiveKafkaProducerTemplateTransactionIntegrationTests.java
@@ -105,8 +105,7 @@ public class ReactiveKafkaProducerTemplateTransactionIntegrationTests {
 		SenderOptions<Integer, String> senderOptions = SenderOptions.create(senderProps);
 		senderOptions = senderOptions
 				.producerProperty(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "reactive.transaction")
-				.producerProperty(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true)
-				.producerProperty(ProducerConfig.RETRIES_CONFIG, 1);
+				.producerProperty(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true);
 		return senderOptions;
 	}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentRecovererTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentRecovererTests.java
@@ -47,7 +47,6 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetCommitCallback;
-import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.Serializer;
@@ -98,7 +97,6 @@ public class SeekToCurrentRecovererTests {
 		containerProps.setPollTimeout(10_000);
 
 		Map<String, Object> senderProps = KafkaTestUtils.producerProps(embeddedKafka);
-		senderProps.put(ProducerConfig.RETRIES_CONFIG, 1);
 		DefaultKafkaProducerFactory<Object, Object> pf = new DefaultKafkaProducerFactory<>(senderProps);
 		final KafkaTemplate<Object, Object> template = new KafkaTemplate<>(pf);
 		Serializer<?> byteArraySerializer = new ByteArraySerializer();

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/TransactionalContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/TransactionalContainerTests.java
@@ -63,7 +63,6 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.Producer;
-import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.ProducerFencedException;
@@ -557,7 +556,6 @@ public class TransactionalContainerTests {
 
 		Map<String, Object> senderProps = KafkaTestUtils.producerProps(embeddedKafka);
 //		senderProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
-		senderProps.put(ProducerConfig.RETRIES_CONFIG, 1);
 		DefaultKafkaProducerFactory<Integer, String> pf = new DefaultKafkaProducerFactory<>(senderProps);
 		pf.setTransactionIdPrefix("rr.");
 
@@ -669,7 +667,6 @@ public class TransactionalContainerTests {
 		containerProps.setIdleEventInterval(500L);
 		containerProps.setFixTxOffsets(true);
 		Map<String, Object> senderProps = KafkaTestUtils.producerProps(embeddedKafka);
-		senderProps.put(ProducerConfig.RETRIES_CONFIG, 1);
 		DefaultKafkaProducerFactory<Integer, String> pf = new DefaultKafkaProducerFactory<>(senderProps);
 		pf.setTransactionIdPrefix("fl.");
 		switch (whichTm) {
@@ -727,7 +724,6 @@ public class TransactionalContainerTests {
 		containerProps.setPollTimeout(10_000);
 
 		Map<String, Object> senderProps = KafkaTestUtils.producerProps(embeddedKafka);
-		senderProps.put(ProducerConfig.RETRIES_CONFIG, 1);
 		DefaultKafkaProducerFactory<Object, Object> pf = new DefaultKafkaProducerFactory<>(senderProps);
 		pf.setTransactionIdPrefix("maxAtt.");
 		final KafkaTemplate<Object, Object> template = new KafkaTemplate<>(pf);
@@ -834,7 +830,6 @@ public class TransactionalContainerTests {
 		containerProps.setPollTimeout(10_000);
 
 		Map<String, Object> senderProps = KafkaTestUtils.producerProps(embeddedKafka);
-		senderProps.put(ProducerConfig.RETRIES_CONFIG, 1);
 		DefaultKafkaProducerFactory<Object, Object> pf = new DefaultKafkaProducerFactory<>(senderProps);
 		pf.setTransactionIdPrefix("noRetries.");
 		final KafkaTemplate<Object, Object> template = new KafkaTemplate<>(pf);

--- a/src/reference/asciidoc/changes-since-1.0.adoc
+++ b/src/reference/asciidoc/changes-since-1.0.adoc
@@ -1,4 +1,50 @@
 [[migration]]
+=== Changes between 2.5 and 2.6
+
+[[x26-kafka-client]]
+==== Kafka Client Version
+
+This version requires the 2.6.0 `kafka-clients`.
+
+==== Listener Container Changes
+
+The default `EOSMode` is now `BETA`.
+See <<exactly-once>> for more information.
+
+Various error handlers (that extend `FailedRecordProcessor`) and the `DefaultAfterRollbackProcessor` now reset the `BackOff` if recovery fails.
+In addition, you can now select the `BackOff` to use based on the failed record and/or exception.
+See <<seek-to-current>>, <<recovering-batch-eh>>, <<dead-letters>> and <<after-rollback>> for more information.
+
+You can now configure an `adviceChain` in the container properties.
+See <<container-props>> for more information.
+
+When the container is configured to publish `ListenerContainerIdleEvent` s, it now publishes a `ListenerContainerNoLongerIdleEvent` when a record is received after publishing an idle event.
+See <<events>> and <<idle-containers>> for more information.
+
+==== @KafkaListener Changes
+
+When using manual partition assignment, you can now specify a wildcard for determining which partitions should be reset to the initial offset.
+In addition, if the listener implements `ConsumerSeekAware`, `onPartitionsAssigned()` is called after the manual assignment.
+(Also added in version 2.5.5).
+See <<manual-assignment>> for more information.
+
+Convenience methods have been added to `AbstractConsumerSeekAware` to make seeking easier.
+See <<seek>> for more information.
+
+==== ErrorHandler Changes
+
+Subclasses of `FailedRecordProcessor` (e.g. `SeekToCurrentErrorHandler`, `DefaultAfterRollbackProcessor`, `RecoveringBatchErrorHandler`) can now be configured to reset the retry state if the exception is a different type to that which occurred previously with this record.
+See <<seek-to-current>>, <<after-rollback>>, <<recovering-batch-eh>> for more information.
+
+==== Producer Factory Changes
+
+You can now set a maximum age for producers after which they will be closed and recreated.
+See <<transactions>> for more information.
+
+You can now update the configuration map after the `DefaultKafkaProducerFactory` has been created.
+This might be useful, for example, if you have to update SSL key/trust store locations after a credentials change.
+See <<producer-factory>> for more information.
+
 === Changes between 2.4 and 2.5
 
 This section covers the changes made from version 2.4 to version 2.5.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -1,48 +1,9 @@
-=== What's New in 2.6 Since 2.5
+=== What's New in 2.7 Since 2.6
 
 This section covers the changes made from version 2.5 to version 2.6.
 For changes in earlier version, see <<history>>.
 
-[[x26-kafka-client]]
+[[x27-kafka-client]]
 ==== Kafka Client Version
 
-This version requires the 2.6.0 `kafka-clients`.
-
-==== Listener Container Changes
-
-The default `EOSMode` is now `BETA`.
-See <<exactly-once>> for more information.
-
-Various error handlers (that extend `FailedRecordProcessor`) and the `DefaultAfterRollbackProcessor` now reset the `BackOff` if recovery fails.
-In addition, you can now select the `BackOff` to use based on the failed record and/or exception.
-See <<seek-to-current>>, <<recovering-batch-eh>>, <<dead-letters>> and <<after-rollback>> for more information.
-
-You can now configure an `adviceChain` in the container properties.
-See <<container-props>> for more information.
-
-When the container is configured to publish `ListenerContainerIdleEvent` s, it now publishes a `ListenerContainerNoLongerIdleEvent` when a record is received after publishing an idle event.
-See <<events>> and <<idle-containers>> for more information.
-
-==== @KafkaListener Changes
-
-When using manual partition assignment, you can now specify a wildcard for determining which partitions should be reset to the initial offset.
-In addition, if the listener implements `ConsumerSeekAware`, `onPartitionsAssigned()` is called after the manual assignment.
-(Also added in version 2.5.5).
-See <<manual-assignment>> for more information.
-
-Convenience methods have been added to `AbstractConsumerSeekAware` to make seeking easier.
-See <<seek>> for more information.
-
-==== ErrorHandler Changes
-
-Subclasses of `FailedRecordProcessor` (e.g. `SeekToCurrentErrorHandler`, `DefaultAfterRollbackProcessor`, `RecoveringBatchErrorHandler`) can now be configured to reset the retry state if the exception is a different type to that which occurred previously with this record.
-See <<seek-to-current>>, <<after-rollback>>, <<recovering-batch-eh>> for more information.
-
-==== Producer Factory Changes
-
-You can now set a maximum age for producers after which they will be closed and recreated.
-See <<transactions>> for more information.
-
-You can now update the configuration map after the `DefaultKafkaProducerFactory` has been created.
-This might be useful, for example, if you have to update SSL key/trust store locations after a credentials change.
-See <<producer-factory>> for more information.
+This version requires the 2.7.0 `kafka-clients`.


### PR DESCRIPTION
- remove `retries` from tests (deprecated)
- deprecate reactive template `flush()`