### PR TITLE
GH-1653: Fix resetStateOnExceptionChange

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ buildscript {
 	ext.kotlinVersion = '1.4.20'
 	repositories {
 		mavenCentral()
+		maven { url 'https://plugins.gradle.org/m2' }
 		maven { url 'https://repo.spring.io/plugins-release' }
 	}
 	dependencies {

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/FailedRecordTrackerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/FailedRecordTrackerTests.java
@@ -171,9 +171,9 @@ public class FailedRecordTrackerTests {
 			.isSameAs(be1);
 		TopicPartitionOffset tpo = new TopicPartitionOffset("foo", 0, 0L);
 		assertThat(tracker.deliveryAttempt(tpo)).isEqualTo(2);
-		tracker.skip(record1, new IllegalStateException());
+		tracker.skip(record1, new ListenerExecutionFailedException("test", new IllegalStateException()));
 		assertThat(tracker.deliveryAttempt(tpo)).isEqualTo(3);
-		tracker.skip(record1, new IllegalArgumentException());
+		tracker.skip(record1, new ListenerExecutionFailedException("test", new IllegalArgumentException()));
 		if (reset) {
 			assertThat(tracker.deliveryAttempt(tpo)).isEqualTo(2);
 			assertThat(KafkaTestUtils.getPropertyValue(failures.get()


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1653

Need to unwrap the cause of `ListenerExecutionFailedException` to determine
if the exception type changed.