### PR TITLE
GH-1659: Only Log Record Metadata true by default

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerProperties.java
@@ -97,7 +97,7 @@ public class ConsumerProperties {
 
 	private LogIfLevelEnabled.Level commitLogLevel = LogIfLevelEnabled.Level.DEBUG;
 
-	private boolean onlyLogRecordMetadata;
+	private boolean onlyLogRecordMetadata = true;
 
 	private Properties kafkaConsumerProperties = new Properties();
 
@@ -372,9 +372,9 @@ public class ConsumerProperties {
 	}
 
 	/**
-	 * Set to true to only log {@code topic-partition@offset} in log messages instead
-	 * of {@code record.toString()}.
-	 * @param onlyLogRecordMetadata true to only log the topic/parrtition/offset.
+	 * Set to false to log {@code record.toString()} in log messages instead
+	 * of {@code topic-partition@offset}.
+	 * @param onlyLogRecordMetadata false to log the entire record.
 	 * @since 2.2.14
 	 */
 	public void setOnlyLogRecordMetadata(boolean onlyLogRecordMetadata) {

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
@@ -668,7 +668,6 @@ public class KafkaMessageListenerContainerTests {
 		containerProps.setGroupId("grp");
 		containerProps.setAckMode(AckMode.RECORD);
 		containerProps.setMissingTopicsFatal(false);
-		containerProps.setOnlyLogRecordMetadata(true);
 		final CountDownLatch latch = new CountDownLatch(2);
 		MessageListener<Integer, String> messageListener = spy(
 				new MessageListener<Integer, String>() { // Cannot be lambda: Mockito doesn't mock final classes

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -2403,7 +2403,7 @@ See `monitorInterval`.
 |onlyLogRecord
 Metadata
 |`false`
-|Set to true to show only the `topic-partition@offset` for a record instead of the whole consumer record (in error, debug logs etc).
+|Set to false to log the complete consumer record (in error, debug logs etc) instead of just `topic-partition@offset`.
 
 |pollTimeout
 |5000

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -7,3 +7,9 @@ For changes in earlier version, see <<history>>.
 ==== Kafka Client Version
 
 This version requires the 2.7.0 `kafka-clients`.
+
+[[x27-container]]
+==== Listener Container Changes
+
+The `onlyLogRecordMetadata` container property is now `true` by default.
+See <<container-props>> for more information.


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1659