### PR TITLE
fixed typo in ContainerProperties

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
@@ -49,6 +49,7 @@ import org.springframework.util.CollectionUtils;
  * @author Artem Yakshin
  * @author Johnny Lim
  * @author Lukasz Kaminski
+ * @author Kyuhyeok Park
  */
 public class ContainerProperties extends ConsumerProperties {
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
@@ -563,6 +563,11 @@ public class ContainerProperties extends ConsumerProperties {
 		return this.consumerStartTimeout;
 	}
 
+	@Deprecated
+	public Duration getConsumerStartTimout() {
+		return this.consumerStartTimeout;
+	}
+
 	/**
 	 * Set the timeout to wait for a consumer thread to start before logging
 	 * an error. Default 30 seconds.
@@ -571,6 +576,11 @@ public class ContainerProperties extends ConsumerProperties {
 	public void setConsumerStartTimeout(Duration consumerStartTimeout) {
 		Assert.notNull(consumerStartTimeout, "'consumerStartTimout' cannot be null");
 		this.consumerStartTimeout = consumerStartTimeout;
+	}
+
+	@Deprecated
+	public void setConsumerStartTimout(Duration consumerStartTimeout) {
+		setConsumerStartTimeout(consumerStartTimeout);
 	}
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -240,7 +240,7 @@ public class ContainerProperties extends ConsumerProperties {
 
 	private boolean micrometerEnabled = true;
 
-	private Duration consumerStartTimout = DEFAULT_CONSUMER_START_TIMEOUT;
+	private Duration consumerStartTimeout = DEFAULT_CONSUMER_START_TIMEOUT;
 
 	private Boolean subBatchPerPartition;
 
@@ -559,18 +559,18 @@ public class ContainerProperties extends ConsumerProperties {
 		return Collections.unmodifiableMap(this.micrometerTags);
 	}
 
-	public Duration getConsumerStartTimout() {
-		return this.consumerStartTimout;
+	public Duration getConsumerStartTimeout() {
+		return this.consumerStartTimeout;
 	}
 
 	/**
 	 * Set the timeout to wait for a consumer thread to start before logging
 	 * an error. Default 30 seconds.
-	 * @param consumerStartTimout the consumer start timeout.
+	 * @param consumerStartTimeout the consumer start timeout.
 	 */
-	public void setConsumerStartTimout(Duration consumerStartTimout) {
-		Assert.notNull(consumerStartTimout, "'consumerStartTimout' cannot be null");
-		this.consumerStartTimout = consumerStartTimout;
+	public void setConsumerStartTimeout(Duration consumerStartTimeout) {
+		Assert.notNull(consumerStartTimeout, "'consumerStartTimout' cannot be null");
+		this.consumerStartTimeout = consumerStartTimeout;
 	}
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -309,7 +309,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 				.getConsumerTaskExecutor()
 				.submitListenable(this.listenerConsumer);
 		try {
-			if (!this.startLatch.await(containerProperties.getConsumerStartTimout().toMillis(), TimeUnit.MILLISECONDS)) {
+			if (!this.startLatch.await(containerProperties.getConsumerStartTimeout().toMillis(), TimeUnit.MILLISECONDS)) {
 				this.logger.error("Consumer thread failed to start - does the configured task executor "
 						+ "have enough threads to support all containers and concurrency?");
 				publishConsumerFailedToStart();

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerMockTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerMockTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -98,7 +98,7 @@ public class ConcurrentMessageListenerContainerMockTests {
 		exec.setCorePoolSize(1);
 		exec.afterPropertiesSet();
 		containerProperties.setConsumerTaskExecutor(exec);
-		containerProperties.setConsumerStartTimout(Duration.ofMillis(50));
+		containerProperties.setConsumerStartTimeout(Duration.ofMillis(50));
 		ConcurrentMessageListenerContainer container = new ConcurrentMessageListenerContainer<>(consumerFactory,
 				containerProperties);
 		container.setConcurrency(2);


### PR DESCRIPTION
- fixed variables and methods which include typo `timout` to `timeout`