### PR TITLE
GH-1675: Validation on @KafkaHandler Methods

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistrar.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2020 the original author or authors.
+ * Copyright 2014-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -187,6 +187,10 @@ public class KafkaListenerEndpointRegistrar implements BeanFactoryAware, Initial
 	protected void registerAllEndpoints() {
 		synchronized (this.endpointDescriptors) {
 			for (KafkaListenerEndpointDescriptor descriptor : this.endpointDescriptors) {
+				if (descriptor.endpoint instanceof MultiMethodKafkaListenerEndpoint
+						&& this.validator != null) {
+					((MultiMethodKafkaListenerEndpoint) descriptor.endpoint).setValidator(this.validator);
+				}
 				this.endpointRegistry.registerListenerContainer(
 						descriptor.endpoint, resolveContainerFactory(descriptor));
 			}

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/MultiMethodKafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/MultiMethodKafkaListenerEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import org.springframework.kafka.listener.adapter.HandlerAdapter;
 import org.springframework.kafka.listener.adapter.MessagingMessageListenerAdapter;
 import org.springframework.lang.Nullable;
 import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
+import org.springframework.validation.Validator;
 
 /**
  * The {@link MethodKafkaListenerEndpoint} extension for several POJO methods
@@ -44,11 +45,16 @@ public class MultiMethodKafkaListenerEndpoint<K, V> extends MethodKafkaListenerE
 
 	private final Method defaultMethod;
 
+	private Validator validator;
+
 	/**
 	 * Construct an instance for the provided methods and bean with no default method.
 	 * @param methods the methods.
 	 * @param bean the bean.
+	 * @deprecated in favor of
+	 * {@link #MultiMethodKafkaListenerEndpoint(List, Method, Object)}.
 	 */
+	@Deprecated
 	public MultiMethodKafkaListenerEndpoint(List<Method> methods, Object bean) {
 		this(methods, null, bean);
 	}
@@ -66,6 +72,15 @@ public class MultiMethodKafkaListenerEndpoint<K, V> extends MethodKafkaListenerE
 		setBean(bean);
 	}
 
+	/**
+	 * Set a payload validator.
+	 * @param validator the validator.
+	 * @since 2.5.11
+	 */
+	public void setValidator(Validator validator) {
+		this.validator = validator;
+	}
+
 	@Override
 	protected HandlerAdapter configureListenerAdapter(MessagingMessageListenerAdapter<K, V> messageListener) {
 		List<InvocableHandlerMethod> invocableHandlerMethods = new ArrayList<InvocableHandlerMethod>();
@@ -79,7 +94,7 @@ public class MultiMethodKafkaListenerEndpoint<K, V> extends MethodKafkaListenerE
 			}
 		}
 		DelegatingInvocableHandler delegatingHandler = new DelegatingInvocableHandler(invocableHandlerMethods,
-				defaultHandler, getBean(), getResolver(), getBeanExpressionContext(), getBeanFactory());
+				defaultHandler, getBean(), getResolver(), getBeanExpressionContext(), getBeanFactory(), this.validator);
 		return new HandlerAdapter(delegatingHandler);
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/DelegatingInvocableHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/DelegatingInvocableHandler.java
@@ -151,7 +151,7 @@ public class DelegatingInvocableHandler {
 	 * @param beanExpressionContext the context.
 	 * @param beanFactory the bean factory.
 	 * @param validator the validator.
-	 * @since 2.1.11
+	 * @since 2.5.11
 	 */
 	public DelegatingInvocableHandler(List<InvocableHandlerMethod> handlers,
 			@Nullable InvocableHandlerMethod defaultHandler,

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/DelegatingInvocableHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/DelegatingInvocableHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,11 +39,15 @@ import org.springframework.kafka.KafkaException;
 import org.springframework.kafka.support.KafkaUtils;
 import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.converter.MessageConverter;
 import org.springframework.messaging.handler.HandlerMethod;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.handler.annotation.support.PayloadMethodArgumentResolver;
 import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
 import org.springframework.util.Assert;
+import org.springframework.validation.Validator;
 
 
 /**
@@ -63,6 +67,9 @@ public class DelegatingInvocableHandler {
 
 	private final ConcurrentMap<Class<?>, InvocableHandlerMethod> cachedHandlers = new ConcurrentHashMap<>();
 
+	private final ConcurrentMap<InvocableHandlerMethod, MethodParameter> payloadMethodParameters =
+			new ConcurrentHashMap<>();
+
 	private final InvocableHandlerMethod defaultHandler;
 
 	private final Map<InvocableHandlerMethod, Expression> handlerSendTo = new HashMap<>();
@@ -77,17 +84,22 @@ public class DelegatingInvocableHandler {
 
 	private final ConfigurableListableBeanFactory beanFactory;
 
+	private final PayloadValidator validator;
+
 	/**
 	 * Construct an instance with the supplied handlers for the bean.
 	 * @param handlers the handlers.
 	 * @param bean the bean.
 	 * @param beanExpressionResolver the expression resolver.
 	 * @param beanExpressionContext the expression context.
+	 * @deprecated in favor of
+	 * {@link #DelegatingInvocableHandler(List, InvocableHandlerMethod, Object, BeanExpressionResolver, BeanExpressionContext, BeanFactory, Validator)}
 	 */
+	@Deprecated
 	public DelegatingInvocableHandler(List<InvocableHandlerMethod> handlers, Object bean,
 			BeanExpressionResolver beanExpressionResolver, BeanExpressionContext beanExpressionContext) {
 
-		this(handlers, null, bean, beanExpressionResolver, beanExpressionContext);
+		this(handlers, null, bean, beanExpressionResolver, beanExpressionContext, null, null);
 	}
 
 	/**
@@ -97,13 +109,16 @@ public class DelegatingInvocableHandler {
 	 * @param bean the bean.
 	 * @param beanExpressionResolver the resolver.
 	 * @param beanExpressionContext the context.
+	 * @deprecated in favor of
+	 * {@link #DelegatingInvocableHandler(List, InvocableHandlerMethod, Object, BeanExpressionResolver, BeanExpressionContext, BeanFactory, Validator)}
 	 * @since 2.1.3
 	 */
+	@Deprecated
 	public DelegatingInvocableHandler(List<InvocableHandlerMethod> handlers,
 			@Nullable InvocableHandlerMethod defaultHandler,
 			Object bean, BeanExpressionResolver beanExpressionResolver, BeanExpressionContext beanExpressionContext) {
 
-		this(handlers, defaultHandler, bean, beanExpressionResolver, beanExpressionContext, null);
+		this(handlers, defaultHandler, bean, beanExpressionResolver, beanExpressionContext, null, null);
 	}
 
 	/**
@@ -114,12 +129,34 @@ public class DelegatingInvocableHandler {
 	 * @param beanExpressionResolver the resolver.
 	 * @param beanExpressionContext the context.
 	 * @param beanFactory the bean factory.
+	 * @deprecated in favor of
+	 * {@link #DelegatingInvocableHandler(List, InvocableHandlerMethod, Object, BeanExpressionResolver, BeanExpressionContext, BeanFactory, Validator)}
+	 * @since 2.5.11
+	 */
+	@Deprecated
+	public DelegatingInvocableHandler(List<InvocableHandlerMethod> handlers,
+			@Nullable InvocableHandlerMethod defaultHandler,
+			Object bean, BeanExpressionResolver beanExpressionResolver, BeanExpressionContext beanExpressionContext,
+			@Nullable BeanFactory beanFactory) {
+
+		this(handlers, defaultHandler, bean, beanExpressionResolver, beanExpressionContext, beanFactory, null);
+	}
+
+	/**
+	 * Construct an instance with the supplied handlers for the bean.
+	 * @param handlers the handlers.
+	 * @param defaultHandler the default handler.
+	 * @param bean the bean.
+	 * @param beanExpressionResolver the resolver.
+	 * @param beanExpressionContext the context.
+	 * @param beanFactory the bean factory.
+	 * @param validator the validator.
 	 * @since 2.1.11
 	 */
 	public DelegatingInvocableHandler(List<InvocableHandlerMethod> handlers,
 			@Nullable InvocableHandlerMethod defaultHandler,
 			Object bean, BeanExpressionResolver beanExpressionResolver, BeanExpressionContext beanExpressionContext,
-			@Nullable BeanFactory beanFactory) {
+			@Nullable BeanFactory beanFactory, @Nullable Validator validator) {
 
 		this.handlers = new ArrayList<>();
 		for (InvocableHandlerMethod handler : handlers) {
@@ -132,6 +169,7 @@ public class DelegatingInvocableHandler {
 		this.beanFactory = beanFactory instanceof ConfigurableListableBeanFactory
 				? (ConfigurableListableBeanFactory) beanFactory
 				: null;
+		this.validator = validator == null ? null : new PayloadValidator(validator);
 	}
 
 	private InvocableHandlerMethod wrapIfNecessary(InvocableHandlerMethod handler) {
@@ -166,6 +204,12 @@ public class DelegatingInvocableHandler {
 	public Object invoke(Message<?> message, Object... providedArgs) throws Exception { //NOSONAR
 		Class<? extends Object> payloadClass = message.getPayload().getClass();
 		InvocableHandlerMethod handler = getHandlerForPayload(payloadClass);
+		if (this.validator != null) {
+			MethodParameter parameter = this.payloadMethodParameters.get(handler);
+			if (parameter != null) {
+				this.validator.validate(message, parameter, message.getPayload());
+			}
+		}
 		Object result;
 		if (handler instanceof MetadataAwareInvocableHandlerMethod) {
 			Object[] args = new Object[providedArgs.length + 1];
@@ -279,23 +323,29 @@ public class DelegatingInvocableHandler {
 			if ((methodParameter.getParameterAnnotations().length == 0
 					|| !methodParameter.hasParameterAnnotation(Header.class))
 					&& methodParameter.getParameterType().isAssignableFrom(payloadClass)) {
+				if (this.validator != null) {
+					this.payloadMethodParameters.put(handler, methodParameter);
+				}
 				return true;
 			}
 		}
 
-		boolean foundCandidate = false;
+		MethodParameter foundCandidate = null;
 		for (int i = 0; i < parameterAnnotations.length; i++) {
 			MethodParameter methodParameter = new MethodParameter(method, i);
 			if ((methodParameter.getParameterAnnotations().length == 0
 					|| !methodParameter.hasParameterAnnotation(Header.class))
 					&& methodParameter.getParameterType().isAssignableFrom(payloadClass)) {
-				if (foundCandidate) {
+				if (foundCandidate != null) {
 					throw new KafkaException("Ambiguous payload parameter for " + method.toGenericString());
 				}
-				foundCandidate = true;
+				foundCandidate = methodParameter;
 			}
 		}
-		return foundCandidate;
+		if (foundCandidate != null && this.validator != null) {
+			this.payloadMethodParameters.put(handler, foundCandidate);
+		}
+		return foundCandidate != null;
 	}
 
 	/**
@@ -321,6 +371,34 @@ public class DelegatingInvocableHandler {
 
 		MetadataAwareInvocableHandlerMethod(HandlerMethod handlerMethod) {
 			super(handlerMethod);
+		}
+
+	}
+
+	private static final class PayloadValidator extends PayloadMethodArgumentResolver {
+
+		PayloadValidator(Validator validator) {
+			super(new MessageConverter() { // Required but never used
+
+				@Override
+				@Nullable
+				public Message<?> toMessage(Object payload, @Nullable
+				MessageHeaders headers) {
+					return null;
+				}
+
+				@Override
+				@Nullable
+				public Object fromMessage(Message<?> message, Class<?> targetClass) {
+					return null;
+				}
+
+			}, validator);
+		}
+
+		@Override
+		public void validate(Message<?> message, MethodParameter parameter, Object target) { // NOSONAR - public
+			super.validate(message, parameter, target);
 		}
 
 	}

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import javax.validation.Valid;
-import javax.validation.ValidationException;
 import javax.validation.constraints.Max;
 
 import org.aopalliance.intercept.MethodInterceptor;
@@ -141,6 +140,7 @@ import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.handler.annotation.support.MethodArgumentNotValidException;
 import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.messaging.support.MessageBuilder;
@@ -438,13 +438,16 @@ public class EnableKafkaIntegrationTests {
 		this.kafkaJsonTemplate.send(new GenericMessage<>(new Foo("one")));
 		this.kafkaJsonTemplate.send(new GenericMessage<>(new Baz("two")));
 		this.kafkaJsonTemplate.send(new GenericMessage<>(new Qux("three")));
+		this.kafkaJsonTemplate.send(new GenericMessage<>(new ValidatedClass(5)));
 		assertThat(this.multiJsonListener.latch1.await(60, TimeUnit.SECONDS)).isTrue();
 		assertThat(this.multiJsonListener.latch2.await(60, TimeUnit.SECONDS)).isTrue();
 		assertThat(this.multiJsonListener.latch3.await(60, TimeUnit.SECONDS)).isTrue();
+		assertThat(this.multiJsonListener.latch4.await(60, TimeUnit.SECONDS)).isTrue();
 		assertThat(this.multiJsonListener.foo.getBar()).isEqualTo("one");
 		assertThat(this.multiJsonListener.baz.getBar()).isEqualTo("two");
 		assertThat(this.multiJsonListener.bar.getBar()).isEqualTo("three");
 		assertThat(this.multiJsonListener.bar).isInstanceOf(Qux.class);
+		assertThat(this.multiJsonListener.validated.isValidated()).isTrue();
 	}
 
 	@Test
@@ -618,7 +621,7 @@ public class EnableKafkaIntegrationTests {
 	public void testValidation() throws Exception {
 		template.send("annotated35", 0, "{\"bar\":42}");
 		assertThat(this.listener.validationLatch.await(60, TimeUnit.SECONDS)).isTrue();
-		assertThat(this.listener.validationException).isInstanceOf(ValidationException.class);
+		assertThat(this.listener.validationException).isInstanceOf(MethodArgumentNotValidException.class);
 	}
 
 	@Test
@@ -1557,7 +1560,12 @@ public class EnableKafkaIntegrationTests {
 
 				@Override
 				public void validate(Object target, Errors errors) {
-					throw new ValidationException();
+					if (target instanceof ValidatedClass && ((ValidatedClass) target).getBar() > 10) {
+						errors.reject("bar too large");
+					}
+					else {
+						((ValidatedClass) target).setValidated(true);
+					}
 				}
 
 				@Override
@@ -2177,17 +2185,21 @@ public class EnableKafkaIntegrationTests {
 	@KafkaListener(id = "multiJson", topics = "annotated33", containerFactory = "kafkaJsonListenerContainerFactory2")
 	static class MultiJsonListenerBean {
 
-		private final CountDownLatch latch1 = new CountDownLatch(1);
+		final CountDownLatch latch1 = new CountDownLatch(1);
 
-		private final CountDownLatch latch2 = new CountDownLatch(1);
+		final CountDownLatch latch2 = new CountDownLatch(1);
 
-		private final CountDownLatch latch3 = new CountDownLatch(1);
+		final CountDownLatch latch3 = new CountDownLatch(1);
 
-		private Foo foo;
+		final CountDownLatch latch4 = new CountDownLatch(1);
 
-		private Baz baz;
+		volatile Foo foo;
 
-		private Bar bar;
+		volatile Baz baz;
+
+		volatile Bar bar;
+
+		volatile ValidatedClass validated;
 
 		@KafkaHandler
 		public void bar(Foo foo) {
@@ -2199,6 +2211,12 @@ public class EnableKafkaIntegrationTests {
 		public void bar(Baz baz) {
 			this.baz = baz;
 			this.latch2.countDown();
+		}
+
+		@KafkaHandler
+		public void bar(@Valid ValidatedClass val) {
+			this.validated = val;
+			this.latch4.countDown();
 		}
 
 		@KafkaHandler(isDefault = true)
@@ -2337,12 +2355,30 @@ public class EnableKafkaIntegrationTests {
 		@Max(10)
 		private int bar;
 
+		private volatile boolean validated;
+
+
+		public ValidatedClass() {
+		}
+
+		public ValidatedClass(int bar) {
+			this.bar = bar;
+		}
+
 		public int getBar() {
 			return this.bar;
 		}
 
 		public void setBar(int bar) {
 			this.bar = bar;
+		}
+
+		public boolean isValidated() {
+			return this.validated;
+		}
+
+		public void setValidated(boolean validated) {
+			this.validated = validated;
 		}
 
 	}

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -1844,6 +1844,7 @@ public class Config implements KafkaListenerConfigurer {
     public void configureKafkaListeners(KafkaListenerEndpointRegistrar registrar) {
       registrar.setValidator(new MyValidator());
     }
+
 }
 ----
 ====
@@ -1906,6 +1907,9 @@ public KafkaListenerErrorHandler validationErrorHandler() {
 }
 ----
 ====
+
+Starting with version 2.5.11, validation now works on payloads for `@KafkaHandler` methods in a class-level listener.
+See <<class-level-kafkalistener>>.
 
 [[rebalance-listeners]]
 ===== Rebalancing Listeners

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -13,3 +13,9 @@ This version requires the 2.7.0 `kafka-clients`.
 
 The `onlyLogRecordMetadata` container property is now `true` by default.
 See <<container-props>> for more information.
+
+[[27-listener]]
+==== `@KafkaListener` Changes
+
+You can now validate the payload parameter of `@KafkaHandler` methods (class-level listeners).
+See <<kafka-validation>> for more information.


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1675

Add support for payload validation with `@KafkaHandler` methods.

**cherry-pick to 2.6.x, 2.5.x**