### PR TITLE
GH-1605: DeadLetterPublishingRecoverer Improvement

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ListenerUtils.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ListenerUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 the original author or authors.
+ * Copyright 2017-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/KafkaHeaders.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/KafkaHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2020 the original author or authors.
+ * Copyright 2014-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -158,6 +158,24 @@ public abstract class KafkaHeaders {
 	 * @since 2.2
 	 */
 	public static final String DLT_EXCEPTION_MESSAGE = PREFIX + "dlt-exception-message";
+
+	/**
+	 * Exception stack trace for a record published to a dead-letter topic.
+	 * @since 2.2
+	 */
+	public static final String DLT_KEY_EXCEPTION_STACKTRACE = PREFIX + "dlt-key-exception-stacktrace";
+
+	/**
+	 * Exception message for a record published to a dead-letter topic.
+	 * @since 2.2
+	 */
+	public static final String DLT_KEY_EXCEPTION_MESSAGE = PREFIX + "dlt-key-exception-message";
+
+	/**
+	 * Exception class name for a record published sent to a dead-letter topic.
+	 * @since 2.2
+	 */
+	public static final String DLT_KEY_EXCEPTION_FQCN = PREFIX + "dlt-key-exception-fqcn";
 
 	/**
 	 * Original topic for a record published to a dead-letter topic.

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/KafkaHeaders.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/KafkaHeaders.java
@@ -160,20 +160,23 @@ public abstract class KafkaHeaders {
 	public static final String DLT_EXCEPTION_MESSAGE = PREFIX + "dlt-exception-message";
 
 	/**
-	 * Exception stack trace for a record published to a dead-letter topic.
-	 * @since 2.2
+	 * Exception stack trace for a record published to a dead-letter topic with a key
+	 * deserialization exception.
+	 * @since 2.7
 	 */
 	public static final String DLT_KEY_EXCEPTION_STACKTRACE = PREFIX + "dlt-key-exception-stacktrace";
 
 	/**
-	 * Exception message for a record published to a dead-letter topic.
-	 * @since 2.2
+	 * Exception message for a record published to a dead-letter topic with a key
+	 * deserialization exception.
+	 * @since 2.7
 	 */
 	public static final String DLT_KEY_EXCEPTION_MESSAGE = PREFIX + "dlt-key-exception-message";
 
 	/**
-	 * Exception class name for a record published sent to a dead-letter topic.
-	 * @since 2.2
+	 * Exception class name for a record published sent to a dead-letter topic with a key
+	 * deserialization exception.
+	 * @since 2.7
 	 */
 	public static final String DLT_KEY_EXCEPTION_FQCN = PREFIX + "dlt-key-exception-fqcn";
 

--- a/src/reference/asciidoc/kafka.adoc
+++ b/src/reference/asciidoc/kafka.adoc
@@ -5169,6 +5169,9 @@ The record sent to the dead-letter topic is enhanced with the following headers:
 * `KafkaHeaders.DLT_EXCEPTION_FQCN`: The Exception class name.
 * `KafkaHeaders.DLT_EXCEPTION_STACKTRACE`: The Exception stack trace.
 * `KafkaHeaders.DLT_EXCEPTION_MESSAGE`: The  Exception message.
+* `KafkaHeaders.DLT_KEY_EXCEPTION_FQCN`: The Exception class name (key deserialization errors only).
+* `KafkaHeaders.DLT_KEY_EXCEPTION_STACKTRACE`: The Exception stack trace (key deserialization errors only).
+* `KafkaHeaders.DLT_KEY_EXCEPTION_MESSAGE`: The  Exception message (key deserialization errors only).
 * `KafkaHeaders.DLT_ORIGINAL_TOPIC`: The original topic.
 * `KafkaHeaders.DLT_ORIGINAL_PARTITION`: The original partition.
 * `KafkaHeaders.DLT_ORIGINAL_OFFSET`: The original offset.
@@ -5219,8 +5222,8 @@ By default, the exception type is not considered.
 Starting with version 2.3, the recoverer can also be used with Kafka Streams - see <<streams-deser-recovery>> for more information.
 
 The `ErrorHandlingDeserializer` adds the deserialization exception(s) in headers `ErrorHandlingDeserializer.VALUE_DESERIALIZER_EXCEPTION_HEADER` and `ErrorHandlingDeserializer.KEY_DESERIALIZER_EXCEPTION_HEADER` (using java serialization).
-By default, these headers are not retained in the message published to the dead letter topic, unless both the key and value fail deserialization.
-In that case, the `DLT_*` headers are based on the value deserialization and the key `DeserializationException` is retained in the header.
+By default, these headers are not retained in the message published to the dead letter topic.
+Starting with version 2.7, if both the key and value fail deserialization, the original values of both are populated in the record sent to the DLT.
 
 If incoming records are dependent on each other, but may arrive out of order, it may be useful to republish a failed record to the tail of the original topic (for some number of times), instead of sending it directly to the dead letter topic.
 See https://stackoverflow.com/questions/64646996[this Stack Overflow Question] for an example.

--- a/src/reference/asciidoc/whats-new.adoc
+++ b/src/reference/asciidoc/whats-new.adoc
@@ -22,3 +22,11 @@ See <<container-props>> for more information.
 
 You can now validate the payload parameter of `@KafkaHandler` methods (class-level listeners).
 See <<kafka-validation>> for more information.
+
+[[27-dlt]]
+==== `DeadLetterPublishingRecover` Changes
+
+Now, if both the key and value fail deserialization, the original values are published to the DLT.
+Previously, the value was populated but the key `DeserializationException` remained in the headers.
+There is a breaking API change, if you subclassed the recoverer and overrode the `createProducerRecord` method.
+See <<dead-letters>> for more information.


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1605

When both the key and value fail deserialization, populate both
original values in the record published to the DLT.