### PR TITLE
use concatMap  instead of flatMap to guarantee message ordering

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/reactive/ReactiveKafkaConsumerTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/reactive/ReactiveKafkaConsumerTemplate.java
@@ -66,7 +66,7 @@ public class ReactiveKafkaConsumerTemplate<K, V> {
 	}
 
 	public Flux<ConsumerRecord<K, V>> receiveAutoAck() {
-		return this.kafkaReceiver.receiveAutoAck().flatMap(Function.identity());
+		return this.kafkaReceiver.receiveAutoAck().concatMap(Function.identity());
 	}
 
 	public Flux<ConsumerRecord<K, V>> receiveAtMostOnce() {


### PR DESCRIPTION
Fixes issue [#GH1693](https://github.com/spring-projects/spring-kafka/issues/1693)