### PR TITLE
GH-1678: Allow CF Property Overrides

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/ConsumerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/ConsumerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -202,6 +202,23 @@ public interface ConsumerFactory<K, V> {
 	 */
 	default List<ConsumerPostProcessor<K, V>> getPostProcessors() {
 		return Collections.emptyList();
+	}
+
+	/**
+	 * Update the consumer configuration map; useful for situations such as
+	 * credential rotation.
+	 * @param updates the configuration properties to update.
+	 * @since 2.7
+	 */
+	default void updateConfigs(Map<String, Object> updates) {
+	}
+
+	/**
+	 * Remove the specified key from the configuration map.
+	 * @param configKey the key to remove.
+	 * @since 2.7
+	 */
+	default void removeConfig(String configKey) {
 	}
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
 import org.aopalliance.aop.Advice;
@@ -121,7 +122,7 @@ public class DefaultKafkaConsumerFactory<K, V> extends KafkaResourceFactory
 			@Nullable Supplier<Deserializer<K>> keyDeserializerSupplier,
 			@Nullable Supplier<Deserializer<V>> valueDeserializerSupplier) {
 
-		this.configs = new HashMap<>(configs);
+		this.configs = new ConcurrentHashMap<>(configs);
 		this.keyDeserializerSupplier = keyDeserializerSupplier == null ? () -> null : keyDeserializerSupplier;
 		this.valueDeserializerSupplier = valueDeserializerSupplier == null ? () -> null : valueDeserializerSupplier;
 	}
@@ -227,6 +228,16 @@ public class DefaultKafkaConsumerFactory<K, V> extends KafkaResourceFactory
 	@Override
 	public boolean removeListener(Listener<K, V> listener) {
 		return this.listeners.remove(listener);
+	}
+
+	@Override
+	public void updateConfigs(Map<String, Object> updates) {
+		this.configs.putAll(updates);
+	}
+
+	@Override
+	public void removeConfig(String configKey) {
+		this.configs.remove(configKey);
 	}
 
 	@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -192,7 +192,7 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 			@Nullable Supplier<Serializer<K>> keySerializerSupplier,
 			@Nullable Supplier<Serializer<V>> valueSerializerSupplier) {
 
-		this.configs = new HashMap<>(configs);
+		this.configs = new ConcurrentHashMap<>(configs);
 		this.keySerializerSupplier = keySerializerSupplier == null ? () -> null : keySerializerSupplier;
 		this.valueSerializerSupplier = valueSerializerSupplier == null ? () -> null : valueSerializerSupplier;
 		if (this.clientIdPrefix == null && configs.get(ProducerConfig.CLIENT_ID_CONFIG) instanceof String) {

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 the original author or authors.
+ * Copyright 2017-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -145,6 +145,10 @@ public class DefaultKafkaConsumerFactoryTests {
 		target.createConsumer(null, null, null, overrides);
 		assertThat(configPassedToKafkaConsumer.get("config1")).isEqualTo("overridden");
 		assertThat(configPassedToKafkaConsumer.get("config2")).isSameAs(originalConfig.get("config2"));
+		target.updateConfigs(Map.of("config1", "newValue"));
+		assertThat(target.getConfigurationProperties().get("config1")).isEqualTo("newValue");
+		target.removeConfig("config1");
+		assertThat(target.getConfigurationProperties().get("config1")).isNull();
 	}
 
 	@Test


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1678

Although the consumer factory can override properties using an overloaded
`createConsumer` method, add update/remove methods for properties to be
consistent with the `ProducerFactory`.

Change maps to concurrent to avoid possible `ConcurrentModificationException`.