### PR TITLE
GH-1700 - changed partition number in default destination resolver to…

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
@@ -55,7 +55,7 @@ public class DeadLetterPublishingRecoverer implements ConsumerRecordRecoverer {
 	protected final LogAccessor logger = new LogAccessor(LogFactory.getLog(getClass())); // NOSONAR
 
 	private static final BiFunction<ConsumerRecord<?, ?>, Exception, TopicPartition>
-		DEFAULT_DESTINATION_RESOLVER = (cr, e) -> new TopicPartition(cr.topic() + ".DLT", cr.partition());
+		DEFAULT_DESTINATION_RESOLVER = (cr, e) -> new TopicPartition(cr.topic() + ".DLT", -1);
 
 	private final KafkaOperations<Object, Object> template;
 


### PR DESCRIPTION
PR to fix issue described in GH-1700; default destination resolver for DL publisher should route to -1 (kafka to select the partition) rather than assuming the DLT has the same partitioning as the original topic.
In general can have less, as the DLT has far less traffic in normal conditions.