### PR TITLE
GH-920 - Topic-based retry support - Improvements and new features

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -3664,8 +3664,9 @@ thing2
 ==== Pausing and Resuming Partitions on Listener Containers
 
 Since version 2.7 you can pause and resume the consumption of specific partitions assigned to that consumer by using the `pausePartition(TopicPartition topicPartition)` and `resumePartition(TopicPartition topicPartition)` methods in the listener containers.
-The pausing and resuming takes place before and after the `poll()` similar to the `pause()` and `resume()` methods.
-The `isPartitionConsumerPaused()` method returns true if pause for that partition has been requested.
+The pausing and resuming takes place respectively before and after the `poll()` similar to the `pause()` and `resume()` methods.
+The `isPartitionPauseRequested()` method returns true if pause for that partition has been requested.
+The `isPartitionPaused()` method returns true if that partition has effectively been paused.
 
 Also since version 2.7 `ConsumerPartitionPausedEvent` and `ConsumerPartitionResumedEvent` instances are published with the container as the `source` property and the `TopicPartition` instance.
 

--- a/spring-kafka-docs/src/main/asciidoc/retrytopic.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/retrytopic.adoc
@@ -4,15 +4,15 @@
 IMPORTANT: This is an experimental feature and the usual rule of no breaking API changes does not apply to this feature until the experimental designation is removed.
 Users are encouraged to try out the feature and provide feedback via GitHub Issues or GitHub discussions.
 
-Achieving non-blocking retry / DLT functionality with Kafka usually requires setting up extra topics and creating and configuring the corresponding listeners.
-Since 2.7 Spring for Apache Kafka offers the `@RetryableTopic` annotation and `RetryTopicConfiguration` class to simplify that bootstraping.
+Achieving non-blocking retry / dlt functionality with Kafka usually requires setting up extra topics and creating and configuring the corresponding listeners.
+Since 2.7 Spring for Apache Kafka offers support for that via the `@RetryableTopic` annotation and `RetryTopicConfiguration` class to simplify that bootstrapping.
 
 === How The Pattern Works
 
-If message processing fails the message is forwarded to a retry topic with a back off timestamp.
+If message processing fails, the message is forwarded to a retry topic with a back off timestamp.
 The retry topic consumer then checks the timestamp and if it's not due it pauses the consumption for that topic's partition.
-When it is due the partition consumption is resumed and the message is consumed again.
-If the message processing fails again the message will be forwarded to the next retry topic, and the pattern is repeated until a successful processing occurs, or the attempts are exhausted and the message is sent to the Dead Letter Topic.
+When it is due the partition consumption is resumed, and the message is consumed again.
+If the message processing fails again the message will be forwarded to the next retry topic, and the pattern is repeated until a successful processing occurs, or the attempts are exhausted, and the message is sent to the Dead Letter Topic (if configured).
 
 To illustrate, if you have a "main-topic" topic, and want to setup non-blocking retry with an exponential backoff of 1000ms with a multiplier of 2 and 4 max attempts, it will create the main-topic-retry-1000, main-topic-retry-2000, main-topic-retry-4000 and main-topic-dlt topics and configure the respective consumers.
 The framework also takes care of creating the topics and setting up and configuring the listeners.
@@ -26,7 +26,7 @@ IMPORTANT: At this time this functionality only supports ConcurrentKafkaListener
 
 ==== Using the `@RetryableTopic` annotation
 
-To configure the retry and dlt topics for a `@KafkaListener` annotated method, you just have to add the `@RetryableTopic` annotation to it and Spring Kafka will bootstrap all the necessary topics and consumers with the default configurations.
+To configure the retry topic and dlt for a `@KafkaListener` annotated method, you just have to add the `@RetryableTopic` annotation to it and Spring Kafka will bootstrap all the necessary topics and consumers with the default configurations.
 
 ====
 [source, java]
@@ -52,7 +52,8 @@ public void processMessage(MyPojo message) {
 ----
 ====
 
-If you don't specify a kafkaTemplate name a bean with name `retryTopicDefaultKafkaTemplate` will be looked up.
+NOTE: If you don't specify a kafkaTemplate name a bean with name `retryTopicDefaultKafkaTemplate` will be looked up.
+If no bean is found an exception is thrown.
 
 ==== Using `RetryTopicConfiguration` beans
 
@@ -70,7 +71,7 @@ return RetryTopicConfiguration
 ----
 ====
 
-This will create retry and dlt topics, as well as the corresponding consumers, for all topics in methods annotated with '@KafkaListener' using the default configurations. The `KafkaTemplate` instance is required for message forwarding.
+This will create retry topics and a dlt, as well as the corresponding consumers, for all topics in methods annotated with '@KafkaListener' using the default configurations. The `KafkaTemplate` instance is required for message forwarding.
 
 To achieve more fine-grained control over how to handle non-blocking retrials for each topic, more than one `RetryTopicConfiguration` bean can be provided.
 
@@ -159,14 +160,17 @@ return RetryTopicConfiguration
 
 NOTE: The default backoff policy is FixedBackOffPolicy with a maximum of 3 attempts and 1000ms intervals.
 
+IMPORTANT: The first attempt counts against the maxAttempts, so if you provide a maxAttempts value of 4 there'll be the original attempt plus 3 retries.
+
 ==== Single Topic Fixed Delay Retries
 
 If you're using fixed delay policies such as `FixedBackOffPolicy` or `NoBackOffPolicy` you can use a single topic to accomplish the non-blocking retries.
+This topic will be suffixed with the provided or default suffix, and will not have either the index or the delay values appended.
 
 ====
 [source, java]
 ----
-@RetryableTopic(backoff = @Backoff(2000), fixedDelayTopicStrategy = RetryTopicConfiguration.FixedDelayTopicStrategy.SINGLE_TOPIC)
+@RetryableTopic(backoff = @Backoff(2000), fixedDelayTopicStrategy = FixedDelayStrategy.SINGLE_TOPIC)
 @KafkaListener(topics = "my-annotated-topic")
 public void processMessage(MyPojo message) {
         // ... message processing
@@ -188,7 +192,38 @@ return RetryTopicConfiguration
 ----
 ====
 
-NOTE: The default behavior is creating separate topics for each attempt, suffixed with retry-0, retry-1, and so on.
+NOTE: The default behavior is creating separate retry topics for each attempt, appended with their index value: retry-0, retry-1, ...
+
+==== Global timeout
+
+You can set the global timeout for the retrying process.
+If that time is reached, the next time the consumer throws an exception the message goes straight to the DLT, or just ends the processing if no DLT is available.
+
+====
+[source, java]
+----
+@RetryableTopic(backoff = @Backoff(2000), timeout = 5000)
+@KafkaListener(topics = "my-annotated-topic")
+public void processMessage(MyPojo message) {
+        // ... message processing
+}
+----
+====
+
+====
+[source, java]
+----
+@Bean
+public RetryTopicConfiguration myRetryTopic(KafkaTemplate<String, MyPojo> template) {
+return RetryTopicConfiguration
+                .builder()
+                .fixedBackoff(2000)
+                .timeoutAfter(5000)
+                .build
+----
+====
+
+NOTE: The default is having no timeout set, which can also be achieved by providing -1 as the timout value.
 
 ==== Exception Classifier
 
@@ -220,129 +255,7 @@ public RetryTopicConfiguration myRetryTopic(KafkaTemplate<String, MyOtherPojo> t
 ----
 ====
 
-NOTE: The default behaviour is retrying on all exceptions and not traversing causes.
-
-==== Retry and Dlt Topic Suffixes
-
-You can specify the suffixes that will be used by the retry and dlt topics.
-
-====
-[source, java]
-----
-@RetryableTopic(retryTopicSuffix = "-my-retry-suffix", dltTopicSuffix = "-my-dlt-suffix")
-@KafkaListener(topics = "my-annotated-topic")
-public void processMessage(MyPojo message) {
-        // ... message processing
-}
-----
-====
-
-====
-[source, java]
-----
-@Bean
-public RetryTopicConfiguration myRetryTopic(KafkaTemplate<String, MyOtherPojo> template) {
-           return RetryTopicConfiguration
-                   .builder()
-                   .retryTopicSuffix("-my-retry-suffix")
-                   .dltTopicSuffix("-my-dlt-suffix")
-                   .create(template);
-           }
-----
-====
-
-The retry suffix also is itself suffixed with the delay for the topic, for example -1000, except for fixed delay configurations where the suffix is -0, -1, etc, and single topic fixed delay configurations which have no suffix besides the first one.
-
-NOTE: The default suffixes are "-retry" and "-dlt", for retry and dlt topics respectively.
-
-==== Dlt Processing
-
-You can specify the method used to process the Dlt for the topic, as well as the behaviour if that processing fails.
-
-To do that you can use the `@DltHandler` annotation in a method of the class with the `@RetryableTopic` annotation(s).
-Note that the same method will be used for all the `@RetryableTopic` annotated methods within that class.
-
-====
-[source, java]
-----
-@RetryableTopic
-@KafkaListener(topics = "my-annotated-topic")
-public void processMessage(MyPojo message) {
-        // ... message processing
-}
-
-@DltHandler
-public void processMessage(MyPojo message) {
-// ... message processing, persistence, etc
-}
-----
-====
-
-The DLT handler method can also be provided through the RetryTopicConfigurationBuilder.dltHandlerMethod(Class, String) method, providing the class and method name that should handle the DLT topic.
-If a bean instance of the provided class is found in the application context that bean is used for Dlt processing, otherwise an instance is created with it's dependencies properly injected.
-
-====
-[source, java]
-----
-@Bean
-public RetryTopicConfigurer myRetryTopic(KafkaTemplate<Integer, MyPojo> template) {
-return RetryTopicConfigurer
-    .builder()
-    .dltProcessor(MyCustomDltProcessor.class, "processDltMessage")
-    .create(template);
-}
-
-@Component
-public class MyCustomDltProcessor {
-
-    private final MyDependency myDependency;
-
-    public MyCustomDltProcessor(MyDependency myDependency) {
-        this.myDependency = myDependency;
-    }
-
-    public void processDltMessage(MyPojo message) {
-       // ... message processing, persistence, etc
-    }
-}
-----
-====
-
-NOTE: If no DLT handler is provided, the default RetryTopicConfigurer.LoggingDltListenerHandlerMethod is used.
-
-==== Dlt Failure Behaviour
-
-Should the Dlt processing fail, there are two possible behaviors available: `ALWAYS_RETRY` and `FAIL`.
-
-In the former the message is forwarded back to the dlt topic so it doesn't block other dlt messages' processing.
-In the latter the consumer ends the execution without forwarding the message.
-
-====
-[source, java]
-----
-
-@RetryableTopic(dltProcessingFailureStrategy =
-			RetryTopicConfiguration.DltProcessingFailureStrategy.FAIL)
-@KafkaListener(topics = "my-annotated-topic")
-public void processMessage(MyPojo message) {
-        // ... message processing
-}
-----
-
-[source, java]
-----
-@Bean
-public RetryTopicConfigurer myRetryTopic(KafkaTemplate<Integer, MyPojo> template) {
-return RetryTopicConfigurer
-    .builder()
-    .dltProcessor(MyCustomDltProcessor.class, "processDltMessage")
-    .doNotRetryOnDltFailure()
-    .create(template);
-}
-----
-====
-
-NOTE: The default behavior is to `ALWAYS_RETRY`.
+NOTE: The default behavior is retrying on all exceptions and not traversing causes.
 
 ==== Include and Exclude Topics
 
@@ -355,7 +268,7 @@ You can decide which topics will and will not be handled by a `RetryTopicConfigu
 public RetryTopicConfigurer myRetryTopic(KafkaTemplate<Integer, MyPojo> template) {
     return RetryTopicConfigurer
         .builder()
-        .includeTopics(List.of("my-include-topic", "my-other-include-topic"))
+        .includeTopics(List.of("my-included-topic", "my-other-included-topic"))
         .create(template);
 }
 
@@ -363,7 +276,7 @@ public RetryTopicConfigurer myRetryTopic(KafkaTemplate<Integer, MyPojo> template
 public RetryTopicConfigurer myOtherRetryTopic(KafkaTemplate<Integer, MyPojo> template) {
     return RetryTopicConfigurer
         .builder()
-        .excludeTopic("my-include-topic")
+        .excludeTopic("my-excluded-topic")
         .create(template);
 }
 
@@ -371,6 +284,7 @@ public RetryTopicConfigurer myOtherRetryTopic(KafkaTemplate<Integer, MyPojo> tem
 ====
 
 NOTE: The default behavior is to include all topics.
+
 
 ==== Topics AutoCreation
 
@@ -416,9 +330,204 @@ return RetryTopicConfigurer
 
 NOTE: By default the topics are autocreated with one partition and a replication factor of one.
 
-==== Specifying a ListenerContainerFactory
 
-By default the RetryTopic configuration will use the provided factory from the `@KafkaListener` annotation, but you can specify a different one to be used to create the retry and dlt topic listener containers.
+=== Topic Naming
+
+Retry topics and DLT are named by suffixing the main topic with a provided or default value, appended by either the delay or index for that topic.
+
+Examples:
+
+"my-topic" -> "my-topic-retry-0", "my-topic-retry-1", ..., "my-topic-dlt"
+
+"my-other-topic" -> "my-topic-myRetrySuffix-1000", "my-topic-myRetrySuffix-2000", ..., "my-topic-myDltSuffix".
+
+==== Retry Topics and Dlt Suffixes
+
+You can specify the suffixes that will be used by the retry and dlt topics.
+
+====
+[source, java]
+----
+@RetryableTopic(retryTopicSuffix = "-my-retry-suffix", dltTopicSuffix = "-my-dlt-suffix")
+@KafkaListener(topics = "my-annotated-topic")
+public void processMessage(MyPojo message) {
+        // ... message processing
+}
+----
+====
+
+====
+[source, java]
+----
+@Bean
+public RetryTopicConfiguration myRetryTopic(KafkaTemplate<String, MyOtherPojo> template) {
+           return RetryTopicConfiguration
+                   .builder()
+                   .retryTopicSuffix("-my-retry-suffix")
+                   .dltTopicSuffix("-my-dlt-suffix")
+                   .create(template);
+           }
+----
+====
+
+NOTE: The default suffixes are "-retry" and "-dlt", for retry topics and dlt respectively.
+
+==== Appending the Topic's Index or Delay
+
+You can either append the topic's index or delay values after the suffix.
+
+====
+[source, java]
+----
+@RetryableTopic(topicSuffixingStrategy = TopicSuffixingStrategy.SUFFIX_WITH_INDEX_VALUE)
+@KafkaListener(topics = "my-annotated-topic")
+public void processMessage(MyPojo message) {
+        // ... message processing
+}
+----
+====
+
+====
+[source, java]
+----
+@Bean
+public RetryTopicConfiguration myRetryTopic(KafkaTemplate<String, MyPojo> template) {
+           return RetryTopicConfiguration
+                    .builder()
+                    .suffixTopicsWithIndexValues()
+                    .create(template);
+           }
+----
+====
+
+NOTE: The default behavior is to suffix with the delay values, except for fixed delay configurations with multiple topics, in which case the topics are suffixed with the topic's index.
+
+=== Dlt Strategies
+
+The framework provides a few strategies for working with DLTs. You can provide a method for DLT processing, use the default logging method, or have no DLT at all. Also you can choose what happens if DLT processing fails.
+
+==== Dlt Processing Method
+
+You can specify the method used to process the Dlt for the topic, as well as the behavior if that processing fails.
+
+To do that you can use the `@DltHandler` annotation in a method of the class with the `@RetryableTopic` annotation(s).
+Note that the same method will be used for all the `@RetryableTopic` annotated methods within that class.
+
+====
+[source, java]
+----
+@RetryableTopic
+@KafkaListener(topics = "my-annotated-topic")
+public void processMessage(MyPojo message) {
+        // ... message processing
+}
+
+@DltHandler
+public void processMessage(MyPojo message) {
+// ... message processing, persistence, etc
+}
+----
+====
+
+The DLT handler method can also be provided through the RetryTopicConfigurationBuilder.dltHandlerMethod(Class, String) method, passing as arguments the class and method name that should process the DLT's messages.
+If a bean instance of the provided class is found in the application context that bean is used for Dlt processing, otherwise an instance is created with full dependency injection support.
+
+====
+[source, java]
+----
+@Bean
+public RetryTopicConfigurer myRetryTopic(KafkaTemplate<Integer, MyPojo> template) {
+return RetryTopicConfigurer
+    .builder()
+    .dltProcessor(MyCustomDltProcessor.class, "processDltMessage")
+    .create(template);
+}
+
+@Component
+public class MyCustomDltProcessor {
+
+    private final MyDependency myDependency;
+
+    public MyCustomDltProcessor(MyDependency myDependency) {
+        this.myDependency = myDependency;
+    }
+
+    public void processDltMessage(MyPojo message) {
+       // ... message processing, persistence, etc
+    }
+}
+----
+====
+
+NOTE: If no DLT handler is provided, the default RetryTopicConfigurer.LoggingDltListenerHandlerMethod is used.
+
+==== Dlt Failure Behavior
+
+Should the Dlt processing fail, there are two possible behaviors available: `ALWAYS_RETRY_ON_ERROR` and `FAIL_ON_ERROR`.
+
+In the former the message is forwarded back to the dlt topic so it doesn't block other dlt messages' processing.
+In the latter the consumer ends the execution without forwarding the message.
+
+====
+[source,java]
+----
+
+@RetryableTopic(dltProcessingFailureStrategy =
+			DltStrategy.FAIL_ON_ERROR)
+@KafkaListener(topics = "my-annotated-topic")
+public void processMessage(MyPojo message) {
+        // ... message processing
+}
+----
+
+[source, java]
+----
+@Bean
+public RetryTopicConfigurer myRetryTopic(KafkaTemplate<Integer, MyPojo> template) {
+return RetryTopicConfigurer
+    .builder()
+    .dltProcessor(MyCustomDltProcessor.class, "processDltMessage")
+    .doNotRetryOnDltFailure()
+    .create(template);
+}
+----
+====
+
+NOTE: The default behavior is to `ALWAYS_RETRY_ON_ERROR`.
+
+==== Configuring No Dlt
+
+The framework also provides the possibility of not configuring a DLT for the topic.
+In this case after retrials are exhausted the processing simply ends.
+
+====
+[source, java]
+----
+
+@RetryableTopic(dltProcessingFailureStrategy =
+			DltStrategy.NO_DLT)
+@KafkaListener(topics = "my-annotated-topic")
+public void processMessage(MyPojo message) {
+        // ... message processing
+}
+----
+
+[source, java]
+----
+@Bean
+public RetryTopicConfigurer myRetryTopic(KafkaTemplate<Integer, MyPojo> template) {
+return RetryTopicConfigurer
+    .builder()
+    .doNotConfigureDlt()
+    .create(template);
+}
+----
+====
+
+
+=== Specifying a ListenerContainerFactory
+
+By default the RetryTopic configuration will use the provided factory from the `@KafkaListener` annotation, but you can specify a different one to be used to create the retry topic and dlt listener containers.
 
 IMPORTANT: The provided factory will be configured for the retry topic functionality, so you should not use the same factory for both retrying and non-retrying topics. You can however share the same factory between many retry topic configurations.
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
@@ -108,7 +108,7 @@ public abstract class AbstractMessageListenerContainer<K, V>
 
 	private ApplicationContext applicationContext;
 
-	private final Set<TopicPartition> pausedPartitions;
+	private final Set<TopicPartition> pauseRequestedPartitions;
 
 	/**
 	 * Construct an instance with the provided factory and properties.
@@ -151,7 +151,7 @@ public abstract class AbstractMessageListenerContainer<K, V>
 			this.containerProperties.setConsumerRebalanceListener(createSimpleLoggingConsumerRebalanceListener());
 		}
 
-		this.pausedPartitions = new HashSet<>();
+		this.pauseRequestedPartitions = new HashSet<>();
 	}
 
 	@Override
@@ -242,22 +242,22 @@ public abstract class AbstractMessageListenerContainer<K, V>
 
 	@Override
 	public boolean isPartitionPauseRequested(TopicPartition topicPartition) {
-		synchronized (this.pausedPartitions) {
-			return this.pausedPartitions.contains(topicPartition);
+		synchronized (this.pauseRequestedPartitions) {
+			return this.pauseRequestedPartitions.contains(topicPartition);
 		}
 	}
 
 	@Override
 	public void pausePartition(TopicPartition topicPartition) {
-		synchronized (this.pausedPartitions) {
-			this.pausedPartitions.add(topicPartition);
+		synchronized (this.pauseRequestedPartitions) {
+			this.pauseRequestedPartitions.add(topicPartition);
 		}
 	}
 
 	@Override
 	public void resumePartition(TopicPartition topicPartition) {
-		synchronized (this.pausedPartitions) {
-			this.pausedPartitions.remove(topicPartition);
+		synchronized (this.pauseRequestedPartitions) {
+			this.pauseRequestedPartitions.remove(topicPartition);
 		}
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
@@ -310,6 +310,14 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 		}
 	}
 
+	@Override
+	public boolean isPartitionPaused(TopicPartition topicPartition) {
+		return this
+				.containers
+				.stream()
+				.anyMatch(container -> container.isPartitionPaused(topicPartition));
+	}
+
 	private boolean containsPartition(TopicPartition topicPartition, KafkaMessageListenerContainer<K, V> container) {
 		Collection<TopicPartition> assignedPartitions = container.getAssignedPartitions();
 		return assignedPartitions != null && assignedPartitions.contains(topicPartition);

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaBackoffException.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaBackoffException.java
@@ -34,7 +34,7 @@ public class KafkaBackoffException extends KafkaException {
 
 	private final TopicPartition topicPartition;
 
-	private final String dueTimestamp;
+	private final long dueTimestamp;
 
 	/**
 	 * Constructor with data from the BackOff event.
@@ -44,7 +44,7 @@ public class KafkaBackoffException extends KafkaException {
 	 * @param listenerId the listenerId for the consumer that was backed off.
 	 * @param dueTimestamp the time at which the message should be consumed.
 	 */
-	public KafkaBackoffException(String message, TopicPartition topicPartition, String listenerId, String dueTimestamp) {
+	public KafkaBackoffException(String message, TopicPartition topicPartition, String listenerId, long dueTimestamp) {
 		super(message);
 		this.listenerId = listenerId;
 		this.topicPartition = topicPartition;
@@ -59,7 +59,7 @@ public class KafkaBackoffException extends KafkaException {
 		return this.topicPartition;
 	}
 
-	public String getDueTimestamp() {
+	public long getDueTimestamp() {
 		return this.dueTimestamp;
 	}
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/MessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/MessageListenerContainer.java
@@ -132,6 +132,16 @@ public interface MessageListenerContainer extends SmartLifecycle {
 	}
 
 	/**
+	 * Whether or not this topic's partition is currently paused.
+	 * @param topicPartition the topic partition to check
+	 * @return true if this partition has been paused.
+	 * @since 2.7
+	 */
+	default boolean isPartitionPaused(TopicPartition topicPartition) {
+		throw new UnsupportedOperationException("This container doesn't support checking if a partition is paused");
+	}
+
+	/**
 	 * Return true if {@link #pause()} has been called; the container might not have actually
 	 * paused yet.
 	 * @return true if pause has been requested.

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/BackOffValuesGenerator.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/BackOffValuesGenerator.java
@@ -42,15 +42,6 @@ import org.springframework.retry.support.RetrySynchronizationManager;
 public class BackOffValuesGenerator {
 
 	private static final BackOffPolicy DEFAULT_BACKOFF_POLICY = new FixedBackOffPolicy();
-	/**
-	 * Default number of times the message processing should be retried.
-	 */
-	public static final int DEFAULT_MAX_ATTEMPTS = 3;
-
-	/**
-	 * Constant to represent that the number of attempts is not set.
-	 */
-	public static final int NOT_SET = -1;
 
 	private final int numberOfvaluesToCreate;
 
@@ -64,7 +55,9 @@ public class BackOffValuesGenerator {
 	}
 
 	public int getMaxAttemps(int providedMaxAttempts) {
-		return providedMaxAttempts != NOT_SET ? providedMaxAttempts : DEFAULT_MAX_ATTEMPTS;
+		return providedMaxAttempts != RetryTopicConstants.NOT_SET
+				? providedMaxAttempts
+				: RetryTopicConstants.DEFAULT_MAX_ATTEMPTS;
 	}
 
 	public List<Long> generateValues() {

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DltStrategy.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DltStrategy.java
@@ -18,27 +18,28 @@ package org.springframework.kafka.retrytopic;
 
 /**
  *
- * Contains the headers that will be used in the forwarded messages.
+ * Strategies for handling DLT processing.
  *
  * @author Tomaz Fernandes
  * @since 2.7
  *
  */
-public abstract class RetryTopicHeaders {
+public enum DltStrategy {
 
 	/**
-	 * The default header for the backoff duetimestamp.
+	 * Don't create a DLT.
 	 */
-	public static final String DEFAULT_HEADER_BACKOFF_TIMESTAMP = "retry_topic-backoff-timestamp";
+	NO_DLT,
 
 	/**
-	 * The default header for the attempts.
+	 * Always send the message back to the DLT for reprocessing in case of failure in
+	 * DLT processing.
 	 */
-	public static final String DEFAULT_HEADER_ATTEMPTS = "retry_topic-attempts";
+	ALWAYS_RETRY_ON_ERROR,
 
 	/**
-	 * The default header for the original message's timestamp.
+	 * Fail if DLT processing throws an error.
 	 */
-	public static final String DEFAULT_HEADER_ORIGINAL_TIMESTAMP = "retry_topic-original-timestamp";
+	FAIL_ON_ERROR
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/FixedDelayStrategy.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/FixedDelayStrategy.java
@@ -18,27 +18,20 @@ package org.springframework.kafka.retrytopic;
 
 /**
  *
- * Contains the headers that will be used in the forwarded messages.
+ * Defines the topic strategy to handle fixed delays.
  *
  * @author Tomaz Fernandes
  * @since 2.7
  *
  */
-public abstract class RetryTopicHeaders {
+public enum FixedDelayStrategy {
+	/**
+	 * Uses a single topic to achieve non-blocking retry.
+	 */
+	SINGLE_TOPIC,
 
 	/**
-	 * The default header for the backoff duetimestamp.
+	 * Uses one separate topic per retry attempt.
 	 */
-	public static final String DEFAULT_HEADER_BACKOFF_TIMESTAMP = "retry_topic-backoff-timestamp";
-
-	/**
-	 * The default header for the attempts.
-	 */
-	public static final String DEFAULT_HEADER_ATTEMPTS = "retry_topic-attempts";
-
-	/**
-	 * The default header for the original message's timestamp.
-	 */
-	public static final String DEFAULT_HEADER_ORIGINAL_TIMESTAMP = "retry_topic-original-timestamp";
-
+	MULTIPLE_TOPICS
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicBootstrapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicBootstrapper.java
@@ -28,7 +28,6 @@ import org.springframework.kafka.listener.KafkaConsumerBackoffManager;
 import org.springframework.kafka.retrytopic.destinationtopic.DefaultDestinationTopicProcessor;
 import org.springframework.kafka.retrytopic.destinationtopic.DestinationTopicContainer;
 
-
 /**
  *
  * Bootstraps the {@link RetryTopicConfigurer} context, registering the dependency
@@ -85,9 +84,9 @@ public class RetryTopicBootstrapper {
 	}
 
 	private void configureBackoffClock() {
-		if (!this.applicationContext.containsBeanDefinition(RetryTopicInternalBeanNames.INTERNAL_BACKOFF_CLOCK_NAME)) {
+		if (!this.applicationContext.containsBeanDefinition(KafkaConsumerBackoffManager.INTERNAL_BACKOFF_CLOCK_BEAN_NAME)) {
 			((SingletonBeanRegistry) this.beanFactory).registerSingleton(
-					RetryTopicInternalBeanNames.INTERNAL_BACKOFF_CLOCK_NAME, Clock.systemUTC());
+					KafkaConsumerBackoffManager.INTERNAL_BACKOFF_CLOCK_BEAN_NAME, Clock.systemUTC());
 		}
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfiguration.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfiguration.java
@@ -123,28 +123,4 @@ public class RetryTopicConfiguration {
 			return this.shouldCreateTopics;
 		}
 	}
-
-	public enum FixedDelayTopicStrategy {
-		/**
-		 * Uses a single topic to achieve non-blocking retry.
-		 */
-		SINGLE_TOPIC,
-
-		/**
-		 * Uses one topic per retry attempt.
-		 */
-		MULTIPLE_TOPICS
-	}
-
-	public enum DltProcessingFailureStrategy {
-		/**
-		 * Always send the message back to the DLT for reprocessing in case of failure.
-		 */
-		ALWAYS_RETRY,
-
-		/**
-		 * Don't retry if DLT processing fails.
-		 */
-		FAIL
-	}
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationProvider.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationProvider.java
@@ -57,7 +57,6 @@ public class RetryTopicConfigurationProvider {
 		this.beanFactory = beanFactory;
 	}
 	public RetryTopicConfiguration findRetryConfigurationFor(String[] topics, Method method, Object bean) {
-		// TODO: Enable class-level annotations
 		RetryableTopic annotation = AnnotationUtils.findAnnotation(method, RetryableTopic.class);
 		return annotation != null
 				? new RetryableTopicAnnotationProcessor(this.beanFactory)

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
@@ -251,7 +251,7 @@ public class RetryTopicConfigurer {
 	public void processMainAndRetryListeners(EndpointProcessor endpointProcessor,
 											MethodKafkaListenerEndpoint<?, ?> mainEndpoint,
 											RetryTopicConfiguration configuration) {
-		throwIfMultiMethodEndpoint(mainEndpoint); // TODO: Add support to MultiMethodEndpoint
+		throwIfMultiMethodEndpoint(mainEndpoint);
 		DestinationTopicProcessor.Context context =
 				new DestinationTopicProcessor.Context(configuration.getDestinationTopicProperties());
 		configureMainEndpoint(mainEndpoint, endpointProcessor, context, configuration);
@@ -485,7 +485,7 @@ public class RetryTopicConfigurer {
 		EndpointHandlerMethod(Class<?> beanClass, String methodName) {
 			Assert.notNull(beanClass, () -> "No destination bean class provided!");
 			Assert.notNull(methodName, () -> "No method name for destination bean class provided!");
-			this.method = Arrays.stream(ReflectionUtils.getDeclaredMethods(beanClass)) // TODO: Maybe cache this result
+			this.method = Arrays.stream(ReflectionUtils.getDeclaredMethods(beanClass))
 					.filter(method -> method.getName().equals(methodName))
 					.findFirst()
 					.orElseThrow(() -> new IllegalArgumentException(String.format("No method %s in class %s", methodName, beanClass)));

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConstants.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConstants.java
@@ -18,27 +18,33 @@ package org.springframework.kafka.retrytopic;
 
 /**
  *
- * Contains the headers that will be used in the forwarded messages.
+ * Constants for the RetryTopic functionality.
  *
  * @author Tomaz Fernandes
  * @since 2.7
  *
  */
-public abstract class RetryTopicHeaders {
+public abstract class RetryTopicConstants {
 
 	/**
-	 * The default header for the backoff duetimestamp.
+	 * Default suffix for retry topics.
 	 */
-	public static final String DEFAULT_HEADER_BACKOFF_TIMESTAMP = "retry_topic-backoff-timestamp";
+	public static final String DEFAULT_RETRY_SUFFIX = "-retry";
 
 	/**
-	 * The default header for the attempts.
+	 * Default suffix for dlt.
 	 */
-	public static final String DEFAULT_HEADER_ATTEMPTS = "retry_topic-attempts";
+	public static final String DEFAULT_DLT_SUFFIX = "-dlt";
 
 	/**
-	 * The default header for the original message's timestamp.
+	 * Default number of times the message processing should be attempted,
+	 * including the first.
 	 */
-	public static final String DEFAULT_HEADER_ORIGINAL_TIMESTAMP = "retry_topic-original-timestamp";
+	public static final int DEFAULT_MAX_ATTEMPTS = 3;
+
+	/**
+	 * Constant to represent that the integer property is not set.
+	 */
+	public static final int NOT_SET = -1;
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryableTopicAnnotationProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryableTopicAnnotationProcessor.java
@@ -87,7 +87,9 @@ public class RetryableTopicAnnotationProcessor {
 				.notRetryOn(Arrays.asList(annotation.exclude()))
 				.traversingCauses(annotation.traversingCauses())
 				.useSingleTopicForFixedDelays(annotation.fixedDelayTopicStrategy())
-				.dltProcessingFailureStrategy(annotation.dltProcessingFailureStrategy())
+				.dltProcessingFailureStrategy(annotation.dltStrategy())
+				.setTopicSuffixingStrategy(annotation.topicSuffixingStrategy())
+				.timeoutAfter(annotation.timeout())
 				.create(getKafkaTemplate(annotation.kafkaTemplate(), topics));
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/TopicSuffixingStrategy.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/TopicSuffixingStrategy.java
@@ -18,27 +18,24 @@ package org.springframework.kafka.retrytopic;
 
 /**
  *
- * Contains the headers that will be used in the forwarded messages.
+ * Constants for the RetryTopic functionality.
  *
  * @author Tomaz Fernandes
  * @since 2.7
  *
  */
-public abstract class RetryTopicHeaders {
+public enum TopicSuffixingStrategy {
 
 	/**
-	 * The default header for the backoff duetimestamp.
+	 * Suffixes the topics with their index in the retry topics.
+	 * E.g. my-retry-topic-0, my-retry-topic-1, my-retry-topic-2.
 	 */
-	public static final String DEFAULT_HEADER_BACKOFF_TIMESTAMP = "retry_topic-backoff-timestamp";
+	SUFFIX_WITH_INDEX_VALUE,
 
 	/**
-	 * The default header for the attempts.
+	 * Suffixes the topics the delay value for the topic.
+	 * E.g. my-retry-topic-1000, my-retry-topic-2000, my-retry-topic-4000.
 	 */
-	public static final String DEFAULT_HEADER_ATTEMPTS = "retry_topic-attempts";
-
-	/**
-	 * The default header for the original message's timestamp.
-	 */
-	public static final String DEFAULT_HEADER_ORIGINAL_TIMESTAMP = "retry_topic-original-timestamp";
+	SUFFIX_WITH_DELAY_VALUE
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/destinationtopic/DestinationTopicResolver.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/destinationtopic/DestinationTopicResolver.java
@@ -18,8 +18,6 @@ package org.springframework.kafka.retrytopic.destinationtopic;
 
 import java.util.Map;
 
-import org.springframework.kafka.core.KafkaOperations;
-
 /**
  *
  * Contains methods for resolving the destination to which a message that failed
@@ -32,10 +30,10 @@ import org.springframework.kafka.core.KafkaOperations;
  */
 public interface DestinationTopicResolver {
 
-	DestinationTopic resolveNextDestination(String topic, Integer attempt, Exception e);
-	String resolveDestinationNextExecutionTime(String topic, Integer attempt, Exception e);
+	DestinationTopic resolveNextDestination(String topic, Integer attempt, Exception e, long originalTimestamp);
+	long resolveDestinationNextExecutionTimestamp(String topic, Integer attempt, Exception e, long originalTimestamp);
+	DestinationTopic getCurrentTopic(String topic);
 	void addDestinations(Map<String, DestinationTopicResolver.DestinationsHolder> sourceDestinationMapToAdd);
-	KafkaOperations<?, ?> getKafkaOperationsFor(String topic);
 
 	static DestinationsHolder holderFor(DestinationTopic sourceDestination, DestinationTopic nextDestination) {
 		return new DestinationsHolder(sourceDestination, nextDestination);

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/BackOffValuesGeneratorTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/BackOffValuesGeneratorTests.java
@@ -31,7 +31,7 @@ import org.springframework.retry.backoff.NoBackOffPolicy;
  * @author Tomaz Fernandes
  * @since 2.7
  */
-class BackOffValuesGeneratorTest {
+class BackOffValuesGeneratorTests {
 
 	@Test
 	void shouldGenerateWithDefaultValues() {

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DeadLetterPublishingRecovererFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DeadLetterPublishingRecovererFactoryTests.java
@@ -29,11 +29,13 @@ import java.math.BigInteger;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.function.Consumer;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.record.TimestampType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -55,12 +57,12 @@ import org.springframework.util.concurrent.ListenableFuture;
  */
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings({"unchecked", "rawtypes"})
-class DeadLetterPublishingRecovererFactoryTest {
+class DeadLetterPublishingRecovererFactoryTests {
 
-	private final Clock clock = Clock.fixed(Instant.EPOCH, ZoneId.systemDefault());
+	private final Clock clock = TestClockUtils.CLOCK;
 
 	@Mock
-	DestinationTopicResolver destinationTopicResolver;
+	private DestinationTopicResolver destinationTopicResolver;
 
 	private String testTopic = "test-topic";
 
@@ -87,24 +89,33 @@ class DeadLetterPublishingRecovererFactoryTest {
 	@Captor
 	private ArgumentCaptor<ProducerRecord> producerRecordCaptor;
 
+	@Mock
+	private Consumer<DeadLetterPublishingRecoverer> dlprCustomizer;
+
+	private long originalTimestamp = Instant.now(this.clock).toEpochMilli();
+
+	private byte[] originalTimestampBytes = BigInteger.valueOf(originalTimestamp).toByteArray();
+
 	@Test
 	void shouldSendMessage() {
 		// setup
 		RuntimeException e = new RuntimeException();
-		given(destinationTopicResolver.resolveNextDestination(testTopic, 1, e)).willReturn(destinationTopic);
+		given(destinationTopicResolver.resolveNextDestination(testTopic, 1, e, originalTimestamp)).willReturn(destinationTopic);
 		given(destinationTopic.isNoOpsTopic()).willReturn(false);
 		given(destinationTopic.getDestinationName()).willReturn(testRetryTopic);
 		given(destinationTopic.getDestinationPartitions()).willReturn(3);
-		given(destinationTopicResolver.resolveDestinationNextExecutionTime(testTopic, 1, e))
-				.willReturn(getFormattedNowTimestamp());
-		willReturn(this.kafkaOperations2).given(destinationTopicResolver).getKafkaOperationsFor(testRetryTopic);
+		given(destinationTopicResolver.resolveDestinationNextExecutionTimestamp(testTopic, 1, e, originalTimestamp))
+				.willReturn(getNowTimestamp());
+		given(destinationTopicResolver.getCurrentTopic(testRetryTopic)).willReturn(destinationTopic);
+		willReturn(this.kafkaOperations2).given(destinationTopic).getKafkaOperations();
 		given(kafkaOperations2.send(any(ProducerRecord.class))).willReturn(listenableFuture);
+		this.consumerRecord.headers().add(RetryTopicHeaders.DEFAULT_HEADER_ORIGINAL_TIMESTAMP, originalTimestampBytes);
 
 		DeadLetterPublishingRecovererFactory.Configuration configuration =
 				new DeadLetterPublishingRecovererFactory.Configuration(this.kafkaOperations);
 		DeadLetterPublishingRecovererFactory factory = new DeadLetterPublishingRecovererFactory(this.destinationTopicResolver);
 
-		// given
+		// when
 		DeadLetterPublishingRecoverer deadLetterPublishingRecoverer = factory.create(configuration);
 		deadLetterPublishingRecoverer.accept(this.consumerRecord, e);
 
@@ -122,7 +133,7 @@ class DeadLetterPublishingRecovererFactoryTest {
 		assertEquals(2, attemptsHeader.value()[0]);
 		Header timestampHeader = producerRecord.headers().lastHeader(RetryTopicHeaders.DEFAULT_HEADER_BACKOFF_TIMESTAMP);
 		assertNotNull(timestampHeader);
-		assertEquals(getFormattedNowTimestamp(), new String(timestampHeader.value()));
+		assertEquals(getNowTimestamp(), new BigInteger(timestampHeader.value()).longValue());
 	}
 
 	@Test
@@ -132,21 +143,23 @@ class DeadLetterPublishingRecovererFactoryTest {
 		RuntimeException e = new RuntimeException();
 		ConsumerRecord consumerRecord = new ConsumerRecord(testTopic, 0, 0, key, value);
 		consumerRecord.headers().add(RetryTopicHeaders.DEFAULT_HEADER_ATTEMPTS, BigInteger.valueOf(1).toByteArray());
+		consumerRecord.headers().add(RetryTopicHeaders.DEFAULT_HEADER_ORIGINAL_TIMESTAMP, this.originalTimestampBytes);
 
-		given(destinationTopicResolver.resolveNextDestination(testTopic, 1, e)).willReturn(destinationTopic);
+		given(destinationTopicResolver.resolveNextDestination(testTopic, 1, e, originalTimestamp)).willReturn(destinationTopic);
 		given(destinationTopic.isNoOpsTopic()).willReturn(false);
 		given(destinationTopic.getDestinationName()).willReturn(testRetryTopic);
 		given(destinationTopic.getDestinationPartitions()).willReturn(1);
-		given(destinationTopicResolver.resolveDestinationNextExecutionTime(testTopic, 1, e))
-				.willReturn(getFormattedNowTimestamp());
-		willReturn(this.kafkaOperations2).given(destinationTopicResolver).getKafkaOperationsFor(testRetryTopic);
+		given(destinationTopicResolver.resolveDestinationNextExecutionTimestamp(testTopic, 1, e, this.originalTimestamp))
+				.willReturn(getNowTimestamp());
+		given(destinationTopicResolver.getCurrentTopic(testRetryTopic)).willReturn(destinationTopic);
+		willReturn(this.kafkaOperations2).given(destinationTopic).getKafkaOperations();
 		given(kafkaOperations2.send(any(ProducerRecord.class))).willReturn(listenableFuture);
 
 		DeadLetterPublishingRecovererFactory.Configuration configuration =
 				new DeadLetterPublishingRecovererFactory.Configuration(this.kafkaOperations);
 		DeadLetterPublishingRecovererFactory factory = new DeadLetterPublishingRecovererFactory(this.destinationTopicResolver);
 
-		// given
+		// when
 		DeadLetterPublishingRecoverer deadLetterPublishingRecoverer = factory.create(configuration);
 		deadLetterPublishingRecoverer.accept(consumerRecord, e);
 
@@ -159,19 +172,91 @@ class DeadLetterPublishingRecovererFactoryTest {
 	}
 
 	@Test
-	void shouldNotSendMessageIfNoOpsDestination() {
+	void shouldAddOriginalTimestampHeader() {
+
 		// setup
 		RuntimeException e = new RuntimeException();
-		given(destinationTopicResolver.resolveNextDestination(testTopic, 1, e)).willReturn(destinationTopic);
-		given(destinationTopic.isNoOpsTopic()).willReturn(true);
-		given(destinationTopicResolver.resolveDestinationNextExecutionTime(testTopic, 1, e))
-				.willReturn(getFormattedNowTimestamp());
+		ConsumerRecord consumerRecord = new ConsumerRecord(testTopic, 0, 0, originalTimestamp,
+				TimestampType.CREATE_TIME, 1234L, -1, -1, key, value);
+
+		given(destinationTopicResolver.resolveNextDestination(testTopic, 1, e, originalTimestamp)).willReturn(destinationTopic);
+		given(destinationTopic.isNoOpsTopic()).willReturn(false);
+		given(destinationTopic.getDestinationName()).willReturn(testRetryTopic);
+		given(destinationTopic.getDestinationPartitions()).willReturn(1);
+		given(destinationTopicResolver.getCurrentTopic(testRetryTopic)).willReturn(destinationTopic);
+		long nextExecutionTimestamp = getNowTimestamp() + destinationTopic.getDestinationDelay();
+		given(destinationTopicResolver.resolveDestinationNextExecutionTimestamp(testTopic, 1, e, this.originalTimestamp))
+				.willReturn(nextExecutionTimestamp);
+		willReturn(this.kafkaOperations2).given(destinationTopic).getKafkaOperations();
+		given(kafkaOperations2.send(any(ProducerRecord.class))).willReturn(listenableFuture);
 
 		DeadLetterPublishingRecovererFactory.Configuration configuration =
 				new DeadLetterPublishingRecovererFactory.Configuration(this.kafkaOperations);
 		DeadLetterPublishingRecovererFactory factory = new DeadLetterPublishingRecovererFactory(this.destinationTopicResolver);
 
-		// given
+		// when
+		DeadLetterPublishingRecoverer deadLetterPublishingRecoverer = factory.create(configuration);
+		deadLetterPublishingRecoverer.accept(consumerRecord, e);
+
+		// then
+		then(kafkaOperations2).should(times(1)).send(producerRecordCaptor.capture());
+		ProducerRecord producerRecord = producerRecordCaptor.getValue();
+		Header originalTimestampHeader = producerRecord.headers().lastHeader(RetryTopicHeaders.DEFAULT_HEADER_ORIGINAL_TIMESTAMP);
+		assertNotNull(originalTimestampHeader);
+		assertEquals(getNowTimestamp(),	new BigInteger(originalTimestampHeader.value()).longValue());
+	}
+
+	@Test
+	void shouldNotReplaceOriginalTimestampHeader() {
+
+		// setup
+		RuntimeException e = new RuntimeException();
+		long timestamp = LocalDateTime.now(this.clock).toInstant(ZoneOffset.UTC).minusMillis(5000).toEpochMilli();
+		ConsumerRecord consumerRecord = new ConsumerRecord(testTopic, 0, 0, timestamp,
+				TimestampType.CREATE_TIME, 1234L, -1, -1, key, value);
+
+		given(destinationTopicResolver.resolveNextDestination(testTopic, 1, e, timestamp)).willReturn(destinationTopic);
+		given(destinationTopic.isNoOpsTopic()).willReturn(false);
+		given(destinationTopic.getDestinationName()).willReturn(testRetryTopic);
+		given(destinationTopic.getDestinationPartitions()).willReturn(1);
+		given(destinationTopicResolver.getCurrentTopic(testRetryTopic)).willReturn(destinationTopic);
+		long nextExecutionTimestamp = getNowTimestamp() + destinationTopic.getDestinationDelay();
+		given(destinationTopicResolver.resolveDestinationNextExecutionTimestamp(testTopic, 1, e, timestamp))
+				.willReturn(nextExecutionTimestamp);
+		willReturn(this.kafkaOperations2).given(destinationTopic).getKafkaOperations();
+		given(kafkaOperations2.send(any(ProducerRecord.class))).willReturn(listenableFuture);
+
+		DeadLetterPublishingRecovererFactory.Configuration configuration =
+				new DeadLetterPublishingRecovererFactory.Configuration(this.kafkaOperations);
+		DeadLetterPublishingRecovererFactory factory = new DeadLetterPublishingRecovererFactory(this.destinationTopicResolver);
+
+		// when
+		DeadLetterPublishingRecoverer deadLetterPublishingRecoverer = factory.create(configuration);
+		deadLetterPublishingRecoverer.accept(consumerRecord, e);
+
+		// then
+		then(kafkaOperations2).should(times(1)).send(producerRecordCaptor.capture());
+		ProducerRecord producerRecord = producerRecordCaptor.getValue();
+		Header originalTimestampHeader = producerRecord.headers().lastHeader(RetryTopicHeaders.DEFAULT_HEADER_ORIGINAL_TIMESTAMP);
+		assertNotNull(originalTimestampHeader);
+		assertEquals(timestamp,	new BigInteger(originalTimestampHeader.value()).longValue());
+	}
+
+	@Test
+	void shouldNotSendMessageIfNoOpsDestination() {
+		// setup
+		RuntimeException e = new RuntimeException();
+		given(destinationTopicResolver.resolveNextDestination(testTopic, 1, e, originalTimestamp)).willReturn(destinationTopic);
+		given(destinationTopic.isNoOpsTopic()).willReturn(true);
+		given(destinationTopicResolver.resolveDestinationNextExecutionTimestamp(testTopic, 1, e, originalTimestamp))
+				.willReturn(getNowTimestamp());
+		this.consumerRecord.headers().add(RetryTopicHeaders.DEFAULT_HEADER_ORIGINAL_TIMESTAMP, originalTimestampBytes);
+
+		DeadLetterPublishingRecovererFactory.Configuration configuration =
+				new DeadLetterPublishingRecovererFactory.Configuration(this.kafkaOperations);
+		DeadLetterPublishingRecovererFactory factory = new DeadLetterPublishingRecovererFactory(this.destinationTopicResolver);
+
+		// when
 		DeadLetterPublishingRecoverer deadLetterPublishingRecoverer = factory.create(configuration);
 		deadLetterPublishingRecoverer.accept(this.consumerRecord, e);
 
@@ -182,13 +267,13 @@ class DeadLetterPublishingRecovererFactoryTest {
 	@Test
 	void shouldThrowIfKafkaBackoffException() {
 		// setup
-		RuntimeException e = new KafkaBackoffException("KBEx", null, "test-listener-id", getFormattedNowTimestamp());
+		RuntimeException e = new KafkaBackoffException("KBEx", null, "test-listener-id", getNowTimestamp());
 
 		DeadLetterPublishingRecovererFactory.Configuration configuration =
 				new DeadLetterPublishingRecovererFactory.Configuration(this.kafkaOperations);
 		DeadLetterPublishingRecovererFactory factory = new DeadLetterPublishingRecovererFactory(this.destinationTopicResolver);
 
-		// given
+		// when
 		DeadLetterPublishingRecoverer deadLetterPublishingRecoverer = factory.create(configuration);
 		assertThrows(NestedRuntimeException.class, () -> deadLetterPublishingRecoverer.accept(this.consumerRecord, e));
 
@@ -197,11 +282,28 @@ class DeadLetterPublishingRecovererFactoryTest {
 	}
 
 	@Test
+	void shouldCallDLPRCustomizer() {
+
+		// setup
+		DeadLetterPublishingRecovererFactory.Configuration configuration =
+				new DeadLetterPublishingRecovererFactory.Configuration(this.kafkaOperations);
+		DeadLetterPublishingRecovererFactory factory = new DeadLetterPublishingRecovererFactory(this.destinationTopicResolver);
+		factory.setDeadLetterPublishingRecovererCustomizer(dlprCustomizer);
+
+		// when
+		DeadLetterPublishingRecoverer deadLetterPublishingRecoverer = factory.create(configuration);
+
+		// then
+		then(dlprCustomizer).should(times(1)).accept(deadLetterPublishingRecoverer);
+	}
+
+
+	@Test
 	void shouldThrowIfNoTemplateProvided() {
 		assertThrows(IllegalArgumentException.class, () -> new DeadLetterPublishingRecovererFactory.Configuration(null));
 	}
 
-	private String getFormattedNowTimestamp() {
-		return LocalDateTime.now(this.clock).format(RetryTopicHeaders.DEFAULT_BACKOFF_TIMESTAMP_HEADER_FORMATTER);
+	private long getNowTimestamp() {
+		return Instant.now(this.clock).toEpochMilli();
 	}
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/ListenerContainerFactoryResolverTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/ListenerContainerFactoryResolverTests.java
@@ -36,7 +36,7 @@ import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
  * @since 2.7
  */
 @ExtendWith(MockitoExtension.class)
-class ListenerContainerFactoryResolverTest {
+class ListenerContainerFactoryResolverTests {
 
 	@Mock
 	private BeanFactory beanFactory;

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicBootstrapperTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicBootstrapperTests.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.retrytopic;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+
+import java.time.Clock;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.config.SingletonBeanRegistry;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.kafka.listener.KafkaConsumerBackoffManager;
+import org.springframework.kafka.retrytopic.destinationtopic.DefaultDestinationTopicProcessor;
+import org.springframework.kafka.retrytopic.destinationtopic.DestinationTopicContainer;
+
+/**
+ * @author Tomaz Fernandes
+ * @since 2.7
+ */
+@ExtendWith(MockitoExtension.class)
+class RetryTopicBootstrapperTests {
+
+	@Mock
+	private ApplicationContext wrongApplicationContext;
+
+	@Mock
+	private GenericApplicationContext applicationContext;
+
+	@Mock
+	private DefaultListableBeanFactory beanFactory;
+
+	@Mock
+	private BeanFactory wrongBeanFactory;
+
+	@Mock
+	private DestinationTopicContainer destinationTopicContainer;
+
+	@Mock
+	private KafkaConsumerBackoffManager kafkaConsumerBackoffManager;
+
+	@Test
+	void shouldThrowIfACDoesntImplementInterfaces() {
+		assertThrows(IllegalStateException.class, () -> new RetryTopicBootstrapper(wrongApplicationContext, beanFactory));
+	}
+
+	@Test
+	void shouldThrowIfBFDoesntImplementInterfaces() {
+		assertThrows(IllegalStateException.class, () -> new RetryTopicBootstrapper(applicationContext, wrongBeanFactory));
+	}
+
+	@Test
+	void shouldRegisterBeansIfNotRegistered() {
+
+		// given
+		given(applicationContext.containsBeanDefinition(any(String.class))).willReturn(false);
+		given(this.applicationContext.getBean(
+				RetryTopicInternalBeanNames.DESTINATION_TOPIC_CONTAINER_NAME, DestinationTopicContainer.class))
+				.willReturn(destinationTopicContainer);
+		given(this.applicationContext.getBean(
+				RetryTopicInternalBeanNames.KAFKA_CONSUMER_BACKOFF_MANAGER, KafkaConsumerBackoffManager.class))
+				.willReturn(kafkaConsumerBackoffManager);
+
+		BeanDefinitionRegistry registry = (BeanDefinitionRegistry) this.applicationContext;
+
+		// when
+		RetryTopicBootstrapper bootstrapper = new RetryTopicBootstrapper(applicationContext, beanFactory);
+		bootstrapper.bootstrapRetryTopic();
+
+		// then
+		then(registry).should(times(1)).registerBeanDefinition(RetryTopicInternalBeanNames.LISTENER_CONTAINER_FACTORY_RESOLVER_NAME, new RootBeanDefinition(ListenerContainerFactoryResolver.class));
+		then(registry).should(times(1)).registerBeanDefinition(RetryTopicInternalBeanNames.DESTINATION_TOPIC_PROCESSOR_NAME, new RootBeanDefinition(DefaultDestinationTopicProcessor.class));
+		then(registry).should(times(1)).registerBeanDefinition(RetryTopicInternalBeanNames.LISTENER_CONTAINER_FACTORY_CONFIGURER_NAME, new RootBeanDefinition(ListenerContainerFactoryConfigurer.class));
+		then(registry).should(times(1)).registerBeanDefinition(RetryTopicInternalBeanNames.DEAD_LETTER_PUBLISHING_RECOVERER_PROVIDER_NAME, new RootBeanDefinition(DeadLetterPublishingRecovererFactory.class));
+		then(registry).should(times(1)).registerBeanDefinition(RetryTopicInternalBeanNames.RETRY_TOPIC_CONFIGURER, new RootBeanDefinition(RetryTopicConfigurer.class));
+		then(registry).should(times(1)).registerBeanDefinition(RetryTopicInternalBeanNames.KAFKA_CONSUMER_BACKOFF_MANAGER, new RootBeanDefinition(KafkaConsumerBackoffManager.class));
+		then(registry).should(times(1)).registerBeanDefinition(RetryTopicInternalBeanNames.DESTINATION_TOPIC_CONTAINER_NAME, new RootBeanDefinition(DestinationTopicContainer.class));
+	}
+
+	@Test
+	void shouldNotRegisterBeansIfRegistered() {
+
+		// given
+		given(applicationContext.containsBeanDefinition(any(String.class))).willReturn(true);
+		given(this.applicationContext.getBean(
+				RetryTopicInternalBeanNames.DESTINATION_TOPIC_CONTAINER_NAME, DestinationTopicContainer.class))
+				.willReturn(destinationTopicContainer);
+		given(this.applicationContext.getBean(
+				RetryTopicInternalBeanNames.KAFKA_CONSUMER_BACKOFF_MANAGER, KafkaConsumerBackoffManager.class))
+				.willReturn(kafkaConsumerBackoffManager);
+
+		BeanDefinitionRegistry registry = (BeanDefinitionRegistry) this.applicationContext;
+
+		// when
+		RetryTopicBootstrapper bootstrapper = new RetryTopicBootstrapper(applicationContext, beanFactory);
+		bootstrapper.bootstrapRetryTopic();
+
+		// then
+		then(registry).should(times(0)).registerBeanDefinition(RetryTopicInternalBeanNames.LISTENER_CONTAINER_FACTORY_RESOLVER_NAME, new RootBeanDefinition(ListenerContainerFactoryResolver.class));
+		then(registry).should(times(0)).registerBeanDefinition(RetryTopicInternalBeanNames.DESTINATION_TOPIC_PROCESSOR_NAME, new RootBeanDefinition(DefaultDestinationTopicProcessor.class));
+		then(registry).should(times(0)).registerBeanDefinition(RetryTopicInternalBeanNames.LISTENER_CONTAINER_FACTORY_CONFIGURER_NAME, new RootBeanDefinition(ListenerContainerFactoryConfigurer.class));
+		then(registry).should(times(0)).registerBeanDefinition(RetryTopicInternalBeanNames.DEAD_LETTER_PUBLISHING_RECOVERER_PROVIDER_NAME, new RootBeanDefinition(DeadLetterPublishingRecovererFactory.class));
+		then(registry).should(times(0)).registerBeanDefinition(RetryTopicInternalBeanNames.RETRY_TOPIC_CONFIGURER, new RootBeanDefinition(RetryTopicConfigurer.class));
+		then(registry).should(times(0)).registerBeanDefinition(RetryTopicInternalBeanNames.KAFKA_CONSUMER_BACKOFF_MANAGER, new RootBeanDefinition(KafkaConsumerBackoffManager.class));
+		then(registry).should(times(0)).registerBeanDefinition(RetryTopicInternalBeanNames.DESTINATION_TOPIC_CONTAINER_NAME, new RootBeanDefinition(DestinationTopicContainer.class));
+	}
+
+	@Test
+	void shouldConfigureClock() {
+
+		// given
+		given(applicationContext.containsBeanDefinition(any(String.class)))
+				.willReturn(false);
+		given(this.applicationContext.getBean(
+				RetryTopicInternalBeanNames.DESTINATION_TOPIC_CONTAINER_NAME, DestinationTopicContainer.class))
+				.willReturn(destinationTopicContainer);
+		given(this.applicationContext.getBean(
+				RetryTopicInternalBeanNames.KAFKA_CONSUMER_BACKOFF_MANAGER, KafkaConsumerBackoffManager.class))
+				.willReturn(kafkaConsumerBackoffManager);
+
+		BeanDefinitionRegistry registry = (BeanDefinitionRegistry) this.applicationContext;
+
+		// when
+		RetryTopicBootstrapper bootstrapper = new RetryTopicBootstrapper(applicationContext, beanFactory);
+		bootstrapper.bootstrapRetryTopic();
+
+		// then
+		then((SingletonBeanRegistry) this.beanFactory).should(times(1)).registerSingleton(
+				KafkaConsumerBackoffManager.INTERNAL_BACKOFF_CLOCK_BEAN_NAME, Clock.systemUTC());
+	}
+
+	@Test
+	void shouldAddApplicationListeners() {
+
+		// given
+		given(applicationContext.containsBeanDefinition(any(String.class)))
+				.willReturn(false);
+		given(this.applicationContext.getBean(
+				RetryTopicInternalBeanNames.DESTINATION_TOPIC_CONTAINER_NAME, DestinationTopicContainer.class))
+				.willReturn(destinationTopicContainer);
+		given(this.applicationContext.getBean(
+				RetryTopicInternalBeanNames.KAFKA_CONSUMER_BACKOFF_MANAGER, KafkaConsumerBackoffManager.class))
+				.willReturn(kafkaConsumerBackoffManager);
+
+		BeanDefinitionRegistry registry = (BeanDefinitionRegistry) this.applicationContext;
+
+		// when
+		RetryTopicBootstrapper bootstrapper = new RetryTopicBootstrapper(applicationContext, beanFactory);
+		bootstrapper.bootstrapRetryTopic();
+		ConfigurableApplicationContext configurableApplicationContext = (ConfigurableApplicationContext) this.applicationContext;
+
+		// then
+		then(configurableApplicationContext).should(times(1)).addApplicationListener(kafkaConsumerBackoffManager);
+		then(configurableApplicationContext).should(times(1)).addApplicationListener(destinationTopicContainer);
+	}
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationBuilderTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationBuilderTests.java
@@ -38,7 +38,7 @@ import org.springframework.test.util.ReflectionTestUtils;
  * @since 2.7
  */
 @ExtendWith(MockitoExtension.class)
-class RetryTopicConfigurationBuilderTest {
+class RetryTopicConfigurationBuilderTests {
 
 	@Mock
 	private KafkaOperations<?, ?> kafkaOperations;

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationProviderTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationProviderTests.java
@@ -40,7 +40,7 @@ import org.springframework.kafka.core.KafkaOperations;
  * @since 2.7
  */
 @ExtendWith(MockitoExtension.class)
-class RetryTopicConfigurationProviderTest {
+class RetryTopicConfigurationProviderTests {
 
 	@Mock
 	private ListableBeanFactory beanFactory;

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurerTests.java
@@ -58,7 +58,7 @@ import org.springframework.kafka.support.Suffixer;
  * @since 2.7
  */
 @ExtendWith(MockitoExtension.class)
-class RetryTopicConfigurerTest {
+class RetryTopicConfigurerTests {
 
 	@Mock
 	private DestinationTopicProcessor destinationTopicProcessor;

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConstantsTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConstantsTests.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.retrytopic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Tomaz Fernandes
+ * @since 2.7
+ */
+class RetryTopicConstantsTests {
+
+	private static final String DEFAULT_RETRY_SUFFIX = "-retry";
+
+	private static final String DEFAULT_DLT_SUFFIX = "-dlt";
+
+	private static final int DEFAULT_MAX_ATTEMPTS = 3;
+
+	private static final int NOT_SET = -1;
+
+	@Test
+	public void assertRetryTopicConstants() {
+		new RetryTopicConstants() { }; // for coverage
+		assertEquals(DEFAULT_DLT_SUFFIX, RetryTopicConstants.DEFAULT_DLT_SUFFIX);
+		assertEquals(DEFAULT_RETRY_SUFFIX, RetryTopicConstants.DEFAULT_RETRY_SUFFIX);
+		assertEquals(DEFAULT_MAX_ATTEMPTS, RetryTopicConstants.DEFAULT_MAX_ATTEMPTS);
+		assertEquals(NOT_SET, RetryTopicConstants.NOT_SET);
+	}
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicHeadersTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicHeadersTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.retrytopic;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Tomaz Fernandes
+ * @since 2.7
+ */
+class RetryTopicHeadersTests {
+
+	private static final String DEFAULT_HEADER_BACKOFF_TIMESTAMP = "retry_topic-backoff-timestamp";
+
+	private static final String DEFAULT_HEADER_ATTEMPTS = "retry_topic-attempts";
+
+	private static final String DEFAULT_HEADER_ORIGINAL_TIMESTAMP = "retry_topic-original-timestamp";
+
+	@Test
+	public void assertRetryTopicHeadersConstants() {
+		new RetryTopicHeaders() { }; // for coverage
+		assertEquals(DEFAULT_HEADER_BACKOFF_TIMESTAMP, RetryTopicHeaders.DEFAULT_HEADER_BACKOFF_TIMESTAMP);
+		assertEquals(DEFAULT_HEADER_ATTEMPTS, RetryTopicHeaders.DEFAULT_HEADER_ATTEMPTS);
+		assertEquals(DEFAULT_HEADER_ORIGINAL_TIMESTAMP, RetryTopicHeaders.DEFAULT_HEADER_ORIGINAL_TIMESTAMP);
+	}
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicInternalBeanNamesTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicInternalBeanNamesTests.java
@@ -16,18 +16,15 @@
 
 package org.springframework.kafka.retrytopic;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
 /**
- *
- * Contains the internal bean names that will be used by the retryable topic configuration.
- *
- * If you provide a bean of your own with the same name that instance will be used instead
- * of the default one.
- *
  * @author Tomaz Fernandes
  * @since 2.7
- *
  */
-public abstract class RetryTopicInternalBeanNames {
+class RetryTopicInternalBeanNamesTests {
 
 	static final String DESTINATION_TOPIC_PROCESSOR_NAME = "internalDestinationTopicProcessor";
 
@@ -47,4 +44,17 @@ public abstract class RetryTopicInternalBeanNames {
 
 	static final String DEFAULT_KAFKA_TEMPLATE_BEAN_NAME = "retryTopicDefaultKafkaTemplate";
 
+	@Test
+	public void assertRetryTopicInternalBeanNamesConstants() {
+		new RetryTopicInternalBeanNames() { }; // for coverage
+		assertEquals(DESTINATION_TOPIC_PROCESSOR_NAME, RetryTopicInternalBeanNames.DESTINATION_TOPIC_PROCESSOR_NAME);
+		assertEquals(KAFKA_CONSUMER_BACKOFF_MANAGER, RetryTopicInternalBeanNames.KAFKA_CONSUMER_BACKOFF_MANAGER);
+		assertEquals(RETRY_TOPIC_CONFIGURER, RetryTopicInternalBeanNames.RETRY_TOPIC_CONFIGURER);
+		assertEquals(LISTENER_CONTAINER_FACTORY_RESOLVER_NAME, RetryTopicInternalBeanNames.LISTENER_CONTAINER_FACTORY_RESOLVER_NAME);
+		assertEquals(LISTENER_CONTAINER_FACTORY_CONFIGURER_NAME, RetryTopicInternalBeanNames.LISTENER_CONTAINER_FACTORY_CONFIGURER_NAME);
+		assertEquals(DEAD_LETTER_PUBLISHING_RECOVERER_PROVIDER_NAME, RetryTopicInternalBeanNames.DEAD_LETTER_PUBLISHING_RECOVERER_PROVIDER_NAME);
+		assertEquals(DESTINATION_TOPIC_CONTAINER_NAME, RetryTopicInternalBeanNames.DESTINATION_TOPIC_CONTAINER_NAME);
+		assertEquals(DEFAULT_LISTENER_FACTORY_BEAN_NAME, RetryTopicInternalBeanNames.DEFAULT_LISTENER_FACTORY_BEAN_NAME);
+		assertEquals(DEFAULT_KAFKA_TEMPLATE_BEAN_NAME, RetryTopicInternalBeanNames.DEFAULT_KAFKA_TEMPLATE_BEAN_NAME);
+	}
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryableTopicAnnotationProcessorTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryableTopicAnnotationProcessorTests.java
@@ -47,7 +47,7 @@ import org.springframework.util.ReflectionUtils;
  * @since 2.7
  */
 @ExtendWith(MockitoExtension.class)
-class RetryableTopicAnnotationProcessorTest {
+class RetryableTopicAnnotationProcessorTests {
 
 	private final String topic1 = "topic1";
 
@@ -266,7 +266,7 @@ class RetryableTopicAnnotationProcessorTest {
 	static class RetryableTopicAnnotationFactory {
 
 		@KafkaListener
-		@RetryableTopic(kafkaTemplate = RetryableTopicAnnotationProcessorTest.kafkaTemplateName)
+		@RetryableTopic(kafkaTemplate = RetryableTopicAnnotationProcessorTests.kafkaTemplateName)
 		void listenWithRetry() {
 			// NoOps
 		}
@@ -276,7 +276,7 @@ class RetryableTopicAnnotationProcessorTest {
 
 		@KafkaListener
 		@RetryableTopic(attempts = 3, backoff = @Backoff(multiplier = 2, value = 1000),
-			dltProcessingFailureStrategy = RetryTopicConfiguration.DltProcessingFailureStrategy.FAIL)
+			dltStrategy = DltStrategy.FAIL_ON_ERROR)
 		void listenWithRetry() {
 			// NoOps
 		}

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/TestClockUtils.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/TestClockUtils.java
@@ -16,29 +16,16 @@
 
 package org.springframework.kafka.retrytopic;
 
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+
 /**
- *
- * Contains the headers that will be used in the forwarded messages.
- *
- * @author Tomaz Fernandes
- * @since 2.7
- *
+ * @author tomazlemos
+ * @since 14/02/21
  */
-public abstract class RetryTopicHeaders {
+public abstract class TestClockUtils {
 
-	/**
-	 * The default header for the backoff duetimestamp.
-	 */
-	public static final String DEFAULT_HEADER_BACKOFF_TIMESTAMP = "retry_topic-backoff-timestamp";
-
-	/**
-	 * The default header for the attempts.
-	 */
-	public static final String DEFAULT_HEADER_ATTEMPTS = "retry_topic-attempts";
-
-	/**
-	 * The default header for the original message's timestamp.
-	 */
-	public static final String DEFAULT_HEADER_ORIGINAL_TIMESTAMP = "retry_topic-original-timestamp";
+	public static Clock CLOCK = Clock.fixed(Instant.ofEpochMilli(325587600000L), ZoneId.systemDefault());
 
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/destinationtopic/DestinationTopicTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/destinationtopic/DestinationTopicTests.java
@@ -26,13 +26,13 @@ import org.springframework.classify.BinaryExceptionClassifierBuilder;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaOperations;
 import org.springframework.kafka.core.KafkaTemplate;
-import org.springframework.kafka.retrytopic.RetryTopicConfiguration;
+import org.springframework.kafka.retrytopic.DltStrategy;
 
 /**
  * @author Tomaz Fernandes
  * @since 2.7
  */
-public class DestinationTopicTest {
+public class DestinationTopicTests {
 
 	// KafkaOperations
 
@@ -51,6 +51,10 @@ public class DestinationTopicTest {
 
 	private String dltSuffix = suffixes.getDltSuffix();
 
+	private long noTimeout = -1;
+
+	private long timeout = 1000;
+
 	// MaxAttempts
 
 	private final int maxAttempts = 3;
@@ -58,34 +62,57 @@ public class DestinationTopicTest {
 	// DestinationTopic Properties
 
 	protected DestinationTopic.Properties mainTopicProps =
-			new DestinationTopic.Properties(0, "", DestinationTopic.Type.RETRY, 4, 1, RetryTopicConfiguration.DltProcessingFailureStrategy.FAIL, kafkaOperations1, getShouldRetryOn());
+			new DestinationTopic.Properties(0, "", DestinationTopic.Type.RETRY, 4, 1,
+					DltStrategy.FAIL_ON_ERROR, kafkaOperations1, getShouldRetryOn(), noTimeout);
 
 	protected DestinationTopic.Properties firstRetryProps =
-			new DestinationTopic.Properties(1000, retrySuffix + "-1000", DestinationTopic.Type.RETRY, 4, 1, RetryTopicConfiguration.DltProcessingFailureStrategy.FAIL, kafkaOperations1, getShouldRetryOn());
+			new DestinationTopic.Properties(1000, retrySuffix + "-1000", DestinationTopic.Type.RETRY, 4, 1,
+					DltStrategy.FAIL_ON_ERROR, kafkaOperations1, getShouldRetryOn(), noTimeout);
 
 	protected DestinationTopic.Properties secondRetryProps =
-			new DestinationTopic.Properties(2000, retrySuffix + "-2000", DestinationTopic.Type.RETRY, 4, 1, RetryTopicConfiguration.DltProcessingFailureStrategy.FAIL, kafkaOperations1, getShouldRetryOn());
+			new DestinationTopic.Properties(2000, retrySuffix + "-2000", DestinationTopic.Type.RETRY, 4, 1,
+					DltStrategy.FAIL_ON_ERROR, kafkaOperations1, getShouldRetryOn(), noTimeout);
 
 	protected DestinationTopic.Properties dltTopicProps =
-			new DestinationTopic.Properties(0, dltSuffix, DestinationTopic.Type.DLT, 4, 1, RetryTopicConfiguration.DltProcessingFailureStrategy.FAIL, kafkaOperations1, (a, e) -> false);
+			new DestinationTopic.Properties(0, dltSuffix, DestinationTopic.Type.DLT, 4, 1,
+					DltStrategy.FAIL_ON_ERROR, kafkaOperations1, (a, e) -> false, noTimeout);
 
 	protected List<DestinationTopic.Properties> allProps = Arrays
 			.asList(mainTopicProps, firstRetryProps, secondRetryProps, dltTopicProps);
 
 	protected DestinationTopic.Properties mainTopicProps2 =
-			new DestinationTopic.Properties(0, "", DestinationTopic.Type.RETRY, 4, 1, RetryTopicConfiguration.DltProcessingFailureStrategy.ALWAYS_RETRY, kafkaOperations2, getShouldRetryOn());
+			new DestinationTopic.Properties(0, "", DestinationTopic.Type.RETRY, 4, 1,
+					DltStrategy.ALWAYS_RETRY_ON_ERROR, kafkaOperations2, getShouldRetryOn(), timeout);
 
 	protected DestinationTopic.Properties firstRetryProps2 =
-			new DestinationTopic.Properties(1000, retrySuffix + "-0", DestinationTopic.Type.RETRY, 4, 1, RetryTopicConfiguration.DltProcessingFailureStrategy.ALWAYS_RETRY, kafkaOperations2, getShouldRetryOn());
+			new DestinationTopic.Properties(1000, retrySuffix + "-0", DestinationTopic.Type.RETRY, 4, 1,
+					DltStrategy.ALWAYS_RETRY_ON_ERROR, kafkaOperations2, getShouldRetryOn(), timeout);
 
 	protected DestinationTopic.Properties secondRetryProps2 =
-			new DestinationTopic.Properties(1000, retrySuffix + "-1", DestinationTopic.Type.RETRY, 4, 1, RetryTopicConfiguration.DltProcessingFailureStrategy.ALWAYS_RETRY, kafkaOperations2, getShouldRetryOn());
+			new DestinationTopic.Properties(1000, retrySuffix + "-1", DestinationTopic.Type.RETRY, 4, 1,
+					DltStrategy.ALWAYS_RETRY_ON_ERROR, kafkaOperations2, getShouldRetryOn(), timeout);
 
 	protected DestinationTopic.Properties dltTopicProps2 =
-			new DestinationTopic.Properties(0, dltSuffix, DestinationTopic.Type.DLT, 4, 1, RetryTopicConfiguration.DltProcessingFailureStrategy.ALWAYS_RETRY, kafkaOperations2, (a, e) -> false);
+			new DestinationTopic.Properties(0, dltSuffix, DestinationTopic.Type.DLT, 4, 1,
+					DltStrategy.ALWAYS_RETRY_ON_ERROR, kafkaOperations2, (a, e) -> false, timeout);
 
 	protected List<DestinationTopic.Properties> allProps2 = Arrays
-			.asList(mainTopicProps, firstRetryProps, secondRetryProps, dltTopicProps);
+			.asList(mainTopicProps2, firstRetryProps2, secondRetryProps2, dltTopicProps2);
+
+	protected DestinationTopic.Properties mainTopicProps3 =
+			new DestinationTopic.Properties(0, "", DestinationTopic.Type.RETRY, 4, 1,
+					DltStrategy.NO_DLT, kafkaOperations2, getShouldRetryOn(), timeout);
+
+	protected DestinationTopic.Properties firstRetryProps3 =
+			new DestinationTopic.Properties(1000, retrySuffix + "-0", DestinationTopic.Type.RETRY, 4, 1,
+					DltStrategy.NO_DLT, kafkaOperations2, getShouldRetryOn(), timeout);
+
+	protected DestinationTopic.Properties secondRetryProps3 =
+			new DestinationTopic.Properties(1000, retrySuffix + "-1", DestinationTopic.Type.RETRY, 4, 1,
+					DltStrategy.NO_DLT, kafkaOperations2, getShouldRetryOn(), timeout);
+
+	protected List<DestinationTopic.Properties> allProps3 = Arrays
+			.asList(mainTopicProps3, firstRetryProps3, secondRetryProps3);
 
 
 	// Holders
@@ -120,6 +147,20 @@ public class DestinationTopicTest {
 	protected List<PropsHolder> allSecondDestinationHolders = Arrays
 			.asList(mainDestinationHolder2, firstRetryDestinationHolder2, secondRetryDestinationHolder2, dltDestinationHolder2);
 
+	protected final static String THIRD_TOPIC = "thirdTopic";
+
+	protected PropsHolder mainDestinationHolder3 =
+			new PropsHolder(THIRD_TOPIC, mainTopicProps3);
+
+	protected PropsHolder firstRetryDestinationHolder3 =
+			new PropsHolder(THIRD_TOPIC, firstRetryProps3);
+
+	protected PropsHolder secondRetryDestinationHolder3 =
+			new PropsHolder(THIRD_TOPIC, secondRetryProps3);
+
+	protected List<PropsHolder> allThirdDestinationHolders = Arrays
+			.asList(mainDestinationHolder3, firstRetryDestinationHolder3, secondRetryDestinationHolder3);
+
 	// DestinationTopics
 
 	protected DestinationTopic mainDestinationTopic =
@@ -135,7 +176,8 @@ public class DestinationTopicTest {
 			new DestinationTopic(FIRST_TOPIC + dltTopicProps.suffix(), dltTopicProps);
 
 	protected DestinationTopic noOpsDestinationTopic =
-			new DestinationTopic(dltDestinationTopic.getDestinationName() + "-noOps", new DestinationTopic.Properties(dltTopicProps, "-noOps", DestinationTopic.Type.NO_OPS));
+			new DestinationTopic(dltDestinationTopic.getDestinationName() + "-noOps",
+					new DestinationTopic.Properties(dltTopicProps, "-noOps", DestinationTopic.Type.NO_OPS));
 
 	protected List<DestinationTopic> allFirstDestinationsTopics = Arrays
 			.asList(mainDestinationTopic, firstRetryDestinationTopic, secondRetryDestinationTopic, dltDestinationTopic);
@@ -153,16 +195,34 @@ public class DestinationTopicTest {
 			new DestinationTopic(SECOND_TOPIC + dltTopicProps2.suffix(), dltTopicProps2);
 
 	protected DestinationTopic noOpsDestinationTopic2 =
-			new DestinationTopic(dltDestinationTopic2.getDestinationName() + "-noOps", new DestinationTopic.Properties(dltTopicProps2, "-noOps", DestinationTopic.Type.NO_OPS));
+			new DestinationTopic(dltDestinationTopic2.getDestinationName() + "-noOps",
+					new DestinationTopic.Properties(dltTopicProps2, "-noOps", DestinationTopic.Type.NO_OPS));
 
 	protected List<DestinationTopic> allSecondDestinationTopics = Arrays
 			.asList(mainDestinationTopic2, firstRetryDestinationTopic2, secondRetryDestinationTopic2, dltDestinationTopic2);
 
+	protected DestinationTopic mainDestinationTopic3 =
+			new DestinationTopic(THIRD_TOPIC + mainTopicProps3.suffix(), mainTopicProps3);
+
+	protected DestinationTopic firstRetryDestinationTopic3 =
+			new DestinationTopic(THIRD_TOPIC + firstRetryProps3.suffix(), firstRetryProps3);
+
+	protected DestinationTopic secondRetryDestinationTopic3 =
+			new DestinationTopic(THIRD_TOPIC + secondRetryProps3.suffix(), secondRetryProps3);
+
+	protected DestinationTopic noOpsDestinationTopic3 =
+			new DestinationTopic(secondRetryDestinationTopic3.getDestinationName() + "-noOps",
+					new DestinationTopic.Properties(secondRetryProps3, "-noOps", DestinationTopic.Type.NO_OPS));
+
+	protected List<DestinationTopic> allThirdDestinationTopics = Arrays
+			.asList(mainDestinationTopic2, firstRetryDestinationTopic2, secondRetryDestinationTopic2, dltDestinationTopic2);
+
 	// Classifiers
 
-	private BinaryExceptionClassifier classifier = new BinaryExceptionClassifierBuilder().retryOn(IllegalArgumentException.class).build();
+	private BinaryExceptionClassifier classifier = new BinaryExceptionClassifierBuilder()
+			.retryOn(IllegalArgumentException.class).build();
 
-	private BiPredicate<Integer, Exception> getShouldRetryOn() {
+	private BiPredicate<Integer, Throwable> getShouldRetryOn() {
 		return (a, e) -> a < maxAttempts && classifier.classify(e);
 	}
 


### PR DESCRIPTION
- Added the ability of setting a global timeout for the retries
- Added the ability of choosing between suffixing the topics with it's delay or index
- Added isPartitionPaused to MessageListenerContainer and it's implementations
- Added option of not using a DLT
- Changed the Backoff Timestamp Header from String (formatted LocalDateTime) to long (millis since epoch UTC)
- Unwraps ListenerExecutionFailedException so that the cause can be classified
- Increased test coverage
- A few cleanups to the API