### PR TITLE
GH-1708: Fix New Package Tangles

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
@@ -78,7 +78,6 @@ import org.springframework.kafka.config.MultiMethodKafkaListenerEndpoint;
 import org.springframework.kafka.listener.KafkaListenerErrorHandler;
 import org.springframework.kafka.retrytopic.RetryTopicBootstrapper;
 import org.springframework.kafka.retrytopic.RetryTopicConfiguration;
-import org.springframework.kafka.retrytopic.RetryTopicConfigurationProvider;
 import org.springframework.kafka.retrytopic.RetryTopicConfigurer;
 import org.springframework.kafka.support.KafkaNull;
 import org.springframework.kafka.support.TopicPartitionOffset;

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryTopicConfigurationProvider.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryTopicConfigurationProvider.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.kafka.retrytopic;
+package org.springframework.kafka.annotation;
 
 import java.lang.reflect.Method;
 import java.util.Map;
@@ -25,7 +25,8 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.core.log.LogAccessor;
-import org.springframework.kafka.annotation.RetryableTopic;
+import org.springframework.kafka.retrytopic.RetryTopicConfiguration;
+import org.springframework.kafka.retrytopic.RetryTopicConfigurer;
 
 
 /**

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryableTopicAnnotationProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryableTopicAnnotationProcessor.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.kafka.retrytopic;
+package org.springframework.kafka.annotation;
 
 import java.lang.reflect.Method;
 import java.util.Arrays;
@@ -27,10 +27,11 @@ import org.springframework.context.expression.BeanFactoryResolver;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
-import org.springframework.kafka.annotation.DltHandler;
-import org.springframework.kafka.annotation.RetryableTopic;
 import org.springframework.kafka.core.KafkaOperations;
 import org.springframework.kafka.listener.adapter.AdapterUtils;
+import org.springframework.kafka.retrytopic.RetryTopicConfiguration;
+import org.springframework.kafka.retrytopic.RetryTopicConfigurer;
+import org.springframework.kafka.retrytopic.RetryTopicInternalBeanNames;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.backoff.ExponentialBackOffPolicy;
 import org.springframework.retry.backoff.ExponentialRandomBackOffPolicy;
@@ -42,7 +43,6 @@ import org.springframework.util.ReflectionUtils;
 import org.springframework.util.StringUtils;
 
 /**
- *
  * Processes the provided {@link RetryableTopic} annotation
  * returning an {@link RetryTopicConfiguration}.
  *

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistry.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2019 the original author or authors.
+ * Copyright 2014-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ import org.springframework.context.SmartLifecycle;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.core.log.LogAccessor;
 import org.springframework.kafka.listener.AbstractMessageListenerContainer;
+import org.springframework.kafka.listener.ListenerContainerRegistry;
 import org.springframework.kafka.listener.MessageListenerContainer;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -66,8 +67,8 @@ import org.springframework.util.StringUtils;
  * @see MessageListenerContainer
  * @see KafkaListenerContainerFactory
  */
-public class KafkaListenerEndpointRegistry implements DisposableBean, SmartLifecycle, ApplicationContextAware,
-		ApplicationListener<ContextRefreshedEvent> {
+public class KafkaListenerEndpointRegistry implements ListenerContainerRegistry, DisposableBean, SmartLifecycle,
+		ApplicationContextAware, ApplicationListener<ContextRefreshedEvent> {
 
 	protected final LogAccessor logger = new LogAccessor(LogFactory.getLog(getClass())); //NOSONAR
 
@@ -96,6 +97,7 @@ public class KafkaListenerEndpointRegistry implements DisposableBean, SmartLifec
 	 * @see KafkaListenerEndpoint#getId()
 	 * @see #getListenerContainerIds()
 	 */
+	@Override
 	public MessageListenerContainer getListenerContainer(String id) {
 		Assert.hasText(id, "Container identifier must not be empty");
 		return this.listenerContainers.get(id);
@@ -106,6 +108,7 @@ public class KafkaListenerEndpointRegistry implements DisposableBean, SmartLifec
 	 * @return the ids.
 	 * @see #getListenerContainer(String)
 	 */
+	@Override
 	public Set<String> getListenerContainerIds() {
 		return Collections.unmodifiableSet(this.listenerContainers.keySet());
 	}
@@ -115,6 +118,7 @@ public class KafkaListenerEndpointRegistry implements DisposableBean, SmartLifec
 	 * @return the managed {@link MessageListenerContainer} instance(s).
 	 * @see #getAllListenerContainers()
 	 */
+	@Override
 	public Collection<MessageListenerContainer> getListenerContainers() {
 		return Collections.unmodifiableCollection(this.listenerContainers.values());
 	}
@@ -128,6 +132,7 @@ public class KafkaListenerEndpointRegistry implements DisposableBean, SmartLifec
 	 * @since 2.2.5
 	 * @see #getListenerContainers()
 	 */
+	@Override
 	public Collection<MessageListenerContainer> getAllListenerContainers() {
 		List<MessageListenerContainer> containers = new ArrayList<>();
 		containers.addAll(getListenerContainers());

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/package-info.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Package for kafka configuration
  */
+@org.springframework.lang.NonNullApi
 package org.springframework.kafka.config;

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaConsumerBackoffManager.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaConsumerBackoffManager.java
@@ -26,7 +26,6 @@ import org.apache.kafka.common.TopicPartition;
 
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationListener;
-import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
 import org.springframework.kafka.event.ListenerContainerPartitionIdleEvent;
 
 /**
@@ -36,6 +35,7 @@ import org.springframework.kafka.event.ListenerContainerPartitionIdleEvent;
  * again after partition consumption is resumed (or seek it manually by other means).
  *
  * @author Tomaz Fernandes
+ * @author Gary Russell
  * @since 2.7
  * @see SeekToCurrentErrorHandler
  */
@@ -46,14 +46,15 @@ public class KafkaConsumerBackoffManager implements ApplicationListener<Listener
 	 */
 	public static final String INTERNAL_BACKOFF_CLOCK_BEAN_NAME = "internalBackOffClock";
 
-	private final KafkaListenerEndpointRegistry registry;
+	private final ListenerContainerRegistry registry;
 
 	private final Map<TopicPartition, Context> backOffTimes;
 
 	private final Clock clock;
 
-	public KafkaConsumerBackoffManager(KafkaListenerEndpointRegistry registry,
+	public KafkaConsumerBackoffManager(ListenerContainerRegistry registry,
 									@Qualifier(INTERNAL_BACKOFF_CLOCK_BEAN_NAME) Clock clock) {
+
 		this.registry = registry;
 		this.clock = clock;
 		this.backOffTimes = new HashMap<>();

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ListenerContainerRegistry.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ListenerContainerRegistry.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import java.util.Collection;
+import java.util.Set;
+
+import org.springframework.kafka.config.KafkaListenerEndpoint;
+
+/**
+ * A registry for listener containers.
+ *
+ * @author Gary Russell
+ * @since 2.7
+ *
+ */
+public interface ListenerContainerRegistry {
+
+	/**
+	 * Return the {@link MessageListenerContainer} with the specified id or
+	 * {@code null} if no such container exists.
+	 * @param id the id of the container
+	 * @return the container or {@code null} if no container with that id exists
+	 * @see KafkaListenerEndpoint#getId()
+	 * @see #getListenerContainerIds()
+	 */
+	MessageListenerContainer getListenerContainer(String id);
+
+	/**
+	 * Return the ids of the managed {@link MessageListenerContainer} instance(s).
+	 * @return the ids.
+	 * @see #getListenerContainer(String)
+	 */
+	Set<String> getListenerContainerIds();
+
+	/**
+	 * Return the managed {@link MessageListenerContainer} instance(s).
+	 * @return the managed {@link MessageListenerContainer} instance(s).
+	 * @see #getAllListenerContainers()
+	 */
+	Collection<MessageListenerContainer> getListenerContainers();
+
+	/**
+	 * Return all {@link MessageListenerContainer} instances including those managed by
+	 * this registry and those declared as beans in the application context.
+	 * Prototype-scoped containers will be included. Lazy beans that have not yet been
+	 * created will not be initialized by a call to this method.
+	 * @return the {@link MessageListenerContainer} instance(s).
+	 * @see #getListenerContainers()
+	 */
+	Collection<MessageListenerContainer> getAllListenerContainers();
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/KafkaBackoffAwareMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/KafkaBackoffAwareMessageListenerAdapter.java
@@ -47,7 +47,9 @@ import org.springframework.kafka.support.Acknowledgment;
 public class KafkaBackoffAwareMessageListenerAdapter<K, V> extends AbstractDelegatingMessageListenerAdapter<AcknowledgingConsumerAwareMessageListener<K, V>> implements AcknowledgingConsumerAwareMessageListener<K, V> {
 
 	private final String listenerId;
+
 	private final String backoffTimestampHeader;
+
 	private final KafkaConsumerBackoffManager kafkaConsumerBackoffManager;
 
 	public KafkaBackoffAwareMessageListenerAdapter(AcknowledgingConsumerAwareMessageListener<K, V> delegate, KafkaConsumerBackoffManager kafkaConsumerBackoffManager, String listenerId, String backoffTimestampHeader) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DeadLetterPublishingRecovererFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DeadLetterPublishingRecovererFactory.java
@@ -30,8 +30,6 @@ import org.springframework.core.NestedRuntimeException;
 import org.springframework.kafka.core.KafkaOperations;
 import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
 import org.springframework.kafka.listener.KafkaBackoffException;
-import org.springframework.kafka.retrytopic.destinationtopic.DestinationTopic;
-import org.springframework.kafka.retrytopic.destinationtopic.DestinationTopicResolver;
 import org.springframework.util.Assert;
 
 /**

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DefaultDestinationTopicProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DefaultDestinationTopicProcessor.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.kafka.retrytopic.destinationtopic;
+package org.springframework.kafka.retrytopic;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DestinationTopic.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DestinationTopic.java
@@ -14,13 +14,12 @@
  * limitations under the License.
  */
 
-package org.springframework.kafka.retrytopic.destinationtopic;
+package org.springframework.kafka.retrytopic;
 
 import java.util.Objects;
 import java.util.function.BiPredicate;
 
 import org.springframework.kafka.core.KafkaOperations;
-import org.springframework.kafka.retrytopic.DltStrategy;
 
 /**
  *

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DestinationTopicContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DestinationTopicContainer.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.kafka.retrytopic.destinationtopic;
+package org.springframework.kafka.retrytopic;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -25,13 +25,12 @@ import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.kafka.listener.ListenerExecutionFailedException;
-import org.springframework.kafka.retrytopic.RetryTopicConstants;
 
 
 /**
  *
  * Contains the destination topics and correlates them with their source via the
- * Map&lt;String, {@link org.springframework.kafka.retrytopic.destinationtopic.DestinationTopicResolver.DestinationsHolder}&gt; map.
+ * Map&lt;String, {@link org.springframework.kafka.retrytopic.DestinationTopicResolver.DestinationsHolder}&gt; map.
  *
  * Implements the {@link DestinationTopicResolver} interface.
  *

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DestinationTopicProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DestinationTopicProcessor.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.kafka.retrytopic.destinationtopic;
+package org.springframework.kafka.retrytopic;
 
 import java.util.Collection;
 import java.util.HashMap;

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DestinationTopicPropertiesFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DestinationTopicPropertiesFactory.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.kafka.retrytopic.destinationtopic;
+package org.springframework.kafka.retrytopic;
 
 import java.util.Arrays;
 import java.util.List;
@@ -24,11 +24,6 @@ import java.util.stream.IntStream;
 
 import org.springframework.classify.BinaryExceptionClassifier;
 import org.springframework.kafka.core.KafkaOperations;
-import org.springframework.kafka.retrytopic.BackOffValuesGenerator;
-import org.springframework.kafka.retrytopic.DltStrategy;
-import org.springframework.kafka.retrytopic.FixedDelayStrategy;
-import org.springframework.kafka.retrytopic.RetryTopicConstants;
-import org.springframework.kafka.retrytopic.TopicSuffixingStrategy;
 import org.springframework.retry.backoff.BackOffPolicy;
 import org.springframework.util.StringUtils;
 
@@ -195,9 +190,10 @@ public class DestinationTopicPropertiesFactory {
 	public static class DestinationTopicSuffixes {
 
 		private final String retryTopicSuffix;
+
 		private final String dltSuffix;
 
-		DestinationTopicSuffixes(String retryTopicSuffix, String dltSuffix) {
+		public DestinationTopicSuffixes(String retryTopicSuffix, String dltSuffix) {
 			this.retryTopicSuffix = StringUtils.hasText(retryTopicSuffix)
 					? retryTopicSuffix
 					: RetryTopicConstants.DEFAULT_RETRY_SUFFIX;

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DestinationTopicResolver.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DestinationTopicResolver.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.kafka.retrytopic.destinationtopic;
+package org.springframework.kafka.retrytopic;
 
 import java.util.Map;
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicBootstrapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicBootstrapper.java
@@ -25,8 +25,6 @@ import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.kafka.listener.KafkaConsumerBackoffManager;
-import org.springframework.kafka.retrytopic.destinationtopic.DefaultDestinationTopicProcessor;
-import org.springframework.kafka.retrytopic.destinationtopic.DestinationTopicContainer;
 
 /**
  *

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfiguration.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfiguration.java
@@ -18,7 +18,6 @@ package org.springframework.kafka.retrytopic;
 
 import java.util.List;
 
-import org.springframework.kafka.retrytopic.destinationtopic.DestinationTopic;
 import org.springframework.kafka.support.AllowDenyCollectionManager;
 
 /**

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationBuilder.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationBuilder.java
@@ -23,8 +23,6 @@ import org.springframework.classify.BinaryExceptionClassifier;
 import org.springframework.classify.BinaryExceptionClassifierBuilder;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.KafkaOperations;
-import org.springframework.kafka.retrytopic.destinationtopic.DestinationTopic;
-import org.springframework.kafka.retrytopic.destinationtopic.DestinationTopicPropertiesFactory;
 import org.springframework.kafka.support.AllowDenyCollectionManager;
 import org.springframework.retry.backoff.BackOffPolicy;
 import org.springframework.retry.backoff.ExponentialBackOffPolicy;
@@ -40,6 +38,7 @@ import org.springframework.util.Assert;
  * Builder class to create {@link RetryTopicConfiguration} instances.
  *
  * @author Tomaz Fernandes
+ * @author Gary Russell
  * @since 2.7
  *
  */
@@ -82,7 +81,9 @@ public class RetryTopicConfigurationBuilder {
 		return this;
 	}
 
-	RetryTopicConfigurationBuilder dltHandlerMethod(RetryTopicConfigurer.EndpointHandlerMethod endpointHandlerMethod) {
+	public RetryTopicConfigurationBuilder dltHandlerMethod(
+			RetryTopicConfigurer.EndpointHandlerMethod endpointHandlerMethod) {
+
 		this.dltHandlerMethod = endpointHandlerMethod;
 		return this;
 	}
@@ -93,7 +94,7 @@ public class RetryTopicConfigurationBuilder {
 		return this;
 	}
 
-	RetryTopicConfigurationBuilder dltProcessingFailureStrategy(
+	public RetryTopicConfigurationBuilder dltProcessingFailureStrategy(
 			DltStrategy dltStrategy) {
 		this.dltStrategy = dltStrategy;
 		return this;
@@ -143,7 +144,7 @@ public class RetryTopicConfigurationBuilder {
 		return this;
 	}
 
-	RetryTopicConfigurationBuilder setTopicSuffixingStrategy(TopicSuffixingStrategy topicSuffixingStrategy) {
+	public RetryTopicConfigurationBuilder setTopicSuffixingStrategy(TopicSuffixingStrategy topicSuffixingStrategy) {
 		this.topicSuffixingStrategy = topicSuffixingStrategy;
 		return this;
 	}
@@ -229,7 +230,7 @@ public class RetryTopicConfigurationBuilder {
 		return this;
 	}
 
-	RetryTopicConfigurationBuilder useSingleTopicForFixedDelays(FixedDelayStrategy useSameTopicForFixedDelays) {
+	public RetryTopicConfigurationBuilder useSingleTopicForFixedDelays(FixedDelayStrategy useSameTopicForFixedDelays) {
 		this.fixedDelayStrategy = useSameTopicForFixedDelays;
 		return this;
 	}
@@ -242,12 +243,16 @@ public class RetryTopicConfigurationBuilder {
 	}
 
 	public RetryTopicConfigurationBuilder autoCreateTopicsWith(int numPartitions, short replicationFactor) {
-		this.topicCreationConfiguration = new RetryTopicConfiguration.TopicCreation(true, numPartitions, replicationFactor);
+		this.topicCreationConfiguration = new RetryTopicConfiguration.TopicCreation(true, numPartitions,
+				replicationFactor);
 		return this;
 	}
 
-	public RetryTopicConfigurationBuilder autoCreateTopics(boolean shouldCreate, int numPartitions, short replicationFactor) {
-		this.topicCreationConfiguration = new RetryTopicConfiguration.TopicCreation(shouldCreate, numPartitions, replicationFactor);
+	public RetryTopicConfigurationBuilder autoCreateTopics(boolean shouldCreate, int numPartitions,
+			short replicationFactor) {
+
+		this.topicCreationConfiguration = new RetryTopicConfiguration.TopicCreation(shouldCreate, numPartitions,
+				replicationFactor);
 		return this;
 	}
 
@@ -282,7 +287,7 @@ public class RetryTopicConfigurationBuilder {
 		return this;
 	}
 
-	RetryTopicConfigurationBuilder traversingCauses(boolean traversing) {
+	public RetryTopicConfigurationBuilder traversingCauses(boolean traversing) {
 		if (traversing) {
 			classifierBuilder().traversingCauses();
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
@@ -38,8 +38,6 @@ import org.springframework.kafka.config.KafkaListenerContainerFactory;
 import org.springframework.kafka.config.MethodKafkaListenerEndpoint;
 import org.springframework.kafka.config.MultiMethodKafkaListenerEndpoint;
 import org.springframework.kafka.listener.ListenerUtils;
-import org.springframework.kafka.retrytopic.destinationtopic.DestinationTopic;
-import org.springframework.kafka.retrytopic.destinationtopic.DestinationTopicProcessor;
 import org.springframework.kafka.support.Suffixer;
 import org.springframework.kafka.support.TopicPartitionOffset;
 import org.springframework.util.Assert;
@@ -66,7 +64,7 @@ import org.springframework.util.ReflectionUtils;
  * <p>If a message processing throws an exception, the configured
  * {@link org.springframework.kafka.listener.SeekToCurrentErrorHandler}
  * and {@link org.springframework.kafka.listener.DeadLetterPublishingRecoverer} forwards the message to the next topic, using a
- * {@link org.springframework.kafka.retrytopic.destinationtopic.DestinationTopicResolver}
+ * {@link org.springframework.kafka.retrytopic.DestinationTopicResolver}
  * to know the next topic and the delay for it.
  *
  * <p>Each forwareded record has a back off timestamp header and, if consumption is
@@ -226,7 +224,7 @@ public class RetryTopicConfigurer {
 
 	private final BeanFactory beanFactory;
 
-	RetryTopicConfigurer(DestinationTopicProcessor destinationTopicProcessor,
+	public RetryTopicConfigurer(DestinationTopicProcessor destinationTopicProcessor,
 						ListenerContainerFactoryResolver containerFactoryResolver,
 						ListenerContainerFactoryConfigurer listenerContainerFactoryConfigurer,
 						BeanFactory beanFactory) {
@@ -244,7 +242,7 @@ public class RetryTopicConfigurer {
 	 * {@link org.springframework.kafka.annotation.KafkaListenerAnnotationBeanPostProcessor}
 	 * processListener method. As a side effect, the created destinations are registered
 	 * at the
-	 * {@link org.springframework.kafka.retrytopic.destinationtopic.DestinationTopicContainer}
+	 * {@link org.springframework.kafka.retrytopic.DestinationTopicContainer}
 	 * @param mainEndpoint the endpoint based on which retry and dlt endpoints are also
 	 * created and processed.
 	 * @param configuration the configuration for the topic
@@ -376,7 +374,7 @@ public class RetryTopicConfigurer {
 	 *  method.
 	 *
 	 *  <p>As a side effect, registers the topics in the
-	 *  {@link org.springframework.kafka.retrytopic.destinationtopic.DestinationTopicContainer}.
+	 *  {@link org.springframework.kafka.retrytopic.DestinationTopicContainer}.
 	 *
 	 */
 
@@ -495,7 +493,7 @@ public class RetryTopicConfigurer {
 		}
 	}
 
-	static class EndpointHandlerMethod {
+	public static class EndpointHandlerMethod {
 
 		private final Class<?> beanClass;
 
@@ -503,7 +501,7 @@ public class RetryTopicConfigurer {
 
 		private Object bean;
 
-		EndpointHandlerMethod(Class<?> beanClass, String methodName) {
+		public EndpointHandlerMethod(Class<?> beanClass, String methodName) {
 			Assert.notNull(beanClass, () -> "No destination bean class provided!");
 			Assert.notNull(methodName, () -> "No method name for destination bean class provided!");
 			this.method = Arrays.stream(ReflectionUtils.getDeclaredMethods(beanClass))
@@ -513,7 +511,7 @@ public class RetryTopicConfigurer {
 			this.beanClass = beanClass;
 		}
 
-		EndpointHandlerMethod(Object bean, Method method) {
+		public EndpointHandlerMethod(Object bean, Method method) {
 			Assert.notNull(bean, () -> "No bean for destination provided!");
 			Assert.notNull(method, () -> "No method for destination bean class provided!");
 			this.method = method;

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicInternalBeanNames.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicInternalBeanNames.java
@@ -45,6 +45,9 @@ public abstract class RetryTopicInternalBeanNames {
 
 	static final String DEFAULT_LISTENER_FACTORY_BEAN_NAME = "retryTopicListenerContainerFactory";
 
-	static final String DEFAULT_KAFKA_TEMPLATE_BEAN_NAME = "retryTopicDefaultKafkaTemplate";
+	/**
+	 * Default Kafka template bean name for publishing to retry topics.
+	 */
+	public static final String DEFAULT_KAFKA_TEMPLATE_BEAN_NAME = "retryTopicDefaultKafkaTemplate";
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/package-info.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Package for retryable topic handling.
+ */
+package org.springframework.kafka.retrytopic;

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DeadLetterPublishingRecovererFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DeadLetterPublishingRecovererFactoryTests.java
@@ -47,8 +47,6 @@ import org.springframework.core.NestedRuntimeException;
 import org.springframework.kafka.core.KafkaOperations;
 import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
 import org.springframework.kafka.listener.KafkaBackoffException;
-import org.springframework.kafka.retrytopic.destinationtopic.DestinationTopic;
-import org.springframework.kafka.retrytopic.destinationtopic.DestinationTopicResolver;
 import org.springframework.util.concurrent.ListenableFuture;
 
 /**

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DefaultDestinationTopicProcessorTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DefaultDestinationTopicProcessorTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.kafka.retrytopic.destinationtopic;
+package org.springframework.kafka.retrytopic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -45,7 +45,7 @@ class DefaultDestinationTopicProcessorTests extends DestinationTopicTests {
 	@Captor
 	private ArgumentCaptor<Map<String, DestinationTopicResolver.DestinationsHolder>> destinationMapCaptor;
 
-	private DefaultDestinationTopicProcessor destinationTopicProcessor =
+	private final DefaultDestinationTopicProcessor destinationTopicProcessor =
 			new DefaultDestinationTopicProcessor(destinationTopicResolver);
 
 	@Test

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DestinationTopicContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DestinationTopicContainerTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.kafka.retrytopic.destinationtopic;
+package org.springframework.kafka.retrytopic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.kafka.listener.ListenerExecutionFailedException;
-import org.springframework.kafka.retrytopic.TestClockUtils;
 
 /**
  * @author Tomaz Fernandes
@@ -42,11 +41,11 @@ class DestinationTopicContainerTests extends DestinationTopicTests {
 
 	private final Clock clock = TestClockUtils.CLOCK;
 
-	private DestinationTopicContainer destinationTopicContainer = new DestinationTopicContainer(clock);
+	private final DestinationTopicContainer destinationTopicContainer = new DestinationTopicContainer(clock);
 
-	private long originalTimestamp = Instant.now(this.clock).toEpochMilli();
+	private final long originalTimestamp = Instant.now(this.clock).toEpochMilli();
 
-	private byte[] originalTimestampBytes = BigInteger.valueOf(originalTimestamp).toByteArray();
+	private final byte[] originalTimestampBytes = BigInteger.valueOf(originalTimestamp).toByteArray();
 
 	@BeforeEach
 	public void setup() {

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DestinationTopicPropertiesFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DestinationTopicPropertiesFactoryTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.kafka.retrytopic.destinationtopic;
+package org.springframework.kafka.retrytopic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -33,10 +33,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.classify.BinaryExceptionClassifier;
 import org.springframework.classify.BinaryExceptionClassifierBuilder;
 import org.springframework.kafka.core.KafkaOperations;
-import org.springframework.kafka.retrytopic.DltStrategy;
-import org.springframework.kafka.retrytopic.FixedDelayStrategy;
-import org.springframework.kafka.retrytopic.RetryTopicConstants;
-import org.springframework.kafka.retrytopic.TopicSuffixingStrategy;
 import org.springframework.retry.backoff.BackOffPolicy;
 import org.springframework.retry.backoff.ExponentialBackOffPolicy;
 import org.springframework.retry.backoff.FixedBackOffPolicy;

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DestinationTopicTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DestinationTopicTests.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.springframework.kafka.retrytopic.destinationtopic;
+package org.springframework.kafka.retrytopic;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -26,7 +26,6 @@ import org.springframework.classify.BinaryExceptionClassifierBuilder;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaOperations;
 import org.springframework.kafka.core.KafkaTemplate;
-import org.springframework.kafka.retrytopic.DltStrategy;
 
 /**
  * @author Tomaz Fernandes
@@ -44,16 +43,16 @@ public class DestinationTopicTests {
 
 	// Suffixes
 
-	private DestinationTopicPropertiesFactory.DestinationTopicSuffixes suffixes =
+	private final DestinationTopicPropertiesFactory.DestinationTopicSuffixes suffixes =
 			new DestinationTopicPropertiesFactory.DestinationTopicSuffixes("", "");
 
-	private String retrySuffix = suffixes.getRetrySuffix();
+	private final String retrySuffix = suffixes.getRetrySuffix();
 
-	private String dltSuffix = suffixes.getDltSuffix();
+	private final String dltSuffix = suffixes.getDltSuffix();
 
-	private long noTimeout = -1;
+	private final long noTimeout = -1;
 
-	private long timeout = 1000;
+	private final long timeout = 1000;
 
 	// MaxAttempts
 
@@ -219,7 +218,7 @@ public class DestinationTopicTests {
 
 	// Classifiers
 
-	private BinaryExceptionClassifier classifier = new BinaryExceptionClassifierBuilder()
+	private final BinaryExceptionClassifier classifier = new BinaryExceptionClassifierBuilder()
 			.retryOn(IllegalArgumentException.class).build();
 
 	private BiPredicate<Integer, Throwable> getShouldRetryOn() {

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicBootstrapperTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicBootstrapperTests.java
@@ -38,8 +38,6 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.kafka.listener.KafkaConsumerBackoffManager;
-import org.springframework.kafka.retrytopic.destinationtopic.DefaultDestinationTopicProcessor;
-import org.springframework.kafka.retrytopic.destinationtopic.DestinationTopicContainer;
 
 /**
  * @author Tomaz Fernandes

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationBuilderTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationBuilderTests.java
@@ -30,7 +30,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.KafkaOperations;
-import org.springframework.kafka.retrytopic.destinationtopic.DestinationTopic;
 import org.springframework.test.util.ReflectionTestUtils;
 
 /**

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationProviderTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationProviderTests.java
@@ -32,6 +32,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import org.springframework.beans.factory.ListableBeanFactory;
+import org.springframework.kafka.annotation.RetryTopicConfigurationProvider;
 import org.springframework.kafka.annotation.RetryableTopic;
 import org.springframework.kafka.core.KafkaOperations;
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurerTests.java
@@ -49,8 +49,6 @@ import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.config.KafkaListenerContainerFactory;
 import org.springframework.kafka.config.MethodKafkaListenerEndpoint;
 import org.springframework.kafka.config.MultiMethodKafkaListenerEndpoint;
-import org.springframework.kafka.retrytopic.destinationtopic.DestinationTopic;
-import org.springframework.kafka.retrytopic.destinationtopic.DestinationTopicProcessor;
 import org.springframework.kafka.support.Suffixer;
 
 /**

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryableTopicAnnotationProcessorTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryableTopicAnnotationProcessorTests.java
@@ -37,8 +37,8 @@ import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.kafka.annotation.DltHandler;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.annotation.RetryableTopic;
+import org.springframework.kafka.annotation.RetryableTopicAnnotationProcessor;
 import org.springframework.kafka.core.KafkaOperations;
-import org.springframework.kafka.retrytopic.destinationtopic.DestinationTopic;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.util.ReflectionUtils;
 


### PR DESCRIPTION
<img width="382" alt="Screen Shot 2021-02-17 at 3 16 10 PM" src="https://user-images.githubusercontent.com/483832/108269146-9151d300-713b-11eb-8f9b-161047ac6aaa.png">
<img width="167" alt="Screen Shot 2021-02-17 at 3 16 00 PM" src="https://user-images.githubusercontent.com/483832/108269148-9151d300-713b-11eb-9f44-ed0c4db9992a.png">

- add a new interface `ListenerContainerRegistry` in the `listener` package
- eliminate the `destinationtopic` sub-pavkage
- move classes with references to the `annotation` package to `annotation`.
- add `package-info.java`