### PR TITLE
Fixes GH-1716. [NOT READY FOR MERGE]

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryableTopic.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryableTopic.java
@@ -174,7 +174,7 @@ public @interface RetryableTopic {
 	TopicSuffixingStrategy topicSuffixingStrategy() default TopicSuffixingStrategy.SUFFIX_WITH_DELAY_VALUE;
 
 	/**
-	 * Whether or not to redeliver to the DLT if delivery fails.
+	 * Whether or not create a DLT, and redeliver to the DLT if delivery fails or just give up.
 	 * @return the dlt strategy.
 	 */
 	DltStrategy dltStrategy() default DltStrategy.ALWAYS_RETRY_ON_ERROR;

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -1260,6 +1260,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			resumeConsumerIfNeccessary();
 			resumePartitionsIfNecessary();
 			debugRecords(records);
+
 			if (records != null && records.count() > 0) {
 				savePositionsIfNeeded(records);
 				notIdle();
@@ -1268,6 +1269,9 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			}
 			else {
 				checkIdle();
+			}
+			if (records == null || records.count() == 0
+					|| records.partitions().size() < this.consumer.assignment().size()) {
 				checkIdlePartitions();
 			}
 		}
@@ -1491,7 +1495,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			if (partitionsToResume.size() > 0) {
 				this.consumer.resume(partitionsToResume);
 				this.pausedPartitions.removeAll(partitionsToResume);
-				this.logger.debug(() -> "Resumed consumption from " + partitionsToResume);
+				this.logger.info(() -> "Resumed consumption from " + partitionsToResume);
 				partitionsToResume.forEach(KafkaMessageListenerContainer.this::publishConsumerPartitionResumedEvent);
 			}
 		}
@@ -2212,7 +2216,12 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 					commitOffsetsIfNeeded(record);
 				}
 				catch (KafkaException ke) {
-					ke.selfLog(ERROR_HANDLER_THREW_AN_EXCEPTION, this.logger);
+					if (ke.contains(KafkaBackoffException.class)) {
+						this.logger.warn(ke.getMessage());
+					}
+					else {
+						ke.selfLog(ERROR_HANDLER_THREW_AN_EXCEPTION, this.logger);
+					}
 					return ke;
 				}
 				catch (RuntimeException ee) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/TimestampedException.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/TimestampedException.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import java.time.Clock;
+import java.time.Instant;
+
+import org.springframework.core.NestedRuntimeException;
+
+/**
+ * A {@link NestedRuntimeException} that records the timestamp
+ * of when it was thrown.
+ *
+ * @author Tomaz Fernandes
+ * @since 2.7
+ */
+public class TimestampedException extends NestedRuntimeException {
+
+	private final long timestamp;
+
+	public TimestampedException(Exception ex, Clock clock) {
+		super(ex.getMessage(), ex);
+		this.timestamp = Instant.now(clock).toEpochMilli();
+	}
+
+	public TimestampedException(Exception ex) {
+		super(ex.getMessage(), ex);
+		this.timestamp = Instant.now(Clock.systemDefaultZone()).toEpochMilli();
+	}
+
+	public long getTimestamp() {
+		return this.timestamp;
+	}
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DeadLetterPublishingRecovererFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DeadLetterPublishingRecovererFactory.java
@@ -46,7 +46,7 @@ import org.springframework.kafka.support.KafkaHeaders;
  */
 public class DeadLetterPublishingRecovererFactory {
 
-	private static final LogAccessor logger = new LogAccessor(LogFactory.getLog(RetryTopicConfigurer.class));
+	private static final LogAccessor logger = new LogAccessor(LogFactory.getLog(DeadLetterPublishingRecovererFactory.class));
 
 	private final DestinationTopicResolver destinationTopicResolver;
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DeadLetterPublishingRecovererFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DeadLetterPublishingRecovererFactory.java
@@ -19,6 +19,7 @@ package org.springframework.kafka.retrytopic;
 import java.math.BigInteger;
 import java.util.function.Consumer;
 
+import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
@@ -27,9 +28,11 @@ import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 
 import org.springframework.core.NestedRuntimeException;
+import org.springframework.core.log.LogAccessor;
 import org.springframework.kafka.core.KafkaOperations;
 import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
 import org.springframework.kafka.listener.SeekUtils;
+import org.springframework.kafka.listener.TimestampedException;
 import org.springframework.kafka.support.KafkaHeaders;
 
 /**
@@ -42,6 +45,8 @@ import org.springframework.kafka.support.KafkaHeaders;
  *
  */
 public class DeadLetterPublishingRecovererFactory {
+
+	private static final LogAccessor logger = new LogAccessor(LogFactory.getLog(RetryTopicConfigurer.class));
 
 	private final DestinationTopicResolver destinationTopicResolver;
 
@@ -100,11 +105,12 @@ public class DeadLetterPublishingRecovererFactory {
 			throw (NestedRuntimeException) e; // Necessary to not commit the offset and seek to current again
 		}
 
-		int attempt = getAttempts(cr);
-		BigInteger originalTimestamp = new BigInteger(getOriginalTimestampHeader(cr));
-
 		DestinationTopic nextDestination = this.destinationTopicResolver.resolveNextDestination(
-				cr.topic(), attempt, e, originalTimestamp.longValue());
+				cr.topic(), getAttempts(cr), e, getOriginalTimestampHeaderLong(cr));
+
+		logger.debug(() -> "Resolved topic: " + (nextDestination.isNoOpsTopic()
+				? "none"
+				: nextDestination.getDestinationName()));
 
 		return nextDestination.isNoOpsTopic()
 					? null
@@ -120,30 +126,61 @@ public class DeadLetterPublishingRecovererFactory {
 	}
 
 	private Headers addHeaders(ConsumerRecord<?, ?> consumerRecord, Exception e, int attempts) {
-
 		Headers headers = new RecordHeaders();
-
-		byte[] originalTimestampHeader = getOriginalTimestampHeader(consumerRecord);
+		byte[] originalTimestampHeader = getOriginalTimestampHeaderBytes(consumerRecord);
 		headers.add(RetryTopicHeaders.DEFAULT_HEADER_ORIGINAL_TIMESTAMP, originalTimestampHeader);
-
 		headers.add(RetryTopicHeaders.DEFAULT_HEADER_ATTEMPTS,
 				BigInteger.valueOf(attempts + 1).toByteArray());
-		long originalTimestamp = new BigInteger(originalTimestampHeader).longValue();
-
-		long nextExecutionTimestamp = this.destinationTopicResolver
-				.resolveDestinationNextExecutionTimestamp(consumerRecord.topic(), attempts, e,
-						originalTimestamp);
-
-		headers.add(RetryTopicHeaders.DEFAULT_HEADER_BACKOFF_TIMESTAMP,	BigInteger.valueOf(nextExecutionTimestamp).toByteArray());
+		headers.add(RetryTopicHeaders.DEFAULT_HEADER_BACKOFF_TIMESTAMP,
+				BigInteger.valueOf(getNextExecutionTimestamp(consumerRecord, e, attempts, originalTimestampHeader))
+						.toByteArray());
 		return headers;
 	}
 
-	private byte[] getOriginalTimestampHeader(ConsumerRecord<?, ?> consumerRecord) {
-		Header currentOriginalTimestampHeader = consumerRecord.headers()
-				.lastHeader(RetryTopicHeaders.DEFAULT_HEADER_ORIGINAL_TIMESTAMP);
+	private long getNextExecutionTimestamp(ConsumerRecord<?, ?> consumerRecord, Exception e, int attempts, byte[] originalTimestampHeader) {
+		long originalTimestamp = new BigInteger(originalTimestampHeader).longValue();
+		long failureTimestamp = getFailureTimestamp(e);
+		long nextExecutionTimestamp = this.destinationTopicResolver
+				.resolveDestinationNextExecutionTimestamp(consumerRecord.topic(), attempts, e,
+						failureTimestamp, originalTimestamp);
+		logger.debug(() -> String.format("FailureTimestamp: %s, Original timestamp: %s, nextExecutionTimestamp: %s",
+				failureTimestamp, originalTimestamp, nextExecutionTimestamp));
+		return nextExecutionTimestamp;
+	}
+
+	private long getFailureTimestamp(Exception e) {
+		return e instanceof NestedRuntimeException && ((NestedRuntimeException) e).contains(TimestampedException.class)
+					? getTimestampedException(e).getTimestamp()
+					: RetryTopicConstants.NOT_SET;
+	}
+
+	private TimestampedException getTimestampedException(Throwable e) {
+		if (e == null) {
+			throw new IllegalArgumentException("Provided exception does not contain a "
+					+ TimestampedException.class.getSimpleName() + " cause.");
+		}
+		return e.getClass().isAssignableFrom(TimestampedException.class)
+				? (TimestampedException) e
+				: getTimestampedException(e.getCause());
+	}
+
+	private byte[] getOriginalTimestampHeaderBytes(ConsumerRecord<?, ?> consumerRecord) {
+		Header currentOriginalTimestampHeader = getOriginaTimeStampHeader(consumerRecord);
 		return currentOriginalTimestampHeader != null
 				? currentOriginalTimestampHeader.value()
 				: BigInteger.valueOf(consumerRecord.timestamp()).toByteArray();
+	}
+
+	private long getOriginalTimestampHeaderLong(ConsumerRecord<?, ?> consumerRecord) {
+		Header currentOriginalTimestampHeader = getOriginaTimeStampHeader(consumerRecord);
+		return currentOriginalTimestampHeader != null
+				? new BigInteger(currentOriginalTimestampHeader.value()).longValue()
+				: consumerRecord.timestamp();
+	}
+
+	private Header getOriginaTimeStampHeader(ConsumerRecord<?, ?> consumerRecord) {
+		return consumerRecord.headers()
+					.lastHeader(RetryTopicHeaders.DEFAULT_HEADER_ORIGINAL_TIMESTAMP);
 	}
 }
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DestinationTopicPropertiesFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DestinationTopicPropertiesFactory.java
@@ -24,7 +24,6 @@ import java.util.stream.IntStream;
 
 import org.springframework.classify.BinaryExceptionClassifier;
 import org.springframework.kafka.core.KafkaOperations;
-import org.springframework.retry.backoff.BackOffPolicy;
 import org.springframework.util.StringUtils;
 
 /**
@@ -60,8 +59,8 @@ public class DestinationTopicPropertiesFactory {
 
 	private final long timeout;
 
-	public DestinationTopicPropertiesFactory(String retryTopicSuffix, String dltSuffix, int maxAttempts,
-			BackOffPolicy backOffPolicy, BinaryExceptionClassifier exceptionClassifier,
+	public DestinationTopicPropertiesFactory(String retryTopicSuffix, String dltSuffix, List<Long> backOffValues,
+			BinaryExceptionClassifier exceptionClassifier,
 			int numPartitions, KafkaOperations<?, ?> kafkaOperations,
 			FixedDelayStrategy fixedDelayStrategy,
 			DltStrategy dltStrategy,
@@ -76,7 +75,7 @@ public class DestinationTopicPropertiesFactory {
 		this.topicSuffixingStrategy = topicSuffixingStrategy;
 		this.timeout = timeout;
 		this.destinationTopicSuffixes = new DestinationTopicSuffixes(retryTopicSuffix, dltSuffix);
-		this.backOffValues = new BackOffValuesGenerator(maxAttempts, backOffPolicy).generateValues();
+		this.backOffValues = backOffValues;
 		// Max Attempts include the initial try.
 		this.maxAttempts = this.backOffValues.size() + 1;
 	}

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DestinationTopicResolver.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DestinationTopicResolver.java
@@ -31,7 +31,8 @@ import java.util.Map;
 public interface DestinationTopicResolver {
 
 	DestinationTopic resolveNextDestination(String topic, Integer attempt, Exception e, long originalTimestamp);
-	long resolveDestinationNextExecutionTimestamp(String topic, Integer attempt, Exception e, long originalTimestamp);
+	long resolveDestinationNextExecutionTimestamp(String topic, Integer attempt, Exception e,
+												long failureTimestamp, long originalTimestamp);
 	DestinationTopic getCurrentTopic(String topic);
 	void addDestinations(Map<String, DestinationTopicResolver.DestinationsHolder> sourceDestinationMapToAdd);
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/ListenerContainerFactoryConfigurer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/ListenerContainerFactoryConfigurer.java
@@ -16,10 +16,18 @@
 
 package org.springframework.kafka.retrytopic;
 
+import java.time.Clock;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
 
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.log.LogAccessor;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.listener.AcknowledgingConsumerAwareMessageListener;
 import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
@@ -49,15 +57,19 @@ public class ListenerContainerFactoryConfigurer {
 
 	private static final Set<ConcurrentKafkaListenerContainerFactory<?, ?>> CONFIGURED_FACTORIES_CACHE;
 
-	private final KafkaConsumerBackoffManager kafkaConsumerBackoffManager;
+	private static final LogAccessor logger = new LogAccessor(LogFactory.getLog(ListenerContainerFactoryConfigurer.class));
 
 	static {
 		CONFIGURED_FACTORIES_CACHE = new HashSet<>();
 	}
 
-	private static final long DEFAULT_IDLE_PARTITION_EVENT_INTERVAL = 1000L;
+	private static final int MIN_POLL_TIMEOUT_VALUE = 250;
 
-	private final DeadLetterPublishingRecovererFactory deadLetterPublishingRecovererFactory;
+	private static final int MAX_POLL_TIMEOUT_VALUE = 5000;
+
+	private static final int IDLE_PARTITION_EVENT_INTERVAL_DIVISOR = 2;
+
+	private static final int POLL_TIMEOUT_DIVISOR = 4;
 
 	private Consumer<ConcurrentMessageListenerContainer<?, ?>> containerCustomizer = container -> {
 	};
@@ -65,34 +77,54 @@ public class ListenerContainerFactoryConfigurer {
 	private Consumer<ErrorHandler> errorHandlerCustomizer = errorHandler -> {
 	};
 
-	ListenerContainerFactoryConfigurer(KafkaConsumerBackoffManager kafkaConsumerBackoffManager,
-			DeadLetterPublishingRecovererFactory deadLetterPublishingRecovererFactory) {
+	private final DeadLetterPublishingRecovererFactory deadLetterPublishingRecovererFactory;
 
+	private final KafkaConsumerBackoffManager kafkaConsumerBackoffManager;
+
+	private final Clock clock;
+
+	ListenerContainerFactoryConfigurer(KafkaConsumerBackoffManager kafkaConsumerBackoffManager,
+									DeadLetterPublishingRecovererFactory deadLetterPublishingRecovererFactory,
+									@Qualifier(KafkaConsumerBackoffManager
+											.INTERNAL_BACKOFF_CLOCK_BEAN_NAME) Clock clock) {
 		this.kafkaConsumerBackoffManager = kafkaConsumerBackoffManager;
 		this.deadLetterPublishingRecovererFactory = deadLetterPublishingRecovererFactory;
+		this.clock = clock;
 	}
 
-	ConcurrentKafkaListenerContainerFactory<?, ?> configure(
-			ConcurrentKafkaListenerContainerFactory<?, ?> containerFactory) {
-		if (existsInCache(containerFactory)) {
-			return containerFactory;
-		}
-		containerFactory.setContainerCustomizer(this::setupBackoffAwareMessageListenerAdapter);
+	public ConcurrentKafkaListenerContainerFactory<?, ?> configure(
+			ConcurrentKafkaListenerContainerFactory<?, ?> containerFactory, Configuration configuration) {
+		return isCached(containerFactory)
+				? containerFactory
+				: doConfigure(containerFactory, configuration.backOffValues);
+	}
+
+	public ConcurrentKafkaListenerContainerFactory<?, ?> configureWithoutBackOff(
+			ConcurrentKafkaListenerContainerFactory<?, ?> containerFactory, Configuration configuration) {
+		return isCached(containerFactory)
+				? containerFactory
+				: doConfigure(containerFactory, Collections.emptyList());
+	}
+
+	private ConcurrentKafkaListenerContainerFactory<?, ?> doConfigure(ConcurrentKafkaListenerContainerFactory<?, ?> containerFactory,
+																	List<Long> backOffValues) {
+		containerFactory.setContainerCustomizer(container ->
+				setupBackoffAwareMessageListenerAdapter(container, backOffValues));
 		containerFactory
 				.setErrorHandler(createErrorHandler(this.deadLetterPublishingRecovererFactory.create()));
-		addToFactoriesCache(containerFactory);
-		return containerFactory;
+		return addToCache(containerFactory);
 	}
 
-	private boolean existsInCache(ConcurrentKafkaListenerContainerFactory<?, ?> containerFactory) {
+	private boolean isCached(ConcurrentKafkaListenerContainerFactory<?, ?> containerFactory) {
 		synchronized (CONFIGURED_FACTORIES_CACHE) {
 			return CONFIGURED_FACTORIES_CACHE.contains(containerFactory);
 		}
 	}
 
-	private void addToFactoriesCache(ConcurrentKafkaListenerContainerFactory<?, ?> containerFactory) {
+	private ConcurrentKafkaListenerContainerFactory<?, ?> addToCache(ConcurrentKafkaListenerContainerFactory<?, ?> containerFactory) {
 		synchronized (CONFIGURED_FACTORIES_CACHE) {
 			CONFIGURED_FACTORIES_CACHE.add(containerFactory);
+			return containerFactory;
 		}
 	}
 
@@ -113,16 +145,43 @@ public class ListenerContainerFactoryConfigurer {
 		return errorHandler;
 	}
 
-	private void setupBackoffAwareMessageListenerAdapter(ConcurrentMessageListenerContainer<?, ?> container) {
+	private void setupBackoffAwareMessageListenerAdapter(ConcurrentMessageListenerContainer<?, ?> container,
+														List<Long> backOffValues) {
 		AcknowledgingConsumerAwareMessageListener<?, ?> listener = checkAndCast(container.getContainerProperties()
 				.getMessageListener(), AcknowledgingConsumerAwareMessageListener.class);
-		Long idlePartitionEventInterval = container.getContainerProperties().getIdlePartitionEventInterval();
-		if (idlePartitionEventInterval == null) {
-			container.getContainerProperties().setIdlePartitionEventInterval(DEFAULT_IDLE_PARTITION_EVENT_INTERVAL);
-		}
+
+		configurePollTimeoutAndIdlePartitionInterval(container, backOffValues);
+
 		container.setupMessageListener(new KafkaBackoffAwareMessageListenerAdapter<>(listener,
-				this.kafkaConsumerBackoffManager, container.getListenerId())); // NOSONAR
+				this.kafkaConsumerBackoffManager, container.getListenerId(), this.clock)); // NOSONAR
+
 		this.containerCustomizer.accept(container);
+	}
+
+	private void configurePollTimeoutAndIdlePartitionInterval(ConcurrentMessageListenerContainer<?, ?> container, List<Long> backOffValues) {
+		if (backOffValues.isEmpty()) {
+			return;
+		}
+
+		Long lowestBackOff = backOffValues
+				.stream()
+				.min(Comparator.naturalOrder())
+				.orElseThrow(() -> new IllegalArgumentException("No back off values found!"));
+
+		long pollTimeoutValue = applyLimits(lowestBackOff / POLL_TIMEOUT_DIVISOR);
+		long idlePartitionEventInterval = pollTimeoutValue;
+
+		logger.debug(() -> "pollTimeout and idlePartitionEventInterval for back off values "
+				+ backOffValues + " will be set to " + pollTimeoutValue
+				+ " and " + idlePartitionEventInterval);
+
+		container.getContainerProperties()
+				.setIdlePartitionEventInterval(idlePartitionEventInterval);
+		container.getContainerProperties().setPollTimeout(pollTimeoutValue);
+	}
+
+	private long applyLimits(long pollTimeoutValue) {
+		return Math.min(Math.max(pollTimeoutValue, MIN_POLL_TIMEOUT_VALUE), MAX_POLL_TIMEOUT_VALUE);
 	}
 
 	@SuppressWarnings("unchecked")
@@ -131,5 +190,14 @@ public class ListenerContainerFactoryConfigurer {
 				() -> String.format("The provided class %s is not assignable from %s",
 						obj.getClass().getSimpleName(), clazz.getSimpleName()));
 		return (T) obj;
+	}
+
+	static class Configuration {
+
+		private final List<Long> backOffValues;
+
+		Configuration(List<Long> backOffValues) {
+			this.backOffValues = backOffValues;
+		}
 	}
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfiguration.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfiguration.java
@@ -42,16 +42,20 @@ public class RetryTopicConfiguration {
 
 	private final ListenerContainerFactoryResolver.Configuration factoryResolverConfig;
 
+	private final ListenerContainerFactoryConfigurer.Configuration factoryConfigurerConfig;
+
 	RetryTopicConfiguration(List<DestinationTopic.Properties> destinationTopicProperties,
-								EndpointHandlerMethod dltHandlerMethod,
-								TopicCreation kafkaTopicAutoCreationConfig,
-								AllowDenyCollectionManager<String> topicAllowListManager,
-								ListenerContainerFactoryResolver.Configuration factoryResolverConfig) {
+							EndpointHandlerMethod dltHandlerMethod,
+							TopicCreation kafkaTopicAutoCreationConfig,
+							AllowDenyCollectionManager<String> topicAllowListManager,
+							ListenerContainerFactoryResolver.Configuration factoryResolverConfig,
+							ListenerContainerFactoryConfigurer.Configuration factoryConfigurerConfig) {
 		this.destinationTopicProperties = destinationTopicProperties;
 		this.dltHandlerMethod = dltHandlerMethod;
 		this.kafkaTopicAutoCreationConfig = kafkaTopicAutoCreationConfig;
 		this.topicAllowListManager = topicAllowListManager;
 		this.factoryResolverConfig = factoryResolverConfig;
+		this.factoryConfigurerConfig = factoryConfigurerConfig;
 	}
 
 	public boolean hasConfigurationForTopics(String[] topics) {
@@ -64,6 +68,10 @@ public class RetryTopicConfiguration {
 
 	public ListenerContainerFactoryResolver.Configuration forContainerFactoryResolver() {
 		return this.factoryResolverConfig;
+	}
+
+	public ListenerContainerFactoryConfigurer.Configuration forContainerFactoryConfigurer() {
+		return this.factoryConfigurerConfig;
 	}
 
 	public EndpointHandlerMethod getDltHandlerMethod() {

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
@@ -351,20 +351,22 @@ public class RetryTopicConfigurer {
 	private ConcurrentKafkaListenerContainerFactory<?, ?> resolveAndConfigureFactoryForMainEndpoint(
 			KafkaListenerContainerFactory<?> providedFactory,
 			String defaultFactoryBeanName, RetryTopicConfiguration configuration) {
-
+		ConcurrentKafkaListenerContainerFactory<?, ?> resolvedFactory = this.containerFactoryResolver
+				.resolveFactoryForMainEndpoint(providedFactory, defaultFactoryBeanName,
+						configuration.forContainerFactoryResolver());
 		return this.listenerContainerFactoryConfigurer
-				.configure(this.containerFactoryResolver.resolveFactoryForMainEndpoint(providedFactory,
-						defaultFactoryBeanName,
-						configuration.forContainerFactoryResolver()));
+				.configureWithoutBackOff(resolvedFactory, configuration.forContainerFactoryConfigurer());
 	}
 
-	private ConcurrentKafkaListenerContainerFactory<?, ?> resolveAndConfigureFactoryForRetryEndpoint(KafkaListenerContainerFactory<?> providedFactory,
-																									String defaultFactoryBeanName,
-																									RetryTopicConfiguration configuration) {
+	private ConcurrentKafkaListenerContainerFactory<?, ?> resolveAndConfigureFactoryForRetryEndpoint(
+			KafkaListenerContainerFactory<?> providedFactory,
+			String defaultFactoryBeanName,
+			RetryTopicConfiguration configuration) {
+		ConcurrentKafkaListenerContainerFactory<?, ?> resolvedFactory =
+				this.containerFactoryResolver.resolveFactoryForRetryEndpoint(providedFactory, defaultFactoryBeanName,
+				configuration.forContainerFactoryResolver());
 		return this.listenerContainerFactoryConfigurer
-				.configure(this.containerFactoryResolver.resolveFactoryForRetryEndpoint(providedFactory,
-						defaultFactoryBeanName,
-						configuration.forContainerFactoryResolver()));
+				.configure(resolvedFactory, configuration.forContainerFactoryConfigurer());
 	}
 
 	private void throwIfMultiMethodEndpoint(MethodKafkaListenerEndpoint<?, ?> mainEndpoint) {
@@ -389,7 +391,6 @@ public class RetryTopicConfigurer {
 	}
 
 	private interface EndpointCustomizer extends Function<MethodKafkaListenerEndpoint<?, ?>, Collection<TopicNamesHolder>> {
-
 		default Collection<TopicNamesHolder> customizeEndpointAndCollectTopics(MethodKafkaListenerEndpoint<?, ?> listenerEndpoint) {
 			return apply(listenerEndpoint);
 		}

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DeadLetterPublishingRecovererFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DeadLetterPublishingRecovererFactoryTests.java
@@ -96,6 +96,8 @@ class DeadLetterPublishingRecovererFactoryTests {
 
 	private final long nowTimestamp = Instant.now(this.clock).toEpochMilli();
 
+	private final long failureTimestamp = Instant.now(this.clock).minusMillis(500).toEpochMilli();
+
 	@Test
 	void shouldSendMessage() {
 		// setup
@@ -104,7 +106,8 @@ class DeadLetterPublishingRecovererFactoryTests {
 		given(destinationTopic.isNoOpsTopic()).willReturn(false);
 		given(destinationTopic.getDestinationName()).willReturn(testRetryTopic);
 		given(destinationTopic.getDestinationPartitions()).willReturn(3);
-		given(destinationTopicResolver.resolveDestinationNextExecutionTimestamp(testTopic, 1, e, originalTimestamp))
+		given(destinationTopicResolver
+				.resolveDestinationNextExecutionTimestamp(testTopic, 1, e, RetryTopicConstants.NOT_SET, originalTimestamp))
 				.willReturn(this.nowTimestamp);
 		given(destinationTopicResolver.getCurrentTopic(testRetryTopic)).willReturn(destinationTopic);
 		willReturn(this.kafkaOperations2).given(destinationTopic).getKafkaOperations();
@@ -147,7 +150,8 @@ class DeadLetterPublishingRecovererFactoryTests {
 		given(destinationTopic.isNoOpsTopic()).willReturn(false);
 		given(destinationTopic.getDestinationName()).willReturn(testRetryTopic);
 		given(destinationTopic.getDestinationPartitions()).willReturn(1);
-		given(destinationTopicResolver.resolveDestinationNextExecutionTimestamp(testTopic, 1, e, this.originalTimestamp))
+		given(destinationTopicResolver.resolveDestinationNextExecutionTimestamp(testTopic, 1, e,
+				RetryTopicConstants.NOT_SET, this.originalTimestamp))
 				.willReturn(this.nowTimestamp);
 		given(destinationTopicResolver.getCurrentTopic(testRetryTopic)).willReturn(destinationTopic);
 		willReturn(this.kafkaOperations2).given(destinationTopic).getKafkaOperations();
@@ -181,7 +185,8 @@ class DeadLetterPublishingRecovererFactoryTests {
 		given(destinationTopic.getDestinationPartitions()).willReturn(1);
 		given(destinationTopicResolver.getCurrentTopic(testRetryTopic)).willReturn(destinationTopic);
 		long nextExecutionTimestamp = this.nowTimestamp + destinationTopic.getDestinationDelay();
-		given(destinationTopicResolver.resolveDestinationNextExecutionTimestamp(testTopic, 1, e, this.originalTimestamp))
+		given(destinationTopicResolver.resolveDestinationNextExecutionTimestamp(testTopic, 1, e,
+				RetryTopicConstants.NOT_SET, this.originalTimestamp))
 				.willReturn(nextExecutionTimestamp);
 		willReturn(this.kafkaOperations2).given(destinationTopic).getKafkaOperations();
 		given(kafkaOperations2.send(any(ProducerRecord.class))).willReturn(listenableFuture);
@@ -215,7 +220,8 @@ class DeadLetterPublishingRecovererFactoryTests {
 		given(destinationTopic.getDestinationPartitions()).willReturn(1);
 		given(destinationTopicResolver.getCurrentTopic(testRetryTopic)).willReturn(destinationTopic);
 		long nextExecutionTimestamp = this.nowTimestamp + destinationTopic.getDestinationDelay();
-		given(destinationTopicResolver.resolveDestinationNextExecutionTimestamp(testTopic, 1, e, timestamp))
+		given(destinationTopicResolver
+				.resolveDestinationNextExecutionTimestamp(testTopic, 1, e, RetryTopicConstants.NOT_SET, timestamp))
 				.willReturn(nextExecutionTimestamp);
 		willReturn(this.kafkaOperations2).given(destinationTopic).getKafkaOperations();
 		given(kafkaOperations2.send(any(ProducerRecord.class))).willReturn(listenableFuture);

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DestinationTopicContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DestinationTopicContainerTests.java
@@ -46,6 +46,8 @@ class DestinationTopicContainerTests extends DestinationTopicTests {
 
 	private final long originalTimestamp = Instant.now(this.clock).toEpochMilli();
 
+	private final long failureTimestamp = Instant.now(this.clock).plusMillis(500).toEpochMilli();
+
 	private final byte[] originalTimestampBytes = BigInteger.valueOf(originalTimestamp).toByteArray();
 
 	@BeforeEach
@@ -173,21 +175,21 @@ class DestinationTopicContainerTests extends DestinationTopicTests {
 	void shouldResolveDestinationNextExecutionTime() {
 		RuntimeException e = new IllegalArgumentException();
 		assertThat(destinationTopicContainer.resolveDestinationNextExecutionTimestamp(
-					mainDestinationTopic.getDestinationName(), 0, e, originalTimestamp))
+					mainDestinationTopic.getDestinationName(), 0, e, failureTimestamp, originalTimestamp))
 				.isEqualTo(getExpectedNextExecutionTime(firstRetryDestinationTopic));
 		assertThat(destinationTopicContainer.resolveDestinationNextExecutionTimestamp(
-					firstRetryDestinationTopic.getDestinationName(), 0, e, originalTimestamp))
+					firstRetryDestinationTopic.getDestinationName(), 0, e, failureTimestamp, originalTimestamp))
 				.isEqualTo(getExpectedNextExecutionTime(secondRetryDestinationTopic));
 		assertThat(destinationTopicContainer.resolveDestinationNextExecutionTimestamp(
-					secondRetryDestinationTopic.getDestinationName(), 0, e, originalTimestamp))
+					secondRetryDestinationTopic.getDestinationName(), 0, e, failureTimestamp, originalTimestamp))
 				.isEqualTo(getExpectedNextExecutionTime(dltDestinationTopic));
 		assertThat(destinationTopicContainer.resolveDestinationNextExecutionTimestamp(
-					dltDestinationTopic.getDestinationName(), 0, e, originalTimestamp))
+					dltDestinationTopic.getDestinationName(), 0, e, failureTimestamp, originalTimestamp))
 				.isEqualTo(getExpectedNextExecutionTime(noOpsDestinationTopic));
 	}
 
 	private long getExpectedNextExecutionTime(DestinationTopic destinationTopic) {
-		return originalTimestamp + destinationTopic.getDestinationDelay();
+		return failureTimestamp + destinationTopic.getDestinationDelay();
 	}
 
 	@Test

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DestinationTopicPropertiesFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DestinationTopicPropertiesFactoryTests.java
@@ -82,9 +82,12 @@ class DestinationTopicPropertiesFactoryTests {
 	@Test
 	void shouldCreateMainAndDltProperties() {
 		// when
+
+		List<Long> backOffValues = new BackOffValuesGenerator(1, backOffPolicy).generateValues();
+
 		List<DestinationTopic.Properties> propertiesList =
-				new DestinationTopicPropertiesFactory(retryTopicSuffix, dltSuffix, 1,
-						backOffPolicy, classifier, numPartitions, kafkaOperations, fixedDelayStrategy,
+				new DestinationTopicPropertiesFactory(retryTopicSuffix, dltSuffix, backOffValues,
+						classifier, numPartitions, kafkaOperations, fixedDelayStrategy,
 						dltStrategy, defaultTopicSuffixingStrategy, RetryTopicConstants.NOT_SET)
 						.createProperties();
 
@@ -123,9 +126,11 @@ class DestinationTopicPropertiesFactoryTests {
 		backOffPolicy.setMultiplier(2);
 		int maxAttempts = 3;
 
+		List<Long> backOffValues = new BackOffValuesGenerator(maxAttempts, backOffPolicy).generateValues();
+
 		List<DestinationTopic.Properties> propertiesList =
-				new DestinationTopicPropertiesFactory(retryTopicSuffix, dltSuffix, maxAttempts,
-						backOffPolicy, classifier, numPartitions, kafkaOperations, fixedDelayStrategy,
+				new DestinationTopicPropertiesFactory(retryTopicSuffix, dltSuffix, backOffValues,
+						classifier, numPartitions, kafkaOperations, fixedDelayStrategy,
 						dltStrategy, TopicSuffixingStrategy.SUFFIX_WITH_DELAY_VALUE, RetryTopicConstants.NOT_SET)
 						.createProperties();
 
@@ -168,9 +173,10 @@ class DestinationTopicPropertiesFactoryTests {
 		backOffPolicy.setMultiplier(2);
 		int maxAttempts = 3;
 
+		List<Long> backOffValues = new BackOffValuesGenerator(maxAttempts, backOffPolicy).generateValues();
+
 		List<DestinationTopic.Properties> propertiesList =
-				new DestinationTopicPropertiesFactory(retryTopicSuffix, dltSuffix, maxAttempts,
-						backOffPolicy, classifier, numPartitions, kafkaOperations, fixedDelayStrategy,
+				new DestinationTopicPropertiesFactory(retryTopicSuffix, dltSuffix, backOffValues, classifier, numPartitions, kafkaOperations, fixedDelayStrategy,
 						noDltStrategy, TopicSuffixingStrategy.SUFFIX_WITH_DELAY_VALUE, RetryTopicConstants.NOT_SET)
 						.createProperties();
 
@@ -192,9 +198,11 @@ class DestinationTopicPropertiesFactoryTests {
 		backOffPolicy.setBackOffPeriod(1000);
 		int maxAttempts = 5;
 
+		List<Long> backOffValues = new BackOffValuesGenerator(maxAttempts, backOffPolicy).generateValues();
+
 		List<DestinationTopic.Properties> propertiesList =
-				new DestinationTopicPropertiesFactory(retryTopicSuffix, dltSuffix, maxAttempts,
-						backOffPolicy, classifier, numPartitions, kafkaOperations, FixedDelayStrategy.SINGLE_TOPIC,
+				new DestinationTopicPropertiesFactory(retryTopicSuffix, dltSuffix, backOffValues,
+						classifier, numPartitions, kafkaOperations, FixedDelayStrategy.SINGLE_TOPIC,
 						dltStrategy, defaultTopicSuffixingStrategy, -1).createProperties();
 
 		List<DestinationTopic> destinationTopicList = propertiesList
@@ -231,9 +239,11 @@ class DestinationTopicPropertiesFactoryTests {
 		backOffPolicy.setBackOffPeriod(5000);
 		int maxAttempts = 3;
 
+		List<Long> backOffValues = new BackOffValuesGenerator(maxAttempts, backOffPolicy).generateValues();
+
 		List<DestinationTopic.Properties> propertiesList =
-				new DestinationTopicPropertiesFactory(retryTopicSuffix, dltSuffix, maxAttempts,
-						backOffPolicy, classifier, numPartitions, kafkaOperations,
+				new DestinationTopicPropertiesFactory(retryTopicSuffix, dltSuffix, backOffValues,
+						classifier, numPartitions, kafkaOperations,
 						FixedDelayStrategy.MULTIPLE_TOPICS,
 						dltStrategy, defaultTopicSuffixingStrategy, -1).createProperties();
 
@@ -275,11 +285,12 @@ class DestinationTopicPropertiesFactoryTests {
 		// setup
 		ExponentialBackOffPolicy backOffPolicy = new ExponentialBackOffPolicy();
 		int maxAttempts = 3;
+		List<Long> backOffValues = new BackOffValuesGenerator(maxAttempts, backOffPolicy).generateValues();
 
 		// when
 		List<DestinationTopic.Properties> propertiesList =
-				new DestinationTopicPropertiesFactory(retryTopicSuffix, dltSuffix, maxAttempts,
-						backOffPolicy, classifier, numPartitions, kafkaOperations,
+				new DestinationTopicPropertiesFactory(retryTopicSuffix, dltSuffix, backOffValues,
+						classifier, numPartitions, kafkaOperations,
 						FixedDelayStrategy.SINGLE_TOPIC,
 						dltStrategy, suffixWithIndexTopicSuffixingStrategy, -1).createProperties();
 
@@ -295,11 +306,12 @@ class DestinationTopicPropertiesFactoryTests {
 		FixedBackOffPolicy backOffPolicy = new FixedBackOffPolicy();
 		backOffPolicy.setBackOffPeriod(1000);
 		int maxAttempts = 3;
+		List<Long> backOffValues = new BackOffValuesGenerator(maxAttempts, backOffPolicy).generateValues();
 
 		// when
 		List<DestinationTopic.Properties> propertiesList =
-				new DestinationTopicPropertiesFactory(retryTopicSuffix, dltSuffix, maxAttempts,
-						backOffPolicy, classifier, numPartitions, kafkaOperations,
+				new DestinationTopicPropertiesFactory(retryTopicSuffix, dltSuffix, backOffValues,
+						classifier, numPartitions, kafkaOperations,
 						FixedDelayStrategy.MULTIPLE_TOPICS,
 						dltStrategy, suffixWithIndexTopicSuffixingStrategy, -1).createProperties();
 
@@ -317,11 +329,12 @@ class DestinationTopicPropertiesFactoryTests {
 		backOffPolicy.setMultiplier(2);
 		backOffPolicy.setMaxInterval(3000);
 		int maxAttempts = 5;
+		List<Long> backOffValues = new BackOffValuesGenerator(maxAttempts, backOffPolicy).generateValues();
 
 		// when
 		List<DestinationTopic.Properties> propertiesList =
-				new DestinationTopicPropertiesFactory(retryTopicSuffix, dltSuffix, maxAttempts,
-						backOffPolicy, classifier, numPartitions, kafkaOperations,
+				new DestinationTopicPropertiesFactory(retryTopicSuffix, dltSuffix, backOffValues,
+						classifier, numPartitions, kafkaOperations,
 						FixedDelayStrategy.MULTIPLE_TOPICS,
 						dltStrategy, defaultTopicSuffixingStrategy, -1).createProperties();
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurerTests.java
@@ -114,6 +114,9 @@ class RetryTopicConfigurerTests {
 	@Mock
 	private ConsumerRecord<?, ?> consumerRecordMessage;
 
+	@Mock
+	private ListenerContainerFactoryConfigurer.Configuration lcfcConfiguration;
+
 	private static final Object objectMessage = new Object();
 
 	private static final List<String> topics = Arrays.asList("topic1", "topic2");
@@ -215,10 +218,14 @@ class RetryTopicConfigurerTests {
 		given(dltDestinationProperties.suffix()).willReturn(dltSuffix);
 		given(mainDestinationProperties.isMainEndpoint()).willReturn(true);
 		given(mainEndpoint.getTopics()).willReturn(topics);
+		given(configuration.forContainerFactoryConfigurer()).willReturn(lcfcConfiguration);
 
 		willReturn(containerFactory).given(containerFactoryResolver).resolveFactoryForRetryEndpoint(containerFactory,
 				defaultFactoryBeanName, factoryResolverConfig);
-		willReturn(containerFactory).given(this.listenerContainerFactoryConfigurer).configure(containerFactory);
+		willReturn(containerFactory).given(this.listenerContainerFactoryConfigurer).configure(containerFactory,
+				lcfcConfiguration);
+		willReturn(containerFactory).given(this.listenerContainerFactoryConfigurer).configureWithoutBackOff(containerFactory,
+				lcfcConfiguration);
 
 		RetryTopicConfigurer configurer = new RetryTopicConfigurer(destinationTopicProcessor, containerFactoryResolver,
 				listenerContainerFactoryConfigurer, defaultListableBeanFactory);

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryableTopicIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryableTopicIntegrationTests.java
@@ -38,6 +38,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
 import org.springframework.kafka.annotation.DltHandler;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -54,6 +55,7 @@ import org.springframework.kafka.listener.KafkaConsumerBackoffManager;
 import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.retry.annotation.Backoff;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.stereotype.Component;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
@@ -360,6 +362,28 @@ public class RetryableTopicIntegrationTests {
 		@Bean(name = KafkaConsumerBackoffManager.INTERNAL_BACKOFF_CLOCK_BEAN_NAME)
 		public Clock clock() {
 			return Clock.systemUTC();
+		}
+
+		@Bean
+		public TaskExecutor taskExecutor() {
+			return new ThreadPoolTaskExecutor();
+		}
+
+		@Bean(destroyMethod = "destroy")
+		public TaskExecutorManager taskExecutorManager(ThreadPoolTaskExecutor taskExecutor) {
+			return new TaskExecutorManager(taskExecutor);
+		}
+	}
+
+	static class TaskExecutorManager {
+		private final ThreadPoolTaskExecutor taskExecutor;
+
+		TaskExecutorManager(ThreadPoolTaskExecutor taskExecutor) {
+			this.taskExecutor = taskExecutor;
+		}
+
+		void destroy() {
+			this.taskExecutor.shutdown();
 		}
 	}
 


### PR DESCRIPTION
@garyrussell, this is the WIP of my work on this issue.

There were three main sources of imprecision:

- the time it takes from the moment the listener throws the exception to the moment the next attempt's timestamp was calculated (around 500ms in my machine);
- we have to wait for 2 polls after the Backoff manager sends the resume command, due to the order things happen in the listener consumer;
- for a consumer that handles only one partition we'll always wait in `pollTimeout` increments, so if the timing is off it would wait until after the timestamp to actually process the message;

For the timing correction I used your wakeup suggestion - I used the default boot's executor for that, mainly because since the RT's beans are not registered at application startup I can't use some Spring goodies such as a destroy method to shutdown the executor if I created one.

If you have a better suggestion please tell me, using the same executor that is offered to the user's application doesn't seem like the best solution. Maybe register RT beans on app startup, or maybe there's another way to register the executor shutdown hook?

Also, the BackOffException exception was still printing the stack trace - I wasn't sure of the best place to handle that - I did it in the ListenerConsumer.

Please let me know what you think and any suggestions you might have.

Thanks!