### PR TITLE
let pass topic to sendMethod of Message

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
@@ -392,7 +392,12 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 	@SuppressWarnings("unchecked")
 	@Override
 	public ListenableFuture<SendResult<K, V>> send(Message<?> message) {
-		ProducerRecord<?, ?> producerRecord = this.messageConverter.fromMessage(message, this.defaultTopic);
+		return send(this.defaultTopic, message);
+	}
+
+	@SuppressWarnings("unchecked")
+	public ListenableFuture<SendResult<K, V>> send(String defaultTopic, Message<?> message) {
+		ProducerRecord<?, ?> producerRecord = this.messageConverter.fromMessage(message, defaultTopic);
 		if (!producerRecord.headers().iterator().hasNext()) { // possibly no Jackson
 			byte[] correlationId = message.getHeaders().get(KafkaHeaders.CORRELATION_ID, byte[].class);
 			if (correlationId != null) {


### PR DESCRIPTION
Allow to send Message<?> to chosen topic without setting topic in header or as defaultTopic of KafkaTemplate.