### PR TITLE
Enable Verbose Test Logging from Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -181,8 +181,14 @@ subprojects { subproject ->
 	[compileJava, compileTestJava]*.options*.compilerArgs = ['-Xlint:all,-options']
 
 	test {
-		// suppress all console output during testing unless running `gradle -i`
-		logging.captureStandardOutput(LogLevel.INFO)
+		testLogging {
+			events "skipped", "failed"
+			showStandardStreams = project.hasProperty("showStandardStreams") ?: false
+			showExceptions = true
+			showStackTraces = true
+			exceptionFormat = 'full'
+		}
+
 		maxHeapSize = '1536m'
 //		jvmArgs '-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=127.0.0.1:8111'
 		jacoco {


### PR DESCRIPTION
With these options, we now see

```
KafkaAdminTests > testTopicConfigs() FAILED
    org.opentest4j.AssertionFailedError:
    Expecting:
     <2>
    to be equal to:
     <3>
    but was not.
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:500)
        at org.springframework.kafka.core.KafkaAdminTests.testTopicConfigs(KafkaAdminTests.java:84)
```

on the console.

It is still useful to capture test results, in case we need to look at STDOUT.