### PR TITLE
Don't wipe out local state stores by default

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/CleanupConfig.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/CleanupConfig.java
@@ -28,7 +28,7 @@ public class CleanupConfig {
 	private final boolean onStop;
 
 	public CleanupConfig() {
-		this(false, true);
+		this(false, false);
 	}
 
 	public CleanupConfig(boolean onStart, boolean onStop) {


### PR DESCRIPTION
I'm a dev on the Kafka Streams project, and we frequently have Spring Boot users asking us why their applications take so long to start up even after a clean shutdown. We discovered that the default options choose to manually wipe out all local state when closing the Kafka Streams app. This configuration is not recommended for production applications, and it's arguable whether it's even preferable for development/OOTB settings. 

Given how often this comes up, I recommend changing the defaults to avoid calling `KafkaStreams#cleanup` during a clean shutdown.