### PR TITLE
GH-1741: Add Message<?> sendAndReceive(Message<?>)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -356,6 +356,8 @@ project ('spring-kafka-docs') {
 	dependencies {
 		api "org.springframework.boot:spring-boot-starter:$springBootVersion"
 		api project (':spring-kafka')
+		optionalApi 'com.fasterxml.jackson.core:jackson-core'
+		optionalApi 'com.fasterxml.jackson.core:jackson-databind'
 	}
 
 	compileKotlin {

--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -765,7 +765,7 @@ Starting with version 2.3, you can customize the header names - the template has
 This is useful if your server is not a Spring application (or does not use the `@KafkaListener`).
 
 [[exchanging-messages]]
-====== Exchanging `Message<?>` s
+====== Request/Reply with `Message<?>` s
 
 Version 2.7 added methods to the `ReplyingKafkaTemplate` to send and receive `spring-messaging` 's `Message<?>` abstraction:
 

--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -545,6 +545,8 @@ RequestReplyFuture<K, V, R> sendAndReceive(ProducerRecord<K, V> record,
 ----
 ====
 
+(Also see <<exchanging-messages>>).
+
 The result is a `ListenableFuture` that is asynchronously populated with the result (or an exception, for a timeout).
 The result also has a `sendFuture` property, which is the result of calling `KafkaTemplate.send()`.
 You can use this future to determine the result of the send operation.
@@ -761,6 +763,57 @@ These header names are used by the `@KafkaListener` infrastructure to route the 
 
 Starting with version 2.3, you can customize the header names - the template has 3 properties `correlationHeaderName`, `replyTopicHeaderName`, and `replyPartitionHeaderName`.
 This is useful if your server is not a Spring application (or does not use the `@KafkaListener`).
+
+[[exchanging-messages]]
+====== Exchanging `Message<?>` s
+
+Version 2.7 added methods to the `ReplyingKafkaTemplate` to send and receive `spring-messaging` 's `Message<?>` abstraction:
+
+====
+[source, java]
+----
+RequestReplyMessageFuture<K, V> sendAndReceive(Message<?> message);
+
+<P> RequestReplyTypedMessageFuture<K, V, P> sendAndReceive(Message<?> message,
+        ParameterizedTypeReference<P> returnType);
+----
+====
+
+These will use the template's default `replyTimeout`, there are also overloaded versions that can take a timeout in the method call.
+
+Use the first method if the consumer's `Deserializer` or the template's `MessageConverter` can convert the payload without any additional information, either via configuration or type metadata in the reply message.
+
+Use the second method if you need to provide type information for the return type, to assist the message converter.
+This also allows the same template to receive different types, even if there is no type metadata in the replies, such as when the server side is not a Spring application.
+The following is an example of the latter:
+
+.Template Bean
+====
+[source, java, role="primary", indent=0]
+.Java
+----
+include::{java-examples}/requestreply/Application.java[tag=beans]
+----
+[source, kotlin, role="secondary",indent=0]
+.Kotlin
+----
+include::{kotlin-examples}/requestreply/Application.kt[tag=beans]
+----
+====
+
+.Using the template
+====
+[source, java, role="primary", indent=0]
+.Java
+----
+include::{java-examples}/requestreply/Application.java[tag=sendReceive]
+----
+[source, kotlin, role="secondary", indent=0]
+.Kotlin
+----
+include::{kotlin-examples}/requestreply/Application.kt[tag=sendReceive]
+----
+====
 
 [[reply-message]]
 ===== Reply Type Message<?>

--- a/spring-kafka-docs/src/main/asciidoc/retrytopic.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/retrytopic.adoc
@@ -1,5 +1,5 @@
 [[retry-topic]]
-== Non-Blocking Retries
+=== Non-Blocking Retries
 
 IMPORTANT: This is an experimental feature and the usual rule of no breaking API changes does not apply to this feature until the experimental designation is removed.
 Users are encouraged to try out the feature and provide feedback via GitHub Issues or GitHub discussions.
@@ -7,7 +7,7 @@ Users are encouraged to try out the feature and provide feedback via GitHub Issu
 Achieving non-blocking retry / dlt functionality with Kafka usually requires setting up extra topics and creating and configuring the corresponding listeners.
 Since 2.7 Spring for Apache Kafka offers support for that via the `@RetryableTopic` annotation and `RetryTopicConfiguration` class to simplify that bootstrapping.
 
-=== How The Pattern Works
+==== How The Pattern Works
 
 If message processing fails, the message is forwarded to a retry topic with a back off timestamp.
 The retry topic consumer then checks the timestamp and if it's not due it pauses the consumption for that topic's partition.
@@ -23,9 +23,9 @@ IMPORTANT: You can set the `AckMode` mode you prefer, but `RECORD` is suggested.
 
 IMPORTANT: At this time this functionality doesn't support class level `@KafkaListener` annotations
 
-=== Back Off Delay Precision
+==== Back Off Delay Precision
 
-==== Overview and Guarantees
+===== Overview and Guarantees
 
 All message processing and backing off is handled by the consumer thread, and, as such, delay precision is guaranteed on a best-effort basis.
 If one message's processing takes longer than the next message's back off period for that consumer, the next message's delay will be higher than expected.
@@ -36,7 +36,7 @@ That being said, for consumers handling a single partition the message's process
 
 IMPORTANT: It is guaranteed that a message will never be processed before its due time.
 
-==== Tuning the Delay Precision
+===== Tuning the Delay Precision
 
 The message's processing delay precision relies on two `ContainerProperties`: `ContainerProperties.pollTimeout` and `ContainerProperties.idlePartitionEventInterval`.
 Both properties will be automatically set in the retry topic and dlt's `ListenerContainerFactory` to one quarter of the smallest delay value for that topic, with a minimum value of 250ms and a maximum value of 5000ms.
@@ -45,9 +45,9 @@ This way you can tune the precision and performance for the retry topics if you 
 
 NOTE: You can have separate `ListenerContainerFactory` instances for the main and retry topics - this way you can have different settings to better suit your needs, such as having a higher polling timeout setting for the main topics and a lower one for the retry topics.
 
-=== Configuration
+==== Configuration
 
-==== Using the `@RetryableTopic` annotation
+===== Using the `@RetryableTopic` annotation
 
 To configure the retry topic and dlt for a `@KafkaListener` annotated method, you just have to add the `@RetryableTopic` annotation to it and Spring Kafka will bootstrap all the necessary topics and consumers with the default configurations.
 
@@ -78,7 +78,7 @@ public void processMessage(MyPojo message) {
 NOTE: If you don't specify a kafkaTemplate name a bean with name `retryTopicDefaultKafkaTemplate` will be looked up.
 If no bean is found an exception is thrown.
 
-==== Using `RetryTopicConfiguration` beans
+===== Using `RetryTopicConfiguration` beans
 
 You can also configure the non-blocking retry support by creating `RetryTopicConfiguration` beans in a `@Configuration` annotated class.
 
@@ -126,11 +126,11 @@ public RetryTopicConfiguration myOtherRetryTopic(KafkaTemplate<String, MyOtherPo
 
 NOTE: The retry topics' and dlt's consumers will be assigned to a consumer group with a group id that is the combination of the one with you provide in the `groupId` parameter of the `@KafkaListener` annotation with the topic's suffix. If you don't provide any they'll all belong to the same group, and rebalance on a retry topic will cause an unnecessary rebalance on the main topic.
 
-=== Features
+==== Features
 
 Most of the features are available both for the `@RetryableTopic` annotation and the `RetryTopicConfiguration` beans.
 
-==== BackOff Configuration
+===== BackOff Configuration
 
 The BackOff configuration relies on the `BackOffPolicy` interface from the `Spring Retry` project.
 
@@ -187,7 +187,7 @@ NOTE: The default backoff policy is FixedBackOffPolicy with a maximum of 3 attem
 
 IMPORTANT: The first attempt counts against the maxAttempts, so if you provide a maxAttempts value of 4 there'll be the original attempt plus 3 retries.
 
-==== Single Topic Fixed Delay Retries
+===== Single Topic Fixed Delay Retries
 
 If you're using fixed delay policies such as `FixedBackOffPolicy` or `NoBackOffPolicy` you can use a single topic to accomplish the non-blocking retries.
 This topic will be suffixed with the provided or default suffix, and will not have either the index or the delay values appended.
@@ -220,7 +220,7 @@ public RetryTopicConfiguration myRetryTopic(KafkaTemplate<String, MyPojo> templa
 
 NOTE: The default behavior is creating separate retry topics for each attempt, appended with their index value: retry-0, retry-1, ...
 
-==== Global timeout
+===== Global timeout
 
 You can set the global timeout for the retrying process.
 If that time is reached, the next time the consumer throws an exception the message goes straight to the DLT, or just ends the processing if no DLT is available.
@@ -252,7 +252,7 @@ public RetryTopicConfiguration myRetryTopic(KafkaTemplate<String, MyPojo> templa
 
 NOTE: The default is having no timeout set, which can also be achieved by providing -1 as the timout value.
 
-==== Exception Classifier
+===== Exception Classifier
 
 You can specify which exceptions you want to retry on and which not to.
 You can also set it to traverse the causes to lookup nested exceptions.
@@ -284,7 +284,7 @@ public RetryTopicConfiguration myRetryTopic(KafkaTemplate<String, MyOtherPojo> t
 
 NOTE: The default behavior is retrying on all exceptions and not traversing causes.
 
-==== Include and Exclude Topics
+===== Include and Exclude Topics
 
 You can decide which topics will and will not be handled by a `RetryTopicConfiguration` bean via the .includeTopic(String topic), .includeTopics(Collection<String> topics) .excludeTopic(String topic) and .excludeTopics(Collection<String> topics) methods.
 
@@ -312,7 +312,7 @@ public RetryTopicConfiguration myOtherRetryTopic(KafkaTemplate<Integer, MyPojo> 
 NOTE: The default behavior is to include all topics.
 
 
-==== Topics AutoCreation
+===== Topics AutoCreation
 
 Unless otherwise specified the framework will auto create the required topics using `NewTopic` beans that are consumed by the `KafkaAdmin` bean.
 You can specify the number of partitions and the replication factor with which the topics will be created, and you can turn this feature off.
@@ -357,7 +357,7 @@ public RetryTopicConfiguration myOtherRetryTopic(KafkaTemplate<Integer, MyPojo> 
 NOTE: By default the topics are autocreated with one partition and a replication factor of one.
 
 
-=== Topic Naming
+==== Topic Naming
 
 Retry topics and DLT are named by suffixing the main topic with a provided or default value, appended by either the delay or index for that topic.
 
@@ -367,7 +367,7 @@ Examples:
 
 "my-other-topic" -> "my-topic-myRetrySuffix-1000", "my-topic-myRetrySuffix-2000", ..., "my-topic-myDltSuffix".
 
-==== Retry Topics and Dlt Suffixes
+===== Retry Topics and Dlt Suffixes
 
 You can specify the suffixes that will be used by the retry and dlt topics.
 
@@ -398,7 +398,7 @@ public RetryTopicConfiguration myRetryTopic(KafkaTemplate<String, MyOtherPojo> t
 
 NOTE: The default suffixes are "-retry" and "-dlt", for retry topics and dlt respectively.
 
-==== Appending the Topic's Index or Delay
+===== Appending the Topic's Index or Delay
 
 You can either append the topic's index or delay values after the suffix.
 
@@ -428,11 +428,11 @@ public RetryTopicConfiguration myRetryTopic(KafkaTemplate<String, MyPojo> templa
 
 NOTE: The default behavior is to suffix with the delay values, except for fixed delay configurations with multiple topics, in which case the topics are suffixed with the topic's index.
 
-=== Dlt Strategies
+==== Dlt Strategies
 
 The framework provides a few strategies for working with DLTs. You can provide a method for DLT processing, use the default logging method, or have no DLT at all. Also you can choose what happens if DLT processing fails.
 
-==== Dlt Processing Method
+===== Dlt Processing Method
 
 You can specify the method used to process the Dlt for the topic, as well as the behavior if that processing fails.
 
@@ -487,7 +487,7 @@ public class MyCustomDltProcessor {
 
 NOTE: If no DLT handler is provided, the default RetryTopicConfigurer.LoggingDltListenerHandlerMethod is used.
 
-==== Dlt Failure Behavior
+===== Dlt Failure Behavior
 
 Should the Dlt processing fail, there are two possible behaviors available: `ALWAYS_RETRY_ON_ERROR` and `FAIL_ON_ERROR`.
 
@@ -521,7 +521,7 @@ public RetryTopicConfiguration myRetryTopic(KafkaTemplate<Integer, MyPojo> templ
 
 NOTE: The default behavior is to `ALWAYS_RETRY_ON_ERROR`.
 
-==== Configuring No Dlt
+===== Configuring No Dlt
 
 The framework also provides the possibility of not configuring a DLT for the topic.
 In this case after retrials are exhausted the processing simply ends.
@@ -551,7 +551,7 @@ public RetryTopicConfiguration myRetryTopic(KafkaTemplate<Integer, MyPojo> templ
 ====
 
 
-=== Specifying a ListenerContainerFactory
+==== Specifying a ListenerContainerFactory
 
 By default the RetryTopic configuration will use the provided factory from the `@KafkaListener` annotation, but you can specify a different one to be used to create the retry topic and dlt listener containers.
 

--- a/spring-kafka-docs/src/main/asciidoc/whats-new.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/whats-new.adoc
@@ -54,6 +54,9 @@ See <<transactions>> for more information.
 ==== `ReplyingKafkaTemplate` Changes
 
 There is now a mechanism to examine a reply and fail the future exceptionally if some condition exists.
+
+Support for sending and receiving `spring-messaging` `Message<?>` s has been added.
+
 See <<replying-template>> for more information.
 
 [[x27-streams]]

--- a/spring-kafka-docs/src/main/java/org/springframework/kafka/jdocs/requestreply/Application.java
+++ b/spring-kafka-docs/src/main/java/org/springframework/kafka/jdocs/requestreply/Application.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.jdocs.requestreply;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.kafka.core.KafkaAdmin;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
+import org.springframework.kafka.requestreply.ReplyingKafkaTemplate;
+import org.springframework.kafka.requestreply.RequestReplyTypedMessageFuture;
+import org.springframework.kafka.support.converter.ByteArrayJsonMessageConverter;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.support.MessageBuilder;
+
+/**
+ * Code snippets for request/reply messaging.
+ *
+ * @author Gary Russell
+ * @since 2.7
+ *
+ */
+@SpringBootApplication
+public class Application {
+
+    private static final Logger log = LoggerFactory.getLogger(Application.class);
+
+    public static void main(String[] args) {
+        System.setProperty("spring.kafka.producer.value-serializer", ByteArraySerializer.class.getName());
+        System.setProperty("spring.kafka.consumer.value-deserializer", ByteArrayDeserializer.class.getName());
+        SpringApplication.run(Application.class, args).close();
+    }
+
+    @Bean
+    public KafkaAdmin.NewTopics topics() {
+        return new KafkaAdmin.NewTopics(
+                TopicBuilder.name("requests")
+                        .partitions(10)
+                        .replicas(1)
+                        .build(),
+                TopicBuilder.name("replies")
+                        .partitions(10)
+                        .replicas(1)
+                        .build());
+    }
+
+    @Bean
+    KafkaTemplate<Object, Object> kafkaTemplate(ProducerFactory<Object, Object> pf) {
+        return new KafkaTemplate<>(pf);
+    }
+
+ // tag::beans[]
+    @Bean
+    ReplyingKafkaTemplate<String, String, String> template(
+            ProducerFactory<String, String> pf,
+            ConcurrentKafkaListenerContainerFactory<String, String> factory) {
+
+        ConcurrentMessageListenerContainer<String, String> replyContainer =
+                factory.createContainer("replies");
+        replyContainer.getContainerProperties().setGroupId("request.replies");
+        ReplyingKafkaTemplate<String, String, String> template =
+                new ReplyingKafkaTemplate<>(pf, replyContainer);
+        template.setMessageConverter(new ByteArrayJsonMessageConverter());
+        template.setDefaultTopic("requests");
+        return template;
+    }
+ // end::beans[]
+
+    @Bean
+    ApplicationRunner runner(ReplyingKafkaTemplate<String, String, String> template) {
+        return args -> {
+// tag::sendReceive[]
+            RequestReplyTypedMessageFuture<String, String, Thing> future1 =
+                    template.sendAndReceive(MessageBuilder.withPayload("getAThing").build(),
+                            new ParameterizedTypeReference<Thing>() { });
+            log.info(future1.getSendFuture().get(10, TimeUnit.SECONDS).getRecordMetadata().toString());
+            Thing thing = future1.get(10, TimeUnit.SECONDS).getPayload();
+            log.info(thing.toString());
+
+            RequestReplyTypedMessageFuture<String, String, List<Thing>> future2 =
+                    template.sendAndReceive(MessageBuilder.withPayload("getThings").build(),
+                            new ParameterizedTypeReference<List<Thing>>() { });
+            log.info(future2.getSendFuture().get(10, TimeUnit.SECONDS).getRecordMetadata().toString());
+            List<Thing> things = future2.get(10, TimeUnit.SECONDS).getPayload();
+            things.forEach(thing1 -> log.info(thing1.toString()));
+// end::sendReceive[]
+        };
+    }
+
+    @KafkaListener(id = "myId", topics = "requests", properties = "auto.offset.reset:earliest")
+    @SendTo
+    public byte[] listen(String in) {
+        log.info(in);
+        if (in.equals("\"getAThing\"")) {
+            return ("{\"thingProp\":\"someValue\"}").getBytes();
+        }
+        if (in.equals("\"getThings\"")) {
+            return ("[{\"thingProp\":\"someValue1\"},{\"thingProp\":\"someValue2\"}]").getBytes();
+        }
+        return in.toUpperCase().getBytes();
+    }
+
+    public static class Thing {
+
+        private String thingProp;
+
+        public String getThingProp() {
+            return this.thingProp;
+        }
+
+        public void setThingProp(String thingProp) {
+            this.thingProp = thingProp;
+        }
+
+        @Override
+        public String toString() {
+            return "Thing [thingProp=" + this.thingProp + "]";
+        }
+
+    }
+
+}
+
+

--- a/spring-kafka-docs/src/main/kotlin/org/springframework/kafka/kdocs/requestreply/Application.kt
+++ b/spring-kafka-docs/src/main/kotlin/org/springframework/kafka/kdocs/requestreply/Application.kt
@@ -47,6 +47,9 @@ import java.util.function.Consumer
  */
 @SpringBootApplication
 class Application {
+
+    private val log = LoggerFactory.getLogger(Application::class.java)
+
     @Bean
     fun topics(): NewTopics {
         return NewTopics(
@@ -61,12 +64,8 @@ class Application {
         )
     }
 
-    /* This is ok in Intellij but fails in gradle
     @Bean
-    fun kafkaTemplate(pf: ProducerFactory<Any, Any>?): KafkaTemplate<Any, Any> {
-        return KafkaTemplate(pf)
-    }
-     */
+    fun kafkaTemplate(pf: ProducerFactory<Any, Any>?) = KafkaTemplate(pf)
 
 // tag::beans[]
     @Bean
@@ -123,14 +122,10 @@ class Application {
         }
     }
 
-    companion object {
-        private val log = LoggerFactory.getLogger(Application::class.java)
-        @JvmStatic
-        fun main(args: Array<String>) {
-            System.setProperty("spring.kafka.producer.value-serializer", ByteArraySerializer::class.java.name)
-            System.setProperty("spring.kafka.consumer.value-deserializer", ByteArrayDeserializer::class.java.name)
-            SpringApplication.run(Application::class.java, *args).close()
-        }
-    }
+}
 
+fun main(args: Array<String>) {
+    System.setProperty("spring.kafka.producer.value-serializer", ByteArraySerializer::class.java.name)
+    System.setProperty("spring.kafka.consumer.value-deserializer", ByteArrayDeserializer::class.java.name)
+    SpringApplication.run(Application::class.java, *args).close()
 }

--- a/spring-kafka-docs/src/main/kotlin/org/springframework/kafka/kdocs/requestreply/Application.kt
+++ b/spring-kafka-docs/src/main/kotlin/org/springframework/kafka/kdocs/requestreply/Application.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.kafka.kdocs.requestreply
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.kafka.core.KafkaAdmin.NewTopics
+import org.springframework.kafka.config.TopicBuilder
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
+import org.springframework.kafka.requestreply.ReplyingKafkaTemplate
+import org.springframework.kafka.support.converter.ByteArrayJsonMessageConverter
+import org.springframework.boot.ApplicationRunner
+import org.springframework.boot.ApplicationArguments
+import org.springframework.kafka.requestreply.RequestReplyTypedMessageFuture
+import org.springframework.messaging.support.MessageBuilder
+import org.springframework.core.ParameterizedTypeReference
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.messaging.handler.annotation.SendTo
+import kotlin.jvm.JvmStatic
+import org.apache.kafka.common.serialization.ByteArrayDeserializer
+import org.apache.kafka.common.serialization.ByteArraySerializer
+import org.slf4j.LoggerFactory
+import org.springframework.boot.SpringApplication
+import org.springframework.context.annotation.Bean
+import org.springframework.kafka.core.ProducerFactory
+import java.util.concurrent.TimeUnit
+import java.util.function.Consumer
+
+/**
+ * Code snippets for request/reply messaging.
+ *
+ * @author Gary Russell
+ * @since 2.7
+ */
+@SpringBootApplication
+class Application {
+    @Bean
+    fun topics(): NewTopics {
+        return NewTopics(
+            TopicBuilder.name("requests")
+                .partitions(10)
+                .replicas(1)
+                .build(),
+            TopicBuilder.name("replies")
+                .partitions(10)
+                .replicas(1)
+                .build()
+        )
+    }
+
+    /* This is ok in Intellij but fails in gradle
+    @Bean
+    fun kafkaTemplate(pf: ProducerFactory<Any, Any>?): KafkaTemplate<Any, Any> {
+        return KafkaTemplate(pf)
+    }
+     */
+
+// tag::beans[]
+    @Bean
+    fun template(
+        pf: ProducerFactory<String?, String>?,
+        factory: ConcurrentKafkaListenerContainerFactory<String?, String?>
+    ): ReplyingKafkaTemplate<String?, String, String?> {
+        val replyContainer = factory.createContainer("replies")
+        replyContainer.containerProperties.groupId = "request.replies"
+        val template = ReplyingKafkaTemplate(pf, replyContainer)
+        template.messageConverter = ByteArrayJsonMessageConverter()
+        template.defaultTopic = "requests"
+        return template
+    }
+// end::beans[]
+
+    @Bean
+    fun runner(template: ReplyingKafkaTemplate<String?, String?, String?>): ApplicationRunner {
+        return ApplicationRunner { _ ->
+// tag::sendReceive[]
+            val future1: RequestReplyTypedMessageFuture<String?, String?, Thing?>? =
+                template.sendAndReceive(MessageBuilder.withPayload("getAThing").build(),
+                    object : ParameterizedTypeReference<Thing?>() {})
+            log.info(future1?.sendFuture?.get(10, TimeUnit.SECONDS)?.recordMetadata?.toString())
+            val thing = future1?.get(10, TimeUnit.SECONDS)?.payload
+            log.info(thing.toString())
+
+            val future2: RequestReplyTypedMessageFuture<String?, String?, List<Thing?>?>? =
+                template.sendAndReceive(MessageBuilder.withPayload("getThings").build(),
+                    object : ParameterizedTypeReference<List<Thing?>?>() {})
+            log.info(future2?.sendFuture?.get(10, TimeUnit.SECONDS)?.recordMetadata.toString())
+            val things = future2?.get(10, TimeUnit.SECONDS)?.payload
+            things?.forEach(Consumer { thing1: Thing? -> log.info(thing1.toString()) })
+// end::sendReceive[]
+        }
+    }
+
+    @KafkaListener(id = "myId", topics = ["requests"], properties = ["auto.offset.reset:earliest"])
+    @SendTo
+    fun listen(`in`: String): ByteArray {
+        log.info(`in`)
+        if (`in` == "\"getAThing\"") {
+            return "{\"thingProp\":\"someValue\"}".toByteArray()
+        }
+        return if (`in` == "\"getThings\"") {
+            "[{\"thingProp\":\"someValue1\"},{\"thingProp\":\"someValue2\"}]".toByteArray()
+        } else `in`.toUpperCase().toByteArray()
+    }
+
+    class Thing {
+        var thingProp: String? = null
+        override fun toString(): String {
+            return "Thing [thingProp=" + thingProp + "]"
+        }
+    }
+
+    companion object {
+        private val log = LoggerFactory.getLogger(Application::class.java)
+        @JvmStatic
+        fun main(args: Array<String>) {
+            System.setProperty("spring.kafka.producer.value-serializer", ByteArraySerializer::class.java.name)
+            System.setProperty("spring.kafka.consumer.value-deserializer", ByteArrayDeserializer::class.java.name)
+            SpringApplication.run(Application::class.java, *args).close()
+        }
+    }
+
+}

--- a/spring-kafka-docs/src/main/kotlin/org/springframework/kafka/kdocs/started/consumer/Application.kt
+++ b/spring-kafka-docs/src/main/kotlin/org/springframework/kafka/kdocs/started/consumer/Application.kt
@@ -17,13 +17,8 @@ package org.springframework.kafka.kdocs.started.consumer
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.apache.kafka.clients.admin.NewTopic
-import org.apache.kafka.common.serialization.ByteArrayDeserializer
-import org.apache.kafka.common.serialization.ByteArraySerializer
-import org.slf4j.LoggerFactory
-import org.springframework.kafka.config.TopicBuilder
 import org.springframework.kafka.annotation.KafkaListener
 import kotlin.jvm.JvmStatic
-import org.springframework.boot.SpringApplication
 import org.springframework.boot.runApplication
 import org.springframework.context.annotation.Bean
 import org.springframework.kafka.kdocs.started.producer.Application
@@ -43,14 +38,12 @@ class Application {
     fun topic() = NewTopic("topic1", 10, 1)
 
     @KafkaListener(id = "myId", topics = ["topic1"])
-    fun listen(`in`: String?) {
-        println(`in`)
-    }
-
-    companion object {
-        @JvmStatic
-        fun main(args: Array<String>) = runApplication<Application>(*args)
+    fun listen(value: String?) {
+        println(value)
     }
 
 }
+
+fun main(args: Array<String>) = runApplication<Application>(*args)
+
 // end::startedConsumer[]

--- a/spring-kafka-docs/src/main/kotlin/org/springframework/kafka/kdocs/started/consumer/Application.kt
+++ b/spring-kafka-docs/src/main/kotlin/org/springframework/kafka/kdocs/started/consumer/Application.kt
@@ -17,6 +17,9 @@ package org.springframework.kafka.kdocs.started.consumer
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.apache.kafka.clients.admin.NewTopic
+import org.apache.kafka.common.serialization.ByteArrayDeserializer
+import org.apache.kafka.common.serialization.ByteArraySerializer
+import org.slf4j.LoggerFactory
 import org.springframework.kafka.config.TopicBuilder
 import org.springframework.kafka.annotation.KafkaListener
 import kotlin.jvm.JvmStatic
@@ -44,7 +47,10 @@ class Application {
         println(`in`)
     }
 
-    fun main(args: Array<String>) = runApplication<Application>(*args)
+    companion object {
+        @JvmStatic
+        fun main(args: Array<String>) = runApplication<Application>(*args)
+    }
 
 }
 // end::startedConsumer[]

--- a/spring-kafka-docs/src/main/kotlin/org/springframework/kafka/kdocs/started/noboot/Sender.kt
+++ b/spring-kafka-docs/src/main/kotlin/org/springframework/kafka/kdocs/started/noboot/Sender.kt
@@ -35,10 +35,5 @@ class Sender(private val template: KafkaTemplate<Int, String>) {
         template.send("topic1", key, toSend)
     }
 
-    fun main(args: Array<String>) {
-        val context = runApplication<Sender>(*args)
-        context.getBean(Sender::class.java).send("test", 42)
-    }
-
 }
 // end::startedNoBootSender[]

--- a/spring-kafka-docs/src/main/kotlin/org/springframework/kafka/kdocs/started/producer/Application.kt
+++ b/spring-kafka-docs/src/main/kotlin/org/springframework/kafka/kdocs/started/producer/Application.kt
@@ -41,7 +41,10 @@ class Application {
     fun runner(template: KafkaTemplate<String?, String?>) =
         ApplicationRunner { template.send("topic1", "test") }
 
-    fun main(args: Array<String>) = runApplication<Application>(*args)
+    companion object {
+        @JvmStatic
+        fun main(args: Array<String>) = runApplication<Application>(*args)
+    }
 
 }
 // end::startedProducer[]

--- a/spring-kafka-docs/src/main/resources/logback.xml
+++ b/spring-kafka-docs/src/main/resources/logback.xml
@@ -13,5 +13,7 @@
   </root>
 
   <logger name="org.springframework" level="WARN" />
+  <logger name="org.springframework.kafka.jdocs" level="INFO" />
+  <logger name="org.springframework.kafka.Kdocs" level="INFO" />
 
 </configuration>

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2015-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,6 @@ import org.springframework.kafka.support.LoggingProducerListener;
 import org.springframework.kafka.support.ProducerListener;
 import org.springframework.kafka.support.SendResult;
 import org.springframework.kafka.support.TransactionSupport;
-import org.springframework.kafka.support.converter.MessageConverter;
 import org.springframework.kafka.support.converter.MessagingMessageConverter;
 import org.springframework.kafka.support.converter.RecordMessageConverter;
 import org.springframework.kafka.support.micrometer.MicrometerHolder;
@@ -234,7 +233,7 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 	 * Return the message converter.
 	 * @return the message converter.
 	 */
-	public MessageConverter getMessageConverter() {
+	public RecordMessageConverter getMessageConverter() {
 		return this.messageConverter;
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/RecordMessagingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/RecordMessagingMessageListenerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,7 +86,7 @@ public class RecordMessagingMessageListenerAdapter<K, V> extends MessagingMessag
 			message = NULL_MESSAGE;
 		}
 		if (logger.isDebugEnabled() && !(getMessageConverter() instanceof ProjectingMessageConverter)) {
-			logger.debug("Processing [" + message + "]");
+			this.logger.debug("Processing [" + message + "]");
 		}
 		try {
 			Object result = invokeHandler(record, acknowledgment, message, consumer);

--- a/spring-kafka/src/main/java/org/springframework/kafka/requestreply/ReplyingKafkaOperations.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/requestreply/ReplyingKafkaOperations.java
@@ -38,7 +38,7 @@ import org.springframework.messaging.Message;
 public interface ReplyingKafkaOperations<K, V, R> {
 
 	/**
-	 * 	 * Send a request message and receive a reply message with the default timeout.
+	 * Send a request message and receive a reply message with the default timeout.
 	 * @param message the message to send.
 	 * @return a RequestReplyMessageFuture.
 	 * @since 2.7

--- a/spring-kafka/src/main/java/org/springframework/kafka/requestreply/ReplyingKafkaOperations.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/requestreply/ReplyingKafkaOperations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 the original author or authors.
+ * Copyright 2018-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,9 @@ import java.time.Duration;
 
 import org.apache.kafka.clients.producer.ProducerRecord;
 
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.lang.Nullable;
+import org.springframework.messaging.Message;
 
 /**
  * Request/reply operations.
@@ -36,6 +38,57 @@ import org.springframework.lang.Nullable;
 public interface ReplyingKafkaOperations<K, V, R> {
 
 	/**
+	 * 	 * Send a request message and receive a reply message with the default timeout.
+	 * @param message the message to send.
+	 * @return a RequestReplyMessageFuture.
+	 * @since 2.7
+	 *
+	 */
+	default RequestReplyMessageFuture<K, V> sendAndReceive(Message<?> message) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Send a request message and receive a reply message.
+	 * @param message the message to send.
+	 * @param replyTimeout the reply timeout; if null, the default will be used.
+	 * @return a RequestReplyMessageFuture.
+	 * @since 2.7
+	 */
+	default RequestReplyMessageFuture<K, V> sendAndReceive(Message<?> message, @Nullable Duration replyTimeout) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Send a request message and receive a reply message.
+	 * @param message the message to send.
+	 * @param returnType a hint to the message converter for the reply payload type.
+	 * @param <P> the reply payload type.
+	 * @return a RequestReplyMessageFuture.
+	 * @since 2.7
+	 */
+	default <P> RequestReplyTypedMessageFuture<K, V, P> sendAndReceive(Message<?> message,
+			ParameterizedTypeReference<P> returnType) {
+
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Send a request message and receive a reply message.
+	 * @param message the message to send.
+	 * @param replyTimeout the reply timeout; if null, the default will be used.
+	 * @param returnType a hint to the message converter for the reply payload type.
+	 * @param <P> the reply payload type.
+	 * @return a RequestReplyMessageFuture.
+	 * @since 2.7
+	 */
+	default <P> RequestReplyTypedMessageFuture<K, V, P> sendAndReceive(Message<?> message, Duration replyTimeout,
+			ParameterizedTypeReference<P> returnType) {
+
+		throw new UnsupportedOperationException();
+	}
+
+	/**
 	 * Send a request and receive a reply with the default timeout.
 	 * @param record the record to send.
 	 * @return a RequestReplyFuture.
@@ -49,6 +102,6 @@ public interface ReplyingKafkaOperations<K, V, R> {
 	 * @return a RequestReplyFuture.
 	 * @since 2.3
 	 */
-	RequestReplyFuture<K, V, R> sendAndReceive(ProducerRecord<K, V> record, @Nullable Duration replyTimeout);
+	RequestReplyFuture<K, V, R> sendAndReceive(ProducerRecord<K, V> record, Duration replyTimeout);
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/requestreply/RequestReplyMessageFuture.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/requestreply/RequestReplyMessageFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,31 +16,33 @@
 
 package org.springframework.kafka.requestreply;
 
-import org.apache.kafka.clients.consumer.ConsumerRecord;
-
 import org.springframework.kafka.support.SendResult;
+import org.springframework.messaging.Message;
 import org.springframework.util.concurrent.ListenableFuture;
 import org.springframework.util.concurrent.SettableListenableFuture;
 
 /**
- * A listenable future for requests/replies.
+ * A listenable future for {@link Message} replies.
  *
  * @param <K> the key type.
  * @param <V> the outbound data type.
- * @param <R> the reply data type.
  *
  * @author Gary Russell
- * @since 2.1.3
+ * @since 2.7
  *
  */
-public class RequestReplyFuture<K, V, R> extends SettableListenableFuture<ConsumerRecord<K, R>> {
+public class RequestReplyMessageFuture<K, V> extends SettableListenableFuture<Message<?>> {
 
-	private volatile ListenableFuture<SendResult<K, V>> sendFuture;
+	private final ListenableFuture<SendResult<K, V>> sendFuture;
 
-	protected void setSendFuture(ListenableFuture<SendResult<K, V>> sendFuture) {
+	RequestReplyMessageFuture(ListenableFuture<SendResult<K, V>> sendFuture) {
 		this.sendFuture = sendFuture;
 	}
 
+	/**
+	 * Return the send future.
+	 * @return the send future.
+	 */
 	public ListenableFuture<SendResult<K, V>> getSendFuture() {
 		return this.sendFuture;
 	}

--- a/spring-kafka/src/main/java/org/springframework/kafka/requestreply/RequestReplyTypedMessageFuture.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/requestreply/RequestReplyTypedMessageFuture.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.requestreply;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.springframework.kafka.support.SendResult;
+import org.springframework.messaging.Message;
+import org.springframework.util.concurrent.ListenableFuture;
+
+/**
+ * A listenable future for {@link Message} replies with a specific payload type.
+ *
+ * @param <K> the key type.
+ * @param <V> the outbound data type.
+ * @param <P> the reply payload type.
+ *
+ * @author Gary Russell
+ * @since 2.7
+ *
+ */
+public class RequestReplyTypedMessageFuture<K, V, P> extends RequestReplyMessageFuture<K, V> {
+
+	RequestReplyTypedMessageFuture(ListenableFuture<SendResult<K, V>> sendFuture) {
+		super(sendFuture);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public Message<P> get() throws InterruptedException, ExecutionException {
+		return (Message<P>) super.get();
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public Message<P> get(long timeout, TimeUnit unit)
+			throws InterruptedException, ExecutionException, TimeoutException {
+
+		return (Message<P>) super.get(timeout, unit);
+	}
+
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/converter/JsonMessageConverter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/converter/JsonMessageConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,6 +45,8 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
  *
  */
 public class JsonMessageConverter extends MessagingMessageConverter {
+
+	private static final JavaType OBJECT = TypeFactory.defaultInstance().constructType(Object.class);
 
 	private final ObjectMapper objectMapper;
 
@@ -100,11 +102,16 @@ public class JsonMessageConverter extends MessagingMessageConverter {
 			return KafkaNull.INSTANCE;
 		}
 
-		JavaType javaType = this.typeMapper.getTypePrecedence().equals(TypePrecedence.INFERRED)
+		JavaType javaType = this.typeMapper.getTypePrecedence().equals(TypePrecedence.INFERRED) && type != null
 				? TypeFactory.defaultInstance().constructType(type)
 				: this.typeMapper.toJavaType(record.headers());
 		if (javaType == null) { // no headers
-			javaType = TypeFactory.defaultInstance().constructType(type);
+			if (type != null) {
+				javaType = TypeFactory.defaultInstance().constructType(type);
+			}
+			else {
+				javaType = OBJECT;
+			}
 		}
 		if (value instanceof Bytes) {
 			value = ((Bytes) value).get();

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -474,16 +474,21 @@ public class EnableKafkaIntegrationTests {
 		Object messageListener = container.getContainerProperties().getMessageListener();
 		DefaultJackson2JavaTypeMapper typeMapper = KafkaTestUtils.getPropertyValue(messageListener,
 				"messageConverter.typeMapper", DefaultJackson2JavaTypeMapper.class);
-		typeMapper.setTypePrecedence(Jackson2JavaTypeMapper.TypePrecedence.TYPE_ID);
-		assertThat(container).isNotNull();
-		Foo foo = new Foo("bar");
-		this.kafkaJsonTemplate.send(MessageBuilder.withPayload(foo)
-				.setHeader(KafkaHeaders.TOPIC, "annotated31")
-				.setHeader(KafkaHeaders.PARTITION_ID, 0)
-				.setHeader(KafkaHeaders.MESSAGE_KEY, 2)
-				.build());
-		assertThat(this.listener.latch19.await(60, TimeUnit.SECONDS)).isTrue();
-		assertThat(this.listener.foo.getBar()).isEqualTo("bar");
+		try {
+			typeMapper.setTypePrecedence(Jackson2JavaTypeMapper.TypePrecedence.TYPE_ID);
+			assertThat(container).isNotNull();
+			Foo foo = new Foo("bar");
+			this.kafkaJsonTemplate.send(MessageBuilder.withPayload(foo)
+					.setHeader(KafkaHeaders.TOPIC, "annotated31")
+					.setHeader(KafkaHeaders.PARTITION_ID, 0)
+					.setHeader(KafkaHeaders.MESSAGE_KEY, 2)
+					.build());
+			assertThat(this.listener.latch19.await(60, TimeUnit.SECONDS)).isTrue();
+			assertThat(this.listener.foo.getBar()).isEqualTo("bar");
+		}
+		finally {
+			typeMapper.setTypePrecedence(Jackson2JavaTypeMapper.TypePrecedence.INFERRED);
+		}
 	}
 
 	@Test
@@ -1977,7 +1982,6 @@ public class EnableKafkaIntegrationTests {
 		@KafkaListener(id = "validated", topics = "annotated35", errorHandler = "validationErrorHandler",
 				containerFactory = "kafkaJsonListenerContainerFactory")
 		public void validatedListener(@Payload @Valid ValidatedClass val) {
-			// NOSONAR
 		}
 
 		@KafkaListener(id = "projection", topics = "annotated37",

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurerTests.java
@@ -24,6 +24,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willReturn;
 import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
 import java.lang.reflect.Method;
@@ -51,7 +52,6 @@ import org.springframework.kafka.config.KafkaListenerContainerFactory;
 import org.springframework.kafka.config.KafkaListenerEndpointRegistrar;
 import org.springframework.kafka.config.MethodKafkaListenerEndpoint;
 import org.springframework.kafka.config.MultiMethodKafkaListenerEndpoint;
-import org.springframework.kafka.listener.ListenerUtils;
 import org.springframework.test.util.ReflectionTestUtils;
 
 /**
@@ -357,11 +357,10 @@ class RetryTopicConfigurerTests {
 
 	@Test
 	void shouldLogConsumerRecordMessage() {
-		ListenerUtils.setLogOnlyMetadata(true);
 		RetryTopicConfigurer.LoggingDltListenerHandlerMethod method =
 				new RetryTopicConfigurer.LoggingDltListenerHandlerMethod();
 		method.logMessage(consumerRecordMessage);
-		then(consumerRecordMessage).should().topic();
+		then(consumerRecordMessage).should(never()).topic();
 	}
 
 	@Test

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurerTests.java
@@ -51,6 +51,7 @@ import org.springframework.kafka.config.KafkaListenerContainerFactory;
 import org.springframework.kafka.config.KafkaListenerEndpointRegistrar;
 import org.springframework.kafka.config.MethodKafkaListenerEndpoint;
 import org.springframework.kafka.config.MultiMethodKafkaListenerEndpoint;
+import org.springframework.kafka.listener.ListenerUtils;
 import org.springframework.test.util.ReflectionTestUtils;
 
 /**
@@ -356,10 +357,11 @@ class RetryTopicConfigurerTests {
 
 	@Test
 	void shouldLogConsumerRecordMessage() {
+		ListenerUtils.setLogOnlyMetadata(true);
 		RetryTopicConfigurer.LoggingDltListenerHandlerMethod method =
 				new RetryTopicConfigurer.LoggingDltListenerHandlerMethod();
 		method.logMessage(consumerRecordMessage);
-		then(consumerRecordMessage).should(times(0)).topic();
+		then(consumerRecordMessage).should().topic();
 	}
 
 	@Test


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1741

`ReplyingKafkaTemplate` enable send and receive with `Message<?>`.

- also fix ToC level for new chapter
- also polishing some tests for left over state