### PR TITLE
GH-1747: Add ConsumerAwareRecordInterceptor

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -1009,6 +1009,8 @@ Access to the `Consumer` object is provided.
 IMPORTANT: The `Consumer` object is not thread-safe.
 You must only invoke its methods on the thread that calls the listener.
 
+IMPORTANT: You should not execute any `Consumer<?, ?>` methods that affect the consumer's positions and or committed offsets in your listener; the container needs to manage such information.
+
 [[message-listener-container]]
 ===== Message Listener Containers
 
@@ -1024,8 +1026,12 @@ Starting with version 2.2.7, you can add a `RecordInterceptor` to the listener c
 If the interceptor returns null, the listener is not called.
 Starting with version 2.7, it has additional methods which are called after the listener exits (normally, or by throwing an exception).
 Also, starting with version 2.7, there is now a `BatchInterceptor`, providing similar functionality for <<batch-listeners>>.
+In addition, the `ConsumerAwareRecordInterceptor` (and `BatchInterceptor`) provide access to the `Consumer<?, ?>`.
+This might be used, for example, to access the consumer metrics in the interceptor.
 
-Starting with version 2.3, the `CompositeRecordInterceptor` and `CompositeBatchInterceptor` can be used to invoke multiple interceptors.
+IMPORTANT: You should not execute any methods that affect the consumer's positions and or committed offsets in these interceptors; the container needs to manage such information.
+
+The `CompositeRecordInterceptor` and `CompositeBatchInterceptor` can be used to invoke multiple interceptors.
 
 By default, when using transactions, the interceptor is invoked after the transaction has started.
 Starting with version 2.3.4, you can set the listener container's `interceptBeforeTx` property to invoke the interceptor before the transaction has started instead.

--- a/spring-kafka-docs/src/main/asciidoc/whats-new.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/whats-new.adoc
@@ -25,6 +25,7 @@ Error handlers and after rollback processors that extend `FailedRecordProcessor`
 See See <<after-rollback>>, <<seek-to-current>>, and <<recovering-batch-eh>> for more information.
 
 The `RecordInterceptor` now has additional methods called after the listener returns (normally, or by throwing an exception).
+It also has a sub-interface `ConsumerAwareRecordInterceptor`.
 In addition, there is now a `BatchInterceptor` for batch listeners.
 See <<message-listener-container>> for more information.
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/BatchInterceptor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/BatchInterceptor.java
@@ -16,6 +16,7 @@
 
 package org.springframework.kafka.listener;
 
+import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 
 import org.springframework.lang.Nullable;
@@ -37,24 +38,27 @@ public interface BatchInterceptor<K, V> {
 	 * Perform some action on the records or return a different one. If null is returned
 	 * the records will be skipped. Invoked before the listener.
 	 * @param records the records.
+	 * @param consumer the consumer.
 	 * @return the records or null.
 	 */
 	@Nullable
-	ConsumerRecords<K, V> intercept(ConsumerRecords<K, V> records);
+	ConsumerRecords<K, V> intercept(ConsumerRecords<K, V> records, Consumer<K, V> consumer);
 
 	/**
 	 * Called after the listener exits normally.
 	 * @param records the records.
+	 * @param consumer the consumer.
 	 */
-	default void success(ConsumerRecords<K, V> records) {
+	default void success(ConsumerRecords<K, V> records, Consumer<K, V> consumer) {
 	}
 
 	/**
 	 * Called after the listener throws an exception.
 	 * @param records the records.
 	 * @param exception the exception.
+	 * @param consumer the consumer.
 	 */
-	default void failure(ConsumerRecords<K, V> records, Exception exception) {
+	default void failure(ConsumerRecords<K, V> records, Exception exception, Consumer<K, V> consumer) {
 	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/CompositeRecordInterceptor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/CompositeRecordInterceptor.java
@@ -38,7 +38,7 @@ import org.springframework.util.Assert;
  * @since 2.3
  *
  */
-public class CompositeRecordInterceptor<K, V> implements RecordInterceptor<K, V> {
+public class CompositeRecordInterceptor<K, V> implements ConsumerAwareRecordInterceptor<K, V> {
 
 	private final Collection<RecordInterceptor<K, V>> delegates = new ArrayList<>();
 
@@ -52,19 +52,6 @@ public class CompositeRecordInterceptor<K, V> implements RecordInterceptor<K, V>
 		Assert.notNull(delegates, "'delegates' cannot be null");
 		Assert.noNullElements(delegates, "'delegates' cannot have null entries");
 		this.delegates.addAll(Arrays.asList(delegates));
-	}
-
-	@Override
-	@Nullable
-	public ConsumerRecord<K, V> intercept(ConsumerRecord<K, V> record) {
-		ConsumerRecord<K, V> recordToIntercept = record;
-		for (RecordInterceptor<K, V> delegate : this.delegates) {
-			recordToIntercept = delegate.intercept(recordToIntercept);
-			if (recordToIntercept == null) {
-				break;
-			}
-		}
-		return recordToIntercept;
 	}
 
 	@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerAwareRecordInterceptor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerAwareRecordInterceptor.java
@@ -31,8 +31,10 @@ import org.springframework.lang.Nullable;
  * @since 2.7
  *
  */
+@FunctionalInterface
 public interface ConsumerAwareRecordInterceptor<K, V> extends RecordInterceptor<K, V> {
 
+	@SuppressWarnings("deprecation")
 	@Override
 	@Nullable
 	default ConsumerRecord<K, V> intercept(ConsumerRecord<K, V> record) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerAwareRecordInterceptor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerAwareRecordInterceptor.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * A {@link RecordInterceptor} that has access to the {@link Consumer}.
+ *
+ * @param <K> the key type.
+ * @param <V> the value type.
+ *
+ * @author Gary Russell
+ * @since 2.7
+ *
+ */
+public interface ConsumerAwareRecordInterceptor<K, V> extends RecordInterceptor<K, V> {
+
+	@Override
+	@Nullable
+	default ConsumerRecord<K, V> intercept(ConsumerRecord<K, V> record) {
+		throw new UnsupportedOperationException("Container should never call this");
+	}
+
+	@Override
+	@Nullable
+	ConsumerRecord<K, V> intercept(ConsumerRecord<K, V> record, Consumer<K, V> consumer);
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -1789,7 +1789,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		}
 
 		private void batchAfterRollback(final ConsumerRecords<K, V> records,
-				final List<ConsumerRecord<K, V>> recordList, RuntimeException e,
+				@Nullable final List<ConsumerRecord<K, V>> recordList, RuntimeException e,
 				AfterRollbackProcessor<K, V> afterRollbackProcessorToUse) {
 
 			RuntimeException rollbackException = decorateException(e);
@@ -1888,10 +1888,10 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			if (this.commonBatchInterceptor != null) {
 				try {
 					if (exception == null) {
-						this.commonBatchInterceptor.success(records);
+						this.commonBatchInterceptor.success(records, this.consumer);
 					}
 					else {
-						this.commonBatchInterceptor.failure(records, exception);
+						this.commonBatchInterceptor.failure(records, exception, this.consumer);
 					}
 				}
 				catch (Exception e) {
@@ -1961,7 +1961,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 
 			ConsumerRecords<K, V> records = recordsArg;
 			if (this.batchInterceptor != null) {
-				records = this.batchInterceptor.intercept(recordsArg);
+				records = this.batchInterceptor.intercept(recordsArg, this.consumer);
 			}
 			if (this.wantsFullRecords) {
 				this.batchListener.onMessage(records, // NOSONAR
@@ -2143,7 +2143,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		private ConsumerRecords<K, V> checkEarlyIntercept(ConsumerRecords<K, V> nextArg) {
 			ConsumerRecords<K, V> next = nextArg;
 			if (this.earlyBatchInterceptor != null) {
-				next = this.earlyBatchInterceptor.intercept(next);
+				next = this.earlyBatchInterceptor.intercept(next, this.consumer);
 				if (next == null) {
 					this.logger.debug(() -> "RecordInterceptor returned null, skipping: "
 						+ nextArg + " with " + nextArg.count() + " records");
@@ -2156,7 +2156,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		private ConsumerRecord<K, V> checkEarlyIntercept(ConsumerRecord<K, V> nextArg) {
 			ConsumerRecord<K, V> next = nextArg;
 			if (this.earlyRecordInterceptor != null) {
-				next = this.earlyRecordInterceptor.intercept(next);
+				next = this.earlyRecordInterceptor.intercept(next, this.consumer);
 				if (next == null) {
 					this.logger.debug(() -> "RecordInterceptor returned null, skipping: "
 						+ ListenerUtils.recordToString(nextArg));
@@ -2258,10 +2258,10 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			if (this.commonRecordInterceptor != null) {
 				try {
 					if (exception == null) {
-						this.commonRecordInterceptor.success(records);
+						this.commonRecordInterceptor.success(records, this.consumer);
 					}
 					else {
-						this.commonRecordInterceptor.failure(records, exception);
+						this.commonRecordInterceptor.failure(records, exception, this.consumer);
 					}
 				}
 				catch (Exception e) {
@@ -2301,7 +2301,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		private void doInvokeOnMessage(final ConsumerRecord<K, V> recordArg) {
 			ConsumerRecord<K, V> record = recordArg;
 			if (this.recordInterceptor != null) {
-				record = this.recordInterceptor.intercept(record);
+				record = this.recordInterceptor.intercept(record, this.consumer);
 			}
 			if (record == null) {
 				this.logger.debug(() -> "RecordInterceptor returned null, skipping: "

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/RecordInterceptor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/RecordInterceptor.java
@@ -16,6 +16,7 @@
 
 package org.springframework.kafka.listener;
 
+import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
 import org.springframework.lang.Nullable;
@@ -44,20 +45,37 @@ public interface RecordInterceptor<K, V> {
 	ConsumerRecord<K, V> intercept(ConsumerRecord<K, V> record);
 
 	/**
-	 * Called after the listener exits normally.
+	 * Perform some action on the record or return a different one. If null is returned
+	 * the record will be skipped. Invoked before the listener.
 	 * @param record the record.
+	 * @param consumer the consumer.
+	 * @return the record or null.
 	 * @since 2.7
 	 */
-	default void success(ConsumerRecord<K, V> record) {
+	@Nullable
+	default ConsumerRecord<K, V> intercept(ConsumerRecord<K, V> record,
+			@SuppressWarnings("unused") Consumer<K, V> consumer) {
+
+		return intercept(record);
+	}
+
+	/**
+	 * Called after the listener exits normally.
+	 * @param record the record.
+	 * @param consumer the consumer.
+	 * @since 2.7
+	 */
+	default void success(ConsumerRecord<K, V> record, Consumer<K, V> consumer) {
 	}
 
 	/**
 	 * Called after the listener throws an exception.
 	 * @param record the record.
 	 * @param exception the exception.
+	 * @param consumer the consumer.
 	 * @since 2.7
 	 */
-	default void failure(ConsumerRecord<K, V> record, Exception exception) {
+	default void failure(ConsumerRecord<K, V> record, Exception exception, Consumer<K, V> consumer) {
 	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/RecordInterceptor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/RecordInterceptor.java
@@ -40,7 +40,10 @@ public interface RecordInterceptor<K, V> {
 	 * the record will be skipped. Invoked before the listener.
 	 * @param record the record.
 	 * @return the record or null.
+	 * @deprecated in favor of {@link #intercept(ConsumerRecord, Consumer)} which will
+	 * become the required method in a future release.
 	 */
+	@Deprecated
 	@Nullable
 	ConsumerRecord<K, V> intercept(ConsumerRecord<K, V> record);
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -1084,7 +1084,7 @@ public class EnableKafkaIntegrationTests {
 			factory.setRecordFilterStrategy(recordFilter());
 			// always send to the same partition so the replies are in order for the test
 			factory.setReplyTemplate(partitionZeroReplyTemplate());
-			factory.setBatchInterceptor(records -> {
+			factory.setBatchInterceptor((records, consumer) -> {
 				this.batchIntercepted = true;
 				return records;
 			});

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerMockTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerMockTests.java
@@ -516,24 +516,24 @@ public class ConcurrentMessageListenerContainerMockTests {
 		CountDownLatch interceptedLatch = new CountDownLatch(2);
 		CountDownLatch successCalled = new CountDownLatch(1);
 		CountDownLatch failureCalled = new CountDownLatch(1);
-		container.setRecordInterceptor(new RecordInterceptor() {
+		container.setRecordInterceptor(new ConsumerAwareRecordInterceptor() {
 
 			@Override
 			@Nullable
-			public ConsumerRecord intercept(ConsumerRecord rec) {
+			public ConsumerRecord intercept(ConsumerRecord rec, Consumer consumer) {
 				order.add("interceptor");
 				latch.countDown();
 				return rec;
 			}
 
 			@Override
-			public void success(ConsumerRecord record) {
+			public void success(ConsumerRecord record, Consumer consumer) {
 				order.add("success");
 				successCalled.countDown();
 			}
 
 			@Override
-			public void failure(ConsumerRecord record, Exception exception) {
+			public void failure(ConsumerRecord record, Exception exception, Consumer consumer) {
 				order.add("failure");
 				failureCalled.countDown();
 			}
@@ -543,20 +543,20 @@ public class ConcurrentMessageListenerContainerMockTests {
 
 			@Override
 			@Nullable
-			public ConsumerRecords intercept(ConsumerRecords recs) {
+			public ConsumerRecords intercept(ConsumerRecords recs, Consumer consumer) {
 				order.add("interceptor");
 				latch.countDown();
 				return recs;
 			}
 
 			@Override
-			public void success(ConsumerRecords records) {
+			public void success(ConsumerRecords records, Consumer consumer) {
 				order.add("success");
 				successCalled.countDown();
 			}
 
 			@Override
-			public void failure(ConsumerRecords records, Exception exception) {
+			public void failure(ConsumerRecords records, Exception exception, Consumer consumer) {
 				order.add("failure");
 				failureCalled.countDown();
 			}


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1747

Also add `Consumer` to the new 2.7 methods and batch interceptor.