### PR TITLE
GH-1751: JsonDeser. Trust Mapped Class Packages

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -167,7 +167,7 @@ public class JsonSerializer<T> implements Serializer<T> {
 						ClassUtils.forName(split[1].trim(), ClassUtils.getDefaultClassLoader()));
 			}
 			catch (ClassNotFoundException | LinkageError e) {
-				throw new IllegalArgumentException(e);
+				throw new IllegalArgumentException("Failed to load: " + split[1] + " for " + split[0], e);
 			}
 		}
 		return mappingsMap;

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/JsonSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/JsonSerializationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -289,6 +289,32 @@ public class JsonSerializationTests {
 		deser.configure(props, false);
 		assertThat(KafkaTestUtils.getPropertyValue(deser, "typeMapper.trustedPackages", Set.class))
 				.contains("foo", "bar", "baz");
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void testTrustMappingPackages() {
+		JsonDeserializer<Object> deser = new JsonDeserializer<>();
+		Map<String, Object> props = Collections.singletonMap(JsonDeserializer.TYPE_MAPPINGS,
+				"foo:" + Foo.class.getName());
+		deser.configure(props, false);
+		assertThat(KafkaTestUtils.getPropertyValue(deser, "typeMapper.trustedPackages", Set.class))
+				.contains(Foo.class.getPackageName());
+		assertThat(KafkaTestUtils.getPropertyValue(deser, "typeMapper.trustedPackages", Set.class))
+			.contains(Foo.class.getPackageName() + ".*");
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void testTrustMappingPackagesMapper() {
+		JsonDeserializer<Object> deser = new JsonDeserializer<>();
+		DefaultJackson2JavaTypeMapper mapper = new DefaultJackson2JavaTypeMapper();
+		mapper.setIdClassMapping(Collections.singletonMap("foo", Foo.class));
+		deser.setTypeMapper(mapper);
+		assertThat(KafkaTestUtils.getPropertyValue(deser, "typeMapper.trustedPackages", Set.class))
+				.contains(Foo.class.getPackageName());
+		assertThat(KafkaTestUtils.getPropertyValue(deser, "typeMapper.trustedPackages", Set.class))
+			.contains(Foo.class.getPackageName() + ".*");
 	}
 
 	@Test


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1751

Always trust packages for classes in the id class mappings, even
with an externally injected type mapper.

We don't normally reconfigure mappers when injected, but in this case
it makes sense and provides an easier user experience.