### PR TITLE
GH-1762 - Extract KafkaConsumerBackoffManager interface

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/reactive/ReactiveKafkaProducerTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/reactive/ReactiveKafkaProducerTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaConsumerBackoffManager.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaConsumerBackoffManager.java
@@ -16,227 +16,33 @@
 
 package org.springframework.kafka.listener;
 
-import java.time.Clock;
-import java.time.Instant;
-import java.util.HashMap;
-import java.util.Map;
-
-import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.common.TopicPartition;
 
-import org.springframework.context.ApplicationListener;
-import org.springframework.core.log.LogAccessor;
-import org.springframework.kafka.event.ListenerContainerPartitionIdleEvent;
 import org.springframework.lang.Nullable;
 
 /**
- *
- * A manager that backs off consumption for a given topic if the timestamp provided is not
- * due. Use with {@link SeekToCurrentErrorHandler} to guarantee that the message is read
- * again after partition consumption is resumed (or seek it manually by other means).
- * It's also necessary to set a {@link ContainerProperties#setIdlePartitionEventInterval(Long)}
- * so the Manager can resume the partition consumption.
- *
- * Note that when a record backs off the partition consumption gets paused for
- * approximately that amount of time, so you must have a fixed backoff value per partition.
+ * Interface for backing off a {@link MessageListenerContainer}
+ * until a given dueTimestamp, if such timestamp is in the future.
  *
  * @author Tomaz Fernandes
  * @author Gary Russell
  * @since 2.7
- * @see SeekToCurrentErrorHandler
  */
-public class KafkaConsumerBackoffManager implements ApplicationListener<ListenerContainerPartitionIdleEvent> {
+public interface KafkaConsumerBackoffManager {
 
-	private static final LogAccessor LOGGER = new LogAccessor(LogFactory.getLog(KafkaConsumerBackoffManager.class));
+	void backOffIfNecessary(Context context);
 
-	private final ListenerContainerRegistry listenerContainerRegistry;
-
-	private final Map<TopicPartition, Context> backOffContexts;
-
-	private final Clock clock;
-
-	private final KafkaConsumerTimingAdjuster kafkaConsumerTimingAdjuster;
-
-	/**
-	 * Constructs an instance with the provided {@link ListenerContainerRegistry} and
-	 * {@link KafkaConsumerTimingAdjuster}.
-	 *
-	 * The ListenerContainerRegistry is used to fetch the {@link MessageListenerContainer}
-	 * that will be backed off / resumed.
-	 *
-	 * The KafkaConsumerTimingAdjuster is used to make timing adjustments
-	 * in the message consumption so that it processes the message closer
-	 * to its due time rather than later.
-	 *
-	 * @param listenerContainerRegistry the listenerContainerRegistry to use.
-	 * @param kafkaConsumerTimingAdjuster the kafkaConsumerTimingAdjuster to use.
-	 */
-	public KafkaConsumerBackoffManager(ListenerContainerRegistry listenerContainerRegistry,
-									KafkaConsumerTimingAdjuster kafkaConsumerTimingAdjuster) {
-
-		this.listenerContainerRegistry = listenerContainerRegistry;
-		this.kafkaConsumerTimingAdjuster = kafkaConsumerTimingAdjuster;
-		this.clock = Clock.systemUTC();
-		this.backOffContexts = new HashMap<>();
-	}
-
-	/**
-	 * Constructs an instance with the provided {@link ListenerContainerRegistry}
-	 * and with no timing adjustment capabilities.
-	 *
-	 * The ListenerContainerRegistry is used to fetch the {@link MessageListenerContainer}
-	 * that will be backed off / resumed.
-	 *
-	 * @param listenerContainerRegistry the listenerContainerRegistry to use.
-	 */
-	public KafkaConsumerBackoffManager(ListenerContainerRegistry listenerContainerRegistry) {
-
-		this.listenerContainerRegistry = listenerContainerRegistry;
-		this.kafkaConsumerTimingAdjuster = null;
-		this.clock = Clock.systemUTC();
-		this.backOffContexts = new HashMap<>();
-	}
-
-	/**
-	 * Creates an instance with the provided {@link ListenerContainerRegistry},
-	 * {@link KafkaConsumerTimingAdjuster} and {@link Clock}.
-	 *
-	 * @param listenerContainerRegistry the listenerContainerRegistry to use.
-	 * @param kafkaConsumerTimingAdjuster the kafkaConsumerTimingAdjuster to use.
-	 * @param clock the clock to use.
-	 */
-	public KafkaConsumerBackoffManager(ListenerContainerRegistry listenerContainerRegistry,
-									KafkaConsumerTimingAdjuster kafkaConsumerTimingAdjuster,
-									Clock clock) {
-
-		this.listenerContainerRegistry = listenerContainerRegistry;
-		this.clock = clock;
-		this.kafkaConsumerTimingAdjuster = kafkaConsumerTimingAdjuster;
-		this.backOffContexts = new HashMap<>();
-	}
-
-	/**
-	 * Creates an instance with the provided {@link ListenerContainerRegistry}
-	 * and {@link Clock}, with no timing adjustment capabilities.
-	 *
-	 * @param listenerContainerRegistry the listenerContainerRegistry to use.
-	 * @param clock the clock to use.
-	 */
-	public KafkaConsumerBackoffManager(ListenerContainerRegistry listenerContainerRegistry, Clock clock) {
-
-		this.listenerContainerRegistry = listenerContainerRegistry;
-		this.clock = clock;
-		this.kafkaConsumerTimingAdjuster = null;
-		this.backOffContexts = new HashMap<>();
-	}
-
-	/**
-	 * Backs off if the current time is before the dueTimestamp provided
-	 * in the {@link Context} object.
-	 * @param context the back off context for this execution.
-	 */
-	public void maybeBackoff(Context context) {
-		long backoffTime = context.dueTimestamp - getCurrentMillisFromClock();
-		if (backoffTime > 0) {
-			pauseConsumptionAndThrow(context, backoffTime);
-		}
-	}
-
-	private void pauseConsumptionAndThrow(Context context, Long backOffTime) throws KafkaBackoffException {
-		TopicPartition topicPartition = context.topicPartition;
-		getListenerContainerFromContext(context).pausePartition(topicPartition);
-		addBackoff(context, topicPartition);
-		throw new KafkaBackoffException(String.format("Partition %s from topic %s is not ready for consumption, " +
-				"backing off for approx. %s millis.", context.topicPartition.partition(),
-				context.topicPartition.topic(), backOffTime),
-				topicPartition, context.listenerId, context.dueTimestamp);
-	}
-
-	@Override
-	public void onApplicationEvent(ListenerContainerPartitionIdleEvent partitionIdleEvent) {
-		LOGGER.debug(() -> String.format("partitionIdleEvent received at %s. Partition: %s",
-				getCurrentMillisFromClock(), partitionIdleEvent.getTopicPartition()));
-
-		Context backOffContext = getBackOffContext(partitionIdleEvent.getTopicPartition());
-		maybeResumeConsumption(backOffContext);
-	}
-
-	private long getCurrentMillisFromClock() {
-		return Instant.now(this.clock).toEpochMilli();
-	}
-
-	private void maybeResumeConsumption(@Nullable Context context) {
-		if (context == null) {
-			return;
-		}
-		long now = getCurrentMillisFromClock();
-		long timeUntilDue = context.dueTimestamp - now;
-		long pollTimeout = getListenerContainerFromContext(context)
-				.getContainerProperties()
-				.getPollTimeout();
-		boolean isDue = timeUntilDue <= pollTimeout;
-
-		long adjustedAmount = applyTimingAdjustment(context, timeUntilDue, pollTimeout);
-
-		if (adjustedAmount != 0L || isDue) {
-			resumePartition(context);
-		}
-		else {
-			LOGGER.debug(() -> String.format("TopicPartition %s not due. DueTimestamp: %s Now: %s ",
-					context.topicPartition, context.dueTimestamp, now));
-		}
-	}
-
-	private long applyTimingAdjustment(Context context, long timeUntilDue, long pollTimeout) {
-		if (this.kafkaConsumerTimingAdjuster == null || context.consumerForTimingAdjustment == null) {
-			LOGGER.debug(() -> String.format(
-					"Skipping timing adjustment for TopicPartition %s.", context.topicPartition));
-			return 0L;
-		}
-		return this.kafkaConsumerTimingAdjuster.adjustTiming(
-						context.consumerForTimingAdjustment, context.topicPartition, pollTimeout, timeUntilDue);
-	}
-
-	private void resumePartition(Context context) {
-		MessageListenerContainer container = getListenerContainerFromContext(context);
-		LOGGER.debug(() -> "Resuming partition at " + getCurrentMillisFromClock());
-		container.resumePartition(context.topicPartition);
-		removeBackoff(context.topicPartition);
-	}
-
-	private MessageListenerContainer getListenerContainerFromContext(Context context) {
-		return this.listenerContainerRegistry.getListenerContainer(context.listenerId);
-	}
-
-	protected void addBackoff(Context context, TopicPartition topicPartition) {
-		synchronized (this.backOffContexts) {
-			this.backOffContexts.put(topicPartition, context);
-		}
-	}
-
-	protected @Nullable Context getBackOffContext(TopicPartition topicPartition) {
-		synchronized (this.backOffContexts) {
-			return this.backOffContexts.get(topicPartition);
-		}
-	}
-
-	protected void removeBackoff(TopicPartition topicPartition) {
-		synchronized (this.backOffContexts) {
-			this.backOffContexts.remove(topicPartition);
-		}
-	}
-
-	public Context createContext(long dueTimestamp, String listenerId, TopicPartition topicPartition,
-								@Nullable Consumer<?, ?> consumerForTimingAdjustment) {
-		return new Context(dueTimestamp, topicPartition, listenerId, consumerForTimingAdjustment);
+	default Context createContext(long dueTimestamp, String listenerId, TopicPartition topicPartition,
+								@Nullable Consumer<?, ?> messageConsumer) {
+		return new Context(dueTimestamp, topicPartition, listenerId, messageConsumer);
 	}
 
 	/**
 	 * Provides the state that will be used for backing off.
 	 * @since 2.7
 	 */
-	public static class Context {
+	class Context {
 
 		/**
 		 * The time after which the message should be processed,
@@ -260,11 +66,27 @@ public class KafkaConsumerBackoffManager implements ApplicationListener<Listener
 		private final Consumer<?, ?> consumerForTimingAdjustment; // NOSONAR
 
 		Context(long dueTimestamp, TopicPartition topicPartition, String listenerId,
-						@Nullable Consumer<?, ?> consumerForTimingAdjustment) {
+				@Nullable Consumer<?, ?> consumerForTimingAdjustment) {
 			this.dueTimestamp = dueTimestamp;
 			this.listenerId = listenerId;
 			this.topicPartition = topicPartition;
 			this.consumerForTimingAdjustment = consumerForTimingAdjustment;
+		}
+
+		public long getDueTimestamp() {
+			return this.dueTimestamp;
+		}
+
+		public String getListenerId() {
+			return this.listenerId;
+		}
+
+		public TopicPartition getTopicPartition() {
+			return this.topicPartition;
+		}
+
+		public @Nullable Consumer<?, ?> getConsumerForTimingAdjustment() {
+			return this.consumerForTimingAdjustment;
 		}
 	}
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/PartitionPausingBackOffManagerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/PartitionPausingBackOffManagerFactory.java
@@ -32,7 +32,7 @@ import org.springframework.util.Assert;
  * @author Tomaz Fernandes
  * @since 2.7
  */
-public class TimingAdjustingKafkaBackOffManagerFactory extends AbstractKafkaBackOffManagerFactory {
+public class PartitionPausingBackOffManagerFactory extends AbstractKafkaBackOffManagerFactory {
 
 	private boolean timingAdjustmentEnabled = true;
 
@@ -48,7 +48,7 @@ public class TimingAdjustingKafkaBackOffManagerFactory extends AbstractKafkaBack
 	 *
 	 * @param timingAdjustmentManager the {@link KafkaConsumerTimingAdjuster} to be used.
 	 */
-	public TimingAdjustingKafkaBackOffManagerFactory(KafkaConsumerTimingAdjuster timingAdjustmentManager) {
+	public PartitionPausingBackOffManagerFactory(KafkaConsumerTimingAdjuster timingAdjustmentManager) {
 		this.clock = getDefaultClock();
 		setTimingAdjustmentManager(timingAdjustmentManager);
 	}
@@ -59,7 +59,7 @@ public class TimingAdjustingKafkaBackOffManagerFactory extends AbstractKafkaBack
 	 *
 	 * @param timingAdjustmentManagerTaskExecutor the {@link TaskExecutor} to be used.
 	 */
-	public TimingAdjustingKafkaBackOffManagerFactory(TaskExecutor timingAdjustmentManagerTaskExecutor) {
+	public PartitionPausingBackOffManagerFactory(TaskExecutor timingAdjustmentManagerTaskExecutor) {
 		this.clock = getDefaultClock();
 		setTaskExecutor(timingAdjustmentManagerTaskExecutor);
 	}
@@ -70,7 +70,7 @@ public class TimingAdjustingKafkaBackOffManagerFactory extends AbstractKafkaBack
 	 *
 	 * @param timingAdjustmentEnabled the {@link KafkaConsumerTimingAdjuster} to be used.
 	 */
-	public TimingAdjustingKafkaBackOffManagerFactory(boolean timingAdjustmentEnabled) {
+	public PartitionPausingBackOffManagerFactory(boolean timingAdjustmentEnabled) {
 		this.clock = getDefaultClock();
 		setTimingAdjustmentEnabled(timingAdjustmentEnabled);
 	}
@@ -80,7 +80,7 @@ public class TimingAdjustingKafkaBackOffManagerFactory extends AbstractKafkaBack
 	 *
 	 * @param listenerContainerRegistry the {@link ListenerContainerRegistry} to be used.
 	 */
-	public TimingAdjustingKafkaBackOffManagerFactory(ListenerContainerRegistry listenerContainerRegistry) {
+	public PartitionPausingBackOffManagerFactory(ListenerContainerRegistry listenerContainerRegistry) {
 		super(listenerContainerRegistry);
 		this.clock = getDefaultClock();
 	}
@@ -88,7 +88,7 @@ public class TimingAdjustingKafkaBackOffManagerFactory extends AbstractKafkaBack
 	/**
 	 * Constructs a factory instance with default dependencies.
 	 */
-	public TimingAdjustingKafkaBackOffManagerFactory() {
+	public PartitionPausingBackOffManagerFactory() {
 		this.clock = getDefaultClock();
 	}
 
@@ -97,7 +97,7 @@ public class TimingAdjustingKafkaBackOffManagerFactory extends AbstractKafkaBack
 	 * with the provided {@link Clock}.
 	 * @param clock the clock instance to be used.
 	 */
-	public TimingAdjustingKafkaBackOffManagerFactory(Clock clock) {
+	public PartitionPausingBackOffManagerFactory(Clock clock) {
 		this.clock = clock;
 	}
 
@@ -133,7 +133,7 @@ public class TimingAdjustingKafkaBackOffManagerFactory extends AbstractKafkaBack
 
 	@Override
 	protected KafkaConsumerBackoffManager doCreateManager(ListenerContainerRegistry registry) {
-		KafkaConsumerBackoffManager kafkaConsumerBackoffManager = getKafkaConsumerBackoffManager(registry);
+		PartitionPausingBackoffManager kafkaConsumerBackoffManager = getKafkaConsumerBackoffManager(registry);
 		super.addApplicationListener(kafkaConsumerBackoffManager);
 		return kafkaConsumerBackoffManager;
 	}
@@ -142,10 +142,10 @@ public class TimingAdjustingKafkaBackOffManagerFactory extends AbstractKafkaBack
 		return Clock.systemUTC();
 	}
 
-	private KafkaConsumerBackoffManager getKafkaConsumerBackoffManager(ListenerContainerRegistry registry) {
+	private PartitionPausingBackoffManager getKafkaConsumerBackoffManager(ListenerContainerRegistry registry) {
 		return this.timingAdjustmentEnabled
-			? new KafkaConsumerBackoffManager(registry, getOrCreateBackOffTimingAdjustmentManager(), this.clock)
-			: new KafkaConsumerBackoffManager(registry, this.clock);
+			? new PartitionPausingBackoffManager(registry, getOrCreateBackOffTimingAdjustmentManager(), this.clock)
+			: new PartitionPausingBackoffManager(registry, this.clock);
 	}
 
 	private KafkaConsumerTimingAdjuster getOrCreateBackOffTimingAdjustmentManager() {

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/PartitionPausingBackoffManager.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/PartitionPausingBackoffManager.java
@@ -1,0 +1,231 @@
+/*
+ * Copyright 2018-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.commons.logging.LogFactory;
+import org.apache.kafka.common.TopicPartition;
+
+import org.springframework.context.ApplicationListener;
+import org.springframework.core.log.LogAccessor;
+import org.springframework.kafka.event.ListenerContainerPartitionIdleEvent;
+import org.springframework.lang.Nullable;
+
+/**
+ *
+ * A manager that backs off consumption for a given topic if the timestamp provided is not
+ * due. Use with {@link SeekToCurrentErrorHandler} to guarantee that the message is read
+ * again after partition consumption is resumed (or seek it manually by other means).
+ * It's also necessary to set a {@link ContainerProperties#setIdlePartitionEventInterval(Long)}
+ * so the Manager can resume the partition consumption.
+ *
+ * Note that when a record backs off the partition consumption gets paused for
+ * approximately that amount of time, so you must have a fixed backoff value per partition.
+ *
+ * @author Tomaz Fernandes
+ * @author Gary Russell
+ * @since 2.7
+ * @see SeekToCurrentErrorHandler
+ */
+public class PartitionPausingBackoffManager implements KafkaConsumerBackoffManager,
+		ApplicationListener<ListenerContainerPartitionIdleEvent> {
+
+	private static final LogAccessor LOGGER = new LogAccessor(LogFactory.getLog(KafkaConsumerBackoffManager.class));
+
+	private final ListenerContainerRegistry listenerContainerRegistry;
+
+	private final Map<TopicPartition, Context> backOffContexts;
+
+	private final Clock clock;
+
+	private final KafkaConsumerTimingAdjuster kafkaConsumerTimingAdjuster;
+
+	/**
+	 * Constructs an instance with the provided {@link ListenerContainerRegistry} and
+	 * {@link KafkaConsumerTimingAdjuster}.
+	 *
+	 * The ListenerContainerRegistry is used to fetch the {@link MessageListenerContainer}
+	 * that will be backed off / resumed.
+	 *
+	 * The KafkaConsumerTimingAdjuster is used to make timing adjustments
+	 * in the message consumption so that it processes the message closer
+	 * to its due time rather than later.
+	 *
+	 * @param listenerContainerRegistry the listenerContainerRegistry to use.
+	 * @param kafkaConsumerTimingAdjuster the kafkaConsumerTimingAdjuster to use.
+	 */
+	public PartitionPausingBackoffManager(ListenerContainerRegistry listenerContainerRegistry,
+										KafkaConsumerTimingAdjuster kafkaConsumerTimingAdjuster) {
+
+		this.listenerContainerRegistry = listenerContainerRegistry;
+		this.kafkaConsumerTimingAdjuster = kafkaConsumerTimingAdjuster;
+		this.clock = Clock.systemUTC();
+		this.backOffContexts = new HashMap<>();
+	}
+
+	/**
+	 * Constructs an instance with the provided {@link ListenerContainerRegistry}
+	 * and with no timing adjustment capabilities.
+	 *
+	 * The ListenerContainerRegistry is used to fetch the {@link MessageListenerContainer}
+	 * that will be backed off / resumed.
+	 *
+	 * @param listenerContainerRegistry the listenerContainerRegistry to use.
+	 */
+	public PartitionPausingBackoffManager(ListenerContainerRegistry listenerContainerRegistry) {
+
+		this.listenerContainerRegistry = listenerContainerRegistry;
+		this.kafkaConsumerTimingAdjuster = null;
+		this.clock = Clock.systemUTC();
+		this.backOffContexts = new HashMap<>();
+	}
+
+	/**
+	 * Creates an instance with the provided {@link ListenerContainerRegistry},
+	 * {@link KafkaConsumerTimingAdjuster} and {@link Clock}.
+	 *
+	 * @param listenerContainerRegistry the listenerContainerRegistry to use.
+	 * @param kafkaConsumerTimingAdjuster the kafkaConsumerTimingAdjuster to use.
+	 * @param clock the clock to use.
+	 */
+	public PartitionPausingBackoffManager(ListenerContainerRegistry listenerContainerRegistry,
+										KafkaConsumerTimingAdjuster kafkaConsumerTimingAdjuster,
+										Clock clock) {
+
+		this.listenerContainerRegistry = listenerContainerRegistry;
+		this.clock = clock;
+		this.kafkaConsumerTimingAdjuster = kafkaConsumerTimingAdjuster;
+		this.backOffContexts = new HashMap<>();
+	}
+
+	/**
+	 * Creates an instance with the provided {@link ListenerContainerRegistry}
+	 * and {@link Clock}, with no timing adjustment capabilities.
+	 *
+	 * @param listenerContainerRegistry the listenerContainerRegistry to use.
+	 * @param clock the clock to use.
+	 */
+	public PartitionPausingBackoffManager(ListenerContainerRegistry listenerContainerRegistry, Clock clock) {
+
+		this.listenerContainerRegistry = listenerContainerRegistry;
+		this.clock = clock;
+		this.kafkaConsumerTimingAdjuster = null;
+		this.backOffContexts = new HashMap<>();
+	}
+
+	/**
+	 * Backs off if the current time is before the dueTimestamp provided
+	 * in the {@link Context} object.
+	 * @param context the back off context for this execution.
+	 */
+	@Override
+	public void backOffIfNecessary(Context context) {
+		long backoffTime = context.getDueTimestamp() - getCurrentMillisFromClock();
+		if (backoffTime > 0) {
+			pauseConsumptionAndThrow(context, backoffTime);
+		}
+	}
+
+	private void pauseConsumptionAndThrow(Context context, Long backOffTime) throws KafkaBackoffException {
+		TopicPartition topicPartition = context.getTopicPartition();
+		getListenerContainerFromContext(context).pausePartition(topicPartition);
+		addBackoff(context, topicPartition);
+		throw new KafkaBackoffException(String.format("Partition %s from topic %s is not ready for consumption, " +
+				"backing off for approx. %s millis.", context.getTopicPartition().partition(),
+				context.getTopicPartition().topic(), backOffTime),
+				topicPartition, context.getListenerId(), context.getDueTimestamp());
+	}
+
+	@Override
+	public void onApplicationEvent(ListenerContainerPartitionIdleEvent partitionIdleEvent) {
+		LOGGER.debug(() -> String.format("partitionIdleEvent received at %s. Partition: %s",
+				getCurrentMillisFromClock(), partitionIdleEvent.getTopicPartition()));
+
+		Context backOffContext = getBackOffContext(partitionIdleEvent.getTopicPartition());
+		maybeResumeConsumption(backOffContext);
+	}
+
+	private long getCurrentMillisFromClock() {
+		return Instant.now(this.clock).toEpochMilli();
+	}
+
+	private void maybeResumeConsumption(@Nullable Context context) {
+		if (context == null) {
+			return;
+		}
+		long now = getCurrentMillisFromClock();
+		long timeUntilDue = context.getDueTimestamp() - now;
+		long pollTimeout = getListenerContainerFromContext(context)
+				.getContainerProperties()
+				.getPollTimeout();
+		boolean isDue = timeUntilDue <= pollTimeout;
+
+		long adjustedAmount = applyTimingAdjustment(context, timeUntilDue, pollTimeout);
+
+		if (adjustedAmount != 0L || isDue) {
+			resumePartition(context);
+		}
+		else {
+			LOGGER.debug(() -> String.format("TopicPartition %s not due. DueTimestamp: %s Now: %s ",
+					context.getTopicPartition(), context.getDueTimestamp(), now));
+		}
+	}
+
+	private long applyTimingAdjustment(Context context, long timeUntilDue, long pollTimeout) {
+		if (this.kafkaConsumerTimingAdjuster == null || context.getConsumerForTimingAdjustment() == null) {
+			LOGGER.debug(() -> String.format(
+					"Skipping timing adjustment for TopicPartition %s.", context.getTopicPartition()));
+			return 0L;
+		}
+		return this.kafkaConsumerTimingAdjuster.adjustTiming(
+						context.getConsumerForTimingAdjustment(),
+						context.getTopicPartition(), pollTimeout, timeUntilDue);
+	}
+
+	private void resumePartition(Context context) {
+		MessageListenerContainer container = getListenerContainerFromContext(context);
+		LOGGER.debug(() -> "Resuming partition at " + getCurrentMillisFromClock());
+		container.resumePartition(context.getTopicPartition());
+		removeBackoff(context.getTopicPartition());
+	}
+
+	private MessageListenerContainer getListenerContainerFromContext(Context context) {
+		return this.listenerContainerRegistry.getListenerContainer(context.getListenerId());
+	}
+
+	protected void addBackoff(Context context, TopicPartition topicPartition) {
+		synchronized (this.backOffContexts) {
+			this.backOffContexts.put(topicPartition, context);
+		}
+	}
+
+	protected @Nullable Context getBackOffContext(TopicPartition topicPartition) {
+		synchronized (this.backOffContexts) {
+			return this.backOffContexts.get(topicPartition);
+		}
+	}
+
+	protected void removeBackoff(TopicPartition topicPartition) {
+		synchronized (this.backOffContexts) {
+			this.backOffContexts.remove(topicPartition);
+		}
+	}
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/KafkaBackoffAwareMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/KafkaBackoffAwareMessageListenerAdapter.java
@@ -91,7 +91,7 @@ public class KafkaBackoffAwareMessageListenerAdapter<K, V>
 								@Nullable Consumer<?, ?> consumer) {
 		maybeGetBackoffTimestamp(consumerRecord)
 				.ifPresent(nextExecutionTimestamp -> this.kafkaConsumerBackoffManager
-						.maybeBackoff(createContext(consumerRecord, nextExecutionTimestamp, consumer)));
+						.backOffIfNecessary(createContext(consumerRecord, nextExecutionTimestamp, consumer)));
 		try {
 			invokeDelegateOnMessage(consumerRecord, acknowledgment, consumer);
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicBootstrapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicBootstrapper.java
@@ -30,7 +30,7 @@ import org.springframework.core.task.TaskExecutor;
 import org.springframework.kafka.listener.KafkaBackOffManagerFactory;
 import org.springframework.kafka.listener.KafkaConsumerBackoffManager;
 import org.springframework.kafka.listener.KafkaConsumerTimingAdjuster;
-import org.springframework.kafka.listener.TimingAdjustingKafkaBackOffManagerFactory;
+import org.springframework.kafka.listener.PartitionPausingBackOffManagerFactory;
 import org.springframework.retry.backoff.ThreadWaitSleeper;
 
 /**
@@ -86,7 +86,7 @@ public class RetryTopicBootstrapper {
 				DefaultDestinationTopicResolver.class);
 		registerIfNotContains(RetryTopicInternalBeanNames.BACKOFF_SLEEPER_BEAN_NAME, ThreadWaitSleeper.class);
 		registerIfNotContains(RetryTopicInternalBeanNames.INTERNAL_KAFKA_CONSUMER_BACKOFF_MANAGER_FACTORY,
-				TimingAdjustingKafkaBackOffManagerFactory.class);
+				PartitionPausingBackOffManagerFactory.class);
 	}
 
 	private void registerSingletons() {
@@ -108,13 +108,13 @@ public class RetryTopicBootstrapper {
 		if (ApplicationContextAware.class.isAssignableFrom(factory.getClass())) {
 			((ApplicationContextAware) factory).setApplicationContext(this.applicationContext);
 		}
-		if (TimingAdjustingKafkaBackOffManagerFactory.class.isAssignableFrom(factory.getClass())) {
-			setupTimingAdjustingBackOffFactory((TimingAdjustingKafkaBackOffManagerFactory) factory);
+		if (PartitionPausingBackOffManagerFactory.class.isAssignableFrom(factory.getClass())) {
+			setupTimingAdjustingBackOffFactory((PartitionPausingBackOffManagerFactory) factory);
 		}
 		return factory.create();
 	}
 
-	private void setupTimingAdjustingBackOffFactory(TimingAdjustingKafkaBackOffManagerFactory factory) {
+	private void setupTimingAdjustingBackOffFactory(PartitionPausingBackOffManagerFactory factory) {
 		if (this.applicationContext.containsBean(RetryTopicInternalBeanNames.BACKOFF_TASK_EXECUTOR)) {
 			factory.setTaskExecutor(this.applicationContext
 					.getBean(RetryTopicInternalBeanNames.BACKOFF_TASK_EXECUTOR, TaskExecutor.class));

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/PartitionPausingBackoffManagerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/PartitionPausingBackoffManagerTests.java
@@ -41,7 +41,7 @@ import org.springframework.kafka.retrytopic.TestClockUtils;
  * @since 2.7
  */
 @ExtendWith(MockitoExtension.class)
-class KafkaConsumerBackoffManagerTests {
+class PartitionPausingBackoffManagerTests {
 
 	@Mock
 	private KafkaListenerEndpointRegistry registry;
@@ -81,15 +81,15 @@ class KafkaConsumerBackoffManagerTests {
 		// given
 		given(this.registry.getListenerContainer(testListenerId)).willReturn(listenerContainer);
 		given(registry.getListenerContainer(testListenerId)).willReturn(listenerContainer);
-		KafkaConsumerBackoffManager backoffManager =
-				new KafkaConsumerBackoffManager(registry, timingAdjustmentManager, clock);
+		PartitionPausingBackoffManager backoffManager =
+				new PartitionPausingBackoffManager(registry, timingAdjustmentManager, clock);
 
 		long dueTimestamp = originalTimestamp + 5000;
 		KafkaConsumerBackoffManager.Context context =
 				backoffManager.createContext(dueTimestamp, testListenerId, topicPartition, consumer);
 
 		// then
-		KafkaBackoffException backoffException = catchThrowableOfType(() -> backoffManager.maybeBackoff(context),
+		KafkaBackoffException backoffException = catchThrowableOfType(() -> backoffManager.backOffIfNecessary(context),
 				KafkaBackoffException.class);
 
 		// when
@@ -104,13 +104,13 @@ class KafkaConsumerBackoffManagerTests {
 	void shouldNotBackoffGivenDueTimestampIsPast() {
 
 		// given
-		KafkaConsumerBackoffManager backoffManager =
-				new KafkaConsumerBackoffManager(registry, timingAdjustmentManager, clock);
+		PartitionPausingBackoffManager backoffManager =
+				new PartitionPausingBackoffManager(registry, timingAdjustmentManager, clock);
 		KafkaConsumerBackoffManager.Context context =
 				backoffManager.createContext(originalTimestamp - 5000, testListenerId, topicPartition, consumer);
 
 		// then
-		backoffManager.maybeBackoff(context);
+		backoffManager.backOffIfNecessary(context);
 
 		// when
 		assertThat(backoffManager.getBackOffContext(topicPartition)).isNull();
@@ -126,8 +126,8 @@ class KafkaConsumerBackoffManagerTests {
 		given(listenerContainer.getContainerProperties()).willReturn(containerProperties);
 		given(containerProperties.getPollTimeout()).willReturn(pollTimeout);
 
-		KafkaConsumerBackoffManager backoffManager =
-				new KafkaConsumerBackoffManager(registry, timingAdjustmentManager, clock);
+		PartitionPausingBackoffManager backoffManager =
+				new PartitionPausingBackoffManager(registry, timingAdjustmentManager, clock);
 
 		long dueTimestamp = originalTimestamp + 5000;
 		KafkaConsumerBackoffManager.Context context =
@@ -162,8 +162,8 @@ class KafkaConsumerBackoffManagerTests {
 		given(timingAdjustmentManager
 				.adjustTiming(consumer, topicPartition, pollTimeout, getTimeUntilDue(dueTimestamp)))
 				.willReturn(0L);
-		KafkaConsumerBackoffManager backoffManager =
-				new KafkaConsumerBackoffManager(registry, timingAdjustmentManager, clock);
+		PartitionPausingBackoffManager backoffManager =
+				new PartitionPausingBackoffManager(registry, timingAdjustmentManager, clock);
 		KafkaConsumerBackoffManager.Context context =
 				backoffManager.createContext(dueTimestamp, testListenerId, topicPartition, consumer);
 		backoffManager.addBackoff(context, topicPartition);
@@ -193,8 +193,8 @@ class KafkaConsumerBackoffManagerTests {
 		given(timingAdjustmentManager
 				.adjustTiming(consumer, topicPartition, pollTimeout, getTimeUntilDue(dueTimestamp)))
 				.willReturn(1000L);
-		KafkaConsumerBackoffManager backoffManager =
-				new KafkaConsumerBackoffManager(registry, timingAdjustmentManager, clock);
+		PartitionPausingBackoffManager backoffManager =
+				new PartitionPausingBackoffManager(registry, timingAdjustmentManager, clock);
 		KafkaConsumerBackoffManager.Context context =
 				backoffManager.createContext(dueTimestamp, testListenerId, topicPartition, consumer);
 		backoffManager.addBackoff(context, topicPartition);

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/adapter/KafkaBackoffAwareMessageListenerAdapterTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/adapter/KafkaBackoffAwareMessageListenerAdapterTests.java
@@ -145,7 +145,7 @@ class KafkaBackoffAwareMessageListenerAdapterTests {
 				.createContext(timestampCaptor.capture(), eq(listenerId), eq(topicPartition), isNull());
 		assertThat(timestampCaptor.getValue()).isEqualTo(originalTimestamp);
 		then(kafkaConsumerBackoffManager).should(times(1))
-				.maybeBackoff(context);
+				.backOffIfNecessary(context);
 
 		then(delegate).should(times(1)).onMessage(data, null, null);
 	}
@@ -173,7 +173,7 @@ class KafkaBackoffAwareMessageListenerAdapterTests {
 				.createContext(timestampCaptor.capture(), eq(listenerId), eq(topicPartition), isNull());
 		assertThat(timestampCaptor.getValue()).isEqualTo(originalTimestamp);
 		then(kafkaConsumerBackoffManager).should(times(1))
-				.maybeBackoff(context);
+				.backOffIfNecessary(context);
 
 		then(delegate).should(times(1)).onMessage(data, null, null);
 	}
@@ -198,7 +198,7 @@ class KafkaBackoffAwareMessageListenerAdapterTests {
 				.createContext(timestampCaptor.capture(), eq(listenerId), eq(topicPartition), isNull());
 		assertThat(timestampCaptor.getValue()).isEqualTo(originalTimestamp);
 		then(kafkaConsumerBackoffManager).should(times(1))
-				.maybeBackoff(context);
+				.backOffIfNecessary(context);
 
 		then(delegate).should(times(1)).onMessage(data, ack, null);
 	}
@@ -222,7 +222,7 @@ class KafkaBackoffAwareMessageListenerAdapterTests {
 				.createContext(timestampCaptor.capture(), eq(listenerId), eq(topicPartition), eq(consumer));
 		assertThat(timestampCaptor.getValue()).isEqualTo(originalTimestamp);
 		then(kafkaConsumerBackoffManager).should(times(1))
-				.maybeBackoff(context);
+				.backOffIfNecessary(context);
 
 		then(delegate).should(times(1)).onMessage(data, null, consumer);
 	}
@@ -247,7 +247,7 @@ class KafkaBackoffAwareMessageListenerAdapterTests {
 				.createContext(timestampCaptor.capture(), eq(listenerId), eq(topicPartition), eq(consumer));
 		assertThat(timestampCaptor.getValue()).isEqualTo(originalTimestamp);
 		then(kafkaConsumerBackoffManager).should(times(1))
-				.maybeBackoff(context);
+				.backOffIfNecessary(context);
 
 		then(delegate).should(times(1)).onMessage(data, ack, consumer);
 	}

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicBootstrapperTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicBootstrapperTests.java
@@ -38,7 +38,7 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.kafka.listener.KafkaBackOffManagerFactory;
 import org.springframework.kafka.listener.KafkaConsumerBackoffManager;
-import org.springframework.kafka.listener.TimingAdjustingKafkaBackOffManagerFactory;
+import org.springframework.kafka.listener.PartitionPausingBackOffManagerFactory;
 import org.springframework.retry.backoff.ThreadWaitSleeper;
 
 /**
@@ -64,7 +64,7 @@ class RetryTopicBootstrapperTests {
 	private DefaultDestinationTopicResolver defaultDestinationTopicResolver;
 
 	@Mock
-	private TimingAdjustingKafkaBackOffManagerFactory kafkaBackOffManagerFactory;
+	private PartitionPausingBackOffManagerFactory kafkaBackOffManagerFactory;
 
 	@Mock
 	private KafkaConsumerBackoffManager kafkaConsumerBackOffManager;


### PR DESCRIPTION
For the issue just opened.

@garyrussell there are a few // NOSONAR comments in the KafkaBackoffManager.Context class that maybe could be removed... Feel free to do so if that's the case, or let me know if you'd like me to.

Let me know if you have any suggestions or if there's anything you'd like me to change.

Thanks!