### PR TITLE
GH-1765 - Fix using same factory for retry & main

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/PartitionPausingBackoffManager.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/PartitionPausingBackoffManager.java
@@ -139,6 +139,7 @@ public class PartitionPausingBackoffManager implements KafkaConsumerBackoffManag
 	@Override
 	public void backOffIfNecessary(Context context) {
 		long backoffTime = context.getDueTimestamp() - getCurrentMillisFromClock();
+		LOGGER.debug(() -> "Back off time: " + backoffTime + " Context: " + context);
 		if (backoffTime > 0) {
 			pauseConsumptionAndThrow(context, backoffTime);
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/ListenerContainerFactoryConfigurer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/ListenerContainerFactoryConfigurer.java
@@ -98,10 +98,10 @@ public class ListenerContainerFactoryConfigurer {
 			ConcurrentKafkaListenerContainerFactory<?, ?> containerFactory, Configuration configuration) {
 		return isCached(containerFactory)
 				? containerFactory
-				: doConfigure(containerFactory, configuration.backOffValues);
+				: addToCache(doConfigure(containerFactory, configuration.backOffValues));
 	}
 
-	public ConcurrentKafkaListenerContainerFactory<?, ?> configureWithoutBackOff(
+	public ConcurrentKafkaListenerContainerFactory<?, ?> configureWithoutBackOffValues(
 			ConcurrentKafkaListenerContainerFactory<?, ?> containerFactory, Configuration configuration) {
 		return isCached(containerFactory)
 				? containerFactory
@@ -114,7 +114,7 @@ public class ListenerContainerFactoryConfigurer {
 				setupBackoffAwareMessageListenerAdapter(container, backOffValues));
 		containerFactory
 				.setErrorHandler(createErrorHandler(this.deadLetterPublishingRecovererFactory.create()));
-		return addToCache(containerFactory);
+		return containerFactory;
 	}
 
 	private boolean isCached(ConcurrentKafkaListenerContainerFactory<?, ?> containerFactory) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
@@ -355,7 +355,7 @@ public class RetryTopicConfigurer {
 				.resolveFactoryForMainEndpoint(providedFactory, defaultFactoryBeanName,
 						configuration.forContainerFactoryResolver());
 		return this.listenerContainerFactoryConfigurer
-				.configureWithoutBackOff(resolvedFactory, configuration.forContainerFactoryConfigurer());
+				.configureWithoutBackOffValues(resolvedFactory, configuration.forContainerFactoryConfigurer());
 	}
 
 	private ConcurrentKafkaListenerContainerFactory<?, ?> resolveAndConfigureFactoryForRetryEndpoint(

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/ListenerContainerFactoryConfigurerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/ListenerContainerFactoryConfigurerTests.java
@@ -304,7 +304,7 @@ class ListenerContainerFactoryConfigurerTests {
 				new ListenerContainerFactoryConfigurer(kafkaConsumerBackoffManager,
 						deadLetterPublishingRecovererFactory, clock);
 		configurer
-				.configureWithoutBackOff(containerFactory, configuration.forContainerFactoryConfigurer());
+				.configureWithoutBackOffValues(containerFactory, configuration.forContainerFactoryConfigurer());
 
 		// then
 		then(containerFactory).should(times(1))

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurerTests.java
@@ -225,7 +225,7 @@ class RetryTopicConfigurerTests {
 				defaultFactoryBeanName, factoryResolverConfig);
 		willReturn(containerFactory).given(this.listenerContainerFactoryConfigurer).configure(containerFactory,
 				lcfcConfiguration);
-		willReturn(containerFactory).given(this.listenerContainerFactoryConfigurer).configureWithoutBackOff(containerFactory,
+		willReturn(containerFactory).given(this.listenerContainerFactoryConfigurer).configureWithoutBackOffValues(containerFactory,
 				lcfcConfiguration);
 
 		RetryTopicConfigurer configurer = new RetryTopicConfigurer(destinationTopicProcessor, containerFactoryResolver,


### PR DESCRIPTION
Fixes #1765

I've also increased the back off times in the Integration Tests - they were too low and where not triggering the back off mechanism, which is why we didn't get this error sooner. It didn't add that much time to the tests in general, just a few seconds.

I also renamed the RetryableTopicIntegrationTests to RetryTopicIntegrationTests since not all listeners have the @RetryableTopic annotation.

Let me know if there's anything to be changed.

Thanks!