### PR TITLE
GH-1770: Fix ClientId for @KafkaListener

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
@@ -51,7 +51,6 @@ import org.springframework.kafka.support.converter.MessageConverter;
 import org.springframework.retry.RecoveryCallback;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
 
 /**
  * Base {@link KafkaListenerContainerFactory} for Spring's base container implementation.
@@ -427,10 +426,8 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 				.acceptIfNotNull(this.phase, instance::setPhase)
 				.acceptIfNotNull(this.applicationContext, instance::setApplicationContext)
 				.acceptIfNotNull(this.applicationEventPublisher, instance::setApplicationEventPublisher)
-				.acceptIfCondition(StringUtils.hasText(endpoint.getGroupId()), endpoint.getGroupId(),
-						instance.getContainerProperties()::setGroupId)
-				.acceptIfCondition(StringUtils.hasText(endpoint.getClientIdPrefix()), endpoint.getClientIdPrefix(),
-						instance.getContainerProperties()::setClientId)
+				.acceptIfHasText(endpoint.getGroupId(), instance.getContainerProperties()::setGroupId)
+				.acceptIfHasText(endpoint.getClientIdPrefix(), instance.getContainerProperties()::setClientId)
 				.acceptIfNotNull(endpoint.getConsumerProperties(),
 						instance.getContainerProperties()::setKafkaConsumerProperties);
 	}

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
@@ -51,6 +51,7 @@ import org.springframework.kafka.support.converter.MessageConverter;
 import org.springframework.retry.RecoveryCallback;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * Base {@link KafkaListenerContainerFactory} for Spring's base container implementation.
@@ -426,8 +427,10 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 				.acceptIfNotNull(this.phase, instance::setPhase)
 				.acceptIfNotNull(this.applicationContext, instance::setApplicationContext)
 				.acceptIfNotNull(this.applicationEventPublisher, instance::setApplicationEventPublisher)
-				.acceptIfNotNull(endpoint.getGroupId(), instance.getContainerProperties()::setGroupId)
-				.acceptIfNotNull(endpoint.getClientIdPrefix(), instance.getContainerProperties()::setClientId)
+				.acceptIfCondition(StringUtils.hasText(endpoint.getGroupId()), endpoint.getGroupId(),
+						instance.getContainerProperties()::setGroupId)
+				.acceptIfCondition(StringUtils.hasText(endpoint.getClientIdPrefix()), endpoint.getClientIdPrefix(),
+						instance.getContainerProperties()::setClientId)
 				.acceptIfNotNull(endpoint.getConsumerProperties(),
 						instance.getContainerProperties()::setKafkaConsumerProperties);
 	}


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1770

The clientId property, if set on the container factory, is overwritten
by an empty String if not defined on the annotation.

Check for an empty String (groupId too).

**cherry-pick to 2.6.x**