### PR TITLE
GH-1772 Add RetryTopicNamesProvider

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/retrytopic.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/retrytopic.adoc
@@ -429,6 +429,50 @@ public RetryTopicConfiguration myRetryTopic(KafkaTemplate<String, MyPojo> templa
 
 NOTE: The default behavior is to suffix with the delay values, except for fixed delay configurations with multiple topics, in which case the topics are suffixed with the topic's index.
 
+===== Custom naming strategies
+
+More complex naming strategies can be accomplished by registering a bean that implements `RetryTopicNamesProviderFactory`. The default implementation is `SuffixingRetryTopicNamesProviderFactory` and a different implementation can be registered in the following way:
+
+====
+[source, java]
+----
+@Bean
+public RetryTopicNamesProviderFactory myRetryNamingProviderFactory() {
+    return new CustomRetryTopicNamesProviderFactory();
+}
+----
+====
+
+As an example the following implementation, in addition to the standard suffix, add a prefix to retry/dl topics names:
+
+====
+[source, java]
+----
+public class CustomRetryTopicNamesProviderFactory implements RetryTopicNamesProviderFactory {
+
+	@Override
+    public RetryTopicNamesProvider createRetryTopicNamesProvider(
+                DestinationTopic.Properties properties) {
+
+        if(properties.isMainEndpoint()) {
+            return new SuffixingRetryTopicNamesProvider(properties);
+        }
+        else {
+            return new SuffixingRetryTopicNamesProvider(properties) {
+
+                @Override
+                public String getTopicName(String topic) {
+                    return "my-prefix-" + super.getTopicName(topic);
+                }
+
+            };
+        }
+    }
+
+}
+----
+====
+
 ==== Dlt Strategies
 
 The framework provides a few strategies for working with DLTs. You can provide a method for DLT processing, use the default logging method, or have no DLT at all. Also you can choose what happens if DLT processing fails.

--- a/spring-kafka-docs/src/main/asciidoc/retrytopic.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/retrytopic.adoc
@@ -443,7 +443,7 @@ public RetryTopicNamesProviderFactory myRetryNamingProviderFactory() {
 ----
 ====
 
-As an example the following implementation, in addition to the standard suffix, add a prefix to retry/dl topics names:
+As an example the following implementation, in addition to the standard suffix, adds a prefix to retry/dl topics names:
 
 ====
 [source, java]

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DefaultRetryTopicNamesProviderFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DefaultRetryTopicNamesProviderFactory.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.retrytopic;
+
+import org.springframework.kafka.config.MethodKafkaListenerEndpoint;
+import org.springframework.kafka.support.Suffixer;
+
+/**
+ * Default handling of retry and dead letter naming.
+ *
+ * @author Andrea Polci
+ */
+public class DefaultRetryTopicNamesProviderFactory implements RetryTopicNamesProviderFactory {
+	@Override
+	public RetryTopicNamesProvider createRetryTopicNamesProvider(DestinationTopic.Properties properties) {
+		return new DefaultRetryTopicNamesProvider(properties);
+	}
+
+	public static class DefaultRetryTopicNamesProvider implements RetryTopicNamesProvider {
+		private final Suffixer suffixer;
+
+		public DefaultRetryTopicNamesProvider(DestinationTopic.Properties properties) {
+			this.suffixer = new Suffixer(properties.suffix());
+		}
+
+		@Override
+		public String getEndpointId(MethodKafkaListenerEndpoint<?, ?> endpoint) {
+			return this.suffixer.maybeAddTo(endpoint.getId());
+		}
+
+		@Override
+		public String getGroupId(MethodKafkaListenerEndpoint<?, ?> endpoint) {
+			return this.suffixer.maybeAddTo(endpoint.getGroupId());
+		}
+
+		@Override
+		public String getClientIdPrefix(MethodKafkaListenerEndpoint<?, ?> endpoint) {
+			return this.suffixer.maybeAddTo(endpoint.getClientIdPrefix());
+		}
+
+		@Override
+		public String getGroup(MethodKafkaListenerEndpoint<?, ?> endpoint) {
+			return this.suffixer.maybeAddTo(endpoint.getGroup());
+		}
+
+		@Override
+		public String getTopicName(String topic) {
+			return this.suffixer.maybeAddTo(topic);
+		}
+	}
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicBootstrapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicBootstrapper.java
@@ -81,6 +81,8 @@ public class RetryTopicBootstrapper {
 				ListenerContainerFactoryConfigurer.class);
 		registerIfNotContains(RetryTopicInternalBeanNames.DEAD_LETTER_PUBLISHING_RECOVERER_PROVIDER_NAME,
 				DeadLetterPublishingRecovererFactory.class);
+		registerIfNotContains(RetryTopicInternalBeanNames.RETRY_TOPIC_NAMES_PROVIDER_FACTORY,
+				DefaultRetryTopicNamesProviderFactory.class);
 		registerIfNotContains(RetryTopicInternalBeanNames.RETRY_TOPIC_CONFIGURER, RetryTopicConfigurer.class);
 		registerIfNotContains(RetryTopicInternalBeanNames.DESTINATION_TOPIC_CONTAINER_NAME,
 				DefaultDestinationTopicResolver.class);

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicBootstrapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicBootstrapper.java
@@ -92,7 +92,8 @@ public class RetryTopicBootstrapper {
 		// Register a RetryTopicNamesProviderFactory implementation only if none is already present in the context
 		try {
 			this.applicationContext.getBean(RetryTopicNamesProviderFactory.class);
-		} catch(NoSuchBeanDefinitionException e) {
+		}
+		catch (NoSuchBeanDefinitionException e) {
 			((BeanDefinitionRegistry) this.applicationContext).registerBeanDefinition(
 					RetryTopicInternalBeanNames.RETRY_TOPIC_NAMES_PROVIDER_FACTORY,
 					new RootBeanDefinition(SuffixingRetryTopicNamesProviderFactory.class));

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicBootstrapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicBootstrapper.java
@@ -82,7 +82,7 @@ public class RetryTopicBootstrapper {
 		registerIfNotContains(RetryTopicInternalBeanNames.DEAD_LETTER_PUBLISHING_RECOVERER_PROVIDER_NAME,
 				DeadLetterPublishingRecovererFactory.class);
 		registerIfNotContains(RetryTopicInternalBeanNames.RETRY_TOPIC_NAMES_PROVIDER_FACTORY,
-				DefaultRetryTopicNamesProviderFactory.class);
+				SuffixingRetryTopicNamesProviderFactory.class);
 		registerIfNotContains(RetryTopicInternalBeanNames.RETRY_TOPIC_CONFIGURER, RetryTopicConfigurer.class);
 		registerIfNotContains(RetryTopicInternalBeanNames.DESTINATION_TOPIC_CONTAINER_NAME,
 				DefaultDestinationTopicResolver.class);

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
@@ -28,6 +28,7 @@ import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
 import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.core.log.LogAccessor;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
@@ -223,11 +224,26 @@ public class RetryTopicConfigurer {
 
 	private final RetryTopicNamesProviderFactory retryTopicNamesProviderFactory;
 
+	/**
+	 * @deprecated use {@link #RetryTopicConfigurer(DestinationTopicProcessor, ListenerContainerFactoryResolver,
+	 * ListenerContainerFactoryConfigurer, BeanFactory, RetryTopicNamesProviderFactory)}
+	 */
+	@Deprecated
+	public RetryTopicConfigurer(DestinationTopicProcessor destinationTopicProcessor,
+								ListenerContainerFactoryResolver containerFactoryResolver,
+								ListenerContainerFactoryConfigurer listenerContainerFactoryConfigurer,
+								BeanFactory beanFactory) {
+
+		this(destinationTopicProcessor, containerFactoryResolver, listenerContainerFactoryConfigurer, beanFactory, new SuffixingRetryTopicNamesProviderFactory());
+	}
+
+	@Autowired
 	public RetryTopicConfigurer(DestinationTopicProcessor destinationTopicProcessor,
 								ListenerContainerFactoryResolver containerFactoryResolver,
 								ListenerContainerFactoryConfigurer listenerContainerFactoryConfigurer,
 								BeanFactory beanFactory,
 								RetryTopicNamesProviderFactory retryTopicNamesProviderFactory) {
+
 		this.destinationTopicProcessor = destinationTopicProcessor;
 		this.containerFactoryResolver = containerFactoryResolver;
 		this.listenerContainerFactoryConfigurer = listenerContainerFactoryConfigurer;
@@ -443,6 +459,7 @@ public class RetryTopicConfigurer {
 
 		private Collection<TopicNamesHolder> customizeAndRegisterTopics(RetryTopicNamesProvider namesProvider,
 																		MethodKafkaListenerEndpoint<?, ?> endpoint) {
+
 			return getTopics(endpoint)
 					.stream()
 					.map(topic -> new TopicNamesHolder(topic, namesProvider.getTopicName(topic)))
@@ -501,6 +518,5 @@ public class RetryTopicConfigurer {
 			}
 		}
 	}
-
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
@@ -224,10 +224,6 @@ public class RetryTopicConfigurer {
 
 	private final RetryTopicNamesProviderFactory retryTopicNamesProviderFactory;
 
-	/**
-	 * @deprecated use {@link #RetryTopicConfigurer(DestinationTopicProcessor, ListenerContainerFactoryResolver,
-	 * ListenerContainerFactoryConfigurer, BeanFactory, RetryTopicNamesProviderFactory)}
-	 */
 	@Deprecated
 	public RetryTopicConfigurer(DestinationTopicProcessor destinationTopicProcessor,
 								ListenerContainerFactoryResolver containerFactoryResolver,

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
@@ -36,7 +36,7 @@ import org.springframework.kafka.config.KafkaListenerEndpointRegistrar;
 import org.springframework.kafka.config.MethodKafkaListenerEndpoint;
 import org.springframework.kafka.config.MultiMethodKafkaListenerEndpoint;
 import org.springframework.kafka.listener.ListenerUtils;
-import org.springframework.kafka.support.Suffixer;
+import org.springframework.kafka.retrytopic.RetryTopicNamesProviderFactory.RetryTopicNamesProvider;
 import org.springframework.kafka.support.TopicPartitionOffset;
 import org.springframework.lang.Nullable;
 
@@ -221,14 +221,18 @@ public class RetryTopicConfigurer {
 
 	private final BeanFactory beanFactory;
 
+	private final RetryTopicNamesProviderFactory retryTopicNamesProviderFactory;
+
 	public RetryTopicConfigurer(DestinationTopicProcessor destinationTopicProcessor,
-						ListenerContainerFactoryResolver containerFactoryResolver,
-						ListenerContainerFactoryConfigurer listenerContainerFactoryConfigurer,
-						BeanFactory beanFactory) {
+								ListenerContainerFactoryResolver containerFactoryResolver,
+								ListenerContainerFactoryConfigurer listenerContainerFactoryConfigurer,
+								BeanFactory beanFactory,
+								RetryTopicNamesProviderFactory retryTopicNamesProviderFactory) {
 		this.destinationTopicProcessor = destinationTopicProcessor;
 		this.containerFactoryResolver = containerFactoryResolver;
 		this.listenerContainerFactoryConfigurer = listenerContainerFactoryConfigurer;
 		this.beanFactory = beanFactory;
+		this.retryTopicNamesProviderFactory = retryTopicNamesProviderFactory;
 	}
 
 	/**
@@ -340,7 +344,8 @@ public class RetryTopicConfigurer {
 
 		return new EndpointCustomizerFactory(destinationTopicProperties,
 				endpointBeanMethod,
-				this.beanFactory)
+				this.beanFactory,
+				this.retryTopicNamesProviderFactory)
 				.createEndpointCustomizer();
 	}
 
@@ -405,40 +410,42 @@ public class RetryTopicConfigurer {
 
 		private final BeanFactory beanFactory;
 
-		EndpointCustomizerFactory(DestinationTopic.Properties destinationProperties,
-								EndpointHandlerMethod beanMethod,
-								BeanFactory beanFactory) {
+		private final RetryTopicNamesProviderFactory retryTopicNamesProviderFactory;
+
+		EndpointCustomizerFactory(DestinationTopic.Properties destinationProperties, EndpointHandlerMethod beanMethod,
+			BeanFactory beanFactory, RetryTopicNamesProviderFactory retryTopicNamesProviderFactory) {
 
 			this.destinationProperties = destinationProperties;
 			this.beanMethod = beanMethod;
 			this.beanFactory = beanFactory;
+			this.retryTopicNamesProviderFactory = retryTopicNamesProviderFactory;
 		}
 
 		public EndpointCustomizer createEndpointCustomizer() {
-			return addSuffixesAndMethod(this.destinationProperties.suffix(), this.beanMethod.resolveBean(this.beanFactory),
+			return addSuffixesAndMethod(this.destinationProperties, this.beanMethod.resolveBean(this.beanFactory),
 					this.beanMethod.getMethod());
 		}
 
-		private EndpointCustomizer addSuffixesAndMethod(String topicSuffix, Object bean, Method method) {
-			Suffixer suffixer = new Suffixer(topicSuffix);
+		private EndpointCustomizer addSuffixesAndMethod(DestinationTopic.Properties properties, Object bean, Method method) {
+			RetryTopicNamesProvider namesProvider = this.retryTopicNamesProviderFactory.createRetryTopicNamesProvider(properties);
 			return endpoint -> {
-				Collection<TopicNamesHolder> topics = customizeAndRegisterTopics(suffixer, endpoint);
-				endpoint.setId(suffixer.maybeAddTo(endpoint.getId()));
-				endpoint.setGroupId(suffixer.maybeAddTo(endpoint.getGroupId()));
+				Collection<TopicNamesHolder> topics = customizeAndRegisterTopics(namesProvider, endpoint);
+				endpoint.setId(namesProvider.getEndpointId(endpoint));
+				endpoint.setGroupId(namesProvider.getGroupId(endpoint));
 				endpoint.setTopics(topics.stream().map(TopicNamesHolder::getProcessedTopic).toArray(String[]::new));
-				endpoint.setClientIdPrefix(suffixer.maybeAddTo(endpoint.getClientIdPrefix()));
-				endpoint.setGroup(suffixer.maybeAddTo(endpoint.getGroup()));
+				endpoint.setClientIdPrefix(namesProvider.getClientIdPrefix(endpoint));
+				endpoint.setGroup(namesProvider.getGroup(endpoint));
 				endpoint.setBean(bean);
 				endpoint.setMethod(method);
 				return topics;
 			};
 		}
 
-		private Collection<TopicNamesHolder> customizeAndRegisterTopics(Suffixer suffixer,
+		private Collection<TopicNamesHolder> customizeAndRegisterTopics(RetryTopicNamesProvider namesProvider,
 																		MethodKafkaListenerEndpoint<?, ?> endpoint) {
 			return getTopics(endpoint)
 					.stream()
-					.map(topic -> new TopicNamesHolder(topic, suffixer.maybeAddTo(topic)))
+					.map(topic -> new TopicNamesHolder(topic, namesProvider.getTopicName(topic)))
 					.collect(Collectors.toList());
 		}
 
@@ -494,4 +501,6 @@ public class RetryTopicConfigurer {
 			}
 		}
 	}
+
+
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicInternalBeanNames.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicInternalBeanNames.java
@@ -53,6 +53,8 @@ public abstract class RetryTopicInternalBeanNames {
 
 	static final String INTERNAL_KAFKA_CONSUMER_BACKOFF_MANAGER_FACTORY = "internalKafkaConsumerBackOffManagerFactory";
 
+	static final String RETRY_TOPIC_NAMES_PROVIDER_FACTORY = "internalRetryTopicNamesProviderFactory";
+
 	/**
 	 * Internal Back Off Clock Bean Name.
 	 */

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicNamesProviderFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicNamesProviderFactory.java
@@ -31,35 +31,40 @@ public interface RetryTopicNamesProviderFactory {
 	interface RetryTopicNamesProvider {
 
 		/**
-		 * Return the endpoint id that will override the endpoint's current id
+		 * Return the endpoint id that will override the endpoint's current id.
+		 *
 		 * @param endpoint the endpoint to override
 		 * @return The endpoint id
 		 */
 		String getEndpointId(MethodKafkaListenerEndpoint<?, ?> endpoint);
 
 		/**
-		 * Return the groupId that will override the endpoint's groupId
+		 * Return the groupId that will override the endpoint's groupId.
+		 *
 		 * @param endpoint the endpoint to override
 		 * @return The groupId
 		 */
 		String getGroupId(MethodKafkaListenerEndpoint<?, ?> endpoint);
 
 		/**
-		 * Return the clientId prefix that will override the endpoint's clientId prefix
+		 * Return the clientId prefix that will override the endpoint's clientId prefix.
+		 *
 		 * @param endpoint the endpoint to override
 		 * @return The clientId prefix
 		 */
 		String getClientIdPrefix(MethodKafkaListenerEndpoint<?, ?> endpoint);
 
 		/**
-		 * Return the group that will override the endpoint's group
+		 * Return the group that will override the endpoint's group.
+		 *
 		 * @param endpoint the endpoint to override
 		 * @return The clientId prefix
 		 */
 		String getGroup(MethodKafkaListenerEndpoint<?, ?> endpoint);
 
 		/**
-		 * Return the tropic name that will override the base topic name
+		 * Return the tropic name that will override the base topic name.
+		 *
 		 * @param topic the base topic name
 		 * @return The topic name
 		 */

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicNamesProviderFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicNamesProviderFactory.java
@@ -22,21 +22,49 @@ import org.springframework.kafka.config.MethodKafkaListenerEndpoint;
  * Handles the naming related to the retry and dead letter topics.
  *
  * @author Andrea Polci
- * @see DefaultRetryTopicNamesProviderFactory
+ * @see SuffixingRetryTopicNamesProviderFactory
  */
 public interface RetryTopicNamesProviderFactory {
 
 	RetryTopicNamesProvider createRetryTopicNamesProvider(DestinationTopic.Properties properties);
 
 	interface RetryTopicNamesProvider {
+
+		/**
+		 * Return the endpoint id that will override the endpoint's current id
+		 * @param endpoint the endpoint to override
+		 * @return The endpoint id
+		 */
 		String getEndpointId(MethodKafkaListenerEndpoint<?, ?> endpoint);
 
+		/**
+		 * Return the groupId that will override the endpoint's groupId
+		 * @param endpoint the endpoint to override
+		 * @return The groupId
+		 */
 		String getGroupId(MethodKafkaListenerEndpoint<?, ?> endpoint);
 
+		/**
+		 * Return the clientId prefix that will override the endpoint's clientId prefix
+		 * @param endpoint the endpoint to override
+		 * @return The clientId prefix
+		 */
 		String getClientIdPrefix(MethodKafkaListenerEndpoint<?, ?> endpoint);
 
+		/**
+		 * Return the group that will override the endpoint's group
+		 * @param endpoint the endpoint to override
+		 * @return The clientId prefix
+		 */
 		String getGroup(MethodKafkaListenerEndpoint<?, ?> endpoint);
 
+		/**
+		 * Return the tropic name that will override the base topic name
+		 * @param topic the base topic name
+		 * @return The topic name
+		 */
 		String getTopicName(String topic);
+
 	}
+
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicNamesProviderFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicNamesProviderFactory.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.retrytopic;
+
+import org.springframework.kafka.config.MethodKafkaListenerEndpoint;
+
+/**
+ * Handles the naming related to the retry and dead letter topics.
+ *
+ * @author Andrea Polci
+ * @see DefaultRetryTopicNamesProviderFactory
+ */
+public interface RetryTopicNamesProviderFactory {
+
+	RetryTopicNamesProvider createRetryTopicNamesProvider(DestinationTopic.Properties properties);
+
+	interface RetryTopicNamesProvider {
+		String getEndpointId(MethodKafkaListenerEndpoint<?, ?> endpoint);
+
+		String getGroupId(MethodKafkaListenerEndpoint<?, ?> endpoint);
+
+		String getClientIdPrefix(MethodKafkaListenerEndpoint<?, ?> endpoint);
+
+		String getGroup(MethodKafkaListenerEndpoint<?, ?> endpoint);
+
+		String getTopicName(String topic);
+	}
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/SuffixingRetryTopicNamesProviderFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/SuffixingRetryTopicNamesProviderFactory.java
@@ -20,20 +20,23 @@ import org.springframework.kafka.config.MethodKafkaListenerEndpoint;
 import org.springframework.kafka.support.Suffixer;
 
 /**
- * Default handling of retry and dead letter naming.
+ * Retry and dead letter naming handling that add a suffix to each name.
+ * The suffix is taken from {@link DestinationTopic.Properties#suffix()}
  *
  * @author Andrea Polci
  */
-public class DefaultRetryTopicNamesProviderFactory implements RetryTopicNamesProviderFactory {
+public class SuffixingRetryTopicNamesProviderFactory implements RetryTopicNamesProviderFactory {
+
 	@Override
 	public RetryTopicNamesProvider createRetryTopicNamesProvider(DestinationTopic.Properties properties) {
-		return new DefaultRetryTopicNamesProvider(properties);
+		return new SuffixingRetryTopicNamesProvider(properties);
 	}
 
-	public static class DefaultRetryTopicNamesProvider implements RetryTopicNamesProvider {
+	public static class SuffixingRetryTopicNamesProvider implements RetryTopicNamesProvider {
+
 		private final Suffixer suffixer;
 
-		public DefaultRetryTopicNamesProvider(DestinationTopic.Properties properties) {
+		public SuffixingRetryTopicNamesProvider(DestinationTopic.Properties properties) {
 			this.suffixer = new Suffixer(properties.suffix());
 		}
 
@@ -61,5 +64,7 @@ public class DefaultRetryTopicNamesProviderFactory implements RetryTopicNamesPro
 		public String getTopicName(String topic) {
 			return this.suffixer.maybeAddTo(topic);
 		}
+
 	}
+
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicBootstrapperTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicBootstrapperTests.java
@@ -122,7 +122,7 @@ class RetryTopicBootstrapperTests {
 						new RootBeanDefinition(ThreadWaitSleeper.class));
 		then(this.applicationContext).should(times(1))
 				.registerBeanDefinition(RetryTopicInternalBeanNames.RETRY_TOPIC_NAMES_PROVIDER_FACTORY,
-						new RootBeanDefinition(DefaultRetryTopicNamesProviderFactory.class));
+						new RootBeanDefinition(SuffixingRetryTopicNamesProviderFactory.class));
 	}
 
 	@Test
@@ -162,7 +162,7 @@ class RetryTopicBootstrapperTests {
 						new RootBeanDefinition(ThreadWaitSleeper.class));
 		then(this.applicationContext).should(times(0))
 				.registerBeanDefinition(RetryTopicInternalBeanNames.RETRY_TOPIC_NAMES_PROVIDER_FACTORY,
-						new RootBeanDefinition(DefaultRetryTopicNamesProviderFactory.class));
+						new RootBeanDefinition(SuffixingRetryTopicNamesProviderFactory.class));
 	}
 
 	@Test

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicBootstrapperTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicBootstrapperTests.java
@@ -31,6 +31,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.config.SingletonBeanRegistry;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.beans.factory.support.RootBeanDefinition;
@@ -69,6 +70,9 @@ class RetryTopicBootstrapperTests {
 	@Mock
 	private KafkaConsumerBackoffManager kafkaConsumerBackOffManager;
 
+	@Mock
+	private RetryTopicNamesProviderFactory retryTopicNamesProviderFactory;
+
 	@Test
 	void shouldThrowIfACDoesntImplementInterfaces() {
 		assertThatIllegalStateException()
@@ -93,7 +97,9 @@ class RetryTopicBootstrapperTests {
 				RetryTopicInternalBeanNames.INTERNAL_KAFKA_CONSUMER_BACKOFF_MANAGER_FACTORY,
 				KafkaBackOffManagerFactory.class))
 				.willReturn(kafkaBackOffManagerFactory);
-
+		given(this.applicationContext.getBean(
+				RetryTopicNamesProviderFactory.class))
+				.willThrow(NoSuchBeanDefinitionException.class);
 		// when
 		RetryTopicBootstrapper bootstrapper = new RetryTopicBootstrapper(applicationContext, beanFactory);
 		bootstrapper.bootstrapRetryTopic();
@@ -133,6 +139,9 @@ class RetryTopicBootstrapperTests {
 		given(this.applicationContext.getBean(
 				RetryTopicInternalBeanNames.DESTINATION_TOPIC_CONTAINER_NAME, DefaultDestinationTopicResolver.class))
 				.willReturn(defaultDestinationTopicResolver);
+		given(this.applicationContext.getBean(
+				RetryTopicNamesProviderFactory.class))
+				.willReturn(this.retryTopicNamesProviderFactory);
 
 		// when
 		RetryTopicBootstrapper bootstrapper = new RetryTopicBootstrapper(applicationContext, beanFactory);
@@ -174,6 +183,10 @@ class RetryTopicBootstrapperTests {
 		given(this.applicationContext
 				.getBean(RetryTopicInternalBeanNames.INTERNAL_KAFKA_CONSUMER_BACKOFF_MANAGER_FACTORY,
 					KafkaBackOffManagerFactory.class)).willReturn(kafkaBackOffManagerFactory);
+		given(this.applicationContext
+				.getBean(RetryTopicNamesProviderFactory.class))
+				.willThrow(NoSuchBeanDefinitionException.class);
+
 		given(kafkaBackOffManagerFactory.create()).willReturn(kafkaConsumerBackOffManager);
 
 		// when
@@ -222,7 +235,9 @@ class RetryTopicBootstrapperTests {
 				RetryTopicInternalBeanNames.INTERNAL_KAFKA_CONSUMER_BACKOFF_MANAGER_FACTORY,
 				KafkaBackOffManagerFactory.class))
 				.willReturn(kafkaBackOffManagerFactory);
-
+		given(this.applicationContext.getBean(
+				RetryTopicNamesProviderFactory.class))
+				.willThrow(NoSuchBeanDefinitionException.class);
 		// when
 		RetryTopicBootstrapper bootstrapper = new RetryTopicBootstrapper(applicationContext, beanFactory);
 		bootstrapper.bootstrapRetryTopic();

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicBootstrapperTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicBootstrapperTests.java
@@ -120,6 +120,9 @@ class RetryTopicBootstrapperTests {
 		then(this.applicationContext).should(times(1))
 				.registerBeanDefinition(RetryTopicInternalBeanNames.BACKOFF_SLEEPER_BEAN_NAME,
 						new RootBeanDefinition(ThreadWaitSleeper.class));
+		then(this.applicationContext).should(times(1))
+				.registerBeanDefinition(RetryTopicInternalBeanNames.RETRY_TOPIC_NAMES_PROVIDER_FACTORY,
+						new RootBeanDefinition(DefaultRetryTopicNamesProviderFactory.class));
 	}
 
 	@Test
@@ -157,6 +160,9 @@ class RetryTopicBootstrapperTests {
 		then(this.applicationContext).should(times(0))
 				.registerBeanDefinition(RetryTopicInternalBeanNames.BACKOFF_SLEEPER_BEAN_NAME,
 						new RootBeanDefinition(ThreadWaitSleeper.class));
+		then(this.applicationContext).should(times(0))
+				.registerBeanDefinition(RetryTopicInternalBeanNames.RETRY_TOPIC_NAMES_PROVIDER_FACTORY,
+						new RootBeanDefinition(DefaultRetryTopicNamesProviderFactory.class));
 	}
 
 	@Test

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurerTests.java
@@ -173,7 +173,7 @@ class RetryTopicConfigurerTests {
 
 		// setup
 		RetryTopicConfigurer configurer = new RetryTopicConfigurer(destinationTopicProcessor, containerFactoryResolver,
-				listenerContainerFactoryConfigurer, beanFactory);
+				listenerContainerFactoryConfigurer, beanFactory, new DefaultRetryTopicNamesProviderFactory());
 
 		// when - then
 		assertThatIllegalArgumentException().isThrownBy(
@@ -229,7 +229,7 @@ class RetryTopicConfigurerTests {
 				lcfcConfiguration);
 
 		RetryTopicConfigurer configurer = new RetryTopicConfigurer(destinationTopicProcessor, containerFactoryResolver,
-				listenerContainerFactoryConfigurer, defaultListableBeanFactory);
+				listenerContainerFactoryConfigurer, defaultListableBeanFactory, new DefaultRetryTopicNamesProviderFactory());
 
 		// when
 		configurer.processMainAndRetryListeners(endpointProcessor, mainEndpoint, configuration, registrar,

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurerTests.java
@@ -173,7 +173,7 @@ class RetryTopicConfigurerTests {
 
 		// setup
 		RetryTopicConfigurer configurer = new RetryTopicConfigurer(destinationTopicProcessor, containerFactoryResolver,
-				listenerContainerFactoryConfigurer, beanFactory, new DefaultRetryTopicNamesProviderFactory());
+				listenerContainerFactoryConfigurer, beanFactory, new SuffixingRetryTopicNamesProviderFactory());
 
 		// when - then
 		assertThatIllegalArgumentException().isThrownBy(
@@ -229,7 +229,7 @@ class RetryTopicConfigurerTests {
 				lcfcConfiguration);
 
 		RetryTopicConfigurer configurer = new RetryTopicConfigurer(destinationTopicProcessor, containerFactoryResolver,
-				listenerContainerFactoryConfigurer, defaultListableBeanFactory, new DefaultRetryTopicNamesProviderFactory());
+				listenerContainerFactoryConfigurer, defaultListableBeanFactory, new SuffixingRetryTopicNamesProviderFactory());
 
 		// when
 		configurer.processMainAndRetryListeners(endpointProcessor, mainEndpoint, configuration, registrar,


### PR DESCRIPTION
Resolves #1772 

Add provider to handle the names used on retry/dl topics (topic name, groupId, etc.). This can be extended to customize the behaviour in addition to the simple suffix parameter.

Currently customizing the default requires to register a bean  implementing RetryTopicNamesProviderFactory interface, with name "internalRetryTopicNamesProviderFactory".