### PR TITLE
GH-1776: Fix transactional Template with Overrides

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
@@ -170,7 +170,6 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 
 		Assert.notNull(producerFactory, "'producerFactory' cannot be null");
 		this.autoFlush = autoFlush;
-		this.transactional = producerFactory.transactionCapable();
 		this.micrometerEnabled = KafkaUtils.MICROMETER_PRESENT;
 		this.customProducerFactory = configOverrides != null && configOverrides.size() > 0;
 		if (this.customProducerFactory) {
@@ -186,6 +185,7 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 		else {
 			this.producerFactory = producerFactory;
 		}
+		this.transactional = this.producerFactory.transactionCapable();
 	}
 
 	@Override

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTests.java
@@ -447,12 +447,14 @@ public class KafkaTemplateTests {
 		pf.setProducerPerThread(true);
 		Map<String, Object> overrides = new HashMap<>();
 		overrides.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+		overrides.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "TX");
 		KafkaTemplate<String, String> template = new KafkaTemplate<>(pf, true, overrides);
 		assertThat(template.getProducerFactory().getConfigurationProperties()
 				.get(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG)).isEqualTo(StringSerializer.class);
 		assertThat(template.getProducerFactory().getPhysicalCloseTimeout()).isEqualTo(Duration.ofSeconds(6));
 		assertThat(template.getProducerFactory().isProducerPerConsumerPartition()).isFalse();
 		assertThat(template.getProducerFactory().isProducerPerThread()).isTrue();
+		assertThat(template.isTransactional()).isTrue();
 	}
 
 	@Test


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1776

Set `transactional` flag using overrides.

**cherry-pick to 2.6.x, 2.5.x**