### PR TITLE
GH-1778: Properly Apply Client Post Processors

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
@@ -350,7 +350,7 @@ public class DefaultKafkaConsumerFactory<K, V> extends KafkaResourceFactory
 			}
 		}
 		for (ConsumerPostProcessor<K, V> pp : this.postProcessors) {
-			pp.apply(kafkaConsumer);
+			kafkaConsumer = pp.apply(kafkaConsumer);
 		}
 		return kafkaConsumer;
 	}

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
@@ -739,9 +739,11 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 	}
 
 	protected Producer<K, V> createRawProducer(Map<String, Object> rawConfigs) {
-		KafkaProducer<K, V> kafkaProducer =
+		Producer<K, V> kafkaProducer =
 				new KafkaProducer<>(rawConfigs, this.keySerializerSupplier.get(), this.valueSerializerSupplier.get());
-		this.postProcessors.forEach(pp -> pp.apply(kafkaProducer));
+		for (ProducerPostProcessor<K, V> pp : this.postProcessors) {
+			kafkaProducer = pp.apply(kafkaProducer);
+		}
 		return kafkaProducer;
 	}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
@@ -29,7 +29,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -41,6 +41,7 @@ import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
@@ -337,10 +338,14 @@ public class DefaultKafkaConsumerFactoryTests {
 		KafkaTemplate<Integer, String> templateTx = new KafkaTemplate<>(pfTx);
 		Map<String, Object> consumerProps = KafkaTestUtils.consumerProps("txCache1Group", "false", this.embeddedKafka);
 		DefaultKafkaConsumerFactory<Integer, String> cf = new DefaultKafkaConsumerFactory<>(consumerProps);
-		AtomicBoolean ppCalled = new AtomicBoolean();
+		AtomicReference<Consumer<Integer, String>> wrapped = new AtomicReference<>();
 		cf.addPostProcessor(consumer -> {
-			ppCalled.set(true);
-			return consumer;
+			ProxyFactory prox = new ProxyFactory();
+			prox.setTarget(consumer);
+			@SuppressWarnings("unchecked")
+			Consumer<Integer, String> proxy =  (Consumer<Integer, String>) prox.getProxy();
+			wrapped.set(proxy);
+			return proxy;
 		});
 		ContainerProperties containerProps = new ContainerProperties("txCache1");
 		CountDownLatch latch = new CountDownLatch(1);
@@ -362,13 +367,13 @@ public class DefaultKafkaConsumerFactoryTests {
 			assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
 			assertThat(KafkaTestUtils.getPropertyValue(pfTx, "cache", Map.class)).hasSize(1);
 			assertThat(pfTx.getCache()).hasSize(1);
+			assertThat(KafkaTestUtils.getPropertyValue(container, "listenerConsumer.consumer")).isSameAs(wrapped.get());
 		}
 		finally {
 			container.stop();
 			pf.destroy();
 			pfTx.destroy();
 		}
-		assertThat(ppCalled.get()).isTrue();
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1778

`Consumer`/`Producer` post processors are `Function`s and the result should
be used; it was previously discarded.

**cherry-pick to 2.6.x, 2.5.x**