### PR TITLE
GH-1781: Configure ObjectMapper in JsonSerializer/JsonDeserializer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,6 +174,7 @@ subprojects { subproject ->
 			exclude group: 'org.hamcrest'
 		}
 		testImplementation "org.hamcrest:hamcrest-core:$hamcrestVersion"
+		testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 		optionalApi "org.assertj:assertj-core:$assertjVersion"
 	}
 

--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -3920,6 +3920,55 @@ They have no effect if you have provided `Serializer` and `Deserializer` instanc
 Starting with version 2.2, the type information headers (if added by the serializer) are removed by the deserializer.
 You can revert to the previous behavior by setting the `removeTypeHeaders` property to `false`, either directly on the deserializer or with the configuration property described earlier.
 
+[[serdes-customize-object-mapper]]
+====== Customize the ObjectMapper
+
+Occasionally, the only way to configure the way information is serialized is by customizing the ObjectMapper used in (de)serialization.
+Because Kafka uses its own ObjectMapper separate from the normal Spring-Boot ObjectMapper, customizing the ObjectMapper typically involved (re)implementing various Kafka factories.
+Since 2.7.1, a new interface `ObjectMapperCustomizer` has been introduced and implemented by the `JsonSerializer<T>` and `JsonDeserializer<T>` classes.
+This makes it simpler to configure the ObjectMapper without losing the convenience of the Spring property configuration capabilities.
+
+The following is an example of how to provide a simple customized serializer class (derived from `JsonSerializer<T>`) to do the configuration.
+
+====
+[source, java]
+----
+package com.example;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+public class CustomJsonSerializer<T> extends JsonSerializer<T> {
+
+	/**
+	 * constructor for custom json serializer.
+	 */
+	public CustomJsonSerializer() {
+		super();
+	}
+
+	@Override
+	public ObjectMapper customizeObjectMapper(ObjectMapper mapper) {
+		mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+		return mapper;
+	}
+}
+----
+====
+
+Then in your properties file, configure your `CustomJsonSerializer<T>` class as the `value-serializer`:
+
+====
+[source, properties]
+----
+spring.kafka.producer.value-serializer=com.example.CustomJsonSerializer
+----
+====
+
+The same general pattern can be applied to create and configure a `CustomJsonDeserializer<T>` class to configure how Json data is deserialized.
+
 [[serdes-mapping-types]]
 ====== Mapping Types
 

--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -3795,6 +3795,7 @@ Also since version 2.7 `ConsumerPartitionPausedEvent` and `ConsumerPartitionResu
 [[serdes]]
 ==== Serialization, Deserialization, and Message Conversion
 
+[[serdes-overview]]
 ===== Overview
 
 Apache Kafka provides a high-level API for serializing and deserializing record values as well as their keys.
@@ -3921,25 +3922,19 @@ Starting with version 2.2, the type information headers (if added by the seriali
 You can revert to the previous behavior by setting the `removeTypeHeaders` property to `false`, either directly on the deserializer or with the configuration property described earlier.
 
 [[serdes-customize-object-mapper]]
-====== Customize the ObjectMapper
+====== Customize the `ObjectMapper`
 
-Occasionally, the only way to configure the way information is serialized is by customizing the ObjectMapper used in (de)serialization.
-Because Kafka uses its own ObjectMapper separate from the normal Spring-Boot ObjectMapper, customizing the ObjectMapper typically involved (re)implementing various Kafka factories.
-Since 2.7.1, a new interface `ObjectMapperCustomizer` has been introduced and implemented by the `JsonSerializer<T>` and `JsonDeserializer<T>` classes.
-This makes it simpler to configure the ObjectMapper without losing the convenience of the Spring property configuration capabilities.
+Occasionally, the only way to configure the way information is serialized is by customizing the `ObjectMapper` used in (de)serialization.
+When instantiated by Apache Kafka, the Spring JSON Serializer and Deserializer use a locally declared `ObjectMapper`.
+The only way to customize the `ObjectMapper` was to inject instances into the producer and consumer factories as discussed <<serdes-overview,here>> rather than by using properties.
+Since version 2.5.13, a new interface `ObjectMapperCustomizer` has been introduced and implemented by the `JsonSerializer<T>` and `JsonDeserializer<T>` classes.
+This makes it simpler to configure the `ObjectMapper` without losing the convenience of the Spring property configuration capabilities.
 
 The following is an example of how to provide a simple customized serializer class (derived from `JsonSerializer<T>`) to do the configuration.
 
 ====
 [source, java]
 ----
-package com.example;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.SerializationFeature;
-
-import org.springframework.kafka.support.serializer.JsonSerializer;
-
 public class CustomJsonSerializer<T> extends JsonSerializer<T> {
 
 	/**
@@ -3958,7 +3953,7 @@ public class CustomJsonSerializer<T> extends JsonSerializer<T> {
 ----
 ====
 
-Then in your properties file, configure your `CustomJsonSerializer<T>` class as the `value-serializer`:
+Then in your Spring Boot properties file, for example, configure your `CustomJsonSerializer<T>` class as the `value-serializer`:
 
 ====
 [source, properties]

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java
@@ -243,7 +243,7 @@ public class JsonDeserializer<T> implements Deserializer<T> {
 			boolean useHeadersIfPresent) {
 
 		Assert.notNull(objectMapper, "'objectMapper' must not be null.");
-		this.objectMapper = objectMapper;
+		this.objectMapper = customizeObjectMapper(objectMapper);
 		JavaType javaType = null;
 		if (targetType == null) {
 			Class<?> genericType = ResolvableType.forClass(getClass()).getSuperType().resolveGeneric(0);
@@ -287,7 +287,7 @@ public class JsonDeserializer<T> implements Deserializer<T> {
 			boolean useHeadersIfPresent) {
 
 		Assert.notNull(objectMapper, "'objectMapper' must not be null.");
-		this.objectMapper = objectMapper;
+		this.objectMapper = customizeObjectMapper(objectMapper);
 		initialize(targetType, useHeadersIfPresent);
 	}
 
@@ -308,6 +308,17 @@ public class JsonDeserializer<T> implements Deserializer<T> {
 		if (typeMapper instanceof AbstractJavaTypeMapper) {
 			addMappingsToTrusted(((AbstractJavaTypeMapper) typeMapper).getIdClassMapping());
 		}
+	}
+
+	/**
+	 * Configure the ObjectMapper before it is used to construct the ObjectWriter.
+	 * @param objectMapper configurable (or replaceable) ObjectMapper instance
+	 * @return configured (or replaced) ObjectMapper instance
+	 * @since 2.7.1
+	 */
+	public ObjectMapper customizeObjectMapper(ObjectMapper objectMapper) {
+		// by default, we do nothing
+		return objectMapper;
 	}
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerializer.java
@@ -49,7 +49,7 @@ import com.fasterxml.jackson.databind.ObjectWriter;
  * @author Gary Russell
  * @author Elliot Kennedy
  */
-public class JsonSerializer<T> implements Serializer<T> {
+public class JsonSerializer<T> implements Serializer<T>, ObjectMapperCustomizer {
 
 	/**
 	 * Kafka config property for disabling adding type headers.
@@ -90,7 +90,7 @@ public class JsonSerializer<T> implements Serializer<T> {
 
 	public JsonSerializer(JavaType targetType, ObjectMapper objectMapper) {
 		Assert.notNull(objectMapper, "'objectMapper' must not be null.");
-		this.objectMapper = objectMapper;
+		this.objectMapper = customizeObjectMapper(objectMapper);
 		this.writer = objectMapper.writerFor(targetType);
 	}
 
@@ -132,6 +132,17 @@ public class JsonSerializer<T> implements Serializer<T> {
 			((AbstractJavaTypeMapper) getTypeMapper())
 					.setUseForKey(isKey);
 		}
+	}
+
+	/**
+	 * Configure the ObjectMapper before it is used to construct the ObjectWriter.
+	 * @param objectMapper configurable (or replaceable) ObjectMapper instance
+	 * @return configured (or replaced) ObjectMapper instance
+	 * @since 2.7.1
+	 */
+	public ObjectMapper customizeObjectMapper(ObjectMapper objectMapper) {
+		// by default, we do nothing
+		return objectMapper;
 	}
 
 	@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ObjectMapperCustomizer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ObjectMapperCustomizer.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support.serializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Provide hook to configure the ObjectMapper used in Json(De)Serializer.
+ *
+ * @author Carl Nygard
+ * @since 2.7.1
+ *
+ */
+@FunctionalInterface
+public interface ObjectMapperCustomizer {
+
+	/**
+	 * Customize (or replace) the ObjectMapper used in serialization.
+	 * @param objectMapper the ObjectMapper instance.
+	 * @return the configured (or possibly new) ObjectMapper instance.
+	 */
+	ObjectMapper customizeObjectMapper(ObjectMapper objectMapper);
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ObjectMapperCustomizer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ObjectMapperCustomizer.java
@@ -16,22 +16,30 @@
 
 package org.springframework.kafka.support.serializer;
 
+import java.util.Map;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Provide hook to configure the ObjectMapper used in Json(De)Serializer.
  *
+ * This will get called from the JsonSerializer.configure() function.
  * @author Carl Nygard
- * @since 2.7.1
+ * @since 2.5.13
  *
  */
-@FunctionalInterface
 public interface ObjectMapperCustomizer {
 
 	/**
 	 * Customize (or replace) the ObjectMapper used in serialization.
-	 * @param objectMapper the ObjectMapper instance.
+	 * @param configs map of configuration values
+	 * @param objectMapper configurable (or replaceable) ObjectMapper instance
 	 * @return the configured (or possibly new) ObjectMapper instance.
+	 * @since 2.5.13
 	 */
-	ObjectMapper customizeObjectMapper(ObjectMapper objectMapper);
+	default ObjectMapper customizeObjectMapper(Map<String, ?> configs, ObjectMapper objectMapper) {
+		// by default, we do nothing
+		return objectMapper;
+	}
+
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/CustomJsonDeserializer.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/CustomJsonDeserializer.java
@@ -16,6 +16,8 @@
 
 package org.springframework.kafka.support.serializer;
 
+import java.util.Map;
+
 import org.springframework.lang.Nullable;
 
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -42,7 +44,7 @@ public class CustomJsonDeserializer<T> extends JsonDeserializer<T> {
 	}
 
 	@Override
-	public ObjectMapper customizeObjectMapper(ObjectMapper mapper) {
+	public ObjectMapper customizeObjectMapper(Map<String, ?> configs, ObjectMapper mapper) {
 		mapper.disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE);
 		return mapper;
 	}

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/CustomJsonDeserializer.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/CustomJsonDeserializer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support.serializer;
+
+import org.springframework.lang.Nullable;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class CustomJsonDeserializer<T> extends JsonDeserializer<T> {
+
+	/**
+	 * constructor for custom json serializer.
+	 */
+	public CustomJsonDeserializer() {
+		super();
+	}
+	public CustomJsonDeserializer(@Nullable JavaType targetType) {
+		super(targetType);
+	}
+	public CustomJsonDeserializer(@Nullable Class<? super T> targetType) {
+		super(targetType);
+	}
+	public CustomJsonDeserializer(@Nullable TypeReference<? super T> targetType) {
+		super(targetType);
+	}
+
+	@Override
+	public ObjectMapper customizeObjectMapper(ObjectMapper mapper) {
+		mapper.disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE);
+		return mapper;
+	}
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/CustomJsonSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/CustomJsonSerializationTests.java
@@ -88,7 +88,6 @@ public class CustomJsonSerializationTests {
 
 	private String timestamp;
 
-
 	@BeforeEach
 	void init() {
 		timestamp = "2021-04-10T19:00:30.123456-04:00";
@@ -114,11 +113,11 @@ public class CustomJsonSerializationTests {
 		jsonWriter.configure(new HashMap<>(), false);
 		jsonWriter.close(); // does nothing, so may be called any time, or not called at all
 		stringReader = new StringDeserializer();
-		stringReader.configure(new HashMap<>(), false);
 		stringWriter = new StringSerializer();
-		stringWriter.configure(new HashMap<>(), false);
-		dummyEntityJsonDeserializer = new DummyEntityWithTimestampJsonSerializer();
+		dummyEntityJsonDeserializer = new DummyEntityWithTimestampJsonDeserializer();
+		dummyEntityJsonDeserializer.configure(new HashMap<>(), false);
 		dummyEntityArrayJsonDeserializer = new DummyEntityWithTimestampArrayJsonDeserializer();
+		dummyEntityArrayJsonDeserializer.configure(new HashMap<>(), false);
 	}
 
 	/*
@@ -229,7 +228,9 @@ public class CustomJsonSerializationTests {
 	@Test
 	void testDeserializerTypeReference() {
 		JsonSerializer<List<DummyEntityWithTimestamp>> ser = new CustomJsonSerializer<>();
+		ser.configure(new HashMap<>(), false);
 		JsonDeserializer<List<DummyEntityWithTimestamp>> de = new CustomJsonDeserializer<>(new TypeReference<List<DummyEntityWithTimestamp>>() { });
+		de.configure(new HashMap<>(), false);
 		List<DummyEntityWithTimestamp> dummy = Arrays.asList(this.entityArray);
 		assertThat(de.deserialize(this.topic, ser.serialize(this.topic, dummy))).isEqualTo(dummy);
 		ser.close();
@@ -366,6 +367,7 @@ public class CustomJsonSerializationTests {
 		JsonDeserializer<Object> deser = new CustomJsonDeserializer<>()
 				.trustedPackages("*")
 				.typeFunction(CustomJsonSerializationTests::fooBarJavaType);
+		deser.configure(new HashMap<>(), false);
 		assertThat(deser.deserialize("", "{\"foo\":\"bar\"}".getBytes())).isInstanceOf(Foo.class);
 		assertThat(deser.deserialize("", new RecordHeaders(), "{\"bar\":\"baz\"}".getBytes()))
 				.isInstanceOf(Bar.class);
@@ -377,6 +379,7 @@ public class CustomJsonSerializationTests {
 		JsonDeserializer<Object> deser = new CustomJsonDeserializer<>()
 				.trustedPackages("*")
 				.typeResolver(CustomJsonSerializationTests::fooBarJavaTypeForTopic);
+		deser.configure(new HashMap<>(), false);
 		assertThat(deser.deserialize("", "{\"foo\":\"bar\"}".getBytes())).isInstanceOf(Foo.class);
 		assertThat(deser.deserialize("", new RecordHeaders(), "{\"bar\":\"baz\"}".getBytes()))
 				.isInstanceOf(Bar.class);
@@ -386,7 +389,9 @@ public class CustomJsonSerializationTests {
 	@Test
 	void testCopyWithType() {
 		JsonDeserializer<Object> deser = new CustomJsonDeserializer<>();
+		deser.configure(new HashMap<>(), false);
 		JsonSerializer<Object> ser = new CustomJsonSerializer<>();
+		ser.configure(new HashMap<>(), false);
 		JsonDeserializer<Parent> typedDeser = deser.copyWithType(Parent.class);
 		JsonSerializer<Parent> typedSer = ser.copyWithType(Parent.class);
 		Child serializedValue = new Child(1);
@@ -423,7 +428,7 @@ public class CustomJsonSerializationTests {
 		return TypeFactory.defaultInstance().constructType(String.class);
 	}
 
-	static class DummyEntityWithTimestampJsonSerializer extends CustomJsonDeserializer<DummyEntityWithTimestamp> {
+	static class DummyEntityWithTimestampJsonDeserializer extends CustomJsonDeserializer<DummyEntityWithTimestamp> {
 
 	}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/CustomJsonSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/CustomJsonSerializationTests.java
@@ -1,0 +1,485 @@
+/*
+ * Copyright 2016-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support.serializer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import java.io.IOException;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.kafka.support.converter.AbstractJavaTypeMapper;
+import org.springframework.kafka.support.converter.DefaultJackson2JavaTypeMapper;
+import org.springframework.kafka.support.converter.Jackson2JavaTypeMapper.TypePrecedence;
+import org.springframework.kafka.support.serializer.testentities.DummyEntityWithTimestamp;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+
+/**
+ * @author Igor Stepanov
+ * @author Artem Bilan
+ * @author Yanming Zhou
+ * @author Torsten Schleede
+ * @author Gary Russell
+ * @author Ivan Ponomarev
+ * @author Carl Nygard
+ */
+public class CustomJsonSerializationTests {
+
+	private StringSerializer stringWriter;
+
+	private StringDeserializer stringReader;
+
+	private CustomJsonSerializer<Object> jsonWriter;
+
+	private CustomJsonDeserializer<DummyEntityWithTimestamp> jsonReader;
+
+	private CustomJsonDeserializer<DummyEntityWithTimestamp[]> jsonArrayReader;
+
+	private CustomJsonDeserializer<DummyEntityWithTimestamp> dummyEntityJsonDeserializer;
+
+	private CustomJsonDeserializer<DummyEntityWithTimestamp[]> dummyEntityArrayJsonDeserializer;
+
+	private DummyEntityWithTimestamp entity;
+
+	private DummyEntityWithTimestamp[] entityArray;
+
+	private String topic;
+
+	private String timestamp;
+
+
+	@BeforeEach
+	void init() {
+		timestamp = "2021-04-10T19:00:30.123456-04:00";
+		entity = new DummyEntityWithTimestamp();
+		entity.intValue = 19;
+		entity.longValue = 7L;
+		entity.stringValue = "dummy";
+		entity.timestampValue = ZonedDateTime.parse(timestamp, DateTimeFormatter.ISO_OFFSET_DATE_TIME);
+		List<String> list = Arrays.asList("dummy1", "dummy2");
+		entity.complexStruct = new HashMap<>();
+		entity.complexStruct.put((short) 4, list);
+		entityArray = new DummyEntityWithTimestamp[] { entity };
+
+		topic = "topic-name";
+
+		jsonReader = new CustomJsonDeserializer<DummyEntityWithTimestamp>() { };
+		jsonReader.configure(new HashMap<>(), false);
+		jsonReader.close(); // does nothing, so may be called any time, or not called at all
+		jsonArrayReader = new CustomJsonDeserializer<DummyEntityWithTimestamp[]>() { };
+		jsonArrayReader.configure(new HashMap<>(), false);
+		jsonArrayReader.close(); // does nothing, so may be called any time, or not called at all
+		jsonWriter = new CustomJsonSerializer<>();
+		jsonWriter.configure(new HashMap<>(), false);
+		jsonWriter.close(); // does nothing, so may be called any time, or not called at all
+		stringReader = new StringDeserializer();
+		stringReader.configure(new HashMap<>(), false);
+		stringWriter = new StringSerializer();
+		stringWriter.configure(new HashMap<>(), false);
+		dummyEntityJsonDeserializer = new DummyEntityWithTimestampJsonSerializer();
+		dummyEntityArrayJsonDeserializer = new DummyEntityWithTimestampArrayJsonDeserializer();
+	}
+
+	/*
+	 * 1. Serialize test entity to byte array.
+	 * 2. Deserialize it back from the created byte array.
+	 * 3. Check the result with the source entity.
+	 */
+	@Test
+	void testDeserializeSerializedEntityEquals() {
+		assertThat(jsonReader.deserialize(topic, jsonWriter.serialize(topic, entity))).isEqualTo(entity);
+		Headers headers = new RecordHeaders();
+		headers.add(AbstractJavaTypeMapper.DEFAULT_CLASSID_FIELD_NAME, DummyEntityWithTimestamp.class.getName().getBytes());
+		assertThat(dummyEntityJsonDeserializer.deserialize(topic, headers, jsonWriter.serialize(topic, entity))).isEqualTo(entity);
+	}
+
+	/*
+	 * 1. Serialize test entity array to byte array.
+	 * 2. Deserialize it back from the created byte array.
+	 * 3. Check the result with the source entity array.
+	 */
+	@Test
+	void testDeserializeSerializedEntityArrayEquals() {
+		assertThat(jsonArrayReader.deserialize(topic, jsonWriter.serialize(topic, entityArray))).isEqualTo(entityArray);
+		Headers headers = new RecordHeaders();
+		headers.add(AbstractJavaTypeMapper.DEFAULT_CLASSID_FIELD_NAME, DummyEntityWithTimestamp[].class.getName().getBytes());
+		assertThat(dummyEntityArrayJsonDeserializer.deserialize(topic, headers, jsonWriter.serialize(topic, entityArray))).isEqualTo(entityArray);
+	}
+
+	/*
+	 * 1. Serialize "dummy" String to byte array.
+	 * 2. Deserialize it back from the created byte array.
+	 * 3. Fails with SerializationException.
+	 */
+	@Test
+	void testDeserializeSerializedDummyException() {
+		assertThatExceptionOfType(SerializationException.class)
+				.isThrownBy(() -> jsonReader.deserialize(topic, stringWriter.serialize(topic, "dummy")))
+				.withMessageStartingWith("Can't deserialize data [")
+				.withCauseInstanceOf(JsonParseException.class);
+
+		Headers headers = new RecordHeaders();
+		headers.add(AbstractJavaTypeMapper.DEFAULT_CLASSID_FIELD_NAME, "com.malware.DummyEntityWithTimestamp".getBytes());
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> dummyEntityJsonDeserializer
+						.deserialize(topic, headers, jsonWriter.serialize(topic, entity)))
+				.withMessageContaining("not in the trusted packages");
+	}
+
+	@Test
+	void testSerializedStringNullEqualsNull() {
+		assertThat(stringWriter.serialize(topic, null)).isEqualTo(null);
+	}
+
+	@Test
+	void testSerializedJsonNullEqualsNull() {
+		assertThat(jsonWriter.serialize(topic, null)).isEqualTo(null);
+	}
+
+	@Test
+	void testDeserializedStringNullEqualsNull() {
+		assertThat(stringReader.deserialize(topic, null)).isEqualTo(null);
+	}
+
+	@Test
+	void testDeserializedJsonNullEqualsNull() {
+		assertThat(jsonReader.deserialize(topic, null)).isEqualTo(null);
+	}
+
+	@Test
+	void testExtraFieldIgnored() {
+		JsonDeserializer<DummyEntityWithTimestamp> deser = new CustomJsonDeserializer<>(DummyEntityWithTimestamp.class);
+		assertThat(deser.deserialize(topic, "{\"intValue\":1,\"extra\":2}".getBytes()))
+				.isInstanceOf(DummyEntityWithTimestamp.class);
+		deser.close();
+	}
+
+	@Test
+	void testDeserTypeHeadersConfig() {
+		this.jsonReader.configure(Collections.singletonMap(JsonDeserializer.USE_TYPE_INFO_HEADERS, false), false);
+		assertThat(KafkaTestUtils.getPropertyValue(this.jsonReader, "typeMapper.typePrecedence"))
+			.isEqualTo(TypePrecedence.INFERRED);
+		this.jsonReader.configure(Collections.singletonMap(JsonDeserializer.USE_TYPE_INFO_HEADERS, true), false);
+		assertThat(KafkaTestUtils.getPropertyValue(this.jsonReader, "typeMapper.typePrecedence"))
+			.isEqualTo(TypePrecedence.TYPE_ID);
+		this.jsonReader.configure(Collections.singletonMap(JsonDeserializer.USE_TYPE_INFO_HEADERS, false), false);
+		assertThat(KafkaTestUtils.getPropertyValue(this.jsonReader, "typeMapper.typePrecedence"))
+			.isEqualTo(TypePrecedence.INFERRED);
+		this.jsonReader.setUseTypeHeaders(true);
+		this.jsonReader.configure(Collections.emptyMap(), false);
+		assertThat(KafkaTestUtils.getPropertyValue(this.jsonReader, "typeMapper.typePrecedence"))
+			.isEqualTo(TypePrecedence.TYPE_ID);
+		this.jsonReader.setTypeMapper(new DefaultJackson2JavaTypeMapper());
+		this.jsonReader.configure(Collections.singletonMap(JsonDeserializer.USE_TYPE_INFO_HEADERS, true), false);
+		assertThat(KafkaTestUtils.getPropertyValue(this.jsonReader, "typeMapper.typePrecedence"))
+			.isEqualTo(TypePrecedence.INFERRED);
+	}
+
+	@Test
+	void testDeserializerTypeInference() {
+		JsonSerializer<List<String>> ser = new CustomJsonSerializer<>();
+		JsonDeserializer<List<String>> de = new CustomJsonDeserializer<>(List.class);
+		List<String> dummy = Arrays.asList("foo", "bar", "baz");
+		assertThat(de.deserialize(topic, ser.serialize(topic, dummy))).isEqualTo(dummy);
+		ser.close();
+		de.close();
+	}
+
+	@Test
+	void testDeserializerTypeReference() {
+		JsonSerializer<List<DummyEntityWithTimestamp>> ser = new CustomJsonSerializer<>();
+		JsonDeserializer<List<DummyEntityWithTimestamp>> de = new CustomJsonDeserializer<>(new TypeReference<List<DummyEntityWithTimestamp>>() { });
+		List<DummyEntityWithTimestamp> dummy = Arrays.asList(this.entityArray);
+		assertThat(de.deserialize(this.topic, ser.serialize(this.topic, dummy))).isEqualTo(dummy);
+		ser.close();
+		de.close();
+	}
+
+	@Test
+	void testDeserializerTypeForcedType() {
+		JsonSerializer<List<Parent>> ser = new CustomJsonSerializer<>(new TypeReference<List<Parent>>() { });
+		JsonDeserializer<List<Parent>> de = new CustomJsonDeserializer<>(new TypeReference<List<Parent>>() { });
+		List<Parent> dummy = Arrays.asList(new Child(1), new Parent(2));
+		assertThat(de.deserialize(this.topic, ser.serialize(this.topic, dummy))).isEqualTo(dummy);
+		ser.close();
+		de.close();
+	}
+
+	@Test
+	void jsonNode() throws IOException {
+		JsonSerializer<Object> ser = new CustomJsonSerializer<>();
+		JsonDeserializer<JsonNode> de = new CustomJsonDeserializer<>();
+		de.configure(Collections.singletonMap(JsonDeserializer.VALUE_DEFAULT_TYPE, JsonNode.class), false);
+		DummyEntityWithTimestamp dummy = new DummyEntityWithTimestamp();
+		byte[] serialized = ser.serialize("foo", dummy);
+		JsonNode node = new ObjectMapper().reader().readTree(serialized);
+		Headers headers = new RecordHeaders();
+		serialized = ser.serialize("foo", headers, node);
+		de.deserialize("foo", headers, serialized);
+	}
+
+	@Test
+	void testPreExistingHeaders() {
+		JsonSerializer<? super Foo> ser = new CustomJsonSerializer<>();
+		Headers headers = new RecordHeaders();
+		ser.serialize("", headers, new Foo());
+		byte[] data = ser.serialize("", headers, new Bar());
+		JsonDeserializer<? super Foo> deser = new CustomJsonDeserializer<>();
+		deser.setRemoveTypeHeaders(false);
+		deser.addTrustedPackages(this.getClass().getPackage().getName());
+		assertThat(deser.deserialize("", headers, data)).isInstanceOf(Bar.class);
+		assertThat(headers.headers(AbstractJavaTypeMapper.DEFAULT_CLASSID_FIELD_NAME)).hasSize(1);
+		ser.close();
+		deser.close();
+	}
+
+	@Test
+	void testDontUseTypeHeaders() {
+		JsonSerializer<? super Foo> ser = new CustomJsonSerializer<>();
+		Headers headers = new RecordHeaders();
+		byte[] data = ser.serialize("", headers, new Bar());
+		JsonDeserializer<? super Foo> deser = new CustomJsonDeserializer<>(Foo.class);
+		deser.setRemoveTypeHeaders(false);
+		deser.setUseTypeHeaders(false);
+		deser.addTrustedPackages(this.getClass().getPackage().getName());
+		assertThat(deser.deserialize("", headers, data)).isExactlyInstanceOf(Foo.class);
+		assertThat(headers.headers(AbstractJavaTypeMapper.DEFAULT_CLASSID_FIELD_NAME)).hasSize(1);
+		ser.close();
+		deser.close();
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void testParseTrustedPackages() {
+		JsonDeserializer<Object> deser = new CustomJsonDeserializer<>();
+		Map<String, Object> props = Collections.singletonMap(JsonDeserializer.TRUSTED_PACKAGES, "foo, bar, \tbaz");
+		deser.configure(props, false);
+		assertThat(KafkaTestUtils.getPropertyValue(deser, "typeMapper.trustedPackages", Set.class))
+				.contains("foo", "bar", "baz");
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void testTrustMappingPackages() {
+		JsonDeserializer<Object> deser = new CustomJsonDeserializer<>();
+		Map<String, Object> props = Collections.singletonMap(JsonDeserializer.TYPE_MAPPINGS,
+				"foo:" + Foo.class.getName());
+		deser.configure(props, false);
+		assertThat(KafkaTestUtils.getPropertyValue(deser, "typeMapper.trustedPackages", Set.class))
+				.contains(Foo.class.getPackageName());
+		assertThat(KafkaTestUtils.getPropertyValue(deser, "typeMapper.trustedPackages", Set.class))
+			.contains(Foo.class.getPackageName() + ".*");
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void testTrustMappingPackagesMapper() {
+		JsonDeserializer<Object> deser = new CustomJsonDeserializer<>();
+		DefaultJackson2JavaTypeMapper mapper = new DefaultJackson2JavaTypeMapper();
+		mapper.setIdClassMapping(Collections.singletonMap("foo", Foo.class));
+		deser.setTypeMapper(mapper);
+		assertThat(KafkaTestUtils.getPropertyValue(deser, "typeMapper.trustedPackages", Set.class))
+				.contains(Foo.class.getPackageName());
+		assertThat(KafkaTestUtils.getPropertyValue(deser, "typeMapper.trustedPackages", Set.class))
+			.contains(Foo.class.getPackageName() + ".*");
+	}
+
+	@Test
+	void testTypeFunctionViaProperties() {
+		JsonDeserializer<Object> deser = new CustomJsonDeserializer<>();
+		Map<String, Object> props = new HashMap<>();
+		props.put(JsonDeserializer.KEY_TYPE_METHOD, getClass().getName() + ".stringType");
+		props.put(JsonDeserializer.VALUE_TYPE_METHOD, getClass().getName() + ".fooBarJavaType");
+		props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+		deser.configure(props, false);
+		assertThat(deser.deserialize("", "{\"foo\":\"bar\"}".getBytes())).isInstanceOf(Foo.class);
+		assertThat(deser.deserialize("", new RecordHeaders(), "{\"bar\":\"baz\"}".getBytes()))
+				.isInstanceOf(Bar.class);
+
+		deser.configure(props, true);
+		assertThat(deser.deserialize("", new RecordHeaders(), "\"foo\"".getBytes()))
+				.isEqualTo("foo");
+		deser.close();
+	}
+
+	@Test
+	void testTypeResolverViaProperties() {
+		JsonDeserializer<Object> deser = new CustomJsonDeserializer<>();
+		Map<String, Object> props = new HashMap<>();
+		props.put(JsonDeserializer.KEY_TYPE_METHOD, getClass().getName() + ".stringTypeForTopic");
+		props.put(JsonDeserializer.VALUE_TYPE_METHOD, getClass().getName() + ".fooBarJavaTypeForTopic");
+		props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+		deser.configure(props, false);
+		assertThat(deser.deserialize("", "{\"foo\":\"bar\"}".getBytes())).isInstanceOf(Foo.class);
+		assertThat(deser.deserialize("", new RecordHeaders(), "{\"bar\":\"baz\"}".getBytes()))
+				.isInstanceOf(Bar.class);
+
+		deser.configure(props, true);
+		assertThat(deser.deserialize("", new RecordHeaders(), "\"foo\"".getBytes()))
+				.isEqualTo("foo");
+		deser.close();
+	}
+
+	@Test
+	void testTypeFunctionDirect() {
+		JsonDeserializer<Object> deser = new CustomJsonDeserializer<>()
+				.trustedPackages("*")
+				.typeFunction(CustomJsonSerializationTests::fooBarJavaType);
+		assertThat(deser.deserialize("", "{\"foo\":\"bar\"}".getBytes())).isInstanceOf(Foo.class);
+		assertThat(deser.deserialize("", new RecordHeaders(), "{\"bar\":\"baz\"}".getBytes()))
+				.isInstanceOf(Bar.class);
+		deser.close();
+	}
+
+	@Test
+	void testTypeResolverDirect() {
+		JsonDeserializer<Object> deser = new CustomJsonDeserializer<>()
+				.trustedPackages("*")
+				.typeResolver(CustomJsonSerializationTests::fooBarJavaTypeForTopic);
+		assertThat(deser.deserialize("", "{\"foo\":\"bar\"}".getBytes())).isInstanceOf(Foo.class);
+		assertThat(deser.deserialize("", new RecordHeaders(), "{\"bar\":\"baz\"}".getBytes()))
+				.isInstanceOf(Bar.class);
+		deser.close();
+	}
+
+	@Test
+	void testCopyWithType() {
+		JsonDeserializer<Object> deser = new CustomJsonDeserializer<>();
+		JsonSerializer<Object> ser = new CustomJsonSerializer<>();
+		JsonDeserializer<Parent> typedDeser = deser.copyWithType(Parent.class);
+		JsonSerializer<Parent> typedSer = ser.copyWithType(Parent.class);
+		Child serializedValue = new Child(1);
+		assertThat(typedDeser.deserialize("", typedSer.serialize("", serializedValue))).isEqualTo(serializedValue);
+		deser.close();
+		ser.close();
+		typedDeser.close();
+		typedSer.close();
+	}
+
+	public static JavaType fooBarJavaType(byte[] data, Headers headers) {
+		if (data[0] == '{' && data[1] == 'f') {
+			return TypeFactory.defaultInstance().constructType(Foo.class);
+		}
+		else {
+			return TypeFactory.defaultInstance().constructType(Bar.class);
+		}
+	}
+
+	public static JavaType fooBarJavaTypeForTopic(String topic, byte[] data, Headers headers) {
+		if (data[0] == '{' && data[1] == 'f') {
+			return TypeFactory.defaultInstance().constructType(Foo.class);
+		}
+		else {
+			return TypeFactory.defaultInstance().constructType(Bar.class);
+		}
+	}
+
+	public static JavaType stringType(byte[] data, Headers headers) {
+		return TypeFactory.defaultInstance().constructType(String.class);
+	}
+
+	public static JavaType stringTypeForTopic(String topic, byte[] data, Headers headers) {
+		return TypeFactory.defaultInstance().constructType(String.class);
+	}
+
+	static class DummyEntityWithTimestampJsonSerializer extends CustomJsonDeserializer<DummyEntityWithTimestamp> {
+
+	}
+
+	static class DummyEntityWithTimestampArrayJsonDeserializer extends CustomJsonDeserializer<DummyEntityWithTimestamp[]> {
+
+	}
+
+	public static class Foo {
+
+		public String foo = "foo";
+
+	}
+
+	public static class Bar extends Foo {
+
+		public String bar = "bar";
+
+	}
+
+	@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+	@JsonSubTypes({
+		@JsonSubTypes.Type(value = Parent.class, name = "parent"),
+		@JsonSubTypes.Type(value = Child.class, name = "child")
+	})
+	public static class Parent {
+		@JsonProperty
+		private int number;
+
+		Parent() { }
+
+		Parent(int number) {
+			this.number = number;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (o == null || !getClass().equals(o.getClass())) {
+				return false;
+			}
+			Parent parent = (Parent) o;
+			return number == parent.number;
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(number);
+		}
+	}
+
+	public static class Child extends Parent {
+		Child() { }
+
+		Child(int number) {
+			super(number);
+		}
+	}
+
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/CustomJsonSerializer.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/CustomJsonSerializer.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support.serializer;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+public class CustomJsonSerializer<T> extends JsonSerializer<T> {
+
+	/**
+	 * constructor for custom json serializer.
+	 */
+	public CustomJsonSerializer() {
+		super();
+	}
+	public CustomJsonSerializer(TypeReference<? super T> targetType) {
+		super(targetType);
+	}
+
+	@Override
+	public ObjectMapper customizeObjectMapper(ObjectMapper mapper) {
+		mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+		return mapper;
+	}
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/CustomJsonSerializer.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/CustomJsonSerializer.java
@@ -16,6 +16,8 @@
 
 package org.springframework.kafka.support.serializer;
 
+import java.util.Map;
+
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -33,7 +35,7 @@ public class CustomJsonSerializer<T> extends JsonSerializer<T> {
 	}
 
 	@Override
-	public ObjectMapper customizeObjectMapper(ObjectMapper mapper) {
+	public ObjectMapper customizeObjectMapper(Map<String, ?> configs, ObjectMapper mapper) {
 		mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
 		return mapper;
 	}

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/testentities/DummyEntityWithTimestamp.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/testentities/DummyEntityWithTimestamp.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2016-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support.serializer.testentities;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * @author Carl Nygard
+ */
+public class DummyEntityWithTimestamp {
+
+	public int intValue;
+
+	public Long longValue;
+
+	public String stringValue;
+
+	public ZonedDateTime timestampValue;
+
+	public Map<Short, List<String>> complexStruct;
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) {
+			return true;
+		}
+		if (o == null || getClass() != o.getClass()) {
+			return false;
+		}
+		DummyEntityWithTimestamp that = (DummyEntityWithTimestamp) o;
+		return intValue == that.intValue &&
+				Objects.equals(longValue, that.longValue) &&
+				Objects.equals(stringValue, that.stringValue) &&
+				Objects.equals(timestampValue, that.timestampValue) &&
+				Objects.equals(complexStruct, that.complexStruct);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(intValue, longValue, stringValue, timestampValue, complexStruct);
+	}
+
+	private <T> String bracket(T obj) {
+		StringBuilder sb = new StringBuilder();
+		return sb.append("[").append(obj).append("]").toString();
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		return sb
+				.append(" int: ").append(bracket(intValue))
+				.append(" long: ").append(bracket(longValue))
+				.append(" string: ").append(bracket(stringValue))
+				.append(" ts: ").append(bracket(timestampValue.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)))
+				.append(" map: ").append(bracket(complexStruct))
+				.toString();
+	}
+}


### PR DESCRIPTION
Fixes GH-1781 (https://github.com/spring-projects/spring-kafka/issues/1781)

* Add ObjectMapperCustomizer interface for customizing local ObjectMapper
* Implement ObjectMapperCustomizer in JsonSerializer / JsonDeserializer
* call customizeObjectMapper() in ctor so ObjectWriter is properly constructed
* added tests / docs