### PR TITLE
GH-1785: Fix ListenerUtils.stoppableSleep()

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ListenerUtils.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ListenerUtils.java
@@ -237,12 +237,12 @@ public final class ListenerUtils {
 	/**
 	 * Sleep for the desired timeout, as long as the container continues to run.
 	 * @param container the container.
-	 * @param timeout the timeout.
+	 * @param interval the timeout.
 	 * @throws InterruptedException if the thread is interrupted.
 	 * @since 2.7
 	 */
-	public static void stoppableSleep(MessageListenerContainer container, long timeout) throws InterruptedException {
-
+	public static void stoppableSleep(MessageListenerContainer container, long interval) throws InterruptedException {
+		long timeout = System.currentTimeMillis() + interval;
 		do {
 			Thread.sleep(SLEEP_INTERVAL);
 			if (!container.isRunning()) {

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ListenerUtilsTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ListenerUtilsTests.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Gary Russell
+ * @since 2.7.1
+ *
+ */
+public class ListenerUtilsTests {
+
+	@Test
+	void stoppableSleep() throws InterruptedException {
+		MessageListenerContainer container = mock(MessageListenerContainer.class);
+		given(container.isRunning()).willReturn(true);
+		long t1 = System.currentTimeMillis();
+		ListenerUtils.stoppableSleep(container, 500);
+		assertThat(System.currentTimeMillis() - t1).isGreaterThanOrEqualTo(500);
+	}
+
+}


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1785

- only slept for 100ms, regardless of next back off interval