### PR TITLE
GH-1789: Content Negotiation for Conversion

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -259,5 +259,20 @@ public @interface KafkaListener {
 	 * @since 2.3.5
 	 */
 	boolean splitIterables() default true;
+
+	/**
+	 * Set the bean name of a
+	 * {@link org.springframework.messaging.converter.SmartMessageConverter} (such as the
+	 * {@link org.springframework.messaging.converter.CompositeMessageConverter}) to use
+	 * in conjunction with the
+	 * {@link org.springframework.messaging.MessageHeaders#CONTENT_TYPE} header to perform
+	 * the conversion to the required type. If a SpEL expression is provided
+	 * ({@code #{...}}), the expression can either evaluate to a
+	 * {@link org.springframework.messaging.converter.SmartMessageConverter} instance or a
+	 * bean name.
+	 * @return the bean name.
+	 * @since 2.7.1
+	 */
+	String contentTypeConverter() default "";
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/MethodKafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/MethodKafkaListenerEndpoint.java
@@ -40,6 +40,8 @@ import org.springframework.kafka.support.converter.BatchMessageConverter;
 import org.springframework.kafka.support.converter.MessageConverter;
 import org.springframework.kafka.support.converter.RecordMessageConverter;
 import org.springframework.lang.Nullable;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.converter.SmartMessageConverter;
 import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.handler.annotation.support.MessageHandlerMethodFactory;
 import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
@@ -68,6 +70,8 @@ public class MethodKafkaListenerEndpoint<K, V> extends AbstractKafkaListenerEndp
 	private MessageHandlerMethodFactory messageHandlerMethodFactory;
 
 	private KafkaListenerErrorHandler errorHandler;
+
+	private SmartMessageConverter messagingConverter;
 
 	/**
 	 * Set the object instance that should manage this endpoint.
@@ -111,6 +115,17 @@ public class MethodKafkaListenerEndpoint<K, V> extends AbstractKafkaListenerEndp
 	 */
 	public void setErrorHandler(KafkaListenerErrorHandler errorHandler) {
 		this.errorHandler = errorHandler;
+	}
+
+	/**
+	 * Set a spring-messaging {@link SmartMessageConverter} to convert the record value to
+	 * the desired type. This will also cause the {@link MessageHeaders#CONTENT_TYPE} to be
+	 * converted to String when mapped inbound.
+	 * @param messagingConverter the converter.
+	 * @since 2.7.1
+	 */
+	public void setMessagingConverter(SmartMessageConverter messagingConverter) {
+		this.messagingConverter = messagingConverter;
 	}
 
 	@Nullable
@@ -208,6 +223,9 @@ public class MethodKafkaListenerEndpoint<K, V> extends AbstractKafkaListenerEndp
 				messageListener.setMessageConverter((RecordMessageConverter) messageConverter);
 			}
 			listener = messageListener;
+		}
+		if (this.messagingConverter != null) {
+			listener.setMessagingConverter(this.messagingConverter);
 		}
 		BeanResolver resolver = getBeanResolver();
 		if (resolver != null) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
@@ -57,6 +57,7 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.converter.MessageConversionException;
+import org.springframework.messaging.converter.SmartMessageConverter;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.messaging.handler.annotation.support.MethodArgumentNotValidException;
@@ -108,6 +109,8 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 
 	private RecordMessageConverter messageConverter = new MessagingMessageConverter();
 
+	private boolean converterSet;
+
 	private Type fallbackType = Object.class;
 
 	private Expression replyTopicExpression;
@@ -136,6 +139,7 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 	 */
 	public void setMessageConverter(RecordMessageConverter messageConverter) {
 		this.messageConverter = messageConverter;
+		this.converterSet = true;
 	}
 
 	/**
@@ -146,6 +150,19 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 	 */
 	protected final RecordMessageConverter getMessageConverter() {
 		return this.messageConverter;
+	}
+
+	/**
+	 * Set the {@link SmartMessageConverter} to use with the default
+	 * {@link MessagingMessageConverter}. Not allowed when a custom
+	 * {@link #setMessageConverter(RecordMessageConverter) messageConverter} is provided.
+	 * @param messageConverter the converter.
+	 * @since 2.7.1
+	 */
+	public void setMessagingConverter(SmartMessageConverter messageConverter) {
+		Assert.isTrue(!this.converterSet, "Cannot set the SmartMessageConverter when setting the messageConverter, "
+				+ "add the SmartConverter to the message converter instead");
+		((MessagingMessageConverter) this.messageConverter).setMessagingConverter(messageConverter);
 	}
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/AbstractKafkaHeaderMapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/AbstractKafkaHeaderMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 the original author or authors.
+ * Copyright 2018-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -135,6 +135,17 @@ public abstract class AbstractKafkaHeaderMapper implements KafkaHeaderMapper {
 			this.rawMappedHeaders.clear();
 			this.rawMappedHeaders.putAll(rawMappedHeaders);
 		}
+	}
+
+	/**
+	 * Add a raw mapped header.
+	 * @param name the header name.
+	 * @param toString convert to string on inbound when true.
+	 * @since 2.7.1
+	 * @see #setRawMappedHeaders(Map)
+	 */
+	public void addRawMappedHeader(String name, boolean toString) {
+		this.rawMappedHeaders.put(name, toString);
 	}
 
 	protected boolean matches(String header, Object value) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/converter/MappingJacksonParameterizedConverter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/converter/MappingJacksonParameterizedConverter.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support.converter;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.utils.Bytes;
+
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.kafka.support.converter.Jackson2JavaTypeMapper.TypePrecedence;
+import org.springframework.lang.Nullable;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.util.Assert;
+import org.springframework.util.MimeType;
+
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.type.TypeFactory;
+
+/**
+ * Subclass of {@link MappingJackson2MessageConverter} that can handle parameterized
+ * (generic) types.
+ *
+ * @author Gary Russell
+ * @since 2.7.1
+ *
+ */
+public class MappingJacksonParameterizedConverter extends MappingJackson2MessageConverter {
+
+	private static final JavaType OBJECT = TypeFactory.defaultInstance().constructType(Object.class);
+
+	private Jackson2JavaTypeMapper typeMapper = new DefaultJackson2JavaTypeMapper();
+
+	/**
+	 * Construct a {@code MappingJacksonParameterizedConverter} supporting
+	 * the {@code application/json} MIME type with {@code UTF-8} character set.
+	 */
+	public MappingJacksonParameterizedConverter() {
+	}
+
+	/**
+	 * Construct a {@code MappingJacksonParameterizedConverter} supporting
+	 * one or more custom MIME types.
+	 * @param supportedMimeTypes the supported MIME types
+	 */
+	public MappingJacksonParameterizedConverter(MimeType... supportedMimeTypes) {
+		super(supportedMimeTypes);
+	}
+
+	/**
+	 * Return the type mapper.
+	 * @return the mapper.
+	 */
+	public Jackson2JavaTypeMapper getTypeMapper() {
+		return this.typeMapper;
+	}
+
+	/**
+	 * Set a customized type mapper.
+	 * @param typeMapper the type mapper.
+	 */
+	public void setTypeMapper(Jackson2JavaTypeMapper typeMapper) {
+		Assert.notNull(typeMapper, "'typeMapper' cannot be null");
+		this.typeMapper = typeMapper;
+	}
+
+	@Override
+	@Nullable
+	protected Object convertFromInternal(Message<?> message, Class<?> targetClass, @Nullable Object conversionHint) {
+		JavaType javaType = determineJavaType(message, conversionHint);
+		Object value = message.getPayload();
+		if (value instanceof Bytes) {
+			value = ((Bytes) value).get();
+		}
+		if (value instanceof String) {
+			try {
+				return getObjectMapper().readValue((String) value, javaType);
+			}
+			catch (IOException e) {
+				throw new ConversionException("Failed to convert from JSON", e);
+			}
+		}
+		else if (value instanceof byte[]) {
+			try {
+				return getObjectMapper().readValue((byte[]) value, javaType);
+			}
+			catch (IOException e) {
+				throw new ConversionException("Failed to convert from JSON", e);
+			}
+		}
+		else {
+			throw new IllegalStateException("Only String, Bytes, or byte[] supported");
+		}
+	}
+
+	private JavaType determineJavaType(Message<?> message, @Nullable Object hint) {
+		JavaType javaType = null;
+		Type type = null;
+		if (hint instanceof Type) {
+			type = (Type) hint;
+			Headers nativeHeaders = message.getHeaders().get(KafkaHeaders.NATIVE_HEADERS, Headers.class);
+			if (nativeHeaders != null) {
+				javaType = this.typeMapper.getTypePrecedence().equals(TypePrecedence.INFERRED)
+						? TypeFactory.defaultInstance().constructType(type)
+						: this.typeMapper.toJavaType(nativeHeaders);
+			}
+		}
+		if (javaType == null) { // no headers
+			if (type != null) {
+				javaType = TypeFactory.defaultInstance().constructType(type);
+			}
+			else {
+				javaType = OBJECT;
+			}
+		}
+		return javaType;
+	}
+
+}


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1789

Default message converter can now delegate to spring-messaging `SmartMessageConverter`
for payload conversion.

Add a spring-messaging implementation of the `JsonMessageConverter`.

**Needs doc before merge**