### PR TITLE
#1811 Make messageConverter parameter nullable

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpoint.java
@@ -135,7 +135,7 @@ public interface KafkaListenerEndpoint {
 	 * @param listenerContainer the listener container to configure
 	 * @param messageConverter the message converter - can be null
 	 */
-	void setupListenerContainer(MessageListenerContainer listenerContainer, MessageConverter messageConverter);
+	void setupListenerContainer(MessageListenerContainer listenerContainer, @Nullable MessageConverter messageConverter);
 
 	/**
 	 * When true, {@link Iterable} return results will be split into discrete records.


### PR DESCRIPTION
It fails in Kotlin when `messageConverter` is null