### PR TITLE
GH-1806: Fix Autowiring Broker in JUnit 5

### DIFF
--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/condition/EmbeddedKafkaCondition.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/condition/EmbeddedKafkaCondition.java
@@ -65,7 +65,12 @@ public class EmbeddedKafkaCondition implements ExecutionCondition, AfterAllCallb
 	public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
 			throws ParameterResolutionException {
 
-		return parameterContext.getParameter().getType().equals(EmbeddedKafkaBroker.class);
+		if (BROKERS.get() == null) {
+			return false;
+		}
+		else {
+			return parameterContext.getParameter().getType().equals(EmbeddedKafkaBroker.class);
+		}
 	}
 
 	@Override

--- a/spring-kafka-test/src/test/java/org/springframework/kafka/test/condition/WithSpringTestContextTests.java
+++ b/spring-kafka-test/src/test/java/org/springframework/kafka/test/condition/WithSpringTestContextTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.test.condition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+/**
+ * @author Gary Russell
+ * @since 2.7.2
+ *
+ */
+@SpringJUnitConfig
+@EmbeddedKafka
+public class WithSpringTestContextTests {
+
+	@Test
+	void canAutowireBrokerInMethod(@Autowired EmbeddedKafkaBroker broker) {
+		assertThat(broker).isNotNull();
+	}
+
+	@Configuration
+	static class Config {
+
+	}
+
+}


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1806

When there is a test application context present, do not resolve the
broker for parameter resolution.

**cherry-pick to all supported branches**