### PR TITLE
GH-1745 - Let users provide a RetryTopicConfigurer bean

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicInternalBeanNames.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicInternalBeanNames.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,8 +33,6 @@ public abstract class RetryTopicInternalBeanNames {
 
 	static final String KAFKA_CONSUMER_BACKOFF_MANAGER = "internalKafkaConsumerBackoffManager";
 
-	static final String RETRY_TOPIC_CONFIGURER = "internalRetryTopicConfigurer";
-
 	static final String LISTENER_CONTAINER_FACTORY_RESOLVER_NAME = "internalListenerContainerFactoryResolver";
 
 	static final String LISTENER_CONTAINER_FACTORY_CONFIGURER_NAME = "internalListenerContainerFactoryConfigurer";
@@ -64,5 +62,15 @@ public abstract class RetryTopicInternalBeanNames {
 	 * Default Kafka template bean name for publishing to retry topics.
 	 */
 	public static final String DEFAULT_KAFKA_TEMPLATE_BEAN_NAME = "retryTopicDefaultKafkaTemplate";
+
+	/**
+	 * RetryTopicBootstrapper bean name.
+	 */
+	public static final String RETRY_TOPIC_BOOTSTRAPPER = "internalRetryTopicBootstrapper";
+
+	/**
+	 * RetryTopicConfigurer bean name.
+	 */
+	public static final String RETRY_TOPIC_CONFIGURER = "internalRetryTopicConfigurer";
 
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This is the other part of the RetryTopicConfigurer extensibility improvement and lets the user provide a custom RetryTopicConfigurer subclass bean. This isn't supposed to be available for non advanced users, so I don't think it should be documented. Please let me know if there's anything to fix or enhance.

With this PR all the changes I had in mind for the RetryTopic feature are complete. From my point of view we can close GH-1745 and also remove the Experimental API designation, if you don't have any other concerns - please let me know if you do.

Thanks a lot for your support so far, it's been amazing!