### PR TITLE
GH-1827: Add ContainerGroupSequencer

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -2397,6 +2397,59 @@ If the function returns `null`, the handler's default `BackOff` will be used.
 Starting with version 2.6.3, set `resetStateOnExceptionChange` to `true` and the retry sequence will be restarted (including the selection of a new `BackOff`, if so configured) if the exception type changes between failures.
 By default, the exception type is not considered.
 
+[[sequencing]]
+===== Starting `@KafkaListener` s in Sequence
+
+A common use case is to start a listener after another listener has consumed all the records in a topic.
+For example, you may want to load the contents of one or more compacted topics into memory before processing records from other topics.
+Starting with version 2.7.3, a new component `ContainerGroupSequencer` has been introduced.
+It uses the `@KafkaListener` `containerGroup` property to group containers together and start the containers in the next group, when all the containers in the current group have gone idle.
+
+It is best illustrated with an example.
+
+====
+[source, java]
+----
+@KafkaListener(id = "listen1", topics = "topic1", containerGroup = "g1", concurrency = "2")
+public void listen1(String in) {
+}
+
+@KafkaListener(id = "listen2", topics = "topic2", containerGroup = "g1", concurrency = "2")
+public void listen2(String in) {
+}
+
+@KafkaListener(id = "listen3", topics = "topic3", containerGroup = "g2", concurrency = "2")
+public void listen3(String in) {
+}
+
+@KafkaListener(id = "listen4", topics = "topic4", containerGroup = "g2", concurrency = "2")
+public void listen4(String in) {
+}
+
+@Bean
+ContainerGroupSequencer sequencer(KafkaListenerEndpointRegistry registry) {
+    return new ContainerGroupSequencer(registry, 5000, "g1", "g2");
+}
+----
+====
+
+Here, we have 4 listeners in two groups, `g1` and `g2`.
+
+During application context initialization, the sequencer, sets the `autoStartup` property of all the containers in the provided groups to `false`.
+It also sets the `idleEventInterval` for any containers (that do not already have one set) to the supplied value (5000ms in this case).
+Then, when the sequencer is started by the application context, the containers in the first group are started.
+As `ListenerContainerIdleEvent` s are received, each individual child container in each container is stopped.
+When all child containers in a `ConcurrentMessageListenerContainer` are stopped, the parent container is stopped.
+When all containers in a group have been stopped, the containers in the next group are started.
+There is no limit to the number of groups or containers in a group.
+
+By default, the containers in the final group (`g2` above) are not stopped when they go idle.
+To modify that behavior, set `stopLastGroupWhenIdle` to `true` on the sequencer.
+
+As an aside; previously, containers in each group were added to a bean of type `Collection<MessageListenerContainer>` with the bean name being the `containerGroup`.
+These collections are now deprecated in favor of beans of type `ContainerGroup` with a bean name that is the group name, suffixed with `.group`; in the example above, there would be 2 beans `g1.group` and `g2.group`.
+The `Collection` beans will be removed in a future release.
+
 [[container-props]]
 ==== Listener Container Properties
 

--- a/spring-kafka-docs/src/main/asciidoc/whats-new.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/whats-new.adoc
@@ -94,3 +94,8 @@ See <<configuring-topics>> for more information.
 
 It is now possible to add a `spring-messaging` `SmartMessageConverter` to the `MessagingMessageConverter`, allowing content negotiation based on the `contentType` header.
 See <<messaging-message-conversion>> for more information.
+
+[[x27-sequencing]]
+==== Sequencing `@KafkaListener` s
+
+See <<container-sequencing>> for more information.

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
@@ -23,6 +23,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.springframework.kafka.listener.ContainerGroup;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 
 /**
@@ -148,11 +149,14 @@ public @interface KafkaListener {
 	TopicPartition[] topicPartitions() default {};
 
 	/**
-	 * If provided, the listener container for this listener will be added to a bean
-	 * with this value as its name, of type {@code Collection<MessageListenerContainer>}.
-	 * This allows, for example, iteration over the collection to start/stop a subset
-	 * of containers.
-	 * <p>SpEL {@code #{...}} and property place holders {@code ${...}} are supported.
+	 * If provided, the listener container for this listener will be added to a bean with
+	 * this value as its name, of type {@code Collection<MessageListenerContainer>}. This
+	 * allows, for example, iteration over the collection to start/stop a subset of
+	 * containers. The {@code Collection} beans are deprecated as of version 2.7.3 and
+	 * will be removed in 2.8. Instead, a bean with name {@code containerGroup + ".group"}
+	 * and type {@link ContainerGroup} should be used instead.
+	 * <p>
+	 * SpEL {@code #{...}} and property place holders {@code ${...}} are supported.
 	 * @return the bean name for the group.
 	 */
 	String containerGroup() default "";

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
@@ -81,6 +81,7 @@ import org.springframework.kafka.config.KafkaListenerEndpointRegistrar;
 import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
 import org.springframework.kafka.config.MethodKafkaListenerEndpoint;
 import org.springframework.kafka.config.MultiMethodKafkaListenerEndpoint;
+import org.springframework.kafka.listener.ContainerGroupSequencer;
 import org.springframework.kafka.listener.KafkaListenerErrorHandler;
 import org.springframework.kafka.retrytopic.RetryTopicBootstrapper;
 import org.springframework.kafka.retrytopic.RetryTopicConfiguration;
@@ -305,6 +306,9 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 
 		// Actually register all listeners
 		this.registrar.afterPropertiesSet();
+		Map<String, ContainerGroupSequencer> sequencers =
+				this.applicationContext.getBeansOfType(ContainerGroupSequencer.class, false, false);
+		sequencers.values().forEach(seq -> seq.initialize());
 	}
 
 	private void buildEnhancer() {

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
@@ -278,10 +278,11 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 	protected void doStop(final Runnable callback) {
 		final AtomicInteger count = new AtomicInteger();
 		if (isRunning()) {
-			if (!isChildRunning()) {
+			boolean childRunning = isChildRunning();
+			setRunning(false);
+			if (!childRunning) {
 				callback.run();
 			}
-			setRunning(false);
 			for (KafkaMessageListenerContainer<K, V> container : this.containers) {
 				if (container.isRunning()) {
 					count.incrementAndGet();

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerGroup.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerGroup.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.context.Lifecycle;
+import org.springframework.core.log.LogAccessor;
+import org.springframework.util.Assert;
+
+/**
+ * A group of listener containers.
+ *
+ * @author Gary Russell
+ * @since 2.7.3
+ *
+ */
+public class ContainerGroup implements Lifecycle {
+
+	private static final LogAccessor LOGGER = new LogAccessor(LogFactory.getLog(ContainerGroup.class));
+
+	private final String name;
+
+	private final Collection<MessageListenerContainer> containers = new LinkedHashSet<>();
+
+	private boolean running;
+
+	/**
+	 * Construct an instance with the provided name.
+	 * @param name the group name.
+	 */
+	public ContainerGroup(String name) {
+		this.name = name;
+	}
+
+	/**
+	 * Construct an instance with the provided name and containers.
+	 * @param name the group name.
+	 * @param containers the containers.
+	 */
+	public ContainerGroup(String name, List<MessageListenerContainer> containers) {
+		this.name = name;
+		this.containers.addAll(containers);
+	}
+
+	/**
+	 * Construct an instance with the provided name and containers.
+	 * @param name the group name.
+	 * @param containers the containers.
+	 */
+	public ContainerGroup(String name, MessageListenerContainer...containers) {
+		this.name = name;
+		for (MessageListenerContainer container : containers) {
+			this.containers.add(container);
+		}
+	}
+
+	/**
+	 * Return the group name.
+	 * @return the name.
+	 */
+	public String getName() {
+		return this.name;
+	}
+
+	/**
+	 * Return the listener ids of the containers in this group.
+	 * @return the listener ids.
+	 */
+	public Collection<String> getListenerIds() {
+		return this.containers.stream()
+				.map(container -> container.getListenerId())
+				.map(id -> {
+					Assert.state(id != null, "Containers must have listener ids to be used here");
+					return id;
+				})
+				.collect(Collectors.toList());
+	}
+
+	/**
+	 * Return true if the provided container is in this group.
+	 * @param container the container.
+	 * @return true if it is in this group.
+	 */
+	public boolean contains(MessageListenerContainer container) {
+		return this.containers.contains(container);
+	}
+
+	/**
+	 * Return true if all containers in this group are stopped.
+	 * @return true if all are stopped.
+	 */
+	public boolean allStopped() {
+		return this.containers.stream()
+				.allMatch(container -> !container.isRunning());
+	}
+
+	/**
+	 * Add one or more containers to the group.
+	 * @param theContainers the container(s).
+	 */
+	public void addContainers(MessageListenerContainer... theContainers) {
+		for (MessageListenerContainer container : theContainers) {
+			this.containers.add(container);
+		}
+	}
+
+	/**
+	 * Remove a container from the group.
+	 * @param container the container.
+	 * @return true if the container was removed.
+	 */
+	public boolean removeContainer(MessageListenerContainer container) {
+		return this.containers.remove(container);
+	}
+
+	@Override
+	public synchronized void start() {
+		if (!this.running) {
+			this.containers.forEach(container -> {
+				LOGGER.debug(() -> "Starting: " + container);
+				container.start();
+			});
+			this.running = true;
+		}
+	}
+
+	@Override
+	public synchronized void stop() {
+		if (this.running) {
+			this.containers.forEach(container -> container.stop());
+			this.running = false;
+		}
+	}
+
+	@Override
+	public synchronized boolean isRunning() {
+		return this.running;
+	}
+
+	@Override
+	public String toString() {
+		return "ContainerGroup [name=" + this.name + ", containers=" + this.containers + "]";
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerGroupSequencer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerGroupSequencer.java
@@ -38,7 +38,7 @@ import org.springframework.kafka.event.ListenerContainerIdleEvent;
  * idle.
  *
  * @author Gary Russell
- * @since 2.8
+ * @since 2.7.3
  *
  */
 public class ContainerGroupSequencer implements ApplicationContextAware,

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerGroupSequencer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerGroupSequencer.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.core.log.LogAccessor;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
+import org.springframework.kafka.event.ListenerContainerIdleEvent;
+
+/**
+ * Sequence the starting of container groups when all containers in the previous group are
+ * idle.
+ *
+ * @author Gary Russell
+ * @since 2.8
+ *
+ */
+public class ContainerGroupSequencer implements ApplicationContextAware,
+		ApplicationListener<ListenerContainerIdleEvent>, SmartLifecycle {
+
+	private static final LogAccessor LOGGER = new LogAccessor(LogFactory.getLog(ContainerGroupSequencer.class));
+
+	private final KafkaListenerEndpointRegistry registry;
+
+	private final long defaultIdleEventInterval;
+
+	private final Collection<String> groupNames = new LinkedHashSet<>();
+
+	private final Collection<ContainerGroup> groups = new LinkedHashSet<>();
+
+	private final TaskExecutor executor = new SimpleAsyncTaskExecutor("container-group-sequencer-");
+
+	private ApplicationContext applicationContext;
+
+	private boolean stopLastGroupWhenIdle;
+
+	private Iterator<ContainerGroup> iterator;
+
+	private ContainerGroup currentGroup;
+
+	private boolean running;
+
+	/**
+	 * Set containers in each group to not auto start. Start the containers in the first
+	 * group. Start containers in group[n] when all containers in group[n-1] are idle;
+	 * stop the containers in group[n-1].
+	 * @param registry the registry.
+	 * @param defaultIdleEventInterval the idle event interval if not already set.
+	 * @param containerGroups The list of container groups, in order.
+	 */
+	public ContainerGroupSequencer(KafkaListenerEndpointRegistry registry, long defaultIdleEventInterval,
+			String... containerGroups) {
+
+		this.registry = registry;
+		this.defaultIdleEventInterval = defaultIdleEventInterval;
+		for (String groupName : containerGroups) {
+			this.groupNames.add(groupName);
+		}
+	}
+
+	@Override
+	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+		this.applicationContext = applicationContext;
+	}
+
+	/**
+	 * Set to true to stop the containers in the final group when they go idle. By
+	 * default, the containers in the final group remain running.
+	 * @param stopLastGroupWhenIdle true to stop containers in the final group.
+	 */
+	public void setStopLastGroupWhenIdle(boolean stopLastGroupWhenIdle) {
+		this.stopLastGroupWhenIdle = stopLastGroupWhenIdle;
+	}
+
+	@Override
+	public synchronized void onApplicationEvent(ListenerContainerIdleEvent event) {
+		LOGGER.debug(() -> event.toString());
+		MessageListenerContainer parent = event.getContainer(MessageListenerContainer.class);
+		MessageListenerContainer container = (MessageListenerContainer) event.getSource();
+		if (this.running) {
+			if (this.currentGroup != null && this.currentGroup.contains(parent)) {
+				if (this.iterator.hasNext() || this.stopLastGroupWhenIdle) {
+					this.executor.execute(() -> {
+						LOGGER.debug(() -> "Stopping: " + container);
+						container.stop(() -> {
+							if (!parent.isChildRunning()) {
+								this.executor.execute(() -> {
+									stopParentAndCheckGroup(parent);
+								});
+							}
+						});
+					});
+				}
+			}
+		}
+	}
+
+	private void stopParentAndCheckGroup(MessageListenerContainer parent) {
+		LOGGER.debug(() -> "Stopping: " + parent);
+		parent.stop(() -> {
+			synchronized (this) {
+				if (this.currentGroup != null) {
+					LOGGER.debug(() -> "Checking group: " + this.currentGroup.toString());
+					if (this.currentGroup.allStopped()) {
+						if (this.iterator.hasNext()) {
+							this.currentGroup = this.iterator.next();
+							LOGGER.debug(() -> "starting next group: " + this.currentGroup);
+							this.currentGroup.start();
+						}
+						else {
+							this.currentGroup = null;
+						}
+					}
+				}
+			}
+		});
+	}
+
+	@Override
+	public synchronized void start() {
+		if (this.currentGroup != null) {
+			LOGGER.debug(() -> "starting first group: " + this.currentGroup);
+			this.currentGroup.start();
+		}
+		this.running = true;
+	}
+
+	public void initialize() {
+		this.groups.clear();
+		for (String group : this.groupNames) {
+			this.groups.add(this.applicationContext.getBean(group + ".group", ContainerGroup.class));
+		}
+		if (this.groups.size() > 0) {
+			this.iterator = this.groups.iterator();
+			this.currentGroup = this.iterator.next();
+			this.groups.forEach(grp -> {
+				Collection<String> ids = grp.getListenerIds();
+				ids.stream().forEach(id -> {
+					MessageListenerContainer container = this.registry.getListenerContainer(id);
+					if (container.getContainerProperties().getIdleEventInterval() == null) {
+						container.getContainerProperties().setIdleEventInterval(this.defaultIdleEventInterval);
+						container.setAutoStartup(false);
+					}
+				});
+			});
+		}
+		LOGGER.debug(() -> "Found: " + this.groups);
+	}
+
+	@Override
+	public synchronized void stop() {
+		this.running = false;
+		if (this.currentGroup != null) {
+			this.currentGroup.stop();
+			this.currentGroup = null;
+		}
+	}
+
+	@Override
+	public synchronized boolean isRunning() {
+		return this.running;
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/MessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/MessageListenerContainer.java
@@ -193,4 +193,13 @@ public interface MessageListenerContainer extends SmartLifecycle {
 		throw new UnsupportedOperationException("This container does not support retrieving the listener id");
 	}
 
+	/**
+	 * If this container has child containers, return true if at least one child is running. If there are not
+	 * child containers, returns {@link #isRunning()}.
+	 * @return true if a child is running.
+	 * @since 2.7.3
+	 */
+	default boolean isChildRunning() {
+		return isRunning();
+	}
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/AliasPropertiesTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/AliasPropertiesTests.java
@@ -99,7 +99,6 @@ public class AliasPropertiesTests {
 				.isEqualTo("onMethodRepeatable2.RepeatableClassAndMethodLevelListener.listen1");
 		assertThat(this.kafkaListenerEndpointRegistry.getListenerContainer("onClassRepeatable2").getGroupId())
 				.isEqualTo("onClassRepeatable2.RepeatableClassAndMethodLevelListener");
-		assertThat(this.config.orderedCalledFirst).isTrue();
 		assertThat(Config.orderedCalledFirst.get()).isTrue();
 	}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ContainerGroupSequencerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ContainerGroupSequencerTests.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.logging.LogFactory;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.event.EventListener;
+import org.springframework.core.log.LogAccessor;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.event.ContainerStoppedEvent;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+/**
+ * @author Gary Russell
+ * @since 2.7.3
+ *
+ */
+@SpringJUnitConfig
+@EmbeddedKafka(topics = "ContainerGroupSequencerTests")
+public class ContainerGroupSequencerTests {
+
+	private static final LogAccessor LOGGER = new LogAccessor(LogFactory.getLog(ContainerGroupSequencerTests.class));
+
+	@Test
+	void sequenceCompletes(@Autowired Config config, @Autowired KafkaTemplate<Integer, String> template)
+			throws InterruptedException {
+
+		template.send("ContainerGroupSequencerTests", "test");
+		assertThat(config.stopped.await(10, TimeUnit.SECONDS))
+				.as("stopped latch still has a count of %d", config.stopped.getCount())
+				.isTrue();
+	}
+
+	@Configuration
+	@EnableKafka
+	public static class Config {
+
+		final CountDownLatch stopped = new CountDownLatch(12); // 8 children, 4 parents
+
+		@KafkaListener(id = "one", topics = "ContainerGroupSequencerTests", containerGroup = "g1", concurrency = "2")
+		public void listen1(String in) {
+		}
+
+		@KafkaListener(id = "two", topics = "ContainerGroupSequencerTests", containerGroup = "g1", concurrency = "2")
+		public void listen2(String in) {
+		}
+
+		@KafkaListener(id = "three", topics = "ContainerGroupSequencerTests", containerGroup = "g2", concurrency = "2")
+		public void listen3(String in) {
+		}
+
+		@KafkaListener(id = "four", topics = "ContainerGroupSequencerTests", containerGroup = "g2", concurrency = "2")
+		public void listen4(String in) {
+		}
+
+		@EventListener
+		public void stopped(ContainerStoppedEvent event) {
+			LOGGER.debug(() -> event.toString());
+			this.stopped.countDown();
+		}
+
+		@Bean
+		ContainerGroupSequencer sequencer(KafkaListenerEndpointRegistry registry) {
+			ContainerGroupSequencer sequencer = new ContainerGroupSequencer(registry, 1000, "g1", "g2");
+			sequencer.setStopLastGroupWhenIdle(true);
+			return sequencer;
+		}
+
+		@Bean
+		ProducerFactory<Integer, String> pf(EmbeddedKafkaBroker broker) {
+			return new DefaultKafkaProducerFactory<>(KafkaTestUtils.producerProps(broker));
+		}
+
+		@Bean
+		KafkaTemplate<Integer, String> template(ProducerFactory<Integer, String> pf) {
+			return new KafkaTemplate<>(pf);
+		}
+
+		@Bean
+		ConsumerFactory<Integer, String> cf(EmbeddedKafkaBroker broker) {
+			return new DefaultKafkaConsumerFactory<>(KafkaTestUtils.consumerProps("", "false", broker));
+		}
+
+		@Bean
+		ConcurrentKafkaListenerContainerFactory<Integer, String> kafkaListenerContainerFactory(
+				ConsumerFactory<Integer, String> cf) {
+
+			ConcurrentKafkaListenerContainerFactory<Integer, String> factory =
+					new ConcurrentKafkaListenerContainerFactory<>();
+			factory.setConsumerFactory(cf);
+			factory.getContainerProperties().setPollTimeout(500);
+			return factory;
+		}
+
+	}
+
+}

--- a/spring-kafka/src/test/resources/log4j2-test.xml
+++ b/spring-kafka/src/test/resources/log4j2-test.xml
@@ -6,7 +6,7 @@
 		</Console>
 	</Appenders>
 	<Loggers>
-		<Logger name="org.springframework.kafka" level="warn"/>
+		<Logger name="org.springframework.kafka" level="debug"/>
 		<Logger name="org.springframework.kafka.ReplyingKafkaTemplate" level="warn"/>
 		<Logger name="org.apache.kafka.clients" level="warn"/>
 		<Logger name="org.apache.kafka.clients.NetworkClient" level="error"/>

--- a/spring-kafka/src/test/resources/log4j2-test.xml
+++ b/spring-kafka/src/test/resources/log4j2-test.xml
@@ -6,7 +6,7 @@
 		</Console>
 	</Appenders>
 	<Loggers>
-		<Logger name="org.springframework.kafka" level="debug"/>
+		<Logger name="org.springframework.kafka" level="warn"/>
 		<Logger name="org.springframework.kafka.ReplyingKafkaTemplate" level="warn"/>
 		<Logger name="org.apache.kafka.clients" level="warn"/>
 		<Logger name="org.apache.kafka.clients.NetworkClient" level="error"/>


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1827

Add a mechanism to automatically control a sequence of containers,
starting a group of containers when the current group goes idle.