### PR TITLE
fix missing bean name in documentation

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -5207,7 +5207,7 @@ Example:
 [source, java]
 ----
 @Bean
-public RecoveringBatchErrorHandler(KafkaTemplate<String, String> template) {
+public RecoveringBatchErrorHandler batchErrorHandler(KafkaTemplate<String, String> template) {
     DeadLetterPublishingRecoverer recoverer =
             new DeadLetterPublishingRecoverer(template);
     RecoveringBatchErrorHandler errorHandler =


### PR DESCRIPTION
updated documentation to add bean name

```diff
- public RecoveringBatchErrorHandler(KafkaTemplate<String, String> template)
+ public RecoveringBatchErrorHandler batchErrorHandler(KafkaTemplate<String, String> template)
```


fixes #1790 