### PR TITLE
GH-1845: Idle Between Polls Improvements

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -1526,13 +1526,14 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 
 		private void idleBetweenPollIfNecessary() {
 			long idleBetweenPolls = this.containerProperties.getIdleBetweenPolls();
-			if (idleBetweenPolls > 0) {
+			Collection<TopicPartition> assigned = getAssignedPartitions();
+			if (idleBetweenPolls > 0 && assigned != null && assigned.size() > 0) {
 				idleBetweenPolls = Math.min(idleBetweenPolls,
 						this.maxPollInterval - (System.currentTimeMillis() - this.lastPoll)
 								- 5000); // NOSONAR - less by five seconds to avoid race condition with rebalance
 				if (idleBetweenPolls > 0) {
 					try {
-						TimeUnit.MILLISECONDS.sleep(idleBetweenPolls);
+						ListenerUtils.stoppableSleep(KafkaMessageListenerContainer.this, idleBetweenPolls);
 					}
 					catch (InterruptedException ex) {
 						Thread.currentThread().interrupt();

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ListenerUtils.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ListenerUtils.java
@@ -49,7 +49,11 @@ public final class ListenerUtils {
 
 	private static final ThreadLocal<Boolean> LOG_METADATA_ONLY = new ThreadLocal<>();
 
-	private static final int SLEEP_INTERVAL = 100;
+	private static final int DEFAULT_SLEEP_INTERVAL = 100;
+
+	private static final int SMALL_SLEEP_INTERVAL = 10;
+
+	private static final long SMALL_INTERVAL_THRESHOLD = 500;
 
 	/**
 	 * Determine the type of the listener.
@@ -243,8 +247,9 @@ public final class ListenerUtils {
 	 */
 	public static void stoppableSleep(MessageListenerContainer container, long interval) throws InterruptedException {
 		long timeout = System.currentTimeMillis() + interval;
+		long sleepInterval = interval > SMALL_INTERVAL_THRESHOLD ? DEFAULT_SLEEP_INTERVAL : SMALL_SLEEP_INTERVAL;
 		do {
-			Thread.sleep(SLEEP_INTERVAL);
+			Thread.sleep(sleepInterval);
 			if (!container.isRunning()) {
 				break;
 			}


### PR DESCRIPTION
https://github.com/spring-projects/spring-kafka/issues/1845

- don't idle until partitions are assigned - it caused delayed assignment
- use `ListenerUtils.stoppableSleep()` - don't hold up container stop while idle
- `ListenerUtils.stoppableSleep()` - reduce sleep time for small intervals to
  improve resolution