### PR TITLE
GH-1858: Fix Regression in JsonDeserializer

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/converter/DefaultJackson2JavaTypeMapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/converter/DefaultJackson2JavaTypeMapper.java
@@ -78,6 +78,9 @@ public class DefaultJackson2JavaTypeMapper extends AbstractJavaTypeMapper
 	 */
 	@Override
 	public void addTrustedPackages(String... packagesToTrust) {
+		if (this.trustedPackages.size() == 0) {
+			return;
+		}
 		if (packagesToTrust != null) {
 			for (String trusted : packagesToTrust) {
 				if ("*".equals(trusted)) {

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/JsonSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/JsonSerializationTests.java
@@ -306,6 +306,17 @@ public class JsonSerializationTests {
 
 	@SuppressWarnings("unchecked")
 	@Test
+	void testTrustMappingPackagesWithAll() {
+		JsonDeserializer<Object> deser = new JsonDeserializer<>();
+		Map<String, Object> props = Map.of(
+				JsonDeserializer.TRUSTED_PACKAGES, "*",
+				JsonDeserializer.TYPE_MAPPINGS, "foo:" + Foo.class.getName());
+		deser.configure(props, false);
+		assertThat(KafkaTestUtils.getPropertyValue(deser, "typeMapper.trustedPackages", Set.class)).isEmpty();
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
 	void testTrustMappingPackagesMapper() {
 		JsonDeserializer<Object> deser = new JsonDeserializer<>();
 		DefaultJackson2JavaTypeMapper mapper = new DefaultJackson2JavaTypeMapper();


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1858

Do not add mapping class packages if trusted packages is already all (`*`).

**cherry-pick to 2.7.x**