### PR TITLE
fix issue #1866 -> pause consumer.

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -1524,6 +1524,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			if (this.consumerPaused && !isPaused() && !this.pausedForAsyncAcks) {
 				this.logger.debug(() -> "Resuming consumption from: " + this.consumer.paused());
 				Set<TopicPartition> paused = this.consumer.paused();
+				paused.forEach(part -> resumePartition(part));
 				this.consumer.resume(paused);
 				this.consumerPaused = false;
 				publishConsumerResumedEvent(paused);

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -1497,6 +1497,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 				this.logger.debug(() -> "Pausing for incomplete async acks: " + this.offsetsInThisBatch);
 			}
 			if (!this.consumerPaused && (isPaused() || this.pausedForAsyncAcks)) {
+				this.consumer.assignment().forEach(part -> pausePartition(part));
 				this.consumer.pause(this.consumer.assignment());
 				this.consumerPaused = true;
 				this.logger.debug(() -> "Paused consumption from: " + this.consumer.paused());

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -1270,7 +1270,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			}
 			debugRecords(records);
 			resumeConsumerIfNeccessary();
-			if (this.consumerPaused && !isPaused()) {
+			if (!this.consumerPaused && !isPaused()) {
 				resumePartitionsIfNecessary();
 			}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -1270,7 +1270,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			}
 			debugRecords(records);
 			resumeConsumerIfNeccessary();
-			if (!this.consumerPaused && !isPaused()) {
+			if (!this.consumerPaused) {
 				resumePartitionsIfNecessary();
 			}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -1498,6 +1498,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			}
 			if (!this.consumerPaused && (isPaused() || this.pausedForAsyncAcks)) {
 				this.consumer.assignment().forEach(part -> pausePartition(part));
+				this.pausedPartitions.addAll(this.consumer.assignment());
 				this.consumer.pause(this.consumer.assignment());
 				this.consumerPaused = true;
 				this.logger.debug(() -> "Paused consumption from: " + this.consumer.paused());
@@ -1525,6 +1526,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 				this.logger.debug(() -> "Resuming consumption from: " + this.consumer.paused());
 				Set<TopicPartition> paused = this.consumer.paused();
 				paused.forEach(part -> resumePartition(part));
+				this.pausedPartitions.removeAll(paused);
 				this.consumer.resume(paused);
 				this.consumerPaused = false;
 				publishConsumerResumedEvent(paused);


### PR DESCRIPTION
fix issue #1866 : call `pausePartition` on all partitions when pausing the consumer so partitions are not restarted by `resumePartitionsIfNecessary.`