### PR TITLE
GH-615: Error Handler Evolution Part 1

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonErrorHandler.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import java.util.List;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+
+import org.springframework.kafka.support.TopicPartitionOffset;
+
+/**
+ * Replacement for {@link ErrorHandler} and {@link BatchErrorHandler} and their
+ * sub-interfaces.
+ *
+ * @author Gary Russell
+ * @since 2.7.4
+ *
+ */
+public interface CommonErrorHandler extends DeliveryAttemptAware {
+
+	/**
+	 * Return true if this error handler is for a batch listener.
+	 * @return true for batch.
+	 */
+	default boolean isBatch() {
+		return false;
+	}
+
+	/**
+	 * Return false if this error handler should only receive the current failed record;
+	 * remaining records will be passed to the listener after the error handler returns.
+	 * When true (default), all remaining records including the failed record are passed
+	 * to the error handler.
+	 * @return false to receive only the failed record.
+	 * @see #handle(Exception, ConsumerRecord, Consumer, MessageListenerContainer)
+	 * @see #handle(Exception, List, Consumer, MessageListenerContainer)
+	 */
+	default boolean remainingRecords() {
+		return true;
+	}
+
+	/**
+	 * Return true if this error handler supports delivery attempts headers.
+	 * @return true if capable.
+	 */
+	default boolean deliveryAttemptHeader() {
+		return false;
+	}
+
+	/**
+	 * Called when an exception is thrown with no records available, e.g. if the consumer
+	 * poll throws an exception.
+	 * @param thrownException the exception.
+	 * @param consumer the consumer.
+	 * @param container the container.
+	 */
+	default void handleConsumerException(Exception thrownException, Consumer<?, ?> consumer,
+			MessageListenerContainer container) {
+	}
+
+	/**
+	 * Handle the exception for a record listener when {@link #remainingRecords()} returns false.
+	 * @param thrownException the exception.
+	 * @param record the record.
+	 * @param consumer the consumer.
+	 * @param container the container.
+	 * @see #remainingRecords()
+	 */
+	default void handle(Exception thrownException, ConsumerRecord<?, ?> record, Consumer<?, ?> consumer,
+			MessageListenerContainer container) {
+	}
+
+	/**
+	 * Handle the exception for a record listener when {@link #remainingRecords()} returns true.
+	 * @param thrownException the exception.
+	 * @param records the remaining records including the one that failed.
+	 * @param consumer the consumer.
+	 * @param container the container.
+	 * @see #remainingRecords()
+	 */
+	default void handle(Exception thrownException, List<ConsumerRecord<?, ?>> records, Consumer<?, ?> consumer,
+			MessageListenerContainer container) {
+	}
+
+	/**
+	 * Handle the exception for a batch listener.
+	 * @param thrownException the exception.
+	 * @param data the consumer records.
+	 * @param consumer the consumer.
+	 * @param container the container.
+	 * @param invokeListener a callback to re-invoke the listener.
+	 */
+	default void handle(Exception thrownException, ConsumerRecords<?, ?> data,
+			Consumer<?, ?> consumer, MessageListenerContainer container, Runnable invokeListener) {
+	}
+
+	@Override
+	default int deliveryAttempt(TopicPartitionOffset topicPartitionOffset) {
+		return 0;
+	}
+
+	/**
+	 * Optional method to clear thread state; will be called just before a consumer
+	 * thread terminates.
+	 */
+	default void clearThreadState() {
+	}
+
+	/**
+	 * Return true if the offset should be committed for a handled error (no exception
+	 * thrown).
+	 * @return true to commit.
+	 */
+	default boolean isAckAfterHandle() {
+		return true;
+	}
+
+	/**
+	 * Set to false to prevent the container from committing the offset of a recovered
+	 * record (when the error handler does not itself throw an exception).
+	 * @param ack false to not commit.
+	 */
+	default void setAckAfterHandle(boolean ack) {
+		throw new UnsupportedOperationException("This error handler does not support setting this property");
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ErrorHandlerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ErrorHandlerAdapter.java
@@ -115,7 +115,7 @@ public class ErrorHandlerAdapter implements CommonErrorHandler {
 
 	@SuppressWarnings({ "unchecked" })
 	@Override
-	public void handleConsumerException(Exception thrownException, Consumer<?, ?> consumer,
+	public void handleOtherException(Exception thrownException, Consumer<?, ?> consumer,
 			MessageListenerContainer container) {
 
 		if (this.errorHandler != null) {
@@ -127,21 +127,21 @@ public class ErrorHandlerAdapter implements CommonErrorHandler {
 	}
 
 	@Override
-	public void handle(Exception thrownException, ConsumerRecord<?, ?> record, Consumer<?, ?> consumer,
+	public void handleRecord(Exception thrownException, ConsumerRecord<?, ?> record, Consumer<?, ?> consumer,
 			MessageListenerContainer container) {
 
 		this.errorHandler.handle(thrownException, record, consumer);
 	}
 
 	@Override
-	public void handle(Exception thrownException, List<ConsumerRecord<?, ?>> records, Consumer<?, ?> consumer,
+	public void handleRemaining(Exception thrownException, List<ConsumerRecord<?, ?>> records, Consumer<?, ?> consumer,
 			MessageListenerContainer container) {
 
 		this.errorHandler.handle(thrownException, records, consumer, container);
 	}
 
 	@Override
-	public void handle(Exception thrownException, ConsumerRecords<?, ?> data, Consumer<?, ?> consumer,
+	public void handleBatch(Exception thrownException, ConsumerRecords<?, ?> data, Consumer<?, ?> consumer,
 			MessageListenerContainer container, Runnable invokeListener) {
 
 		this.batchErrorHandler.handle(thrownException, data, consumer, container, invokeListener);

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ErrorHandlerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ErrorHandlerAdapter.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+
+import org.springframework.kafka.support.TopicPartitionOffset;
+import org.springframework.util.Assert;
+
+/**
+ * Adapts a legacy {@link ErrorHandler} or {@link BatchErrorHandler}.
+ *
+ * @author Gary Russell
+ * @since 2.7.4
+ *
+ */
+public class ErrorHandlerAdapter implements CommonErrorHandler {
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	private static final ConsumerRecords EMPTY_BATCH = new ConsumerRecords(Collections.emptyMap());
+
+	private final ErrorHandler errorHandler;
+
+	private final BatchErrorHandler batchErrorHandler;
+
+	/**
+	 * Adapt an {@link ErrorHandler}.
+	 * @param errorHandler the handler.
+	 */
+	public ErrorHandlerAdapter(ErrorHandler errorHandler) {
+		Assert.notNull(errorHandler, "'errorHandler' cannot be null");
+		this.errorHandler = errorHandler;
+		this.batchErrorHandler = null;
+	}
+
+	/**
+	 * Adapt a {@link BatchErrorHandler}.
+	 * @param batchErrorHandler the handler.
+	 */
+	public ErrorHandlerAdapter(BatchErrorHandler batchErrorHandler) {
+		Assert.notNull(batchErrorHandler, "'batchErrorHandler' cannot be null");
+		this.errorHandler = null;
+		this.batchErrorHandler = batchErrorHandler;
+	}
+
+	@Override
+	public boolean isBatch() {
+		return this.batchErrorHandler != null;
+	}
+
+	@Override
+	public boolean remainingRecords() {
+		return this.errorHandler instanceof RemainingRecordsErrorHandler;
+	}
+
+	@Override
+	public boolean deliveryAttemptHeader() {
+		return this.errorHandler instanceof DeliveryAttemptAware;
+	}
+
+	@Override
+	public void clearThreadState() {
+		if (this.errorHandler != null) {
+			this.errorHandler.clearThreadState();
+		}
+		else {
+			this.batchErrorHandler.clearThreadState();
+		}
+	}
+
+	@Override
+	public boolean isAckAfterHandle() {
+		if (this.errorHandler != null) {
+			return this.errorHandler.isAckAfterHandle();
+		}
+		else {
+			return this.batchErrorHandler.isAckAfterHandle();
+		}
+	}
+
+	@Override
+	public void setAckAfterHandle(boolean ack) {
+		if (this.errorHandler != null) {
+			this.errorHandler.setAckAfterHandle(ack);
+		}
+		else {
+			this.batchErrorHandler.setAckAfterHandle(ack);
+		}
+	}
+
+	@Override
+	public int deliveryAttempt(TopicPartitionOffset topicPartitionOffset) {
+		Assert.state(deliveryAttemptHeader(), "This method should not be called by the container");
+		return ((DeliveryAttemptAware) this.errorHandler).deliveryAttempt(topicPartitionOffset);
+	}
+
+	@SuppressWarnings({ "unchecked" })
+	@Override
+	public void handleConsumerException(Exception thrownException, Consumer<?, ?> consumer,
+			MessageListenerContainer container) {
+
+		if (this.errorHandler != null) {
+			this.errorHandler.handle(thrownException, Collections.EMPTY_LIST, consumer, container);
+		}
+		else {
+			this.batchErrorHandler.handle(thrownException, EMPTY_BATCH, consumer, container, () -> { });
+		}
+	}
+
+	@Override
+	public void handle(Exception thrownException, ConsumerRecord<?, ?> record, Consumer<?, ?> consumer,
+			MessageListenerContainer container) {
+
+		this.errorHandler.handle(thrownException, record, consumer);
+	}
+
+	@Override
+	public void handle(Exception thrownException, List<ConsumerRecord<?, ?>> records, Consumer<?, ?> consumer,
+			MessageListenerContainer container) {
+
+		this.errorHandler.handle(thrownException, records, consumer, container);
+	}
+
+	@Override
+	public void handle(Exception thrownException, ConsumerRecords<?, ?> data, Consumer<?, ?> consumer,
+			MessageListenerContainer container, Runnable invokeListener) {
+
+		this.batchErrorHandler.handle(thrownException, data, consumer, container, invokeListener);
+	}
+
+}
+

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -578,9 +578,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 
 		private final BlockingQueue<TopicPartitionOffset> seeks = new LinkedBlockingQueue<>();
 
-		private final ErrorHandler errorHandler;
-
-		private final BatchErrorHandler batchErrorHandler;
+		private final CommonErrorHandler commonErrorHandler;
 
 		private final PlatformTransactionManager transactionManager = this.containerProperties.getTransactionManager();
 
@@ -758,16 +756,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			this.listenerType = listenerType;
 			this.isConsumerAwareListener = listenerType.equals(ListenerType.ACKNOWLEDGING_CONSUMER_AWARE)
 					|| listenerType.equals(ListenerType.CONSUMER_AWARE);
-			if (this.isBatchListener) {
-				validateErrorHandler(true);
-				this.errorHandler = new LoggingErrorHandler();
-				this.batchErrorHandler = determineBatchErrorHandler(errHandler);
-			}
-			else {
-				validateErrorHandler(false);
-				this.errorHandler = determineErrorHandler(errHandler);
-				this.batchErrorHandler = new BatchLoggingErrorHandler();
-			}
+			this.commonErrorHandler = determineCommonErrorHandler(errHandler);
 			Assert.state(!this.isBatchListener || !this.isRecordAck,
 					"Cannot use AckMode.RECORD with a batch listener");
 			if (this.containerProperties.getScheduler() != null) {
@@ -805,6 +794,30 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			this.lastAlertPartition = new HashMap<>();
 			this.wasIdlePartition = new HashMap<>();
 			this.pausedPartitions = new HashSet<>();
+		}
+
+		@Nullable
+		private CommonErrorHandler determineCommonErrorHandler(GenericErrorHandler<?> errHandler) {
+			if (this.isBatchListener) {
+				validateErrorHandler(true);
+				BatchErrorHandler batchErrorHandler = determineBatchErrorHandler(errHandler);
+				if (batchErrorHandler != null) {
+					return new ErrorHandlerAdapter(batchErrorHandler);
+				}
+				else {
+					return null;
+				}
+			}
+			else {
+				validateErrorHandler(false);
+				ErrorHandler eh = determineErrorHandler(errHandler);
+				if (eh != null) {
+					return new ErrorHandlerAdapter(eh);
+				}
+				else {
+					return null;
+				}
+			}
 		}
 
 		private Properties propertiesFromProperties() {
@@ -872,8 +885,8 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 					}
 				}
 				else {
-					if (this.errorHandler instanceof DeliveryAttemptAware) {
-						aware = (DeliveryAttemptAware) this.errorHandler;
+					if (this.commonErrorHandler.deliveryAttemptHeader()) {
+						aware = this.commonErrorHandler;
 					}
 				}
 			}
@@ -1097,11 +1110,13 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			}
 		}
 
+		@Nullable
 		protected BatchErrorHandler determineBatchErrorHandler(GenericErrorHandler<?> errHandler) {
 			return errHandler != null ? (BatchErrorHandler) errHandler
 					: this.transactionManager != null ? null : new RecoveringBatchErrorHandler();
 		}
 
+		@Nullable
 		protected ErrorHandler determineErrorHandler(GenericErrorHandler<?> errHandler) {
 			return errHandler != null ? (ErrorHandler) errHandler
 					: this.transactionManager != null ? null : new SeekToCurrentErrorHandler();
@@ -1635,8 +1650,8 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			}
 			this.consumer.close();
 			getAfterRollbackProcessor().clearThreadState();
-			if (this.errorHandler != null) {
-				this.errorHandler.clearThreadState();
+			if (this.commonErrorHandler != null) {
+				this.commonErrorHandler.clearThreadState();
 			}
 			if (this.consumerSeekAwareListener != null) {
 				this.consumerSeekAwareListener.onPartitionsRevoked(partitions);
@@ -1657,14 +1672,9 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 				return;
 			}
 			try {
-				if (!this.isBatchListener && this.errorHandler != null) {
-					this.errorHandler.handle(e, Collections.emptyList(), this.consumer,
-							KafkaMessageListenerContainer.this.thisOrParentContainer);
-				}
-				else if (this.isBatchListener && this.batchErrorHandler != null) {
-					this.batchErrorHandler.handle(e, new ConsumerRecords<K, V>(Collections.emptyMap()), this.consumer,
-							KafkaMessageListenerContainer.this.thisOrParentContainer, () -> {
-							});
+				if (this.commonErrorHandler != null) {
+						this.commonErrorHandler.handleConsumerException(e, this.consumer,
+								KafkaMessageListenerContainer.this.thisOrParentContainer);
 				}
 				else {
 					this.logger.error(e, "Consumer exception");
@@ -1948,14 +1958,16 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 				successTimer(sample);
 				if (this.batchFailed) {
 					this.batchFailed = false;
-					this.batchErrorHandler.clearThreadState();
+					if (this.commonErrorHandler != null) {
+						this.commonErrorHandler.clearThreadState();
+					}
 					getAfterRollbackProcessor().clearThreadState();
 				}
 			}
 			catch (RuntimeException e) {
 				failureTimer(sample);
 				batchInterceptAfter(records, e);
-				if (this.batchErrorHandler == null) {
+				if (this.commonErrorHandler == null) {
 					throw e;
 				}
 				try {
@@ -1983,7 +1995,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		}
 
 		private void commitOffsetsIfNeeded(final ConsumerRecords<K, V> records) {
-			if ((!this.autoCommit && this.batchErrorHandler.isAckAfterHandle())
+			if ((!this.autoCommit && this.commonErrorHandler.isAckAfterHandle())
 					|| this.producer != null) {
 				this.acks.addAll(getHighestOffsetRecords(records));
 				if (this.producer != null) {
@@ -2116,7 +2128,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		private void invokeBatchErrorHandler(final ConsumerRecords<K, V> records,
 				@Nullable List<ConsumerRecord<K, V>> list, RuntimeException rte) {
 
-			this.batchErrorHandler.handle(rte, records, this.consumer,
+			this.commonErrorHandler.handle(rte, records, this.consumer,
 					KafkaMessageListenerContainer.this.thisOrParentContainer,
 					() -> invokeBatchOnMessageWithRecordsOrList(records, list));
 		}
@@ -2326,7 +2338,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			catch (RuntimeException e) {
 				failureTimer(sample);
 				recordInterceptAfter(record, e);
-				if (this.errorHandler == null) {
+				if (this.commonErrorHandler == null) {
 					throw e;
 				}
 				try {
@@ -2355,7 +2367,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		}
 
 		private void commitOffsetsIfNeeded(final ConsumerRecord<K, V> record) {
-			if ((!this.autoCommit && this.errorHandler.isAckAfterHandle())
+			if ((!this.autoCommit && this.commonErrorHandler.isAckAfterHandle())
 					|| this.producer != null) {
 				if (this.isManualAck) {
 					this.commitRecovered = true;
@@ -2452,7 +2464,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		private void invokeErrorHandler(final ConsumerRecord<K, V> record,
 				Iterator<ConsumerRecord<K, V>> iterator, RuntimeException rte) {
 
-			if (this.errorHandler instanceof RemainingRecordsErrorHandler) {
+			if (this.commonErrorHandler.remainingRecords()) {
 				if (this.producer == null) {
 					processCommits();
 				}
@@ -2461,11 +2473,12 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 				while (iterator.hasNext()) {
 					records.add(iterator.next());
 				}
-				this.errorHandler.handle(rte, records, this.consumer,
+				this.commonErrorHandler.handle(rte, records, this.consumer,
 						KafkaMessageListenerContainer.this.thisOrParentContainer);
 			}
 			else {
-				this.errorHandler.handle(rte, record, this.consumer);
+				this.commonErrorHandler.handle(rte, record, this.consumer,
+						KafkaMessageListenerContainer.this.thisOrParentContainer);
 			}
 		}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -1673,7 +1673,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			}
 			try {
 				if (this.commonErrorHandler != null) {
-						this.commonErrorHandler.handleConsumerException(e, this.consumer,
+						this.commonErrorHandler.handleOtherException(e, this.consumer,
 								KafkaMessageListenerContainer.this.thisOrParentContainer);
 				}
 				else {
@@ -2128,7 +2128,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		private void invokeBatchErrorHandler(final ConsumerRecords<K, V> records,
 				@Nullable List<ConsumerRecord<K, V>> list, RuntimeException rte) {
 
-			this.commonErrorHandler.handle(rte, records, this.consumer,
+			this.commonErrorHandler.handleBatch(rte, records, this.consumer,
 					KafkaMessageListenerContainer.this.thisOrParentContainer,
 					() -> invokeBatchOnMessageWithRecordsOrList(records, list));
 		}
@@ -2473,11 +2473,11 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 				while (iterator.hasNext()) {
 					records.add(iterator.next());
 				}
-				this.commonErrorHandler.handle(rte, records, this.consumer,
+				this.commonErrorHandler.handleRemaining(rte, records, this.consumer,
 						KafkaMessageListenerContainer.this.thisOrParentContainer);
 			}
 			else {
-				this.commonErrorHandler.handle(rte, record, this.consumer,
+				this.commonErrorHandler.handleRecord(rte, record, this.consumer,
 						KafkaMessageListenerContainer.this.thisOrParentContainer);
 			}
 		}


### PR DESCRIPTION
Flatten `GenericErrorHandler` into a single interface.
Create an adapter for legacy error handlers.

See https://github.com/spring-projects/spring-kafka/issues/615