### PR TITLE
GH-615: Add DefaultErrorHandler

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonDelegatingErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonDelegatingErrorHandler.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * An error handler that delegates to different error handlers, depending on the exception
+ * type. The delegates must have compatible properties ({@link #isAckAfterHandle()} etc.
+ * {@link #deliveryAttemptHeader()} is not supported - always returns false.
+ *
+ * @author Gary Russell
+ * @since 2.8
+ *
+ */
+public class CommonDelegatingErrorHandler implements CommonErrorHandler {
+
+	private final CommonErrorHandler defaultErrorHandler;
+
+	private final Map<Class<? extends Throwable>, CommonErrorHandler> delegates = new LinkedHashMap<>();
+
+	/**
+	 * Construct an instance with a default error handler that will be invoked if the
+	 * exception has no matches.
+	 * @param defaultErrorHandler the default error handler.
+	 */
+	public CommonDelegatingErrorHandler(CommonErrorHandler defaultErrorHandler) {
+		Assert.notNull(defaultErrorHandler, "'defaultErrorHandler' cannot be null");
+		this.defaultErrorHandler = defaultErrorHandler;
+	}
+
+	/**
+	 * Set the delegate error handlers; a {@link LinkedHashMap} argument is recommended so
+	 * that the delegates are searched in a known order.
+	 * @param delegates the delegates.
+	 */
+	public void setErrorHandlers(Map<Class<? extends Throwable>, CommonErrorHandler> delegates) {
+		this.delegates.clear();
+		this.delegates.putAll(delegates);
+		checkDelegates();
+	}
+
+
+	@Override
+	public boolean remainingRecords() {
+		return this.defaultErrorHandler.remainingRecords();
+	}
+
+	@Override
+	public void clearThreadState() {
+		this.defaultErrorHandler.clearThreadState();
+		this.delegates.values().forEach(handler -> handler.clearThreadState());
+	}
+
+	@Override
+	public boolean isAckAfterHandle() {
+		return this.defaultErrorHandler.isAckAfterHandle();
+	}
+
+	@Override
+	public void setAckAfterHandle(boolean ack) {
+		this.defaultErrorHandler.setAckAfterHandle(ack);
+	}
+
+	/**
+	 * Add a delegate to the end of the current collection.
+	 * @param throwable the throwable for this handler.
+	 * @param handler the handler.
+	 */
+	public void addDelegate(Class<? extends Throwable> throwable, CommonErrorHandler handler) {
+		this.delegates.put(throwable, handler);
+		checkDelegates();
+	}
+
+	private void checkDelegates() {
+		boolean remainingRecords = this.defaultErrorHandler.remainingRecords();
+		boolean ackAfterHandle = this.defaultErrorHandler.isAckAfterHandle();
+		this.delegates.values().forEach(handler -> {
+			Assert.isTrue(remainingRecords == handler.remainingRecords(),
+					"All delegates must return the same value when calling 'remainingRecords()'");
+			Assert.isTrue(ackAfterHandle == handler.isAckAfterHandle(),
+					"All delegates must return the same value when calling 'isAckAfterHandle()'");
+		});
+	}
+
+	@Override
+	public void handleRemaining(Exception thrownException, List<ConsumerRecord<?, ?>> records,
+			Consumer<?, ?> consumer, MessageListenerContainer container) {
+
+		CommonErrorHandler handler = findDelegate(thrownException);
+		if (handler != null) {
+			handler.handleRemaining(thrownException, records, consumer, container);
+		}
+		else {
+			this.defaultErrorHandler.handleRemaining(thrownException, records, consumer, container);
+		}
+	}
+
+	@Override
+	public void handleBatch(Exception thrownException, ConsumerRecords<?, ?> data, Consumer<?, ?> consumer,
+			MessageListenerContainer container, Runnable invokeListener) {
+
+		CommonErrorHandler handler = findDelegate(thrownException);
+		if (handler != null) {
+			handler.handleBatch(thrownException, data, consumer, container, invokeListener);
+		}
+		else {
+			this.defaultErrorHandler.handleBatch(thrownException, data, consumer, container, invokeListener);
+		}
+	}
+
+	@Override
+	public void handleOtherException(Exception thrownException, Consumer<?, ?> consumer,
+			MessageListenerContainer container) {
+
+		CommonErrorHandler handler = findDelegate(thrownException);
+		if (handler != null) {
+			handler.handleOtherException(thrownException, consumer, container);
+		}
+		else {
+			this.defaultErrorHandler.handleOtherException(thrownException, consumer, container);
+		}
+	}
+
+	@Nullable
+	private CommonErrorHandler findDelegate(Throwable thrownException) {
+		Throwable cause = thrownException;
+		if (cause instanceof ListenerExecutionFailedException) {
+			cause = thrownException.getCause();
+		}
+		if (cause != null) {
+			Class<? extends Throwable> causeClass = cause.getClass();
+			for (Entry<Class<? extends Throwable>, CommonErrorHandler> entry : this.delegates.entrySet()) {
+				if (entry.getKey().isAssignableFrom(causeClass)) {
+					return entry.getValue();
+				}
+			}
+		}
+		return null;
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConditionalDelegatingBatchErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConditionalDelegatingBatchErrorHandler.java
@@ -30,10 +30,13 @@ import org.springframework.util.Assert;
  * An error handler that delegates to different error handlers, depending on the exception
  * type.
  *
+ * @deprecated in favor of {@link CommonDelegatingErrorHandler}.
+ *
  * @author Gary Russell
  * @since 2.7.4
  *
  */
+@Deprecated
 public class ConditionalDelegatingBatchErrorHandler implements ListenerInvokingBatchErrorHandler {
 
 	private final ContainerAwareBatchErrorHandler defaultErrorHandler;

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConditionalDelegatingErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConditionalDelegatingErrorHandler.java
@@ -31,10 +31,13 @@ import org.springframework.util.Assert;
  * An error handler that delegates to different error handlers, depending on the exception
  * type.
  *
+ * @deprecated in favor of {@link CommonDelegatingErrorHandler}.
+ *
  * @author Gary Russell
  * @since 2.7.4
  *
  */
+@Deprecated
 public class ConditionalDelegatingErrorHandler implements ContainerAwareErrorHandler {
 
 	private final ContainerAwareErrorHandler defaultErrorHandler;

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/DefaultErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/DefaultErrorHandler.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import java.util.List;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.errors.SerializationException;
+
+import org.springframework.lang.Nullable;
+import org.springframework.util.backoff.BackOff;
+
+/**
+ * An error handler that, for record listeners, seeks to the current offset for each topic
+ * in the remaining records. Used to rewind partitions after a message failure so that it
+ * can be replayed. For batch listeners, seeks to the current offset for each topic in a
+ * batch of records. Used to rewind partitions after a message failure so that the batch
+ * can be replayed. If the listener throws a {@link BatchListenerFailedException}, with
+ * the failed record. The records before the record will have their offsets committed and
+ * the partitions for the remaining records will be repositioned and/or the failed record
+ * can be recovered and skipped. If some other exception is thrown, or a valid record is
+ * not provided in the exception, error handling is delegated to a
+ * {@link RetryingBatchErrorHandler} with this handler's {@link BackOff}. If the record is
+ * recovered, its offset is committed. This is a replacement for the legacy
+ * {@link SeekToCurrentErrorHandler} and {@link SeekToCurrentBatchErrorHandler} (but the
+ * fallback now can send the messages to a recoverer after retries are completed instead
+ * of retring indefinitely).
+ *
+ * @author Gary Russell
+ *
+ * @since 2.8
+ *
+ */
+public class DefaultErrorHandler extends FailedBatchProcessor implements CommonErrorHandler {
+
+	private boolean ackAfterHandle = true;
+
+	/**
+	 * Construct an instance with the default recoverer which simply logs the record after
+	 * {@value SeekUtils#DEFAULT_MAX_FAILURES} (maxFailures) have occurred for a
+	 * topic/partition/offset, with the default back off (9 retries, no delay).
+	 */
+	public DefaultErrorHandler() {
+		this(null, SeekUtils.DEFAULT_BACK_OFF);
+	}
+
+	/**
+	 * Construct an instance with the default recoverer which simply logs the record after
+	 * the backOff returns STOP for a topic/partition/offset.
+	 * @param backOff the {@link BackOff}.
+	 */
+	public DefaultErrorHandler(BackOff backOff) {
+		this(null, backOff);
+	}
+
+	/**
+	 * Construct an instance with the provided recoverer which will be called after
+	 * {@value SeekUtils#DEFAULT_MAX_FAILURES} (maxFailures) have occurred for a
+	 * topic/partition/offset.
+	 * @param recoverer the recoverer.
+	 */
+	public DefaultErrorHandler(ConsumerRecordRecoverer recoverer) {
+		this(recoverer, SeekUtils.DEFAULT_BACK_OFF);
+	}
+
+	/**
+	 * Construct an instance with the provided recoverer which will be called after
+	 * the backOff returns STOP for a topic/partition/offset.
+	 * @param recoverer the recoverer; if null, the default (logging) recoverer is used.
+	 * @param backOff the {@link BackOff}.
+	 */
+	public DefaultErrorHandler(@Nullable ConsumerRecordRecoverer recoverer, BackOff backOff) {
+		super(recoverer, backOff, createFallback(backOff, recoverer));
+	}
+
+	private static CommonErrorHandler createFallback(BackOff backOff, ConsumerRecordRecoverer recoverer) {
+		return new ErrorHandlerAdapter(new RetryingBatchErrorHandler(backOff, recoverer));
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * The container must be configured with
+	 * {@link org.springframework.kafka.listener.ContainerProperties.AckMode#MANUAL_IMMEDIATE}.
+	 * Whether or not the commit is sync or async depends on the container's syncCommits
+	 * property.
+	 * @param commitRecovered true to commit.
+	 */
+	@Override
+	public void setCommitRecovered(boolean commitRecovered) { // NOSONAR enhanced javadoc
+		super.setCommitRecovered(commitRecovered);
+	}
+
+	@Override
+	public boolean isAckAfterHandle() {
+		return this.ackAfterHandle;
+	}
+
+	@Override
+	public void setAckAfterHandle(boolean ackAfterHandle) {
+		this.ackAfterHandle = ackAfterHandle;
+	}
+
+	@Override
+	public void handleRemaining(Exception thrownException, List<ConsumerRecord<?, ?>> records,
+			Consumer<?, ?> consumer, MessageListenerContainer container) {
+
+		SeekUtils.seekOrRecover(thrownException, records, consumer, container, isCommitRecovered(), // NOSONAR
+				getRecoveryStrategy(records, thrownException), this.logger, getLogLevel());
+	}
+
+	@Override
+	public void handleBatch(Exception thrownException, ConsumerRecords<?, ?> data, Consumer<?, ?> consumer,
+			MessageListenerContainer container, Runnable invokeListener) {
+
+		doHandle(thrownException, data, consumer, container, invokeListener);
+	}
+
+	@Override
+	public void handleOtherException(Exception thrownException, Consumer<?, ?> consumer,
+			MessageListenerContainer container) {
+
+		if (thrownException instanceof SerializationException) {
+			throw new IllegalStateException("This error handler cannot process 'SerializationException's directly; "
+					+ "please consider configuring an 'ErrorHandlingDeserializer' in the value and/or key "
+					+ "deserializer", thrownException);
+		}
+		else {
+			throw new IllegalStateException("This error handler cannot process '"
+					+ thrownException.getClass().getName()
+					+ "'s; no record information is available", thrownException);
+		}
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ErrorHandlingUtils.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ErrorHandlingUtils.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import java.time.Duration;
+import java.util.function.BiConsumer;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+
+import org.springframework.core.log.LogAccessor;
+import org.springframework.kafka.KafkaException;
+import org.springframework.util.backoff.BackOff;
+import org.springframework.util.backoff.BackOffExecution;
+
+/**
+ * Utilities for error handling.
+ *
+ * @author Gary Russell
+ * @since 2.8
+ *
+ */
+public final class ErrorHandlingUtils {
+
+	private ErrorHandlingUtils() {
+	}
+
+	/**
+	 * Retry a complete batch by pausing the consumer and then, in a loop, poll the
+	 * consumer, wait for the next back off, then call the listener. When retries are
+	 * exhausted, call the recoverer with the {@link ConsumerRecords}.
+	 * @param thrownException the exception.
+	 * @param records the records.
+	 * @param consumer the consumer.
+	 * @param container the container.
+	 * @param invokeListener the {@link Runnable} to run (call the listener).
+	 * @param backOff the backOff.
+	 * @param seeker the common error handler that re-seeks the entire batch.
+	 * @param recoverer the recoverer.
+	 * @param logger the logger.
+	 * @param logLevel the log level.
+	 */
+	public static void retryBatch(Exception thrownException, ConsumerRecords<?, ?> records, Consumer<?, ?> consumer,
+			MessageListenerContainer container, Runnable invokeListener, BackOff backOff,
+			CommonErrorHandler seeker, BiConsumer<ConsumerRecords<?, ?>, Exception> recoverer, LogAccessor logger,
+			KafkaException.Level logLevel) {
+
+		BackOffExecution execution = backOff.start();
+		long nextBackOff = execution.nextBackOff();
+		String failed = null;
+		consumer.pause(consumer.assignment());
+		try {
+			while (nextBackOff != BackOffExecution.STOP) {
+				consumer.poll(Duration.ZERO);
+				try {
+					ListenerUtils.stoppableSleep(container, nextBackOff);
+				}
+				catch (InterruptedException e1) {
+					Thread.currentThread().interrupt();
+					seeker.handleBatch(thrownException, records, consumer, container, () -> { });
+					throw new KafkaException("Interrupted during retry", logLevel, e1);
+				}
+				try {
+					invokeListener.run();
+					return;
+				}
+				catch (Exception e) {
+					if (failed == null) {
+						failed = recordsToString(records);
+					}
+					String toLog = failed;
+					logger.debug(e, () -> "Retry failed for: " + toLog);
+				}
+				nextBackOff = execution.nextBackOff();
+			}
+			try {
+				recoverer.accept(records, thrownException);
+			}
+			catch (Exception e) {
+				logger.error(e, () -> "Recoverer threw an exception; re-seeking batch");
+				seeker.handleBatch(thrownException, records, consumer, container, () -> { });
+			}
+		}
+		finally {
+			consumer.resume(consumer.assignment());
+		}
+	}
+
+	/**
+	 * Represent the records as a comma-delimited String of {@code topic-part@offset}.
+	 * @param records the records.
+	 * @return the String.
+	 */
+	public static String recordsToString(ConsumerRecords<?, ?> records) {
+		StringBuffer sb = new StringBuffer();
+		records.spliterator().forEachRemaining(rec -> sb
+				.append(ListenerUtils.recordToString(rec, true))
+				.append(','));
+		sb.deleteCharAt(sb.length() - 1);
+		return sb.toString();
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedBatchProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedBatchProcessor.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiConsumer;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetCommitCallback;
+import org.apache.kafka.common.TopicPartition;
+
+import org.springframework.kafka.KafkaException;
+import org.springframework.lang.Nullable;
+import org.springframework.util.backoff.BackOff;
+
+/**
+ * Subclass of {@link FailedRecordProcessor} that can process (and recover) a batch. If
+ * the listener throws a {@link BatchListenerFailedException}, the offsets prior to the
+ * failed record are committed and the remaining records have seeks performed. When the
+ * retries are exhausted, the failed record is sent to the recoverer instead of being
+ * included in the seeks. If other exceptions are thrown processing is delegated to the
+ * fallback handler.
+ *
+ * @author Gary Russell
+ * @since 2.8
+ *
+ */
+public abstract class FailedBatchProcessor extends FailedRecordProcessor {
+
+	private static final LoggingCommitCallback LOGGING_COMMIT_CALLBACK = new LoggingCommitCallback();
+
+	private final CommonErrorHandler fallbackHandler;
+
+	/**
+	 * Construct an instance with the provided properties.
+	 * @param recoverer the recoverer.
+	 * @param backOff the back off.
+	 * @param fallbackHandler the fall back handler.
+	 */
+	public FailedBatchProcessor(@Nullable BiConsumer<ConsumerRecord<?, ?>, Exception> recoverer, BackOff backOff,
+			CommonErrorHandler fallbackHandler) {
+
+		super(recoverer, backOff);
+		this.fallbackHandler = fallbackHandler;
+	}
+
+	protected void doHandle(Exception thrownException, ConsumerRecords<?, ?> data, Consumer<?, ?> consumer,
+			MessageListenerContainer container, Runnable invokeListener) {
+
+		BatchListenerFailedException batchListenerFailedException = getBatchListenerFailedException(thrownException);
+		if (batchListenerFailedException == null) {
+			this.logger.debug(thrownException, "Expected a BatchListenerFailedException; re-seeking batch");
+			this.fallbackHandler.handleBatch(thrownException, data, consumer, container, invokeListener);
+		}
+		else {
+			ConsumerRecord<?, ?> record = batchListenerFailedException.getRecord();
+			int index = record != null ? findIndex(data, record) : batchListenerFailedException.getIndex();
+			if (index < 0 || index >= data.count()) {
+				this.logger.warn(batchListenerFailedException, () ->
+						String.format("Record not found in batch: %s-%d@%d; re-seeking batch",
+								record.topic(), record.partition(), record.offset()));
+				this.fallbackHandler.handleBatch(thrownException, data, consumer, container, invokeListener);
+			}
+			else {
+				seekOrRecover(thrownException, data, consumer, container, index);
+			}
+		}
+	}
+
+	private int findIndex(ConsumerRecords<?, ?> data, ConsumerRecord<?, ?> record) {
+		if (record == null) {
+			return -1;
+		}
+		int i = 0;
+		Iterator<?> iterator = data.iterator();
+		while (iterator.hasNext()) {
+			ConsumerRecord<?, ?> candidate = (ConsumerRecord<?, ?>) iterator.next();
+			if (candidate.topic().equals(record.topic()) && candidate.partition() == record.partition()
+					&& candidate.offset() == record.offset()) {
+				break;
+			}
+			i++;
+		}
+		return i;
+	}
+
+	private void seekOrRecover(Exception thrownException, @Nullable ConsumerRecords<?, ?> data, Consumer<?, ?> consumer, MessageListenerContainer container, int indexArg) {
+
+		if (data == null) {
+			return;
+		}
+		Iterator<?> iterator = data.iterator();
+		List<ConsumerRecord<?, ?>> toCommit = new ArrayList<>();
+		List<ConsumerRecord<?, ?>> remaining = new ArrayList<>();
+		int index = indexArg;
+		while (iterator.hasNext()) {
+			ConsumerRecord<?, ?> record = (ConsumerRecord<?, ?>) iterator.next();
+			if (index-- > 0) {
+				toCommit.add(record);
+			}
+			else {
+				remaining.add(record);
+			}
+		}
+		Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
+		toCommit.forEach(rec -> offsets.compute(new TopicPartition(rec.topic(), rec.partition()),
+				(key, val) -> new OffsetAndMetadata(rec.offset() + 1)));
+		if (offsets.size() > 0) {
+			commit(consumer, container, offsets);
+		}
+		if (remaining.size() > 0) {
+			SeekUtils.seekOrRecover(thrownException, remaining, consumer, container, false,
+				getRecoveryStrategy(remaining, thrownException), this.logger, getLogLevel());
+			ConsumerRecord<?, ?> recovered = remaining.get(0);
+			commit(consumer, container,
+					Collections.singletonMap(new TopicPartition(recovered.topic(), recovered.partition()),
+							new OffsetAndMetadata(recovered.offset() + 1)));
+			if (remaining.size() > 1) {
+				throw new KafkaException("Seek to current after exception", getLogLevel(), thrownException);
+			}
+		}
+	}
+
+	private void commit(Consumer<?, ?> consumer, MessageListenerContainer container, Map<TopicPartition, OffsetAndMetadata> offsets) {
+
+		boolean syncCommits = container.getContainerProperties().isSyncCommits();
+		Duration timeout = container.getContainerProperties().getSyncCommitTimeout();
+		if (syncCommits) {
+			consumer.commitSync(offsets, timeout);
+		}
+		else {
+			OffsetCommitCallback commitCallback = container.getContainerProperties().getCommitCallback();
+			if (commitCallback == null) {
+				commitCallback = LOGGING_COMMIT_CALLBACK;
+			}
+			consumer.commitAsync(offsets, commitCallback);
+		}
+	}
+
+	@Nullable
+	private BatchListenerFailedException getBatchListenerFailedException(Throwable throwableArg) {
+		if (throwableArg == null || throwableArg instanceof BatchListenerFailedException) {
+			return (BatchListenerFailedException) throwableArg;
+		}
+
+		BatchListenerFailedException target = null;
+
+		Throwable throwable = throwableArg;
+		Set<Throwable> checked = new HashSet<>();
+		while (throwable.getCause() != null && !checked.contains(throwable.getCause())) {
+			throwable = throwable.getCause();
+			checked.add(throwable);
+
+			if (throwable instanceof BatchListenerFailedException) {
+				target = (BatchListenerFailedException) throwable;
+				break;
+			}
+		}
+
+		return target;
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -797,13 +797,16 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		}
 
 		@Nullable
-		private CommonErrorHandler determineCommonErrorHandler(GenericErrorHandler<?> errHandler) {
+		private CommonErrorHandler determineCommonErrorHandler(@Nullable GenericErrorHandler<?> errHandler) {
 			CommonErrorHandler common = getCommonErrorHandler();
 			if (common != null) {
 				if (errHandler != null) {
 					this.logger.debug("GenericErrorHandler is ignored when a CommonErrorHandler is provided");
 				}
 				return common;
+			}
+			if (errHandler == null && this.transactionManager == null) {
+				return new DefaultErrorHandler();
 			}
 			if (this.isBatchListener) {
 				validateErrorHandler(true);

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/CommonDelegatingErrorHandlerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/CommonDelegatingErrorHandlerTests.java
@@ -31,59 +31,61 @@ import org.junit.jupiter.api.Test;
 import org.springframework.kafka.KafkaException;
 
 /**
+ * Tests for {@link CommonDelegatingErrorHandler}. Copied from
+ * {@link ConditionalDelegatingErrorHandlerTests} with changed handler type.
+ *
  * @author Gary Russell
- * @since 2.7.4
+ * @since 2.8
  *
  */
-@SuppressWarnings("deprecation")
-public class ConditionalDelegatingErrorHandlerTests {
+public class CommonDelegatingErrorHandlerTests {
 
 	@Test
 	void testRecordDelegates() {
-		var def = mock(ContainerAwareErrorHandler.class);
-		var one = mock(ContainerAwareErrorHandler.class);
-		var two = mock(ContainerAwareErrorHandler.class);
-		var three = mock(ContainerAwareErrorHandler.class);
-		var eh = new ConditionalDelegatingErrorHandler(def);
+		var def = mock(CommonErrorHandler.class);
+		var one = mock(CommonErrorHandler.class);
+		var two = mock(CommonErrorHandler.class);
+		var three = mock(CommonErrorHandler.class);
+		var eh = new CommonDelegatingErrorHandler(def);
 		eh.setErrorHandlers(Map.of(IllegalStateException.class, one, IllegalArgumentException.class, two));
 		eh.addDelegate(RuntimeException.class, three);
 
-		eh.handle(wrap(new IOException()), Collections.emptyList(), mock(Consumer.class),
+		eh.handleRemaining(wrap(new IOException()), Collections.emptyList(), mock(Consumer.class),
 				mock(MessageListenerContainer.class));
-		verify(def).handle(any(), any(), any(), any());
-		eh.handle(wrap(new KafkaException("test")), Collections.emptyList(), mock(Consumer.class),
+		verify(def).handleRemaining(any(), any(), any(), any());
+		eh.handleRemaining(wrap(new KafkaException("test")), Collections.emptyList(), mock(Consumer.class),
 				mock(MessageListenerContainer.class));
-		verify(three).handle(any(), any(), any(), any());
-		eh.handle(wrap(new IllegalArgumentException()), Collections.emptyList(), mock(Consumer.class),
+		verify(three).handleRemaining(any(), any(), any(), any());
+		eh.handleRemaining(wrap(new IllegalArgumentException()), Collections.emptyList(), mock(Consumer.class),
 				mock(MessageListenerContainer.class));
-		verify(two).handle(any(), any(), any(), any());
-		eh.handle(wrap(new IllegalStateException()), Collections.emptyList(), mock(Consumer.class),
+		verify(two).handleRemaining(any(), any(), any(), any());
+		eh.handleRemaining(wrap(new IllegalStateException()), Collections.emptyList(), mock(Consumer.class),
 				mock(MessageListenerContainer.class));
-		verify(one).handle(any(), any(), any(), any());
+		verify(one).handleRemaining(any(), any(), any(), any());
 	}
 
 	@Test
 	void testBatchDelegates() {
-		var def = mock(ContainerAwareBatchErrorHandler.class);
-		var one = mock(ContainerAwareBatchErrorHandler.class);
-		var two = mock(ContainerAwareBatchErrorHandler.class);
-		var three = mock(ContainerAwareBatchErrorHandler.class);
-		var eh = new ConditionalDelegatingBatchErrorHandler(def);
+		var def = mock(CommonErrorHandler.class);
+		var one = mock(CommonErrorHandler.class);
+		var two = mock(CommonErrorHandler.class);
+		var three = mock(CommonErrorHandler.class);
+		var eh = new CommonDelegatingErrorHandler(def);
 		eh.setErrorHandlers(Map.of(IllegalStateException.class, one, IllegalArgumentException.class, two));
 		eh.addDelegate(RuntimeException.class, three);
 
-		eh.handle(wrap(new IOException()), mock(ConsumerRecords.class), mock(Consumer.class),
+		eh.handleBatch(wrap(new IOException()), mock(ConsumerRecords.class), mock(Consumer.class),
 				mock(MessageListenerContainer.class), mock(Runnable.class));
-		verify(def).handle(any(), any(), any(), any(), any());
-		eh.handle(wrap(new KafkaException("test")), mock(ConsumerRecords.class), mock(Consumer.class),
+		verify(def).handleBatch(any(), any(), any(), any(), any());
+		eh.handleBatch(wrap(new KafkaException("test")), mock(ConsumerRecords.class), mock(Consumer.class),
 				mock(MessageListenerContainer.class), mock(Runnable.class));
-		verify(three).handle(any(), any(), any(), any(), any());
-		eh.handle(wrap(new IllegalArgumentException()), mock(ConsumerRecords.class), mock(Consumer.class),
+		verify(three).handleBatch(any(), any(), any(), any(), any());
+		eh.handleBatch(wrap(new IllegalArgumentException()), mock(ConsumerRecords.class), mock(Consumer.class),
 				mock(MessageListenerContainer.class), mock(Runnable.class));
-		verify(two).handle(any(), any(), any(), any(), any());
-		eh.handle(wrap(new IllegalStateException()), mock(ConsumerRecords.class), mock(Consumer.class),
+		verify(two).handleBatch(any(), any(), any(), any(), any());
+		eh.handleBatch(wrap(new IllegalStateException()), mock(ConsumerRecords.class), mock(Consumer.class),
 				mock(MessageListenerContainer.class), mock(Runnable.class));
-		verify(one).handle(any(), any(), any(), any(), any());
+		verify(one).handleBatch(any(), any(), any(), any(), any());
 	}
 
 	private Exception wrap(Exception ex) {

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/DefaultErrorHandlerBatchIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/DefaultErrorHandlerBatchIntegrationTests.java
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2020-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaOperations;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.event.ConsumerStoppedEvent;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.condition.EmbeddedKafkaCondition;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.util.backoff.FixedBackOff;
+
+/**
+ * {@link DefaultErrorHandler} tests for batch listeners. Copied from
+ * {@link RecoveringBatchErrorHandlerIntegrationTests} changing error handler type.
+ * @author Gary Russell
+ * @since 2.8
+ *
+ */
+@EmbeddedKafka(topics = {
+		DefaultErrorHandlerBatchIntegrationTests.topic1,
+		DefaultErrorHandlerBatchIntegrationTests.topic1DLT,
+		DefaultErrorHandlerBatchIntegrationTests.topic2,
+		DefaultErrorHandlerBatchIntegrationTests.topic2DLT })
+public class DefaultErrorHandlerBatchIntegrationTests {
+
+	public static final String topic1 = "dehTopic1";
+
+	public static final String topic1DLT = "dehTopic1.DLT";
+
+	public static final String topic2 = "dehTopic2";
+
+	public static final String topic2DLT = "dehTopic2.DLT";
+
+	private static EmbeddedKafkaBroker embeddedKafka;
+
+	@BeforeAll
+	public static void setup() {
+		embeddedKafka = EmbeddedKafkaCondition.getBroker();
+	}
+
+	@Test
+	public void recoveryAndDlt() throws InterruptedException {
+		Map<String, Object> props = KafkaTestUtils.consumerProps("recoverBatch", "false", embeddedKafka);
+		props.put(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, 1000);
+		props.put(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG, 500);
+		DefaultKafkaConsumerFactory<Integer, String> cf = new DefaultKafkaConsumerFactory<>(props);
+		ContainerProperties containerProps = new ContainerProperties(topic1);
+		containerProps.setPollTimeout(10_000);
+
+		Map<String, Object> senderProps = KafkaTestUtils.producerProps(embeddedKafka);
+		DefaultKafkaProducerFactory<Object, Object> pf = new DefaultKafkaProducerFactory<>(senderProps);
+		final KafkaOperations<Object, Object> template = new KafkaTemplate<>(pf);
+		final CountDownLatch latch = new CountDownLatch(3);
+		List<ConsumerRecord<Integer, String>> data = new ArrayList<>();
+		containerProps.setMessageListener((BatchMessageListener<Integer, String>) records -> {
+			data.addAll(records);
+			latch.countDown();
+			records.forEach(rec -> {
+				if (rec.value().equals("baz")) {
+					throw new BatchListenerFailedException("fail", rec);
+				}
+			});
+		});
+
+		KafkaMessageListenerContainer<Integer, String> container =
+				new KafkaMessageListenerContainer<>(cf, containerProps);
+		container.setBeanName("recoverBatch");
+		DeadLetterPublishingRecoverer recoverer =
+				new DeadLetterPublishingRecoverer(template,
+						(r, e) -> new TopicPartition(topic1DLT, r.partition()));
+		DefaultErrorHandler errorHandler = new DefaultErrorHandler(recoverer, new FixedBackOff(0L, 1));
+		container.setCommonErrorHandler(errorHandler);
+		final CountDownLatch stopLatch = new CountDownLatch(1);
+		container.setApplicationEventPublisher(e -> {
+			if (e instanceof ConsumerStoppedEvent) {
+				stopLatch.countDown();
+			}
+		});
+		container.start();
+
+		template.send(topic1, 0, 0, "foo");
+		template.send(topic1, 0, 0, "bar");
+		template.send(topic1, 0, 0, "baz");
+		template.send(topic1, 0, 0, "qux");
+		template.send(topic1, 0, 0, "fiz");
+		template.send(topic1, 0, 0, "buz");
+		assertThat(latch.await(60, TimeUnit.SECONDS)).isTrue();
+		assertThat(data).hasSize(13);
+		assertThat(data)
+				.extracting(rec -> rec.value())
+				.containsExactly(
+					"foo", "bar", "baz", "qux", "fiz", "buz",
+					"baz", "qux", "fiz", "buz",
+					"qux", "fiz", "buz");
+
+		props.put(ConsumerConfig.GROUP_ID_CONFIG, "recoverBatch.dlt");
+		DefaultKafkaConsumerFactory<Integer, String> dltcf = new DefaultKafkaConsumerFactory<>(props);
+		Consumer<Integer, String> consumer = dltcf.createConsumer();
+		embeddedKafka.consumeFromAnEmbeddedTopic(consumer, topic1DLT);
+		ConsumerRecord<Integer, String> dltRecord = KafkaTestUtils.getSingleRecord(consumer, topic1DLT);
+		assertThat(dltRecord.value()).isEqualTo("baz");
+		container.stop();
+		pf.destroy();
+		consumer.close();
+		assertThat(stopLatch.await(10, TimeUnit.SECONDS)).isTrue();
+	}
+
+	@Test
+	public void recoveryFails() throws InterruptedException {
+		Map<String, Object> props = KafkaTestUtils.consumerProps("recoverBatch2", "false", embeddedKafka);
+		props.put(ConsumerConfig.FETCH_MIN_BYTES_CONFIG, 1000);
+		props.put(ConsumerConfig.FETCH_MAX_WAIT_MS_CONFIG, 500);
+		DefaultKafkaConsumerFactory<Integer, String> cf = new DefaultKafkaConsumerFactory<>(props);
+		ContainerProperties containerProps = new ContainerProperties(topic2);
+		containerProps.setPollTimeout(10_000);
+
+		Map<String, Object> senderProps = KafkaTestUtils.producerProps(embeddedKafka);
+		DefaultKafkaProducerFactory<Object, Object> pf = new DefaultKafkaProducerFactory<>(senderProps);
+		final KafkaOperations<Object, Object> template = new KafkaTemplate<>(pf);
+		final CountDownLatch latch = new CountDownLatch(4);
+		List<ConsumerRecord<Integer, String>> data = new ArrayList<>();
+		containerProps.setMessageListener((BatchMessageListener<Integer, String>) records -> {
+			data.addAll(records);
+			latch.countDown();
+			records.forEach(rec -> {
+				if (rec.value().equals("baz")) {
+					throw new BatchListenerFailedException("fail", rec);
+				}
+			});
+		});
+
+		KafkaMessageListenerContainer<Integer, String> container =
+				new KafkaMessageListenerContainer<>(cf, containerProps);
+		container.setBeanName("recoverBatch");
+		final AtomicBoolean failRecovery = new AtomicBoolean(true);
+		DeadLetterPublishingRecoverer recoverer =
+				new DeadLetterPublishingRecoverer(template,
+						(r, e) -> new TopicPartition(topic2DLT, r.partition())) {
+
+			@Override
+			public void accept(ConsumerRecord<?, ?> record, Consumer<?, ?> consumer, Exception exception) {
+				if (failRecovery.getAndSet(false)) {
+					throw new RuntimeException("Recovery failed");
+				}
+				super.accept(record, consumer, exception);
+			}
+
+		};
+		DefaultErrorHandler errorHandler = new DefaultErrorHandler(recoverer, new FixedBackOff(0L, 1));
+		errorHandler.setResetStateOnRecoveryFailure(false);
+		container.setCommonErrorHandler(errorHandler);
+		final CountDownLatch stopLatch = new CountDownLatch(1);
+		container.setApplicationEventPublisher(e -> {
+			if (e instanceof ConsumerStoppedEvent) {
+				stopLatch.countDown();
+			}
+		});
+		container.start();
+
+		template.send(topic2, 0, 0, "foo");
+		template.send(topic2, 0, 0, "bar");
+		template.send(topic2, 0, 0, "baz");
+		template.send(topic2, 0, 0, "qux");
+		template.send(topic2, 0, 0, "fiz");
+		template.send(topic2, 0, 0, "buz");
+		assertThat(latch.await(60, TimeUnit.SECONDS)).isTrue();
+		assertThat(data).hasSize(17);
+		assertThat(data)
+				.extracting(rec -> rec.value())
+				.containsExactly(
+					"foo", "bar", "baz", "qux", "fiz", "buz",
+					"baz", "qux", "fiz", "buz",
+					// recovery failed first time so we get the whole batch again
+					"baz", "qux", "fiz", "buz",
+					"qux", "fiz", "buz");
+
+		props.put(ConsumerConfig.GROUP_ID_CONFIG, "recoverBatch2.dlt");
+		DefaultKafkaConsumerFactory<Integer, String> dltcf = new DefaultKafkaConsumerFactory<>(props);
+		Consumer<Integer, String> consumer = dltcf.createConsumer();
+		embeddedKafka.consumeFromAnEmbeddedTopic(consumer, topic2DLT);
+		ConsumerRecord<Integer, String> dltRecord = KafkaTestUtils.getSingleRecord(consumer, topic2DLT);
+		assertThat(dltRecord.value()).isEqualTo("baz");
+		container.stop();
+		pf.destroy();
+		consumer.close();
+		assertThat(stopLatch.await(10, TimeUnit.SECONDS)).isTrue();
+	}
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/DefaultErrorHandlerBatchTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/DefaultErrorHandlerBatchTests.java
@@ -1,0 +1,319 @@
+/*
+ * Copyright 2020-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willAnswer;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.record.TimestampType;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.KafkaException;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.messaging.MessagingException;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.util.backoff.FixedBackOff;
+
+/**
+ * {@link DefaultErrorHandler} tests for batch listeners.
+ * Copied from {@link RecoveringBatchErrorHandlerTests} replacing error handler type.
+ *
+ * @author Gary Russell
+ * @since 2.8
+ *
+ */
+@SpringJUnitConfig
+@DirtiesContext
+public class DefaultErrorHandlerBatchTests {
+
+	private static final String CONTAINER_ID = "container";
+
+	@SuppressWarnings("rawtypes")
+	@Autowired
+	private Consumer consumer;
+
+	@Autowired
+	private Config config;
+
+	@Autowired
+	private KafkaListenerEndpointRegistry registry;
+
+	/*
+	 * Deliver 6 records; record "baz" always fails.
+	 */
+	@SuppressWarnings("unchecked")
+	@Test
+	void seekAndRecover() throws Exception {
+		assertThat(this.config.deliveryLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		this.registry.stop();
+		assertThat(this.config.closeLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		InOrder inOrder = inOrder(this.consumer);
+		inOrder.verify(this.consumer).subscribe(any(Collection.class), any(ConsumerRebalanceListener.class));
+		inOrder.verify(this.consumer).poll(Duration.ofMillis(ContainerProperties.DEFAULT_POLL_TIMEOUT));
+		Map<TopicPartition, OffsetAndMetadata> offsets = new LinkedHashMap<>();
+		offsets.put(new TopicPartition("foo", 0), new OffsetAndMetadata(2L));
+		inOrder.verify(this.consumer).commitSync(offsets, Duration.ofMinutes(1));
+		inOrder.verify(this.consumer).seek(new TopicPartition("foo", 0), 2L);
+		inOrder.verify(this.consumer).poll(Duration.ofMillis(ContainerProperties.DEFAULT_POLL_TIMEOUT));
+		inOrder.verify(this.consumer).seek(new TopicPartition("foo", 0), 3L);
+		offsets = new LinkedHashMap<>();
+		offsets.put(new TopicPartition("foo", 0), new OffsetAndMetadata(3L));
+		inOrder.verify(this.consumer).commitSync(offsets, Duration.ofMinutes(1));
+		inOrder.verify(this.consumer).poll(Duration.ofMillis(ContainerProperties.DEFAULT_POLL_TIMEOUT));
+		offsets = new LinkedHashMap<>();
+		offsets.put(new TopicPartition("foo", 0), new OffsetAndMetadata(6L));
+		inOrder.verify(this.consumer).commitSync(offsets, Duration.ofMinutes(1));
+		assertThat(config.received).containsExactly(
+				"foo", "bar", "baz", "qux", "fiz", "buz",
+				"baz", "qux", "fiz", "buz",
+				"qux", "fiz", "buz");
+		assertThat(this.config.recovered.value()).isEqualTo("baz");
+		assertThat(this.config.listenerFailed.value()).isEqualTo("baz");
+		assertThat(this.config.listenerRecovered.value()).isEqualTo("baz");
+	}
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Test
+	void outOfRange() {
+		Consumer mockConsumer = mock(Consumer.class);
+		DefaultErrorHandler beh = new DefaultErrorHandler((cr, ex) -> {
+			throw new KafkaException("not recovered");
+		}, new FixedBackOff(0, 0));
+		TopicPartition tp = new TopicPartition("foo", 0);
+		ConsumerRecords<?, ?> records = new ConsumerRecords(Collections.singletonMap(tp,
+				Collections.singletonList(
+						new ConsumerRecord("foo", 0, 0L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "foo"))));
+		assertThatExceptionOfType(KafkaException.class).isThrownBy(() ->
+			beh.handleBatch(new ListenerExecutionFailedException("",
+					new BatchListenerFailedException("", 2)), records, mockConsumer,
+						mock(MessageListenerContainer.class), () -> { }))
+				.withMessageStartingWith("Seek to current after exception");
+		verify(mockConsumer).seek(tp, 0L);
+	}
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Test
+	void wrappedBatchListenerFailedException() {
+		Consumer mockConsumer = mock(Consumer.class);
+		InOrder inOrder = inOrder(mockConsumer);
+
+		MessageListenerContainer container = mock(MessageListenerContainer.class);
+		ContainerProperties containerProperties = mock(ContainerProperties.class);
+		given(container.getContainerProperties()).willReturn(containerProperties);
+		given(containerProperties.isSyncCommits()).willReturn(true);
+
+		Duration syncCommitTimeout = Duration.ofMillis(1000);
+		given(containerProperties.getSyncCommitTimeout()).willReturn(syncCommitTimeout);
+
+		DefaultErrorHandler beh = new DefaultErrorHandler(new FixedBackOff(0, 0));
+		TopicPartition tp = new TopicPartition("foo", 0);
+		ConsumerRecords<?, ?> records = new ConsumerRecords(Collections.singletonMap(tp,
+			Arrays.asList(
+				new ConsumerRecord("foo", 0, 0L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "foo"),
+				new ConsumerRecord("foo", 0, 1L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "bar"),
+				new ConsumerRecord("foo", 0, 2L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "baz"))
+		));
+		assertThatExceptionOfType(KafkaException.class).isThrownBy(() ->
+			beh.handleBatch(new ListenerExecutionFailedException("", new MessagingException("",
+					new BatchListenerFailedException("", 1))), records, mockConsumer, container, () -> { })
+		);
+
+		Map<TopicPartition, OffsetAndMetadata> offsets = new LinkedHashMap<>();
+		offsets.put(tp, new OffsetAndMetadata(1L));
+		inOrder.verify(mockConsumer).commitSync(offsets, syncCommitTimeout);
+
+		inOrder.verify(mockConsumer).seek(tp, 2);
+
+		offsets = new LinkedHashMap<>();
+		offsets.put(tp, new OffsetAndMetadata(2L));
+		inOrder.verify(mockConsumer).commitSync(offsets, syncCommitTimeout);
+	}
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Test
+	void missingRecordSoFallback() {
+		Consumer mockConsumer = mock(Consumer.class);
+		DefaultErrorHandler beh = new DefaultErrorHandler((cr, ex) -> {
+			throw new KafkaException("not recovered");
+		}, new FixedBackOff(0, 0));
+		TopicPartition tp = new TopicPartition("foo", 0);
+		ConsumerRecords<?, ?> records = new ConsumerRecords(Collections.singletonMap(tp,
+				Collections.singletonList(
+						new ConsumerRecord("foo", 0, 0L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "foo"))));
+		assertThatExceptionOfType(KafkaException.class).isThrownBy(() ->
+			beh.handleBatch(new ListenerExecutionFailedException("",
+						new BatchListenerFailedException("",
+					new ConsumerRecord("bar", 0, 0L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "foo"))),
+					records, mockConsumer, mock(MessageListenerContainer.class), () -> { }))
+				.withMessageStartingWith("Seek to current after exception");
+		verify(mockConsumer).seek(tp, 0L);
+	}
+
+	@Configuration
+	@EnableKafka
+	public static class Config {
+
+		final CountDownLatch deliveryLatch = new CountDownLatch(3);
+
+		final CountDownLatch closeLatch = new CountDownLatch(1);
+
+		final List<String> received = new ArrayList<>();
+
+		volatile ConsumerRecord<?, ?> recovered;
+
+		volatile ConsumerRecord<?, ?> listenerFailed;
+
+		volatile ConsumerRecord<?, ?> listenerRecovered;
+
+		@KafkaListener(id = CONTAINER_ID, topics = "foo")
+		public void foo(List<String> in) {
+			received.addAll(in);
+			this.deliveryLatch.countDown();
+			for (int i = 0; i < in.size(); i++) {
+				if (in.get(i).equals("baz")) {
+					throw new BatchListenerFailedException("fail", i);
+				}
+			}
+		}
+
+		@SuppressWarnings({ "rawtypes" })
+		@Bean
+		public ConsumerFactory consumerFactory() {
+			ConsumerFactory consumerFactory = mock(ConsumerFactory.class);
+			final Consumer consumer = consumer();
+			given(consumerFactory.createConsumer(CONTAINER_ID, "", "-0", KafkaTestUtils.defaultPropertyOverrides()))
+				.willReturn(consumer);
+			return consumerFactory;
+		}
+
+		@SuppressWarnings({ "rawtypes", "unchecked" })
+		@Bean
+		public Consumer consumer() {
+			final Consumer consumer = mock(Consumer.class);
+			final TopicPartition topicPartition = new TopicPartition("foo", 0);
+			willAnswer(i -> {
+				((ConsumerRebalanceListener) i.getArgument(1)).onPartitionsAssigned(
+						Collections.singletonList(topicPartition));
+				return null;
+			}).given(consumer).subscribe(any(Collection.class), any(ConsumerRebalanceListener.class));
+			List<ConsumerRecord> records1 = new ArrayList<>();
+			records1.add(new ConsumerRecord("foo", 0, 0L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "foo"));
+			records1.add(new ConsumerRecord("foo", 0, 1L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "bar"));
+			List<ConsumerRecord> records2 = new ArrayList<>();
+			records2.add(new ConsumerRecord("foo", 0, 2L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "baz"));
+			List<ConsumerRecord> records3 = new ArrayList<>();
+			records3.add(new ConsumerRecord("foo", 0, 3L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "qux"));
+			records3.add(new ConsumerRecord("foo", 0, 4L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "fiz"));
+			records3.add(new ConsumerRecord("foo", 0, 5L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, 0, null, "buz"));
+			List<ConsumerRecord> recordsOne = new ArrayList<>(records1);
+			recordsOne.addAll(records2);
+			recordsOne.addAll(records3);
+			List<ConsumerRecord> recordsTwo = new ArrayList<>(records2);
+			recordsTwo.addAll(records3);
+			Map<TopicPartition, List<ConsumerRecord>> crs1 = Collections.singletonMap(topicPartition, recordsOne);
+			Map<TopicPartition, List<ConsumerRecord>> crs2 = Collections.singletonMap(topicPartition, recordsTwo);
+			Map<TopicPartition, List<ConsumerRecord>> crs3 = Collections.singletonMap(topicPartition, records3);
+			final AtomicInteger which = new AtomicInteger();
+			willAnswer(i -> {
+				switch (which.getAndIncrement()) {
+					case 0:
+						return new ConsumerRecords(crs1);
+					case 1:
+						return new ConsumerRecords(crs2);
+					case 2:
+						return new ConsumerRecords(crs3);
+					default:
+						try {
+							Thread.sleep(100);
+						}
+						catch (InterruptedException e) {
+							Thread.currentThread().interrupt();
+						}
+						return new ConsumerRecords(Collections.emptyMap());
+				}
+			}).given(consumer).poll(Duration.ofMillis(ContainerProperties.DEFAULT_POLL_TIMEOUT));
+			willAnswer(i -> {
+				this.closeLatch.countDown();
+				return null;
+			}).given(consumer).close();
+			return consumer;
+		}
+
+		@SuppressWarnings({ "rawtypes", "unchecked" })
+		@Bean
+		public ConcurrentKafkaListenerContainerFactory kafkaListenerContainerFactory() {
+			ConcurrentKafkaListenerContainerFactory factory = new ConcurrentKafkaListenerContainerFactory();
+			factory.setConsumerFactory(consumerFactory());
+			DefaultErrorHandler errorHandler = new DefaultErrorHandler((cr, ex) -> this.recovered = cr,
+					new FixedBackOff(0, 1));
+			errorHandler.setRetryListeners(new RetryListener() {
+
+				@Override
+				public void failedDelivery(ConsumerRecord<?, ?> record, Exception ex, int deliveryAttempt) {
+					Config.this.listenerFailed = record;
+				}
+
+				@Override
+				public void recovered(ConsumerRecord<?, ?> record, Exception ex) {
+					Config.this.listenerRecovered = record;
+				}
+
+			});
+			factory.setCommonErrorHandler(errorHandler);
+			factory.setBatchListener(true);
+			factory.getContainerProperties().setSubBatchPerPartition(false);
+			factory.setMissingTopicsFatal(false);
+			return factory;
+		}
+
+	}
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/DefaultErrorHandlerRecordTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/DefaultErrorHandlerRecordTests.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2019-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.SerializationException;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+
+import org.springframework.kafka.KafkaException;
+import org.springframework.kafka.support.converter.ConversionException;
+import org.springframework.kafka.support.serializer.DeserializationException;
+import org.springframework.util.backoff.FixedBackOff;
+
+/**
+ * {@link DefaultErrorHandler} tests for record listeners.
+ * Copied from {@link SeekToCurrentErrorHandlerTests} changing the error handler type.
+ *
+ * @author Gary Russell
+ * @since 2.8
+ *
+ */
+public class DefaultErrorHandlerRecordTests {
+
+	@Test
+	public void testClassifier() {
+		ListenerUtils.setLogOnlyMetadata(true);
+		AtomicReference<ConsumerRecord<?, ?>> recovered = new AtomicReference<>();
+		AtomicBoolean recovererShouldFail = new AtomicBoolean(false);
+		DefaultErrorHandler handler = new DefaultErrorHandler((r, t) -> {
+			if (recovererShouldFail.getAndSet(false)) {
+				throw new RuntimeException("test recoverer failure");
+			}
+			recovered.set(r);
+		});
+		AtomicInteger failedDeliveryAttempt = new AtomicInteger();
+		AtomicReference<Exception> recoveryFailureEx = new AtomicReference<>();
+		AtomicBoolean isRecovered = new AtomicBoolean();
+		handler.setRetryListeners(new RetryListener() {
+
+			@Override
+			public void failedDelivery(ConsumerRecord<?, ?> record, Exception ex, int deliveryAttempt) {
+				failedDeliveryAttempt.set(deliveryAttempt);
+			}
+
+			@Override
+			public void recovered(ConsumerRecord<?, ?> record, Exception ex) {
+				isRecovered.set(true);
+			}
+
+			@Override
+			public void recoveryFailed(ConsumerRecord<?, ?> record, Exception original, Exception failure) {
+				recoveryFailureEx.set(failure);
+			}
+
+		});
+		ConsumerRecord<String, String> record1 = new ConsumerRecord<>("foo", 0, 0L, "foo", "bar");
+		ConsumerRecord<String, String> record2 = new ConsumerRecord<>("foo", 1, 1L, "foo", "bar");
+		List<ConsumerRecord<?, ?>> records = Arrays.asList(record1, record2);
+		IllegalStateException illegalState = new IllegalStateException();
+		Consumer<?, ?> consumer = mock(Consumer.class);
+		assertThatExceptionOfType(KafkaException.class).isThrownBy(() -> handler.handleRemaining(illegalState, records,
+					consumer, mock(MessageListenerContainer.class)))
+				.withCause(illegalState);
+		handler.handleRemaining(new DeserializationException("intended", null, false, illegalState), records,
+				consumer, mock(MessageListenerContainer.class));
+		assertThat(recovered.get()).isSameAs(record1);
+		recovered.set(null);
+		handler.handleRemaining(new ConversionException("intended", null), records,
+				consumer, mock(MessageListenerContainer.class));
+		assertThat(recovered.get()).isSameAs(record1);
+		handler.addNotRetryableExceptions(IllegalStateException.class);
+		recovered.set(null);
+		recovererShouldFail.set(true);
+		assertThatExceptionOfType(RuntimeException.class).isThrownBy(() ->
+			handler.handleRemaining(illegalState, records, consumer, mock(MessageListenerContainer.class)));
+		handler.handleRemaining(illegalState, records, consumer, mock(MessageListenerContainer.class));
+		assertThat(recovered.get()).isSameAs(record1);
+		InOrder inOrder = inOrder(consumer);
+		inOrder.verify(consumer).seek(new TopicPartition("foo", 0), 0L); // not recovered so seek
+		inOrder.verify(consumer, times(3)).seek(new TopicPartition("foo", 1), 1L);
+		inOrder.verify(consumer).seek(new TopicPartition("foo", 0), 0L); // recovery failed
+		inOrder.verify(consumer, times(2)).seek(new TopicPartition("foo", 1), 1L);
+		inOrder.verifyNoMoreInteractions();
+		assertThat(failedDeliveryAttempt.get()).isEqualTo(1);
+		assertThat(recoveryFailureEx.get())
+				.isInstanceOf(RuntimeException.class)
+				.extracting(ex -> ex.getMessage())
+				.isEqualTo("test recoverer failure");
+		assertThat(isRecovered.get()).isTrue();
+	}
+
+	@Test
+	void testSerializationException() {
+		DefaultErrorHandler handler = new DefaultErrorHandler();
+		SerializationException thrownException = new SerializationException();
+		assertThatIllegalStateException().isThrownBy(() -> handler.handleRemaining(thrownException, null, null, null))
+				.withCause(thrownException);
+	}
+
+	@Test
+	void testNotRetryableWithNoRecords() {
+		DefaultErrorHandler handler = new DefaultErrorHandler();
+		ClassCastException thrownException = new ClassCastException();
+		assertThatIllegalStateException().isThrownBy(
+					() -> handler.handleRemaining(thrownException, Collections.emptyList(), null, null))
+				.withCause(thrownException);
+	}
+
+	@Test
+	void testEarlyExitBackOff() {
+		DefaultErrorHandler handler = new DefaultErrorHandler(new FixedBackOff(1, 10_000));
+		Consumer<?, ?> consumer = mock(Consumer.class);
+		ConsumerRecord<String, String> record1 = new ConsumerRecord<>("foo", 0, 0L, "foo", "bar");
+		ConsumerRecord<String, String> record2 = new ConsumerRecord<>("foo", 1, 1L, "foo", "bar");
+		List<ConsumerRecord<?, ?>> records = Arrays.asList(record1, record2);
+		IllegalStateException illegalState = new IllegalStateException();
+		MessageListenerContainer container = mock(MessageListenerContainer.class);
+		given(container.isRunning()).willReturn(false);
+		long t1 = System.currentTimeMillis();
+		assertThatExceptionOfType(KafkaException.class).isThrownBy(() -> handler.handleRemaining(illegalState,
+						records, consumer, container));
+		assertThat(System.currentTimeMillis() < t1 + 5_000);
+	}
+
+	@Test
+	void testNoEarlyExitBackOff() {
+		DefaultErrorHandler handler = new DefaultErrorHandler(new FixedBackOff(1, 200));
+		Consumer<?, ?> consumer = mock(Consumer.class);
+		ConsumerRecord<String, String> record1 = new ConsumerRecord<>("foo", 0, 0L, "foo", "bar");
+		ConsumerRecord<String, String> record2 = new ConsumerRecord<>("foo", 1, 1L, "foo", "bar");
+		List<ConsumerRecord<?, ?>> records = Arrays.asList(record1, record2);
+		IllegalStateException illegalState = new IllegalStateException();
+		MessageListenerContainer container = mock(MessageListenerContainer.class);
+		given(container.isRunning()).willReturn(true);
+		long t1 = System.currentTimeMillis();
+		assertThatExceptionOfType(KafkaException.class).isThrownBy(() -> handler.handleRemaining(illegalState,
+						records, consumer, container));
+		assertThat(System.currentTimeMillis() >= t1 + 200);
+	}
+
+}


### PR DESCRIPTION
See https://github.com/spring-projects/spring-kafka/issues/615

Replaces legacy `SeekToCurrentErrorHandler` and `RecoveringBatchErrorHandler`.
These were the previous defaults when no transaction manager is present.
They will be deprecated in a future PR.

- refactor common code into superclass/utilities
- copy existing test case classes, changing the error handler types