### PR TITLE
GH-1876: Seek To Timestamp with Manual Assignment

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/TopicPartitionOffset.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/TopicPartitionOffset.java
@@ -62,7 +62,8 @@ public class TopicPartitionOffset {
 		END,
 
 		/**
-		 * Seek to the time stamp.
+		 * Seek to the time stamp; if no records exist with a timestamp greater than or
+		 * equal to the timestamp seek to the end.
 		 */
 		TIMESTAMP
 


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1876

Support initial seek to timestamp when manually assigning partitions.

**cherry-pick to 2.7.x**