### PR TITLE
Make `JacksonUtils` compatible with Native

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -307,6 +307,12 @@ project ('spring-kafka') {
 
 		optionalApi 'com.fasterxml.jackson.core:jackson-core'
 		optionalApi 'com.fasterxml.jackson.core:jackson-databind'
+		optionalApi 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8'
+		optionalApi 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+		optionalApi 'com.fasterxml.jackson.datatype:jackson-datatype-joda'
+		optionalApi ('com.fasterxml.jackson.module:jackson-module-kotlin') {
+			exclude group: 'org.jetbrains.kotlin'
+		}
 
 		// Spring Data projection message binding support
 		optionalApi ("org.springframework.data:spring-data-commons") {


### PR DESCRIPTION
* Extract inner classes for Jackson modules
and use them only when respective `static boolean` is true
according presence of required class in CP
* Add `optional` dependencies for Jackson modules for compilation

**Cherry-pick to `2.7.x`**