### PR TITLE
GH-1888: Revert Deprec. setTransactionDefinition()

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
@@ -32,6 +32,7 @@ import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.aop.support.AopUtils;
 import org.springframework.core.task.AsyncListenableTaskExecutor;
 import org.springframework.kafka.support.TopicPartitionOffset;
+import org.springframework.kafka.transaction.KafkaTransactionManager;
 import org.springframework.lang.Nullable;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -750,16 +751,17 @@ public class ContainerProperties extends ConsumerProperties {
 	/**
 	 * Set a transaction definition with properties (e.g. timeout) that will be copied to
 	 * the container's transaction template. Note that this is only generally useful when
-	 * used with a
-	 * {@link org.springframework.kafka.transaction.ChainedKafkaTransactionManager}
-	 * configured with a non-Kafka transaction manager. Kafka has no concept of
-	 * transaction timeout, for example.
+	 * used with a {@link #setTransactionManager(PlatformTransactionManager)
+	 * PlatformTransactionManager} that supports a custom definition; this does NOT
+	 * include the {@link KafkaTransactionManager} which has no concept of transaction
+	 * timeout. It can be useful to start, for example a database transaction, in the
+	 * container, rather than using {@code @Transactional} on the listener, because then a
+	 * record interceptor, or filter in a listener adapter can participate in the
+	 * transaction.
 	 * @param transactionDefinition the definition.
 	 * @since 2.5.4
-	 * @deprecated Refer to the
-	 * {@link org.springframework.data.transaction.ChainedTransactionManager} javadocs.
+	 * @see #setTransactionManager(PlatformTransactionManager)
 	 */
-	@Deprecated
 	public void setTransactionDefinition(TransactionDefinition transactionDefinition) {
 		this.transactionDefinition = transactionDefinition;
 	}


### PR DESCRIPTION
Resolves: https://github.com/spring-projects/spring-kafka/issues/1888

Incorrectly deprecated when ChainedKafkaTransactionManager was deprecated.

There are still valid use cases for this property.

**cherry-pick to 2.7.x**