### PR TITLE
GH-1880: SpEL Improvements for Property Overrides

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
@@ -247,6 +247,10 @@ public @interface KafkaListener {
 	 * <li>{@code key value}</li>
 	 * </ul>
 	 * {@code group.id} and {@code client.id} are ignored.
+	 * <p>SpEL {@code #{...}} and property place holders {@code ${...}} are supported.
+	 * SpEL expressions must resolve to a {@link String}, a @{link String[]} or a
+	 * {@code Collection<String>} where each member of the array or collection is a
+	 * property name + value with the above formats.
 	 * @return the properties.
 	 * @since 2.2.4
 	 * @see org.apache.kafka.clients.consumer.ConsumerConfig


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1880

SpEL can resolve to `String`, `String[]` or `Collection<String>`.