### PR TITLE
Improve Decorated ListenerExecutionFailedException

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -2484,12 +2484,49 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			Exception toHandle = ex;
 			if (toHandle instanceof ListenerExecutionFailedException) {
 				toHandle = new ListenerExecutionFailedException(toHandle.getMessage(), this.consumerGroupId,
-						toHandle.getCause()); // NOSONAR
+						toHandle.getCause()); // NOSONAR restored below
+				fixStackTrace(ex, toHandle);
 			}
 			else {
 				toHandle = new ListenerExecutionFailedException("Listener failed", this.consumerGroupId, toHandle);
 			}
 			return (RuntimeException) toHandle;
+		}
+
+		private void fixStackTrace(Exception ex, Exception toHandle) {
+			try {
+				StackTraceElement[] stackTrace = ex.getStackTrace();
+				if (stackTrace != null && stackTrace.length > 0) {
+					StackTraceElement[] stackTrace2 = toHandle.getStackTrace();
+					if (stackTrace2 != null) {
+						int matching = -1;
+						for (int i = 0; i < stackTrace2.length; i++) {
+							StackTraceElement se2 = stackTrace[i];
+							for (StackTraceElement se : stackTrace2) {
+								if (se2.equals(se)) {
+									matching = i;
+									break;
+								}
+							}
+							if (matching >= 0) {
+								break;
+							}
+						}
+						if (matching >= 0) {
+							StackTraceElement[] merged = new StackTraceElement[matching];
+							System.arraycopy(stackTrace, 0, merged, 0, matching);
+							ListenerExecutionFailedException suppressed =
+									new ListenerExecutionFailedException("Restored Stack Trace");
+							suppressed.setStackTrace(merged);
+							toHandle.addSuppressed(suppressed);
+						}
+					}
+				}
+			}
+			catch (Exception ex2) {
+				this.logger.debug(ex2,
+						"Could not restore the stack trace when decorating the LEFE with the group id");
+			}
 		}
 
 		public void checkDeser(final ConsumerRecord<K, V> record, String headerName) {


### PR DESCRIPTION
When decorating a `ListenerExecutionFailedException` with the consumer's
group id, add the lost stack trace of the original LEFE in a suppressed
exception. This retains the top stack frames which were otherwise lost;
suppressed exceptions are printed nested within the stacktrace of the new 
exception so we can now see the complete stack trace with no loss.

```
Caused by: org.springframework.kafka.listener.ListenerExecutionFailedException: Listener method 'public void com.example.demo.Gitter97Application.listen(java.lang.String)' threw exception; nested exception is java.lang.RuntimeException: x; nested exception is java.lang.RuntimeException: x
        at org.springframework.kafka.listener.KafkaMessageListenerContainer$ListenerConsumer.decorateException(KafkaMessageListenerContainer.java:2487) ~[spring-kafka-2.8.0-SNAPSHOT.jar:2.8.0-SNAPSHOT]
        at org.springframework.kafka.listener.KafkaMessageListenerContainer$ListenerConsumer.doInvokeOnMessage(KafkaMessageListenerContainer.java:2457) ~[spring-kafka-2.8.0-SNAPSHOT.jar:2.8.0-SNAPSHOT]
        at org.springframework.kafka.listener.KafkaMessageListenerContainer$ListenerConsumer.invokeOnMessage(KafkaMessageListenerContainer.java:2418) ~[spring-kafka-2.8.0-SNAPSHOT.jar:2.8.0-SNAPSHOT]
        at org.springframework.kafka.listener.KafkaMessageListenerContainer$ListenerConsumer.doInvokeRecordListener(KafkaMessageListenerContainer.java:2332) ~[spring-kafka-2.8.0-SNAPSHOT.jar:2.8.0-SNAPSHOT]
        ... 9 common frames omitted
        Suppressed: org.springframework.kafka.listener.ListenerExecutionFailedException: Restored Stack Trace
                at org.springframework.kafka.listener.adapter.MessagingMessageListenerAdapter.invokeHandler(MessagingMessageListenerAdapter.java:363) ~[spring-kafka-2.8.0-SNAPSHOT.jar:2.8.0-SNAPSHOT]
                at org.springframework.kafka.listener.adapter.RecordMessagingMessageListenerAdapter.onMessage(RecordMessagingMessageListenerAdapter.java:92) ~[spring-kafka-2.8.0-SNAPSHOT.jar:2.8.0-SNAPSHOT]
                at org.springframework.kafka.listener.adapter.RecordMessagingMessageListenerAdapter.onMessage(RecordMessagingMessageListenerAdapter.java:53) ~[spring-kafka-2.8.0-SNAPSHOT.jar:2.8.0-SNAPSHOT]
                at org.springframework.kafka.listener.KafkaMessageListenerContainer$ListenerConsumer.doInvokeOnMessage(KafkaMessageListenerContainer.java:2437) ~[spring-kafka-2.8.0-SNAPSHOT.jar:2.8.0-SNAPSHOT]
Caused by: java.lang.RuntimeException: x
```

**cherry-pick to 2.7.x**
