### PR TITLE
GH-1879: Factories Now Configure (De)Serializers

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -529,6 +529,8 @@ void removeConfig(String configKey);
 ----
 ====
 
+Starting with version 2.8, if you provide serializers as objects (in the constructor or via the setters), the factory will invoke the `configure()` method to configure them with the configuration properties.
+
 [[replying-template]]
 ===== Using `ReplyingKafkaTemplate`
 
@@ -1132,6 +1134,8 @@ This can happen when, for example, the configured user is denied access to read 
 Defining `authorizationExceptionRetryInterval` should help the application to recover as soon as proper permissions are granted.
 
 NOTE: By default, no interval is configured - authorization errors are considered fatal, which causes the container to stop.
+
+Starting with version 2.8, when creating the consumer factory, if you provide deserializers as objects (in the constructor or via the setters), the factory will invoke the `configure()` method to configure them with the configuration properties.
 
 [[using-ConcurrentMessageListenerContainer]]
 ====== Using `ConcurrentMessageListenerContainer`
@@ -3943,6 +3947,9 @@ You can revert to the previous behavior by setting the `removeTypeHeaders` prope
 
 See also <<tip-json>>.
 
+IMPORTANT: Starting with version 2.8, if you construct the serializer or deserializer programmatically as shown in <<prog-json>>, the above properties will be applied by the factories, as long as you have not set any properties explicitly (using `set*()` methods or using the fluent API).
+Previously, when creating programmatically, the configuration properties were never applied; this is still the case if you explicitly set properties on the object directly.
+
 [[serdes-mapping-types]]
 ====== Mapping Types
 
@@ -4073,6 +4080,7 @@ public static JavaType thing1Thing2JavaTypeForTopic(String topic, byte[] data, H
 ----
 ====
 
+[[prog-json]]
 ====== Programmatic Construction
 
 When constructing the serializer/deserializer programmatically for use in the producer/consumer factory, since version 2.3, you can use the fluent API, which simplifies configuration.
@@ -4121,6 +4129,8 @@ JsonDeserializer<Object> deser = new JsonDeserializer<>()
         .typeFunction(MyUtils::thingOneOrThingTwo);
 ----
 ====
+
+Alternatively, as long as you don't use the fluent API to configure properties, or set them using `set*()` methods, the factories will configure the serializer/deserializer using the configuration properties; see <<serdes-json-config>>.
 
 [[delegating-serialization]]
 ===== Delegating Serializer and Deserializer

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/ProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/ProducerFactory.java
@@ -251,6 +251,29 @@ public interface ProducerFactory<K, V> {
 	}
 
 	/**
+	 * Return the configured key serializer (if provided as an object instead
+	 * of a class name in the properties).
+	 * @return the serializer.
+	 * @since 2.8
+	 */
+	@Nullable
+	default Serializer<K> getKeySerializer() {
+		return null;
+	}
+
+	/**
+	 * Return the configured value serializer (if provided as an object instead
+	 * of a class name in the properties).
+	 * @return the serializer.
+	 * @since 2.8
+	 */
+	@Nullable
+	default Serializer<V> getValueSerializer() {
+		return null;
+	}
+
+
+	/**
 	 * Called whenever a producer is added or removed.
 	 *
 	 * @param <K> the key type.

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/converter/AbstractJavaTypeMapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/converter/AbstractJavaTypeMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,8 +18,8 @@ package org.springframework.kafka.support.converter;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
@@ -72,9 +72,9 @@ public abstract class AbstractJavaTypeMapper implements BeanClassLoaderAware {
 	 */
 	public static final String KEY_DEFAULT_KEY_CLASSID_FIELD_NAME = "__Key_KeyTypeId__";
 
-	private final Map<String, Class<?>> idClassMapping = new HashMap<String, Class<?>>();
+	private final Map<String, Class<?>> idClassMapping = new ConcurrentHashMap<String, Class<?>>();
 
-	private final Map<Class<?>, byte[]> classIdMapping = new HashMap<Class<?>, byte[]>();
+	private final Map<Class<?>, byte[]> classIdMapping = new ConcurrentHashMap<Class<?>, byte[]>();
 
 	private String classIdFieldName = DEFAULT_CLASSID_FIELD_NAME;
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -83,6 +83,7 @@ public class DelegatingDeserializer implements Deserializer<Object> {
 			((Map<String, Object>) value).forEach((selector, deser) -> {
 				if (deser instanceof Deserializer) {
 					this.delegates.put(selector, (Deserializer<?>) deser);
+					((Deserializer<?>) deser).configure(configs, isKey);
 				}
 				else if (deser instanceof Class) {
 					instantiateAndConfigure(configs, isKey, this.delegates, selector, (Class<?>) deser);

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -108,6 +108,7 @@ public class DelegatingSerializer implements Serializer<Object> {
 			((Map<String, Object>) value).forEach((selector, serializer) -> {
 				if (serializer instanceof Serializer) {
 					this.delegates.put(selector, (Serializer<?>) serializer);
+					((Serializer<?>) serializer).configure(configs, isKey);
 				}
 				else if (serializer instanceof Class) {
 					instantiateAndConfigure(configs, isKey, this.delegates, selector, (Class<?>) serializer);

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java
@@ -22,7 +22,9 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BiFunction;
 
 import org.apache.kafka.common.errors.SerializationException;
@@ -66,12 +68,10 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
  */
 public class JsonDeserializer<T> implements Deserializer<T> {
 
-	private static final String KEY_DEFAULT_TYPE_STRING = "spring.json.key.default.type";
-
 	/**
 	 * Kafka config property for the default key type if no header.
 	 */
-	public static final String KEY_DEFAULT_TYPE = KEY_DEFAULT_TYPE_STRING;
+	public static final String KEY_DEFAULT_TYPE = "spring.json.key.default.type";
 
 	/**
 	 * Kafka config property for the default value type if no header.
@@ -112,6 +112,19 @@ public class JsonDeserializer<T> implements Deserializer<T> {
 	 */
 	public static final String VALUE_TYPE_METHOD = "spring.json.value.type.method";
 
+	private static final Set<String> OUR_KEYS = new HashSet<>();
+
+	static {
+		OUR_KEYS.add(KEY_DEFAULT_TYPE);
+		OUR_KEYS.add(VALUE_DEFAULT_TYPE);
+		OUR_KEYS.add(TRUSTED_PACKAGES);
+		OUR_KEYS.add(TYPE_MAPPINGS);
+		OUR_KEYS.add(REMOVE_TYPE_INFO_HEADERS);
+		OUR_KEYS.add(USE_TYPE_INFO_HEADERS);
+		OUR_KEYS.add(KEY_TYPE_METHOD);
+		OUR_KEYS.add(VALUE_TYPE_METHOD);
+	}
+
 	protected final ObjectMapper objectMapper; // NOSONAR
 
 	protected JavaType targetType; // NOSONAR
@@ -127,6 +140,8 @@ public class JsonDeserializer<T> implements Deserializer<T> {
 	private boolean useTypeHeaders = true;
 
 	private JsonTypeResolver typeResolver;
+
+	private boolean setterCalled;
 
 	private boolean configured;
 
@@ -314,7 +329,7 @@ public class JsonDeserializer<T> implements Deserializer<T> {
 		if (typeMapper instanceof AbstractJavaTypeMapper) {
 			addMappingsToTrusted(((AbstractJavaTypeMapper) typeMapper).getIdClassMapping());
 		}
-		this.configured = true;
+		this.setterCalled = true;
 	}
 
 	/**
@@ -323,11 +338,15 @@ public class JsonDeserializer<T> implements Deserializer<T> {
 	 * @since 2.1.3
 	 */
 	public void setUseTypeMapperForKey(boolean isKey) {
+		doSetUseTypeMapperForKey(isKey);
+		this.setterCalled = true;
+	}
+
+	private void doSetUseTypeMapperForKey(boolean isKey) {
 		if (!this.typeMapperExplicitlySet
 				&& this.getTypeMapper() instanceof AbstractJavaTypeMapper) {
 			((AbstractJavaTypeMapper) this.getTypeMapper()).setUseForKey(isKey);
 		}
-		this.configured = true;
 	}
 
 	/**
@@ -338,7 +357,7 @@ public class JsonDeserializer<T> implements Deserializer<T> {
 	 */
 	public void setRemoveTypeHeaders(boolean removeTypeHeaders) {
 		this.removeTypeHeaders = removeTypeHeaders;
-		this.configured = true;
+		this.setterCalled = true;
 	}
 
 	/**
@@ -354,7 +373,7 @@ public class JsonDeserializer<T> implements Deserializer<T> {
 			this.useTypeHeaders = useTypeHeaders;
 			setUpTypePrecedence(Collections.emptyMap());
 		}
-		this.configured = true;
+		this.setterCalled = true;
 	}
 
 	/**
@@ -365,7 +384,7 @@ public class JsonDeserializer<T> implements Deserializer<T> {
 	 */
 	public void setTypeFunction(BiFunction<byte[], Headers, JavaType> typeFunction) {
 		this.typeResolver = (topic, data, headers) -> typeFunction.apply(data, headers);
-		this.configured = true;
+		this.setterCalled = true;
 	}
 
 	/**
@@ -376,15 +395,17 @@ public class JsonDeserializer<T> implements Deserializer<T> {
 	 */
 	public void setTypeResolver(JsonTypeResolver typeResolver) {
 		this.typeResolver = typeResolver;
-		this.configured = true;
+		this.setterCalled = true;
 	}
 
 	@Override
-	public void configure(Map<String, ?> configs, boolean isKey) {
+	public synchronized void configure(Map<String, ?> configs, boolean isKey) {
 		if (this.configured) {
 			return;
 		}
-		setUseTypeMapperForKey(isKey);
+		Assert.state(!this.setterCalled || !configsHasOurKeys(configs),
+				"JsonDeserializer must be configured with property setters, or via configuration properties; not both");
+		doSetUseTypeMapperForKey(isKey);
 		setUpTypePrecedence(configs);
 		setupTarget(configs, isKey);
 		if (configs.containsKey(TRUSTED_PACKAGES)
@@ -401,6 +422,15 @@ public class JsonDeserializer<T> implements Deserializer<T> {
 		}
 		setUpTypeMethod(configs, isKey);
 		this.configured = true;
+	}
+
+	private boolean configsHasOurKeys(Map<String, ?> configs) {
+		for (String key : configs.keySet()) {
+			if (OUR_KEYS.contains(key)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private Map<String, Class<?>> createMappings(Map<String, ?> configs) {
@@ -494,9 +524,9 @@ public class JsonDeserializer<T> implements Deserializer<T> {
 	 * @param packages the packages.
 	 * @since 2.1
 	 */
-	public void addTrustedPackages(String... packages) {
+	public synchronized void addTrustedPackages(String... packages) {
 		doAddTrustedPackages(packages);
-		this.configured = true;
+		this.setterCalled = true;
 	}
 
 	private void addMappingsToTrusted(Map<String, Class<?>> mappings) {
@@ -674,7 +704,7 @@ public class JsonDeserializer<T> implements Deserializer<T> {
 	 * @return the deserializer.
 	 * @since 2,5
 	 */
-	public JsonDeserializer<T> trustedPackages(String... packages) {
+	public synchronized JsonDeserializer<T> trustedPackages(String... packages) {
 		Assert.isTrue(!this.typeMapperExplicitlySet, "When using a custom type mapper, set the trusted packages there");
 		this.typeMapper.addTrustedPackages(packages);
 		return this;

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
@@ -19,6 +19,7 @@ package org.springframework.kafka.core;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import java.util.AbstractMap;
 import java.util.ArrayList;
@@ -38,6 +39,7 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.junit.jupiter.api.Test;
 
@@ -457,6 +459,20 @@ public class DefaultKafkaConsumerFactoryTests {
 		assertThat(removals).hasSize(0);
 		consum.close();
 		assertThat(removals).hasSize(1);
+	}
+
+	@Test
+	void configDeserializer() {
+		Deserializer key = mock(Deserializer.class);
+		Deserializer value = mock(Deserializer.class);
+		Map<String, Object> config = new HashMap<>();
+		DefaultKafkaConsumerFactory cf = new DefaultKafkaConsumerFactory<>(config, key, value);
+		Deserializer keyDeserializer = cf.getKeyDeserializer();
+		assertThat(keyDeserializer).isSameAs(key);
+		verify(key).configure(config, true);
+		Deserializer valueDeserializer = cf.getValueDeserializer();
+		assertThat(valueDeserializer).isSameAs(value);
+		verify(value).configure(config, false);
 	}
 
 	@Configuration

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
@@ -461,12 +461,13 @@ public class DefaultKafkaConsumerFactoryTests {
 		assertThat(removals).hasSize(1);
 	}
 
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
 	void configDeserializer() {
 		Deserializer key = mock(Deserializer.class);
 		Deserializer value = mock(Deserializer.class);
 		Map<String, Object> config = new HashMap<>();
-		DefaultKafkaConsumerFactory cf = new DefaultKafkaConsumerFactory<>(config, key, value);
+		DefaultKafkaConsumerFactory cf = new DefaultKafkaConsumerFactory(config, key, value);
 		Deserializer keyDeserializer = cf.getKeyDeserializer();
 		assertThat(keyDeserializer).isSameAs(key);
 		verify(key).configure(config, true);

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaProducerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaProducerFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 the original author or authors.
+ * Copyright 2018-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -480,6 +480,7 @@ public class DefaultKafkaProducerFactoryTests {
 		assertThatIllegalArgumentException().isThrownBy(() -> pf1.updateConfigs(configs));
 	}
 
+	@SuppressWarnings("unchecked")
 	@Test
 	void configSerializer() {
 		Serializer<String> key = mock(Serializer.class);
@@ -488,8 +489,12 @@ public class DefaultKafkaProducerFactoryTests {
 		DefaultKafkaProducerFactory<String, String> pf = new DefaultKafkaProducerFactory<>(config, key, value);
 		Serializer<String> keySerializer = pf.getKeySerializer();
 		assertThat(keySerializer).isSameAs(key);
+		keySerializer = pf.getKeySerializerSupplier().get();
+		assertThat(keySerializer).isSameAs(key);
 		verify(key).configure(any(), eq(true));
 		Serializer<String> valueSerializer = pf.getValueSerializer();
+		assertThat(valueSerializer).isSameAs(value);
+		value = pf.getValueSerializerSupplier().get();
 		assertThat(valueSerializer).isSameAs(value);
 		verify(value).configure(any(), eq(false));
 	}

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaProducerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaProducerFactoryTests.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willAnswer;
@@ -47,6 +48,7 @@ import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.errors.ProducerFencedException;
 import org.apache.kafka.common.errors.UnknownProducerIdException;
+import org.apache.kafka.common.serialization.Serializer;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 
@@ -476,6 +478,20 @@ public class DefaultKafkaProducerFactoryTests {
 		assertThat(KafkaTestUtils.getPropertyValue(pf1, "transactionIdPrefix")).isEqualTo("tx2-");
 		configs.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, null);
 		assertThatIllegalArgumentException().isThrownBy(() -> pf1.updateConfigs(configs));
+	}
+
+	@Test
+	void configSerializer() {
+		Serializer<String> key = mock(Serializer.class);
+		Serializer<String> value = mock(Serializer.class);
+		Map<String, Object> config = new HashMap<>();
+		DefaultKafkaProducerFactory<String, String> pf = new DefaultKafkaProducerFactory<>(config, key, value);
+		Serializer<String> keySerializer = pf.getKeySerializer();
+		assertThat(keySerializer).isSameAs(key);
+		verify(key).configure(any(), eq(true));
+		Serializer<String> valueSerializer = pf.getValueSerializer();
+		assertThat(valueSerializer).isSameAs(value);
+		verify(value).configure(any(), eq(false));
 	}
 
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/JsonSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/JsonSerializationTests.java
@@ -19,6 +19,7 @@ package org.springframework.kafka.support.serializer;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -207,6 +208,7 @@ public class JsonSerializationTests {
 			.isEqualTo(TypePrecedence.TYPE_ID);
 		this.jsonReader.setTypeMapper(new DefaultJackson2JavaTypeMapper());
 		dfa.setPropertyValue("configured", false);
+		dfa.setPropertyValue("setterCalled", false);
 		this.jsonReader.configure(Collections.singletonMap(JsonDeserializer.USE_TYPE_INFO_HEADERS, true), false);
 		assertThat(KafkaTestUtils.getPropertyValue(this.jsonReader, "typeMapper.typePrecedence"))
 			.isEqualTo(TypePrecedence.INFERRED);
@@ -407,16 +409,16 @@ public class JsonSerializationTests {
 	}
 
 	@Test
-	void configIgnoredAfterPropertiesSet() {
+	void configRejectedIgnoredAfterPropertiesSet() {
 		JsonDeserializer<Object> deser = new JsonDeserializer<>();
 		deser.setUseTypeHeaders(false);
 		Map<String, Object> configs = Map.of(JsonDeserializer.USE_TYPE_INFO_HEADERS, true);
-		deser.configure(configs, false);
+		assertThatIllegalStateException().isThrownBy(() -> deser.configure(configs, false));
 		assertThat(KafkaTestUtils.getPropertyValue(deser, "useTypeHeaders", Boolean.class)).isFalse();
 		JsonSerializer<Object> ser = new JsonSerializer<>();
 		ser.setAddTypeInfo(false);
-		configs = Map.of(JsonSerializer.ADD_TYPE_INFO_HEADERS, true);
-		assertThat(KafkaTestUtils.getPropertyValue(ser, "addTypeInfo", Boolean.class)).isFalse();
+		Map<String, Object> configs2 = Map.of(JsonSerializer.ADD_TYPE_INFO_HEADERS, true);
+		assertThatIllegalStateException().isThrownBy(() -> ser.configure(configs2, false));
 	}
 
 	public static JavaType fooBarJavaType(byte[] data, Headers headers) {


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1879

It was not intuitive that configuration properties were not applied when
construcing (De)Serializers programmatically.

The producer and consumer factories now call the `configure()` method.
However, the JSON implementations cannot be configured with a mixture
of setters and configuration properties.