### PR TITLE
GH-1827: Fix Race

### DIFF
--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ContainerGroupSequencerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ContainerGroupSequencerTests.java
@@ -137,7 +137,7 @@ public class ContainerGroupSequencerTests {
 
 		@Bean
 		ContainerGroupSequencer sequencer(KafkaListenerEndpointRegistry registry) {
-			ContainerGroupSequencer sequencer = new ContainerGroupSequencer(registry, 1000, "g1", "g2");
+			ContainerGroupSequencer sequencer = new ContainerGroupSequencer(registry, 3000, "g1", "g2");
 			sequencer.setStopLastGroupWhenIdle(true);
 			sequencer.setAutoStartup(false);
 			return sequencer;


### PR DESCRIPTION
- increase idle event interval to prevent sequencer stopping the container too soon.
- tighten up synchronization in the sequencer

**cherry-pick to 2.7.x**