### PR TITLE
GH-1918: Don't Retry DLT Fatal Exceptions

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/retrytopic.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/retrytopic.adoc
@@ -532,11 +532,11 @@ public class MyCustomDltProcessor {
 
 NOTE: If no DLT handler is provided, the default RetryTopicConfigurer.LoggingDltListenerHandlerMethod is used.
 
-===== Dlt Failure Behavior
+===== DLT Failure Behavior
 
-Should the Dlt processing fail, there are two possible behaviors available: `ALWAYS_RETRY_ON_ERROR` and `FAIL_ON_ERROR`.
+Should the DLT processing fail, there are two possible behaviors available: `ALWAYS_RETRY_ON_ERROR` and `FAIL_ON_ERROR`.
 
-In the former the message is forwarded back to the dlt topic so it doesn't block other dlt messages' processing.
+In the former the record is forwarded back to the DLT topic so it doesn't block other DLT records' processing.
 In the latter the consumer ends the execution without forwarding the message.
 
 ====
@@ -566,7 +566,21 @@ public RetryTopicConfiguration myRetryTopic(KafkaTemplate<Integer, MyPojo> templ
 
 NOTE: The default behavior is to `ALWAYS_RETRY_ON_ERROR`.
 
-===== Configuring No Dlt
+IMPORTANT: Starting with version 2.8, `ALWAYS_RETRY_ON_ERROR` will NOT route a record back to the DLT if the record causes a fatal exception to be thrown,
+such as a `DeserializationException` because, generally, such exceptions will always be thrown.
+
+Exceptions that are considered fatal are
+
+* `DeserializationException`
+* `MessageConversionException`
+* `ConversionException`
+* `MethodArgumentResolutionException`
+* `NoSuchMethodException`
+* `ClassCastException`
+
+You can add exceptions to and remove exceptions from this list using methods on the `DeadLetterPublishingRecovererFactory` bean.
+
+===== Configuring No DLT
 
 The framework also provides the possibility of not configuring a DLT for the topic.
 In this case after retrials are exhausted the processing simply ends.

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ExceptionClassifier.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ExceptionClassifier.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.classify.BinaryExceptionClassifier;
+import org.springframework.kafka.support.converter.ConversionException;
+import org.springframework.kafka.support.serializer.DeserializationException;
+import org.springframework.messaging.converter.MessageConversionException;
+import org.springframework.messaging.handler.invocation.MethodArgumentResolutionException;
+import org.springframework.util.Assert;
+
+/**
+ * Supports exception classification.
+ *
+ * @author Gary Russell
+ * @since 2.8
+ *
+ */
+public abstract class ExceptionClassifier extends KafkaExceptionLogLevelAware {
+
+	private ExtendedBinaryExceptionClassifier classifier;
+
+	/**
+	 * Construct the instance.
+	 */
+	public ExceptionClassifier() {
+		this.classifier = configureDefaultClassifier();
+	}
+
+	private static ExtendedBinaryExceptionClassifier configureDefaultClassifier() {
+		Map<Class<? extends Throwable>, Boolean> classified = new HashMap<>();
+		classified.put(DeserializationException.class, false);
+		classified.put(MessageConversionException.class, false);
+		classified.put(ConversionException.class, false);
+		classified.put(MethodArgumentResolutionException.class, false);
+		classified.put(NoSuchMethodException.class, false);
+		classified.put(ClassCastException.class, false);
+		return new ExtendedBinaryExceptionClassifier(classified, true);
+	}
+
+	/**
+	 * Return the exception classifier.
+	 * @return the classifier.
+	 */
+	protected BinaryExceptionClassifier getClassifier() {
+		return this.classifier;
+	}
+
+	/**
+	 * Set an exception classifications to determine whether the exception should cause a retry
+	 * (until exhaustion) or not. If not, we go straight to the recoverer. By default,
+	 * the following exceptions will not be retried:
+	 * <ul>
+	 * <li>{@link DeserializationException}</li>
+	 * <li>{@link MessageConversionException}</li>
+	 * <li>{@link MethodArgumentResolutionException}</li>
+	 * <li>{@link NoSuchMethodException}</li>
+	 * <li>{@link ClassCastException}</li>
+	 * </ul>
+	 * All others will be retried.
+	 * When calling this method, the defaults will not be applied.
+	 * @param classifications the classifications.
+	 * @param defaultValue whether or not to retry non-matching exceptions.
+	 * @see BinaryExceptionClassifier#BinaryExceptionClassifier(Map, boolean)
+	 * @see #addNotRetryableExceptions(Class...)
+	 */
+	public void setClassifications(Map<Class<? extends Throwable>, Boolean> classifications, boolean defaultValue) {
+		Assert.notNull(classifications, "'classifications' + cannot be null");
+		this.classifier = new ExtendedBinaryExceptionClassifier(classifications, defaultValue);
+	}
+
+	/**
+	 * Add exception types to the default list. By default, the following exceptions will
+	 * not be retried:
+	 * <ul>
+	 * <li>{@link DeserializationException}</li>
+	 * <li>{@link MessageConversionException}</li>
+	 * <li>{@link ConversionException}</li>
+	 * <li>{@link MethodArgumentResolutionException}</li>
+	 * <li>{@link NoSuchMethodException}</li>
+	 * <li>{@link ClassCastException}</li>
+	 * </ul>
+	 * All others will be retried.
+	 * @param exceptionTypes the exception types.
+	 * @see #removeNotRetryableException(Class)
+	 * @see #setClassifications(Map, boolean)
+	 */
+	@SafeVarargs
+	@SuppressWarnings("varargs")
+	public final void addNotRetryableExceptions(Class<? extends Exception>... exceptionTypes) {
+		Assert.notNull(exceptionTypes, "'exceptionTypes' cannot be null");
+		Assert.noNullElements(exceptionTypes, "'exceptionTypes' cannot contain nulls");
+		for (Class<? extends Exception> exceptionType : exceptionTypes) {
+			Assert.isTrue(Exception.class.isAssignableFrom(exceptionType),
+					() -> "exceptionType " + exceptionType + " must be an Exception");
+			this.classifier.getClassified().put(exceptionType, false);
+		}
+	}
+
+	/**
+	 * Remove an exception type from the configured list. By default, the following
+	 * exceptions will not be retried:
+	 * <ul>
+	 * <li>{@link DeserializationException}</li>
+	 * <li>{@link MessageConversionException}</li>
+	 * <li>{@link ConversionException}</li>
+	 * <li>{@link MethodArgumentResolutionException}</li>
+	 * <li>{@link NoSuchMethodException}</li>
+	 * <li>{@link ClassCastException}</li>
+	 * </ul>
+	 * All others will be retried.
+	 * @param exceptionType the exception type.
+	 * @return true if the removal was successful.
+	 * @see #addNotRetryableExceptions(Class...)
+	 * @see #setClassifications(Map, boolean)
+	 */
+	public boolean removeNotRetryableException(Class<? extends Exception> exceptionType) {
+		return this.classifier.getClassified().remove(exceptionType);
+	}
+
+	/**
+	 * Extended to provide visibility to the current classified exceptions.
+	 *
+	 * @author Gary Russell
+	 *
+	 */
+	@SuppressWarnings("serial")
+	private static final class ExtendedBinaryExceptionClassifier extends BinaryExceptionClassifier {
+
+		ExtendedBinaryExceptionClassifier(Map<Class<? extends Throwable>, Boolean> typeMap, boolean defaultValue) {
+			super(typeMap, defaultValue);
+			setTraverseCauses(true);
+		}
+
+		@Override
+		protected Map<Class<? extends Throwable>, Boolean> getClassified() { // NOSONAR worthless override
+			return super.getClassified();
+		}
+
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicBootstrapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicBootstrapper.java
@@ -49,6 +49,7 @@ import org.springframework.retry.backoff.ThreadWaitSleeper;
 public class RetryTopicBootstrapper {
 
 	private final ApplicationContext applicationContext;
+
 	private final BeanFactory beanFactory;
 
 	public RetryTopicBootstrapper(ApplicationContext applicationContext, BeanFactory beanFactory) {


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1918

Do not publish records with fatal exceptions to the same topic, it
causes an irrecoverable endless loop.

Log at ERROR when such a situation is detected.

Extract a new abstract super class for exception classification.