### PR TITLE
GH-1909: Add idleBeforeDataMultiplier

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -2477,6 +2477,12 @@ See https://issues.apache.org/jira/browse/KAFKA-10683[KAFKA-10683] for more info
 |`null`
 |Overrides the consumer `group.id` property; automatically set by the `@KafkaListener` `id` or `groupId` property.
 
+|idleBeforeDataMultiplier
+|5.0
+|Multiplier for `idleEventInterval` that is applied before any records are received.
+After a record is received, the multiplier is no longer applied.
+Available since version 2.8.
+
 |idleBetweenPolls
 |0
 |Used to slow down deliveries by sleeping the thread between polls.
@@ -2485,6 +2491,7 @@ The time to process a batch of records plus this value must be less than the `ma
 |idleEventInterval
 |`null`
 |When set, enables publication of `ListenerContainerIdleEvent` s, see <<events>> and <<idle-containers>>.
+Also see `idleBeforeDataMultiplier`.
 
 |idlePartitionEventInterval
 |`null`

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
@@ -177,6 +177,8 @@ public class ContainerProperties extends ConsumerProperties {
 
 	private static final int DEFAULT_ACK_TIME = 5000;
 
+	private static final double DEFAULT_IDLE_BEFORE_DATA_MULTIPLIER = 5.0;
+
 	private final Map<String, String> micrometerTags = new HashMap<>();
 
 	private final List<Advice> adviceChain = new ArrayList<>();
@@ -246,6 +248,8 @@ public class ContainerProperties extends ConsumerProperties {
 	private Long idleEventInterval;
 
 	private Long idlePartitionEventInterval;
+
+	private double idleBeforeDataMultiplier = DEFAULT_IDLE_BEFORE_DATA_MULTIPLIER;
 
 	private PlatformTransactionManager transactionManager;
 
@@ -418,9 +422,21 @@ public class ContainerProperties extends ConsumerProperties {
 	 * Set the idle event interval; when set, an event is emitted if a poll returns
 	 * no records and this interval has elapsed since a record was returned.
 	 * @param idleEventInterval the interval.
+	 * @see #setIdleBeforeDataMultiplier(double)
 	 */
 	public void setIdleEventInterval(@Nullable Long idleEventInterval) {
 		this.idleEventInterval = idleEventInterval;
+	}
+
+	/**
+	 * Multiply the {@link #setIdleEventInterval(Long)} by this value until at least
+	 * one record is received. Default 5.0.
+	 * @param idleBeforeDataMultiplier false to allow publishing.
+	 * @since 2.8
+	 * @see #setIdleEventInterval(Long)
+	 */
+	public void setIdleBeforeDataMultiplier(double idleBeforeDataMultiplier) {
+		this.idleBeforeDataMultiplier = idleBeforeDataMultiplier;
 	}
 
 	/**
@@ -461,9 +477,24 @@ public class ContainerProperties extends ConsumerProperties {
 		return this.shutdownTimeout;
 	}
 
+	/**
+	 * Return the idle event interval.
+	 * @return the interval.
+	 */
 	@Nullable
 	public Long getIdleEventInterval() {
 		return this.idleEventInterval;
+	}
+
+	/**
+	 * Multiply the {@link #setIdleEventInterval(Long)} by this value until at least
+	 * one record is received. Default 5.0.
+	 * @return the noIdleBeforeData.
+	 * @since 2.8
+	 * @see #getIdleEventInterval()
+	 */
+	public double getIdleBeforeDataMultiplier() {
+		return this.idleBeforeDataMultiplier;
 	}
 
 	/**
@@ -900,6 +931,7 @@ public class ContainerProperties extends ConsumerProperties {
 				+ "\n stopContainerWhenFenced=" + this.stopContainerWhenFenced
 				+ "\n stopImmediate=" + this.stopImmediate
 				+ "\n asyncAcks=" + this.asyncAcks
+				+ "\n idleBeforeDataMultiplier" + this.idleBeforeDataMultiplier
 				+ "\n]";
 	}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ContainerGroupSequencerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ContainerGroupSequencerTests.java
@@ -137,7 +137,7 @@ public class ContainerGroupSequencerTests {
 
 		@Bean
 		ContainerGroupSequencer sequencer(KafkaListenerEndpointRegistry registry) {
-			ContainerGroupSequencer sequencer = new ContainerGroupSequencer(registry, 3000, "g1", "g2");
+			ContainerGroupSequencer sequencer = new ContainerGroupSequencer(registry, 600, "g1", "g2");
 			sequencer.setStopLastGroupWhenIdle(true);
 			sequencer.setAutoStartup(false);
 			return sequencer;
@@ -165,7 +165,7 @@ public class ContainerGroupSequencerTests {
 			ConcurrentKafkaListenerContainerFactory<Integer, String> factory =
 					new ConcurrentKafkaListenerContainerFactory<>();
 			factory.setConsumerFactory(cf);
-			factory.getContainerProperties().setPollTimeout(500);
+			factory.getContainerProperties().setPollTimeout(200);
 			return factory;
 		}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
@@ -1622,6 +1622,7 @@ public class KafkaMessageListenerContainerTests {
 		containerProps.setSyncCommits(true);
 		containerProps.setAckMode(AckMode.RECORD);
 		containerProps.setIdleEventInterval(60000L);
+		containerProps.setIdleBeforeDataMultiplier(1.0);
 
 		KafkaMessageListenerContainer<Integer, String> container = new KafkaMessageListenerContainer<>(cf,
 				containerProps);
@@ -1668,7 +1669,7 @@ public class KafkaMessageListenerContainerTests {
 			}
 
 		});
-		assertThat(idleLatch.await(60, TimeUnit.SECONDS));
+		assertThat(idleLatch.await(60, TimeUnit.SECONDS)).isTrue();
 		assertThat(idleEventPublished.get()).isTrue();
 		assertThat(latch.get().await(60, TimeUnit.SECONDS)).isTrue();
 		container.stop();


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1909

Increase `idleEventInterval` before data is received, to avoid false positives
with small event intervals.