### PR TITLE
GH-1915: Batch Manual AckMode Improvements

### DIFF
--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ManualImmediateNackBatchTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ManualImmediateNackBatchTests.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import org.springframework.kafka.listener.ContainerProperties.AckMode;
+
+/**
+ * @author Gary Russell
+ * @since 2.8
+ *
+ */
+public class ManualImmediateNackBatchTests extends ManualNackBatchTests {
+
+	static {
+		ackMode = AckMode.MANUAL_IMMEDIATE;
+	}
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ManualNackBatchTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ManualNackBatchTests.java
@@ -73,6 +73,12 @@ public class ManualNackBatchTests {
 
 	private static final String CONTAINER_ID = "container";
 
+	protected static AckMode ackMode;
+
+	static {
+		ackMode = AckMode.MANUAL;
+	}
+
 	@SuppressWarnings("rawtypes")
 	@Autowired
 	private Consumer consumer;
@@ -216,7 +222,7 @@ public class ManualNackBatchTests {
 			ConcurrentKafkaListenerContainerFactory factory = new ConcurrentKafkaListenerContainerFactory();
 			factory.setConsumerFactory(consumerFactory());
 			factory.setBatchListener(true);
-			factory.getContainerProperties().setAckMode(AckMode.MANUAL);
+			factory.getContainerProperties().setAckMode(ackMode);
 			return factory;
 		}
 


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1915

- perform acks within the scope of the ack call so users can catch exceptions with sync commits
- when using MANUAL_IMMEDIATE, commit offsets for the batch instead of one-at-a-time