### PR TITLE
GH-1936: Batch Listener Handle ConversionException

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -4179,6 +4179,22 @@ It is not necessary to configure serializers or deserializers for these types, t
 
 For another technique to send different types to different topics, see <<routing-template>>.
 
+2.8 introduced the `DelegatingByTypeSerializer`.
+
+====
+[source, java]
+----
+@Bean
+public ProducerFactory<Integer, Object> producerFactory(Map<String, Object> config) {
+	return new DefaultKafkaProducerFactory<>(config,
+			null, new DelegatingByTypeSerializer(Map.of(
+					byte[].class, new ByteArraySerializer(),
+					Bytes.class, new BytesSerializer(),
+					String.class, new StringSerializer())));
+}
+----
+====
+
 [[retrying-deserialization]]
 ===== Retrying Deserializer
 
@@ -4399,6 +4415,28 @@ consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingD
 consumerProps.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, JsonDeserializer.class);
 consumerProps.put(ErrorHandlingDeserializer.VALUE_FUNCTION, FailedFooProvider.class);
 ...
+----
+====
+
+When using an `ErrorHandlingDeserializer` with a batch listener, you must check for the deserialization exceptions in message headers.
+When used with a `RecoveringBatchErrorHandler`, you can use that header to determine which record the exception failed on and communicate to the error handler via a `BatchListenerFailedException`.
+
+====
+[source, java]
+----
+@KafkaListener(id = "test", topics = "test")
+void listen(List<Thing> in, @Header(KafkaHeaders.BATCH_CONVERTED_HEADERS) List<Map<String, Object>> headers) {
+    for (int i = 0; i < in.size(); i++) {
+        Thing thing = in.get(i);
+        if (thing == null
+                && headers.get(i).get(ErrorHandlingDeserializer.VALUE_DESERIALIZER_EXCEPTION_HEADER) != null) {
+
+            throw new BatchListenerFailedException("deserialization error",
+                    new DeserializationException("Batch listener", null, false, null), i);
+        }
+        process(foo);
+    }
+}
 ----
 ====
 
@@ -4909,6 +4947,7 @@ The container commits any pending offset commits before calling the error handle
 
 If you are using Spring Boot, you simply need to add the error handler as a `@Bean` and Boot will add it to the auto-configured factory.
 
+[[default-eh]]
 ===== DefaultErrorHandler
 
 This new error handler replaces the `SeekToCurrentErrorHandler` and `RecoveringBatchErrorHandler`, which have been the default error handlers for several releases now.
@@ -5067,6 +5106,31 @@ Set `resetStateOnExceptionChange` to `true` and the retry sequence will be resta
 By default, the exception type is not considered.
 
 Also see <<delivery-header>>.
+
+[[batch-listener-conv-errors]]
+==== Conversion Errors with Batch Error Handlers
+
+Starting with version 2.8, batch listeners can now properly handle conversion errors, when using a `MessageConverter` with a `ByteArrayDeserializer`, a `BytesDeserializer` or a `StringDeserializer`, as well as a `DefaultErrorHandler`.
+When a conversion error occurs, the payload is set to null and a deserialization exception is added to the record headers, similar to the `ErrorHandlingDeserializer`.
+A list of `ConversionException` s is available in the listener so the listener can throw a `BatchListenerFailedException` indicating the first index at which a conversion exception occurred.
+
+Example:
+
+====
+[source, java]
+----
+@KafkaListener(id = "test", topics = "topic")
+void listen(List<Thing> in, @Header(KafkaHeaders.CONVERSION_FAILURES) List<ConversionException> exceptions) {
+    for (int i = 0; i < in.size(); i++) {
+        Foo foo = in.get(i);
+        if (foo == null && exceptions.get(i) != null) {
+            throw new BatchListenerFailedException("Conversion error", exceptions.get(i), i);
+        }
+        process(foo);
+    }
+}
+---
+====
 
 [[retrying-batch-eh]]
 ===== Retrying Batch Error Handler

--- a/spring-kafka-docs/src/main/asciidoc/whats-new.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/whats-new.adoc
@@ -20,7 +20,12 @@ See <<ooo-commits>> for more information.
 
 It is now possible to specify whether the listener method is a batch listener on the method itself.
 This allows the same container factory to be used for both record and batch listeners.
+
 See <<batch-listeners>> for more information.
+
+Batch listeners can now handle conversion exceptions.
+
+See <<batch-listener-conv-errors>> for more information.
 
 [[x28-template]]
 ==== `KafkaTemplate` Changes

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/KafkaHeaders.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/KafkaHeaders.java
@@ -314,4 +314,12 @@ public abstract class KafkaHeaders {
 	 * @since 2.2
 	 */
 	public static final String ORIGINAL_TIMESTAMP_TYPE = PREFIX + "original-timestamp-type";
+
+	/**
+	 * The header containing a list of conversion failures (for batch listeners only).
+	 * Type: List&lt;ConversionException&gt;.
+	 * @since 2.8
+	 */
+	public static final String CONVERSION_FAILURES = PREFIX + "conversionFailures";
+
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/converter/ConversionException.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/converter/ConversionException.java
@@ -35,11 +35,11 @@ import org.springframework.messaging.Message;
 @SuppressWarnings("serial")
 public class ConversionException extends KafkaException {
 
-	private final ConsumerRecord<?, ?> record;
+	private transient ConsumerRecord<?, ?> record;
 
-	private final List<ConsumerRecord<?, ?>> records = new ArrayList<>();
+	private transient List<ConsumerRecord<?, ?>> records = new ArrayList<>();
 
-	private final Message<?> message;
+	private transient Message<?> message;
 
 	/**
 	 * Construct an instance with the provided properties.

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingByTypeSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingByTypeSerializer.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support.serializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.common.errors.SerializationException;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.serialization.Serializer;
+
+/**
+ * Delegates to a serializer based on type.
+ *
+ * @author Gary Russell
+ * @since 2.8
+ *
+ */
+public class DelegatingByTypeSerializer implements Serializer<Object> {
+
+	@SuppressWarnings("rawtypes")
+	private final Map<Class<?>, Serializer> delegates = new HashMap<>();
+
+	/**
+	 * Construct an instance with the map of delegates.
+	 * @param delegates the delegates.
+	 */
+	@SuppressWarnings("rawtypes")
+	public DelegatingByTypeSerializer(Map<Class<?>, Serializer> delegates) {
+		this.delegates.putAll(delegates);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public void configure(Map<String, ?> configs, boolean isKey) {
+		this.delegates.values().forEach(del -> del.configure(configs, isKey));
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Override
+	public byte[] serialize(String topic, Object data) {
+		Serializer delegate = findDelegate(data);
+		return delegate.serialize(topic, data);
+	}
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Override
+	public byte[] serialize(String topic, Headers headers, Object data) {
+		Serializer delegate = findDelegate(data);
+		return delegate.serialize(topic, headers, data);
+	}
+
+	@SuppressWarnings("rawtypes")
+	private Serializer findDelegate(Object data) {
+		Serializer delegate = this.delegates.get(data.getClass());
+		if (delegate == null) {
+			throw new SerializationException("No matching delegate for type");
+		}
+		return delegate;
+	}
+
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingByTypeSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingByTypeSerializer.java
@@ -18,10 +18,13 @@ package org.springframework.kafka.support.serializer;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Serializer;
+
+import org.springframework.util.Assert;
 
 /**
  * Delegates to a serializer based on type.
@@ -41,6 +44,8 @@ public class DelegatingByTypeSerializer implements Serializer<Object> {
 	 */
 	@SuppressWarnings("rawtypes")
 	public DelegatingByTypeSerializer(Map<Class<?>, Serializer> delegates) {
+		Assert.notNull(delegates, "'delegates' cannot be null");
+		Assert.noNullElements(delegates.values(), "Serializers in delegates map cannot be null");
 		this.delegates.putAll(delegates);
 	}
 
@@ -68,7 +73,10 @@ public class DelegatingByTypeSerializer implements Serializer<Object> {
 	private Serializer findDelegate(Object data) {
 		Serializer delegate = this.delegates.get(data.getClass());
 		if (delegate == null) {
-			throw new SerializationException("No matching delegate for type");
+			throw new SerializationException("No matching delegate for type: " + data.getClass().getName()
+					+ "; supported types: " + this.delegates.keySet().stream()
+							.map(clazz -> clazz.getName())
+							.collect(Collectors.toList()));
 		}
 		return delegate;
 	}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ErrorHandlingDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ErrorHandlingDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 the original author or authors.
+ * Copyright 2018-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -188,7 +188,7 @@ public class ErrorHandlingDeserializer<T> implements Deserializer<T> {
 			return this.delegate.deserialize(topic, headers, data);
 		}
 		catch (Exception e) {
-			deserializationException(headers, data, e);
+			deserializationException(headers, data, e, this.isForKey);
 			return recoverFromSupplier(topic, headers, data, e);
 		}
 	}
@@ -211,20 +211,28 @@ public class ErrorHandlingDeserializer<T> implements Deserializer<T> {
 		}
 	}
 
-	private void deserializationException(Headers headers, byte[] data, Exception e) {
+	/**
+	 * Populate the record headers with a serialized {@link DeserializationException}.
+	 * @param headers the headers.
+	 * @param data the data.
+	 * @param ex the exception.
+	 * @param isForKeyArg true if this is a key deserialization problem, otherwise value.
+	 * @since 2.8
+	 */
+	public static void deserializationException(Headers headers, byte[] data, Exception ex, boolean isForKeyArg) {
 		ByteArrayOutputStream stream = new ByteArrayOutputStream();
 		DeserializationException exception =
-				new DeserializationException("failed to deserialize", data, this.isForKey, e);
+				new DeserializationException("failed to deserialize", data, isForKeyArg, ex);
 		try (ObjectOutputStream oos = new ObjectOutputStream(stream)) {
 			oos.writeObject(exception);
 		}
-		catch (IOException ex) {
+		catch (IOException ioex) {
 			stream = new ByteArrayOutputStream();
 			try (ObjectOutputStream oos = new ObjectOutputStream(stream)) {
 				exception = new DeserializationException("failed to deserialize",
-						data, this.isForKey, new RuntimeException("Could not deserialize type "
-						+ e.getClass().getName() + " with message " + e.getMessage()
-						+ " failure: " + ex.getMessage()));
+						data, isForKeyArg, new RuntimeException("Could not deserialize type "
+						+ ioex.getClass().getName() + " with message " + ioex.getMessage()
+						+ " failure: " + ioex.getMessage()));
 				oos.writeObject(exception);
 			}
 			catch (IOException ex2) {
@@ -232,7 +240,7 @@ public class ErrorHandlingDeserializer<T> implements Deserializer<T> {
 			}
 		}
 		headers.add(
-				new RecordHeader(this.isForKey
+				new RecordHeader(isForKeyArg
 						? KEY_DESERIALIZER_EXCEPTION_HEADER
 						: VALUE_DESERIALIZER_EXCEPTION_HEADER,
 						stream.toByteArray()));

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/adapter/BatchAdapterConversionErrorsTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/adapter/BatchAdapterConversionErrorsTests.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.Mockito.mock;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.listener.BatchListenerFailedException;
+import org.springframework.kafka.listener.ListenerExecutionFailedException;
+import org.springframework.kafka.listener.ListenerUtils;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.kafka.support.converter.BatchMessagingMessageConverter;
+import org.springframework.kafka.support.converter.ConversionException;
+import org.springframework.kafka.support.converter.JsonMessageConverter;
+import org.springframework.kafka.support.serializer.DeserializationException;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+/**
+ * @author Gary Russell
+ * @since 2.2.5
+ *
+ */
+@SpringJUnitConfig
+@DirtiesContext
+public class BatchAdapterConversionErrorsTests {
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void testNullInList(@Autowired KafkaListenerEndpointRegistry registry, @Autowired Listener listener) {
+		BatchMessagingMessageListenerAdapter<String, String> adapter =
+				(BatchMessagingMessageListenerAdapter<String, String>) registry
+					.getListenerContainer("foo").getContainerProperties().getMessageListener();
+		ConsumerRecord<String, String> junkRecord = new ConsumerRecord<>("foo", 0, 0L, null, "JUNK");
+		assertThatExceptionOfType(ListenerExecutionFailedException.class).isThrownBy(() ->
+				adapter.onMessage(List.of(
+						new ConsumerRecord<>("foo", 0, 0L, null, "{\"bar\":\"baz\"}"),
+						junkRecord,
+						new ConsumerRecord<>("foo", 0, 0L, null, "{\"bar\":\"qux\"}")), null, null))
+				.withCauseExactlyInstanceOf(BatchListenerFailedException.class)
+				.extracting(t -> t.getCause())
+				.extracting("index")
+				.isEqualTo(1);
+		assertThat(listener.values).containsExactly(new Foo("baz"), null, new Foo("qux"));
+		DeserializationException vDeserEx = ListenerUtils.getExceptionFromHeader(junkRecord,
+				ErrorHandlingDeserializer.VALUE_DESERIALIZER_EXCEPTION_HEADER, null);
+		assertThat(vDeserEx).isNotNull();
+		assertThat(vDeserEx.getData()).isEqualTo("JUNK".getBytes());
+	}
+
+	public static class Listener {
+
+		final List<Foo> values = new ArrayList<>();
+
+		@KafkaListener(id = "foo", topics = "foo", autoStartup = "false")
+		public void listen(List<Foo> list,
+				@Header(KafkaHeaders.CONVERSION_FAILURES) List<ConversionException> conversionFailures) {
+
+			this.values.addAll(list);
+			for (int i = 0; i < list.size(); i++) {
+				if (conversionFailures.get(i) != null) {
+					throw new BatchListenerFailedException("Conversion Failed", conversionFailures.get(i), i);
+				}
+			}
+		}
+
+	}
+
+	public static class Foo {
+
+		private String bar;
+
+		public Foo() {
+		}
+
+		public Foo(String bar) {
+			this.bar = bar;
+		}
+
+		public String getBar() {
+			return this.bar;
+		}
+
+		public void setBar(String bar) {
+			this.bar = bar;
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(bar);
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj) {
+				return true;
+			}
+			if (obj == null) {
+				return false;
+			}
+			if (getClass() != obj.getClass()) {
+				return false;
+			}
+			Foo other = (Foo) obj;
+			return Objects.equals(this.bar, other.bar);
+		}
+
+		@Override
+		public String toString() {
+			return "Foo [bar=" + this.bar + "]";
+		}
+
+	}
+
+	@Configuration
+	@EnableKafka
+	public static class Config {
+
+		@Bean
+		public Listener foo() {
+			return new Listener();
+		}
+
+		@SuppressWarnings({ "rawtypes" })
+		@Bean
+		public ConsumerFactory consumerFactory() {
+			ConsumerFactory consumerFactory = mock(ConsumerFactory.class);
+			return consumerFactory;
+		}
+
+		@SuppressWarnings({ "rawtypes", "unchecked" })
+		@Bean
+		public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+			ConcurrentKafkaListenerContainerFactory factory = new ConcurrentKafkaListenerContainerFactory();
+			factory.setConsumerFactory(consumerFactory());
+			factory.setMessageConverter(new BatchMessagingMessageConverter(new JsonMessageConverter()));
+			factory.setBatchListener(true);
+			return factory;
+		}
+	}
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/adapter/BatchAdapterConversionErrorsTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/adapter/BatchAdapterConversionErrorsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,7 +50,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 /**
  * @author Gary Russell
- * @since 2.2.5
+ * @since 2.8
  *
  */
 @SpringJUnitConfig

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/DelegatingSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/DelegatingSerializationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.kafka.support.serializer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -25,9 +26,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.BytesDeserializer;
 import org.apache.kafka.common.serialization.BytesSerializer;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
@@ -202,6 +205,20 @@ public class DelegatingSerializationTests {
 		assertThat(spy.deserialize("foo", headers, data)).isSameAs(data);
 		spy.deserialize("foo", headers, data);
 		verify(spy, times(1)).trySerdes("junk");
+	}
+
+	@Test
+	void byTypeBadType() {
+		DelegatingByTypeSerializer serializer = new DelegatingByTypeSerializer(Map.of(String.class,
+				new StringSerializer(), byte[].class, new ByteArraySerializer()));
+		byte[] foo = "foo".getBytes();
+		assertThat(serializer.serialize("foo", foo)).isSameAs(foo);
+		String bar = "bar";
+		assertThat(serializer.serialize("foo", bar)).isEqualTo(bar.getBytes());
+		assertThatExceptionOfType(SerializationException.class).isThrownBy(
+						() -> serializer.serialize("foo", new Bytes(foo)))
+				.withMessage("No matching delegate for type: " + Bytes.class.getName()
+						+ "; supported types: [java.lang.String, [B]");
 	}
 
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/DelegatingSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/DelegatingSerializationTests.java
@@ -217,8 +217,8 @@ public class DelegatingSerializationTests {
 		assertThat(serializer.serialize("foo", bar)).isEqualTo(bar.getBytes());
 		assertThatExceptionOfType(SerializationException.class).isThrownBy(
 						() -> serializer.serialize("foo", new Bytes(foo)))
-				.withMessage("No matching delegate for type: " + Bytes.class.getName()
-						+ "; supported types: [java.lang.String, [B]");
+				.withMessageMatching("No matching delegate for type: " + Bytes.class.getName()
+						+ "; supported types: \\[(java.lang.String, \\[B|\\[B, java.lang.String)\\]");
 	}
 
 }

--- a/src/checkstyle/checkstyle-suppressions.xml
+++ b/src/checkstyle/checkstyle-suppressions.xml
@@ -7,7 +7,7 @@
 	<suppress files="[\\/]test[\\/]" checks="RequireThis"/>
 	<suppress files="[\\/]test[\\/]" checks="Javadoc*"/>
 	<suppress files="KafkaMatchersTests" checks="RegexpSinglelineJava"/>
-	<suppress files="DeserializationException" checks="MutableException"/>
+	<suppress files="(DeserializationException|ConversionException)" checks="MutableException"/>
 	<suppress files="[\\/]kafka.jdocs[\\/]" checks="Regexp*"/>
 	<suppress files="[\\/]kafka.kdocs[\\/]" checks="Regexp*"/>
 </suppressions>


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1936

Make it easier to detect and recover from conversion exceptions in batch
listeners.

Also add `DelegatingByTypeSerializer`.