### PR TITLE
GH-1938: Support Whole Batch Filtering

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -1624,6 +1624,7 @@ public void pollResults(ConsumerRecords<?, ?> records) {
 
 IMPORTANT: If the container factory has a `RecordFilterStrategy` configured, it is ignored for `ConsumerRecords<?, ?>` listeners, with a `WARN` log message emitted.
 Records can only be filtered with a batch listener if the `<List<?>>` form of listener is used.
+By default, records are filtered one-at-a-time; starting with version 2.8, you can override `filterBatch` to filter the entire batch in one call.
 
 [[annotation-properties]]
 ====== Annotation Properties

--- a/spring-kafka-docs/src/main/asciidoc/whats-new.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/whats-new.adoc
@@ -28,7 +28,7 @@ Batch listeners can now handle conversion exceptions.
 See <<batch-listener-conv-errors>> for more information.
 
 `RecordFilterStrategy`, when used with batch listeners, can now filter the entire batch in one call.
-See <<>> for more information.
+See the note at the end of <<batch-listeners>> for more information.
 
 [[x28-template]]
 ==== `KafkaTemplate` Changes

--- a/spring-kafka-docs/src/main/asciidoc/whats-new.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/whats-new.adoc
@@ -27,6 +27,9 @@ Batch listeners can now handle conversion exceptions.
 
 See <<batch-listener-conv-errors>> for more information.
 
+`RecordFilterStrategy`, when used with batch listeners, can now filter the entire batch in one call.
+See <<>> for more information.
+
 [[x28-template]]
 ==== `KafkaTemplate` Changes
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/AbstractFilteringMessageListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/AbstractFilteringMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,10 @@ public abstract class AbstractFilteringMessageListener<K, V, T>
 		super(delegate);
 		Assert.notNull(recordFilterStrategy, "'recordFilterStrategy' cannot be null");
 		this.recordFilterStrategy = recordFilterStrategy;
+	}
+
+	protected RecordFilterStrategy<K, V> getRecordFilterStrategy() {
+		return this.recordFilterStrategy;
 	}
 
 	protected boolean filter(ConsumerRecord<K, V> consumerRecord) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/RecordFilterStrategy.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/RecordFilterStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,9 @@
  */
 
 package org.springframework.kafka.listener.adapter;
+
+import java.util.Iterator;
+import java.util.List;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
@@ -37,5 +40,22 @@ public interface RecordFilterStrategy<K, V> {
 	 * @return true to discard.
 	 */
 	boolean filter(ConsumerRecord<K, V> consumerRecord);
+
+	/**
+	 * Filter an entire batch of records; to filter all records, return an empty list, not
+	 * null.
+	 * @param records the records.
+	 * @return the filtered records.
+	 * @since 2.8
+	 */
+	default List<ConsumerRecord<K, V>> filterBatch(List<ConsumerRecord<K, V>> records) {
+		Iterator<ConsumerRecord<K, V>> iterator = records.iterator();
+		while (iterator.hasNext()) {
+			if (filter(iterator.next())) {
+				iterator.remove();
+			}
+		}
+		return records;
+	}
 
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -552,7 +552,7 @@ public class EnableKafkaIntegrationTests {
 		List<?> list = (List<?>) this.listener.payload;
 		assertThat(list.size()).isGreaterThan(0);
 		assertThat(list.get(0)).isInstanceOf(String.class);
-		assertThat(this.recordFilter.called).isTrue();
+		assertThat(this.recordFilter.batchCalled).isTrue();
 		assertThat(this.config.listen10Exception).isNotNull();
 		assertThat(this.listener.receivedGroupId).isEqualTo("list1");
 
@@ -2474,13 +2474,24 @@ public class EnableKafkaIntegrationTests {
 
 	public static class RecordPassAllFilter implements RecordFilterStrategy<Integer, CharSequence> {
 
-		private boolean called;
+		boolean called;
+
+		boolean batchCalled;
 
 		@Override
 		public boolean filter(ConsumerRecord<Integer, CharSequence> consumerRecord) {
-			called = true;
+			this.called = true;
 			return false;
 		}
+
+		@Override
+		public List<ConsumerRecord<Integer, CharSequence>> filterBatch(
+				List<ConsumerRecord<Integer, CharSequence>> records) {
+
+			this.batchCalled = true;
+			return records;
+		}
+
 
 	}
 


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1938

Previously, when adding a filter strategy to a batch listener, the batch
members were filtered one-at-a-time. When database lookups are involved
it is more efficient to act on the entire batch.

Add another method to the filter strategy to allow filtering the entire
batch in one call.