### PR TITLE
GH-1952: Fix Possible NPE

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/DelegatingInvocableHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/DelegatingInvocableHandler.java
@@ -21,7 +21,6 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -72,9 +71,9 @@ public class DelegatingInvocableHandler {
 
 	private final InvocableHandlerMethod defaultHandler;
 
-	private final Map<InvocableHandlerMethod, Expression> handlerSendTo = new HashMap<>();
+	private final Map<InvocableHandlerMethod, Expression> handlerSendTo = new ConcurrentHashMap<>();
 
-	private final Map<InvocableHandlerMethod, Boolean> handlerReturnsMessage = new HashMap<>();
+	private final Map<InvocableHandlerMethod, Boolean> handlerReturnsMessage = new ConcurrentHashMap<>();
 
 	private final Object bean;
 


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1952

Since maps are built on the fly, maps need to support concurrency.

**cherry-pick back to 2.5.x**