### PR TITLE
doc: fix topic name in RequestReply-Example

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -592,7 +592,7 @@ public class KRequestingApplication {
             ConcurrentKafkaListenerContainerFactory<String, String> containerFactory) {
 
         ConcurrentMessageListenerContainer<String, String> repliesContainer =
-                containerFactory.createContainer("replies");
+                containerFactory.createContainer("kReplies");
         repliesContainer.getContainerProperties().setGroupId("repliesGroup");
         repliesContainer.setAutoStartup(false);
         return repliesContainer;


### PR DESCRIPTION
The Topic created in `kReplies()` is `"kReplies"`, so this should be reflected in the `repliesContainer`.