### PR TITLE
GH-1970: Add container.isInExpectedState()

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonContainerStoppingErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonContainerStoppingErrorHandler.java
@@ -84,7 +84,8 @@ public class CommonContainerStoppingErrorHandler extends KafkaExceptionLogLevelA
 	}
 
 	private void stopContainer(MessageListenerContainer container, Exception thrownException) {
-		this.executor.execute(() -> container.stop());
+		this.executor.execute(() -> container.stopAbnormally(() -> {
+		}));
 		// isRunning is false before the container.stop() waits for listener thread
 		try {
 			ListenerUtils.stoppableSleep(container, 10_000); // NOSONAR

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -160,7 +160,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 
 	private String clientIdSuffix;
 
-	private Runnable emergencyStop = () -> stop(() -> {
+	private Runnable emergencyStop = () -> stopAbnormally(() -> {
 		// NOSONAR
 	});
 
@@ -288,6 +288,11 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 	}
 
 	@Override
+	public boolean isInExpectedState() {
+		return isRunning() || isStoppedNormally();
+	}
+
+	@Override
 	public Map<String, Map<MetricName, ? extends Metric>> metrics() {
 		ListenerConsumer listenerConsumerForMetrics = this.listenerConsumer;
 		if (listenerConsumerForMetrics != null) {
@@ -360,11 +365,12 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 	}
 
 	@Override
-	protected void doStop(final Runnable callback) {
+	protected void doStop(final Runnable callback, boolean normal) {
 		if (isRunning()) {
 			this.listenerConsumerFuture.addCallback(new StopCallback(callback));
 			setRunning(false);
 			this.listenerConsumer.wakeIfNecessary();
+			setStoppedNormally(normal);
 		}
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/MessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/MessageListenerContainer.java
@@ -202,4 +202,27 @@ public interface MessageListenerContainer extends SmartLifecycle {
 	default boolean isChildRunning() {
 		return isRunning();
 	}
+
+	/**
+	 * Return true if the container is running, has never been started, or has been
+	 * stopped.
+	 * @return true if the state is as expected.
+	 * @since 2.8
+	 * @see #stopAbnormally(Runnable)
+	 */
+	default boolean isInExpectedState() {
+		return true;
+	}
+
+	/**
+	 * Stop the container after some exception so that {@link #isInExpectedState()} will
+	 * return false.
+	 * @param callback the callback.
+	 * @since 2.8
+	 * @see #isInExpectedState()
+ 	 */
+	default void stopAbnormally(Runnable callback) {
+		stop(callback);
+	}
+
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/CommonContainerStoppingErrorHandler1Tests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/CommonContainerStoppingErrorHandler1Tests.java
@@ -116,6 +116,7 @@ public class CommonContainerStoppingErrorHandler1Tests {
 		assertThat(this.config.count).isEqualTo(4);
 		assertThat(this.config.contents.toArray()).isEqualTo(new String[]
 				{ "foo", "bar", "baz", "qux" });
+		assertThat(container.isInExpectedState()).isFalse();
 	}
 
 	@Configuration

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
@@ -181,6 +181,7 @@ public class ConcurrentMessageListenerContainerTests {
 		template.flush();
 		assertThat(intercepted.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(latch.await(60, TimeUnit.SECONDS)).isTrue();
+		assertThat(payloads).containsExactlyInAnyOrder("foo", "bar", "qux");
 		for (String threadName : listenerThreadNames) {
 			assertThat(threadName).contains("-C-");
 		}
@@ -200,7 +201,6 @@ public class ConcurrentMessageListenerContainerTests {
 		container.stop();
 		assertThat(stopLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(container.isInExpectedState()).isTrue();
-		assertThat(payloads).containsExactlyInAnyOrder("foo", "bar", "qux");
 		events.forEach(e -> {
 			assertThat(e.getContainer(MessageListenerContainer.class)).isSameAs(container);
 			if (e instanceof ContainerStoppedEvent) {

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/TestOOMError.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/TestOOMError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 the original author or authors.
+ * Copyright 2018-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,6 +86,7 @@ public class TestOOMError {
 		container.start();
 		assertThat(stopLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(container.isRunning()).isFalse();
+		assertThat(container.isInExpectedState()).isFalse();
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1970

SCSt health check uses `isRunning()` to measure health. However a container
that was `autoStartup=false` (or has been stopped) is healthy, it is just
not running.

- add `isInexpectedState()`
- add `stopAbnormally()`
- call `stopAbnormally` (from `emergencyStop`) when a listener throws an `Error`
- call `stopAbnormally` from the container stopping error handler