### PR TITLE
GH-1970: Container Stopping EH Improvement

### DIFF
--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/CommonContainerStoppingErrorHandler2Tests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/CommonContainerStoppingErrorHandler2Tests.java
@@ -104,6 +104,7 @@ public class CommonContainerStoppingErrorHandler2Tests {
 		assertThat(this.config.count).isEqualTo(4);
 		assertThat(this.config.contents.toArray()).isEqualTo(new String[]
 				{ "foo", "bar", "baz", "qux" });
+		assertThat(container.isInExpectedState()).isTrue();
 	}
 
 	@Configuration
@@ -202,6 +203,8 @@ public class CommonContainerStoppingErrorHandler2Tests {
 				@Override
 				public void handleRemaining(Exception thrownException, List<ConsumerRecord<?, ?>> records,
 						Consumer<?, ?> consumer, MessageListenerContainer container) {
+
+					setStopContainerAbnormally(false);
 					RuntimeException exception = null;
 					try {
 						super.handleRemaining(thrownException, records, consumer, container);


### PR DESCRIPTION
Add an option to stop the container normally.

There might be a case where the container is stopped due to an error, but
the user wants the container to remain 'healthy', e.g. to avoid Kubernetes
restarting the instance.