### PR TITLE
GH-1974: Fix Default Task Executor

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
@@ -33,6 +33,8 @@ import org.apache.kafka.common.TopicPartition;
 
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.core.task.AsyncListenableTaskExecutor;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.support.TopicPartitionOffset;
 import org.springframework.lang.Nullable;
@@ -59,6 +61,8 @@ import org.springframework.util.Assert;
 public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageListenerContainer<K, V> {
 
 	private final List<KafkaMessageListenerContainer<K, V>> containers = new ArrayList<>();
+
+	private final List<AsyncListenableTaskExecutor> executors = new ArrayList<>();
 
 	private int concurrency = 1;
 
@@ -230,6 +234,19 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 			stopAbnormally(() -> {
 			});
 		});
+		AsyncListenableTaskExecutor exec = container.getContainerProperties().getConsumerTaskExecutor();
+		if (exec == null) {
+			if ((this.executors.size() > index)) {
+				exec = this.executors.get(index);
+			}
+			else {
+				String containerBeanName = container.getBeanName();
+				exec = new SimpleAsyncTaskExecutor(
+						(containerBeanName == null ? "" : containerBeanName) + "-C-");
+				this.executors.add(exec);
+			}
+			container.getContainerProperties().setConsumerTaskExecutor(exec);
+		}
 	}
 
 	private KafkaMessageListenerContainer<K, V> constructContainer(ContainerProperties containerProperties,

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
@@ -214,9 +214,7 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 
 	private void configureChildContainer(int index, KafkaMessageListenerContainer<K, V> container) {
 		String beanName = getBeanName();
-		if (beanName == null) {
-			beanName = "consumer" + "-" + index;
-		}
+		beanName = (beanName == null ? "consumer" : beanName) + "-" + index;
 		container.setBeanName(beanName);
 		ApplicationContext applicationContext = getApplicationContext();
 		if (applicationContext != null) {
@@ -243,7 +241,7 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 				exec = this.executors.get(index);
 			}
 			else {
-				exec = new SimpleAsyncTaskExecutor(beanName);
+				exec = new SimpleAsyncTaskExecutor(beanName + "-C-");
 				this.executors.add(exec);
 			}
 			container.getContainerProperties().setConsumerTaskExecutor(exec);

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
@@ -214,7 +214,10 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 
 	private void configureChildContainer(int index, KafkaMessageListenerContainer<K, V> container) {
 		String beanName = getBeanName();
-		container.setBeanName((beanName != null ? beanName : "consumer") + "-" + index);
+		if (beanName == null) {
+			beanName = "consumer" + "-" + index;
+		}
+		container.setBeanName(beanName);
 		ApplicationContext applicationContext = getApplicationContext();
 		if (applicationContext != null) {
 			container.setApplicationContext(applicationContext);
@@ -240,9 +243,7 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 				exec = this.executors.get(index);
 			}
 			else {
-				String containerBeanName = container.getBeanName();
-				exec = new SimpleAsyncTaskExecutor(
-						(containerBeanName == null ? "" : containerBeanName) + "-C-");
+				exec = new SimpleAsyncTaskExecutor(beanName);
 				this.executors.add(exec);
 			}
 			container.getContainerProperties().setConsumerTaskExecutor(exec);


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1974

A new `SimpleAsyncTaskExecutor` was created for each child container when
the container was stopped/started.
Reuse the same container for each child; handle an increase to `concurrency` between
stop and start