### PR TITLE
GH-1991: Exclude slf4j impl and log4j via Zookeeper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -342,7 +342,10 @@ project ('spring-kafka-test') {
 			exclude group: 'org.springframework'
 		}
 
-		api "org.apache.zookeeper:zookeeper:$zookeeperVersion"
+		api ("org.apache.zookeeper:zookeeper:$zookeeperVersion") {
+			exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+			exclude group: 'log4j'
+		}
 		api "org.apache.kafka:kafka-clients:$kafkaVersion:test"
 		api "org.apache.kafka:kafka-metadata:$kafkaVersion"
 		api "org.apache.kafka:kafka-streams-test-utils:$kafkaVersion"


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1991

We had to add ZK to the spring-kafka-test classpath because Kafka no longer
puts it on the compile classpath since 3.0.0.

This inadvertently pulled in undesired logging dependencies.