### PR TITLE
GH-1902: AuthenticationException Fatal By Default

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -1128,12 +1128,12 @@ It does not apply if the container is configured to listen to a topic pattern (r
 Previously, the container threads looped within the `consumer.poll()` method waiting for the topic to appear while logging many messages.
 Aside from the logs, there was no indication that there was a problem.
 
-As of version 2.3.5, a new container property called `authorizationExceptionRetryInterval` has been introduced.
-This causes the container to retry fetching messages after getting any `AuthorizationException` from `KafkaConsumer`.
-This can happen when, for example, the configured user is denied access to read certain topic.
-Defining `authorizationExceptionRetryInterval` should help the application to recover as soon as proper permissions are granted.
+As of version 2.8, a new container property `authExceptionRetryInterval` has been introduced.
+This causes the container to retry fetching messages after getting any `AuthenticationException` or `AuthorizationException` from the `KafkaConsumer`.
+This can happen when, for example, the configured user is denied access to read a certain topic or credentials are incorrect.
+Defining `authExceptionRetryInterval` allows the container to recover when proper permissions are granted.
 
-NOTE: By default, no interval is configured - authorization errors are considered fatal, which causes the container to stop.
+NOTE: By default, no interval is configured - authentication and authorization errors are considered fatal, which causes the container to stop.
 
 Starting with version 2.8, when creating the consumer factory, if you provide deserializers as objects (in the constructor or via the setters), the factory will invoke the `configure()` method to configure them with the configuration properties.
 
@@ -2433,9 +2433,9 @@ When creating the `TopicPartitionOffset` s for the request, only positive, absol
 |Whether or not to commit the initial position on assignment; by default, the initial offset will only be committed if the `ConsumerConfig.AUTO_OFFSET_RESET_CONFIG` is `latest` and it won't run in a transaction even if there is a transaction manager present.
 See the javadocs for `ContainerProperties.AssignmentCommitOption` for more information about the available options.
 
-|[[authorizationExceptionRetryInterval]]<<authorizationExceptionRetryInterval,`authorizationExceptionRetryInterval`>>
+|[[authExceptionRetryInterval]]<<authExceptionRetryInterval,`authExceptionRetryInterval`>>
 |`null`
-|When not null, a `Duration` to sleep between polls when an `AuthorizationException` is thrown by the Kafka client.
+|When not null, a `Duration` to sleep between polls when an `AuthenticationException` or `AuthorizationException` is thrown by the Kafka client.
 When null, such exceptions are considered fatal and the container will stop.
 
 |[[clientId]]<<clientId,`clientId`>>
@@ -2805,7 +2805,7 @@ In addition, the `ConsumerStoppedEvent` has the following additional property:
 ** `NORMAL` - the consumer stopped normally (container was stopped).
 ** `ERROR` - a `java.lang.Error` was thrown.
 ** `FENCED` - the transactional producer was fenced and the `stopContainerWhenFenced` container property is `true`.
-** `AUTH` - an `AuthorizationException` was thrown and the `authorizationExceptionRetryInterval` is not configured.
+** `AUTH` - an `AuthenticationException` or `AuthorizationException` was thrown and the `authExceptionRetryInterval` is not configured.
 ** `NO_OFFSET` - there is no offset for a partition and the `auto.offset.reset` policy is `none`.
 
 You can use this event to restart the container after such a condition:

--- a/spring-kafka-docs/src/main/asciidoc/whats-new.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/whats-new.adoc
@@ -61,6 +61,11 @@ See <<error-handlers>> for more information.
 
 The `interceptBeforeTx` container property is now `true` by default.
 
+The `authorizationExceptionRetryInterval` property has been renamed to `authExceptionRetryInterval` and now applies to `AuthenticationException` s in addition to `AuthorizationException` s previously.
+Both exceptions are considered fatal and the container will stop by default, unless this property is set.
+
+See <<kafka-container>> and <<container-props>> for more information.
+
 [[x28-serializers]]
 ==== Serializer/Deserializer Changes
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerProperties.java
@@ -349,9 +349,11 @@ public class ConsumerProperties {
 	}
 
 	/**
-	 *
+	 * Get the authentication/authorization retry interval.
 	 * @return the interval.
+	 * @deprecated in favor of {@link #getAuthExceptionRetryInterval()}.
 	 */
+	@Deprecated
 	@Nullable
 	public Duration getAuthorizationExceptionRetryInterval() {
 		return this.authExceptionRetryInterval;

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerProperties.java
@@ -23,6 +23,7 @@ import java.util.regex.Pattern;
 
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.OffsetCommitCallback;
+import org.apache.kafka.common.errors.AuthenticationException;
 
 import org.springframework.kafka.support.LogIfLevelEnabled;
 import org.springframework.kafka.support.TopicPartitionOffset;
@@ -101,7 +102,7 @@ public class ConsumerProperties {
 
 	private Properties kafkaConsumerProperties = new Properties();
 
-	private Duration authorizationExceptionRetryInterval;
+	private Duration authExceptionRetryInterval;
 
 	private int commitRetries = DEFAULT_COMMIT_RETRIES;
 
@@ -347,22 +348,52 @@ public class ConsumerProperties {
 		this.kafkaConsumerProperties = kafkaConsumerProperties;
 	}
 
+	/**
+	 *
+	 * @return the interval.
+	 */
+	@Nullable
 	public Duration getAuthorizationExceptionRetryInterval() {
-		return this.authorizationExceptionRetryInterval;
+		return this.authExceptionRetryInterval;
 	}
 
 	/**
-	 * Set the interval between retries after {@code AuthorizationException} is thrown
-	 * by {@code KafkaConsumer}. By default the field is null and retries are disabled.
-	 * In such case the container will be stopped.
+	 * Set the interval between retries after and {@link AuthenticationException} or
+	 * {@code AuthorizationException} is thrown by {@code KafkaConsumer}. By default the
+	 * field is null and retries are disabled. In such case the container will be stopped.
 	 *
 	 * The interval must be less than {@code max.poll.interval.ms} consumer property.
 	 *
 	 * @param authorizationExceptionRetryInterval the duration between retries
 	 * @since 2.3.5
+	 * @deprecated in favor of {@link #setAuthExceptionRetryInterval(Duration)}.
 	 */
+	@Deprecated
 	public void setAuthorizationExceptionRetryInterval(Duration authorizationExceptionRetryInterval) {
-		this.authorizationExceptionRetryInterval = authorizationExceptionRetryInterval;
+		this.authExceptionRetryInterval = authorizationExceptionRetryInterval;
+	}
+
+	/**
+	 * Get the authentication/authorization retry interval.
+	 * @return the interval.
+	 */
+	@Nullable
+	public Duration getAuthExceptionRetryInterval() {
+		return this.authExceptionRetryInterval;
+	}
+
+	/**
+	 * Set the interval between retries after and {@link AuthenticationException} or
+	 * {@code AuthorizationException} is thrown by {@code KafkaConsumer}. By default the
+	 * field is null and retries are disabled. In such case the container will be stopped.
+	 *
+	 * The interval must be less than {@code max.poll.interval.ms} consumer property.
+	 *
+	 * @param authExceptionRetryInterval the duration between retries
+	 * @since 2.8
+	 */
+	public void setAuthExceptionRetryInterval(Duration authExceptionRetryInterval) {
+		this.authExceptionRetryInterval = authExceptionRetryInterval;
 	}
 
 	/**
@@ -449,7 +480,7 @@ public class ConsumerProperties {
 				+ "\n syncCommits=" + this.syncCommits
 				+ (this.syncCommitTimeout != null ? "\n syncCommitTimeout=" + this.syncCommitTimeout : "")
 				+ (this.kafkaConsumerProperties.size() > 0 ? "\n properties=" + this.kafkaConsumerProperties : "")
-				+ "\n authorizationExceptionRetryInterval=" + this.authorizationExceptionRetryInterval
+				+ "\n authExceptionRetryInterval=" + this.authExceptionRetryInterval
 				+ "\n commitRetries=" + this.commitRetries
 				+ "\n fixTxOffsets" + this.fixTxOffsets;
 	}


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/1902

Rename property and use for both exception types.