### PR TITLE
Fix typo

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/whats-new.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/whats-new.adoc
@@ -6,7 +6,7 @@ For changes in earlier version, see <<history>>.
 [[x28-kafka-client]]
 ==== Kafka Client Version
 
-This version requires the 3.0.0 `kafka-clients
+This version requires the 3.0.0 `kafka-clients`
 
 IMPORTANT: When using transactions, `kafka-clients` 3.0.0 and later no longer support `EOSMode.V2` (aka `BETA`) (and automatic fallback to `V1` - aka `ALPHA`) with brokers earlier than 2.5; you must therefore override the default `EOSMode` (`V2`) with `V1` if your brokers are older (or upgrade your brokers).
 


### PR DESCRIPTION
There is a missing left quote in [doc](https://docs.spring.io/spring-kafka/docs/current/reference/html/#x28-kafka-client).