### PR TITLE
Add MediaMessage annotation support.

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/MediaMessage.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/MediaMessage.java
@@ -1,0 +1,33 @@
+package org.springframework.kafka.annotation;
+
+import org.springframework.util.MimeTypeUtils;
+
+import java.lang.annotation.*;
+
+/**
+ * Used to define the content type of {@code Message} with {@code MediaMessageResolver}.
+ *
+ * @author Scruel Tao
+ * @date 2021/12/24
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.PARAMETER})
+public @interface MediaMessage {
+	/**
+	 * The string value of the content type of message, which can support parse,
+	 * Default application/json.
+	 *
+	 * @return the string value of mime type.
+	 * @see org.springframework.util.MimeType
+	 */
+	String type() default MimeTypeUtils.APPLICATION_JSON_VALUE;
+
+	/**
+	 * Regardless of whether there is a type header in the {@code Message}, the parse
+	 * progress will set the header of {@code Message} by this annotation {@link #type()}.
+	 *
+	 * @return whether to force parse with the annotation {@link #type()}
+	 */
+	boolean force() default false;
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/resolver/MediaMessageResolver.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/resolver/MediaMessageResolver.java
@@ -1,0 +1,48 @@
+package org.springframework.kafka.support.resolver;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.kafka.annotation.MediaMessage;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import org.springframework.messaging.converter.MessageConverter;
+import org.springframework.messaging.handler.annotation.support.PayloadMethodArgumentResolver;
+import org.springframework.messaging.support.MessageBuilder;
+
+/**
+ * A resolver to extract and convert the payload of a message using a MessageConverter.
+ * This HandlerMethodArgumentResolver only work with MediaMessage annotation now.
+ *
+ * @author Scruel Tao
+ */
+public class MediaMessageResolver extends PayloadMethodArgumentResolver {
+	/**
+	 * Create a new {@code MediaMessageResolver} with the given
+	 * {@link MessageConverter}.
+	 *
+	 * @param messageConverter the MessageConverter to use (required)
+	 */
+	public MediaMessageResolver(MessageConverter messageConverter) {
+		super(messageConverter);
+	}
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return parameter.hasParameterAnnotation(MediaMessage.class);
+	}
+
+	@Override
+	public Object resolveArgument(MethodParameter parameter, Message<?> message) throws Exception {
+		MediaMessage ann = parameter.getParameterAnnotation(MediaMessage.class);
+		if (null == ann) {
+			throw new IllegalStateException("Annotation parsing failed.");
+		}
+		// If not present, parse content type from annotation
+		if (message.getHeaders().get(MessageHeaders.CONTENT_TYPE) == null) {
+			message = MessageBuilder.fromMessage(message)
+					.setHeader(MessageHeaders.CONTENT_TYPE, ann.type())
+					.build();
+		}
+		return super.resolveArgument(parameter, message);
+	}
+
+}


### PR DESCRIPTION
Supports the ability to define the content type of Message from the client side for resolving.

Usage example:
```
@Configuration
public class MediaMessageConfig implements KafkaListenerConfigurer {
  @Autowired
  private CompositeMessageConverter messageConverters;

  @Bean
  public CompositeMessageConverter brokerMessageConverter() {
    List<MessageConverter> converters = new ArrayList<>();
    converters.add(new StringMessageConverter());
    converters.add(new ByteArrayMessageConverter());
    converters.add(createJacksonConverter());
    return new CompositeMessageConverter(converters);
  }

  protected MappingJackson2MessageConverter createJacksonConverter() {
    MappingJackson2MessageConverter converter = new MappingJackson2MessageConverter();
    converter.setContentTypeResolver(new DefaultContentTypeResolver());
    return converter;
  }

  @Override
  public void configureKafkaListeners(@JsonDeserialize KafkaListenerEndpointRegistrar registrar) {
    registrar.setCustomMethodArgumentResolvers(new MediaMessageResolver(messageConverters));
  }
}
```