### PR TITLE
Updated the DefaultKafkaProducerFactory to support producer configs overrides

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 the original author or authors.
+ * Copyright 2016-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
@@ -888,6 +888,12 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 		}
 	}
 
+	/**
+	 * Return the configuration of a producer.
+	 * @return the configuration of a producer.
+	 * @since 2.8.3
+	 * @see #createKafkaProducer()
+	 */
 	protected Map<String, Object> getProducerConfigs() {
 		final Map<String, Object> newProducerConfigs = new HashMap<>(this.configs);
 		checkBootstrap(newProducerConfigs);
@@ -898,6 +904,13 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 		return newProducerConfigs;
 	}
 
+	/**
+	 * Return the configuration of a transactional producer.
+	 * @param transactionId the transactionId.
+	 * @return the configuration of a transactional producer.
+	 * @since 2.8.3
+	 * @see #doCreateTxProducer(String, String, BiPredicate)
+	 */
 	protected Map<String, Object> getTxProducerConfigs(String transactionId) {
 		final Map<String, Object> newProducerConfigs = getProducerConfigs();
 		newProducerConfigs.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionId);

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaProducerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaProducerFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 the original author or authors.
+ * Copyright 2018-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
The DefaultKafkaProducerFactory has been updated to support producer config overrides as described in the issue #2070.

Two protected methods have been created to allow retrieving the configs of transactional and non-transactional producers.
These methods can be overridden in case of override.