### PR TITLE
JsonSerde Improvement

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerde.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerde.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,9 +18,7 @@ package org.springframework.kafka.support.serializer;
 
 import java.util.Map;
 
-import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.Serde;
-import org.apache.kafka.common.serialization.Serializer;
 
 import org.springframework.core.ResolvableType;
 import org.springframework.kafka.support.JacksonUtils;
@@ -116,12 +114,12 @@ public class JsonSerde<T> implements Serde<T> {
 	}
 
 	@Override
-	public Serializer<T> serializer() {
+	public JsonSerializer<T> serializer() {
 		return this.jsonSerializer;
 	}
 
 	@Override
-	public Deserializer<T> deserializer() {
+	public JsonDeserializer<T> deserializer() {
 		return this.jsonDeserializer;
 	}
 


### PR DESCRIPTION
Narrow return types of `serializer()`, `deserializer()` to avoid casting
if the user wants to programmatically customize the objects.

**cherry-pick to 2.8.x**