### PR TITLE
Docs: fixed "Handling Exceptions" section levels

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -5202,7 +5202,7 @@ By default, the exception type is not considered.
 Also see <<delivery-header>>.
 
 [[batch-listener-conv-errors]]
-==== Conversion Errors with Batch Error Handlers
+===== Conversion Errors with Batch Error Handlers
 
 Starting with version 2.8, batch listeners can now properly handle conversion errors, when using a `MessageConverter` with a `ByteArrayDeserializer`, a `BytesDeserializer` or a `StringDeserializer`, as well as a `DefaultErrorHandler`.
 When a conversion error occurs, the payload is set to null and a deserialization exception is added to the record headers, similar to the `ErrorHandlingDeserializer`.


### PR DESCRIPTION
The topic "Conversion Errors with Batch Error Handlers" was at the same section level "Handling Exceptions" but should be a subsection of it. Other subsections of  "Handling Exceptions" were erroneously subsections of "Handling Exceptions".

I fixed section level of "Conversion Errors with Batch Error Handlers" to align with other subsections of "Handling Exceptions".