### PR TITLE
GH-2089: Add Deprecations for 3.0 Removal

### DIFF
--- a/spring-kafka-test/src/test/java/org/springframework/kafka/test/hamcrest/KafkaMatchersTests.java
+++ b/spring-kafka-test/src/test/java/org/springframework/kafka/test/hamcrest/KafkaMatchersTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,10 @@ import static org.springframework.kafka.test.hamcrest.KafkaMatchers.hasPartition
 import static org.springframework.kafka.test.hamcrest.KafkaMatchers.hasTimestamp;
 import static org.springframework.kafka.test.hamcrest.KafkaMatchers.hasValue;
 
+import java.util.Optional;
+
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.record.TimestampType;
 import org.junit.jupiter.api.Test;
 
@@ -37,7 +40,8 @@ public class KafkaMatchersTests {
 	@Test
 	public void testKeyMatcher() {
 		ConsumerRecord<String, String> record = new ConsumerRecord<>("topic", 0, 10,
-				1487694048607L, TimestampType.CREATE_TIME, 123L, 2, 3, "key1", "value1");
+				1487694048607L, TimestampType.CREATE_TIME, 2, 3, "key1", "value1", new RecordHeaders(),
+				Optional.empty());
 		assertThat(record, hasKey("key1"));
 		assertThat(record, hasValue("value1"));
 		assertThat(record, hasPartition(0));
@@ -48,7 +52,8 @@ public class KafkaMatchersTests {
 	@Test
 	public void noMatchOnTimestamp() {
 		ConsumerRecord<String, String> record = new ConsumerRecord<>("topic", 0, 10,
-				1487694048607L, TimestampType.CREATE_TIME, 123L, 2, 3, "key1", "value1");
+				1487694048607L, TimestampType.CREATE_TIME, 2, 3, "key1", "value1", new RecordHeaders(),
+				Optional.empty());
 
 		assertThatExceptionOfType(AssertionError.class).isThrownBy(() -> assertThat(record, hasTimestamp(123L)))
 				.withMessageContaining(

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
@@ -191,7 +191,9 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 	 * Set a callback to be used with the {@link #setRetryTemplate(RetryTemplate)
 	 * retryTemplate}.
 	 * @param recoveryCallback the callback.
+	 * @deprecated since 2.8 - use a suitably configured error handler instead.
 	 */
+	@Deprecated
 	public void setRecoveryCallback(RecoveryCallback<? extends Object> recoveryCallback) {
 		this.recoveryCallback = recoveryCallback;
 	}

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -326,6 +326,7 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 		this.ackDiscarded = ackDiscarded;
 	}
 
+	@Deprecated
 	@Nullable
 	protected RetryTemplate getRetryTemplate() {
 		return this.retryTemplate;
@@ -341,6 +342,7 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 		this.retryTemplate = retryTemplate;
 	}
 
+	@Deprecated
 	@Nullable
 	protected RecoveryCallback<?> getRecoveryCallback() {
 		return this.recoveryCallback;
@@ -349,7 +351,9 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 	/**
 	 * Set a callback to be used with the {@link #setRetryTemplate(RetryTemplate)}.
 	 * @param recoveryCallback the callback.
+	 * @deprecated since 2.8 - use a suitably configured error handler instead.
 	 */
+	@Deprecated
 	public void setRecoveryCallback(RecoveryCallback<? extends Object> recoveryCallback) {
 		this.recoveryCallback = recoveryCallback;
 	}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 the original author or authors.
+ * Copyright 2016-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -148,7 +148,9 @@ public class ContainerProperties extends ConsumerProperties {
 
 		/**
 		 * 'transactional.id' fencing (0.11 - 2.4 brokers).
+		 * @deprecated 3.0 and later will require 2.5+ brokers
 		 */
+		@Deprecated
 		V1,
 
 		/**
@@ -188,7 +190,9 @@ public class ContainerProperties extends ConsumerProperties {
 		/**
 		 * Return the mode or the aliased mode.
 		 * @return the mode.
+		 * @deprecated aliases will be removed in 3.0
 		 */
+		@Deprecated
 		public EOSMode getMode() {
 			return this.mode;
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -926,6 +926,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			}
 		}
 
+		@SuppressWarnings("deprecation")
 		private boolean setupSubBatchPerPartition() {
 			Boolean subBatching = this.containerProperties.getSubBatchPerPartition();
 			if (subBatching != null) {

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/SubBatchPerPartitionTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/SubBatchPerPartitionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -133,6 +133,7 @@ public class SubBatchPerPartitionTests {
 		this.registry.stop();
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	void defaults() {
 		Map<String, Object> props = KafkaTestUtils.consumerProps("sbpp", "false", this.broker);

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/TransactionalContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/TransactionalContainerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -143,21 +143,25 @@ public class TransactionalContainerTests {
 		embeddedKafka = EmbeddedKafkaCondition.getBroker();
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testConsumeAndProduceTransactionKTM() throws Exception {
 		testConsumeAndProduceTransactionGuts(false, AckMode.RECORD, EOSMode.V1);
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testConsumeAndProduceTransactionHandleError() throws Exception {
 		testConsumeAndProduceTransactionGuts(true, AckMode.RECORD, EOSMode.V1);
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testConsumeAndProduceTransactionKTMManual() throws Exception {
 		testConsumeAndProduceTransactionGuts(false, AckMode.MANUAL_IMMEDIATE, EOSMode.V1);
 	}
 
+	@SuppressWarnings("deprecation")
 	@Test
 	public void testConsumeAndProduceTransactionKTM_BETA() throws Exception {
 		testConsumeAndProduceTransactionGuts(false, AckMode.RECORD, EOSMode.V1);


### PR DESCRIPTION
In preparation for https://github.com/spring-projects/spring-kafka/issues/2089

Missed deprecations.