### PR TITLE
GH-2069: Same factory for retryable and normal endpoints

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/retrytopic.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/retrytopic.adoc
@@ -668,8 +668,6 @@ public RetryTopicConfiguration myRetryTopic(KafkaTemplate<Integer, MyPojo> templ
 
 By default the RetryTopic configuration will use the provided factory from the `@KafkaListener` annotation, but you can specify a different one to be used to create the retry topic and dlt listener containers.
 
-IMPORTANT: The provided factory will be configured for the retry topic functionality, so you should not use the same factory for both retrying and non-retrying topics. You can however share the same factory between many retry topic configurations.
-
 For the `@RetryableTopic` annotation you can provide the factory's bean name, and using the `RetryTopicConfiguration` bean you can either provide the bean name or the instance itself.
 
 ====
@@ -702,6 +700,27 @@ public RetryTopicConfiguration myOtherRetryTopic(KafkaTemplate<Integer, MyPojo> 
 }
 ----
 ====
+
+
+IMPORTANT: Since 2.8.3 you can use the same factory for retryable and non-retryable topics.
+
+If you need to revert the factory configuration behavior to prior 2.8.3, you can replace the standard `RetryTopicConfigurer` bean and set `useLegacyFactoryConfigurer` to `true`, such as:
+
+====
+[source, java]
+----
+
+@Bean(name = RetryTopicInternalBeanNames.RETRY_TOPIC_CONFIGURER)
+public RetryTopicConfigurer retryTopicConfigurer(DestinationTopicProcessor destinationTopicProcessor,
+                                                ListenerContainerFactoryResolver containerFactoryResolver,
+                                                ListenerContainerFactoryConfigurer listenerContainerFactoryConfigurer,
+                                                BeanFactory beanFactory,
+                                                RetryTopicNamesProviderFactory retryTopicNamesProviderFactory) {
+    RetryTopicConfigurer retryTopicConfigurer = new RetryTopicConfigurer(destinationTopicProcessor, containerFactoryResolver, listenerContainerFactoryConfigurer, beanFactory, retryTopicNamesProviderFactory);
+    retryTopicConfigurer.useLegacyFactoryConfigurer(true);
+    return retryTopicConfigurer;
+}
+----
 
 [[change-kboe-logging-level]]
 ==== Changing KafkaBackOffException Logging Level

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
@@ -220,6 +220,8 @@ public class RetryTopicConfigurer {
 
 	private final RetryTopicNamesProviderFactory retryTopicNamesProviderFactory;
 
+	private boolean useLegacyFactoryConfigurer = false;
+
 	/**
 	 * Create an instance with the provided properties.
 	 * @param destinationTopicProcessor the destination topic processor.
@@ -297,7 +299,7 @@ public class RetryTopicConfigurer {
 											RetryTopicConfiguration configuration, DestinationTopicProcessor.Context context,
 											DestinationTopic.Properties destinationTopicProperties) {
 
-		ConcurrentKafkaListenerContainerFactory<?, ?> resolvedFactory =
+		KafkaListenerContainerFactory<?> resolvedFactory =
 				destinationTopicProperties.isMainEndpoint()
 						? resolveAndConfigureFactoryForMainEndpoint(factory, defaultFactoryBeanName, configuration)
 						: resolveAndConfigureFactoryForRetryEndpoint(factory, defaultFactoryBeanName, configuration);
@@ -360,25 +362,32 @@ public class RetryTopicConfigurer {
 		return dltEndpointHandlerMethod != null ? dltEndpointHandlerMethod : DEFAULT_DLT_HANDLER;
 	}
 
-	private ConcurrentKafkaListenerContainerFactory<?, ?> resolveAndConfigureFactoryForMainEndpoint(
+	private KafkaListenerContainerFactory<?> resolveAndConfigureFactoryForMainEndpoint(
 			KafkaListenerContainerFactory<?> providedFactory,
 			String defaultFactoryBeanName, RetryTopicConfiguration configuration) {
 		ConcurrentKafkaListenerContainerFactory<?, ?> resolvedFactory = this.containerFactoryResolver
 				.resolveFactoryForMainEndpoint(providedFactory, defaultFactoryBeanName,
 						configuration.forContainerFactoryResolver());
-		return this.listenerContainerFactoryConfigurer
-				.configureWithoutBackOffValues(resolvedFactory, configuration.forContainerFactoryConfigurer());
+
+		return this.useLegacyFactoryConfigurer
+				? this.listenerContainerFactoryConfigurer
+				.configureWithoutBackOffValues(resolvedFactory, configuration.forContainerFactoryConfigurer())
+				: this.listenerContainerFactoryConfigurer
+					.decorateFactoryWithoutBackOffValues(resolvedFactory, configuration.forContainerFactoryConfigurer());
 	}
 
-	private ConcurrentKafkaListenerContainerFactory<?, ?> resolveAndConfigureFactoryForRetryEndpoint(
+	private KafkaListenerContainerFactory<?> resolveAndConfigureFactoryForRetryEndpoint(
 			KafkaListenerContainerFactory<?> providedFactory,
 			String defaultFactoryBeanName,
 			RetryTopicConfiguration configuration) {
 		ConcurrentKafkaListenerContainerFactory<?, ?> resolvedFactory =
 				this.containerFactoryResolver.resolveFactoryForRetryEndpoint(providedFactory, defaultFactoryBeanName,
 				configuration.forContainerFactoryResolver());
-		return this.listenerContainerFactoryConfigurer
-				.configure(resolvedFactory, configuration.forContainerFactoryConfigurer());
+		return this.useLegacyFactoryConfigurer
+				? this.listenerContainerFactoryConfigurer.configure(resolvedFactory,
+					configuration.forContainerFactoryConfigurer())
+				: this.listenerContainerFactoryConfigurer
+					.decorateFactory(resolvedFactory, configuration.forContainerFactoryConfigurer());
 	}
 
 	private void throwIfMultiMethodEndpoint(MethodKafkaListenerEndpoint<?, ?> mainEndpoint) {
@@ -393,6 +402,15 @@ public class RetryTopicConfigurer {
 
 	public static EndpointHandlerMethod createHandlerMethodWith(Object bean, Method method) {
 		return new EndpointHandlerMethod(bean, method);
+	}
+
+	/**
+	 * Set to true if you want the {@link ListenerContainerFactoryConfigurer} to behave as before 2.8.3.
+	 * @param useLegacyFactoryConfigurer Whether to use the legacy factory configuration.
+	 */
+	@Deprecated
+	public void useLegacyFactoryConfigurer(boolean useLegacyFactoryConfigurer) {
+		this.useLegacyFactoryConfigurer = useLegacyFactoryConfigurer;
 	}
 
 	public interface EndpointProcessor extends Consumer<MethodKafkaListenerEndpoint<?, ?>> {

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
@@ -405,8 +405,10 @@ public class RetryTopicConfigurer {
 	}
 
 	/**
-	 * Set to true if you want the {@link ListenerContainerFactoryConfigurer} to behave as before 2.8.3.
+	 * Set to true if you want the {@link ListenerContainerFactoryConfigurer} to
+	 * behave as before 2.8.3.
 	 * @param useLegacyFactoryConfigurer Whether to use the legacy factory configuration.
+	 * @deprecated for removal after the deprecated legacy configuration methods are removed.
 	 */
 	@Deprecated
 	public void useLegacyFactoryConfigurer(boolean useLegacyFactoryConfigurer) {

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -224,9 +224,9 @@ class RetryTopicConfigurerTests {
 
 		willReturn(containerFactory).given(containerFactoryResolver).resolveFactoryForRetryEndpoint(containerFactory,
 				defaultFactoryBeanName, factoryResolverConfig);
-		willReturn(containerFactory).given(this.listenerContainerFactoryConfigurer).configure(containerFactory,
+		willReturn(containerFactory).given(this.listenerContainerFactoryConfigurer).decorateFactory(containerFactory,
 				lcfcConfiguration);
-		willReturn(containerFactory).given(this.listenerContainerFactoryConfigurer).configureWithoutBackOffValues(containerFactory,
+		willReturn(containerFactory).given(this.listenerContainerFactoryConfigurer).decorateFactoryWithoutBackOffValues(containerFactory,
 				lcfcConfiguration);
 
 		RetryTopicConfigurer configurer = new RetryTopicConfigurer(destinationTopicProcessor, containerFactoryResolver,

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicLegacyFactoryConfigurerIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicLegacyFactoryConfigurerIntegrationTests.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2021-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.retrytopic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.DltHandler;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.annotation.RetryableTopic;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.stereotype.Component;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+/**
+ * @author Tomaz Fernandes
+ * @since 2.8.3
+ */
+@SpringJUnitConfig
+@DirtiesContext
+@EmbeddedKafka(topics = RetryTopicLegacyFactoryConfigurerIntegrationTests.FIRST_TOPIC, partitions = 1)
+public class RetryTopicLegacyFactoryConfigurerIntegrationTests {
+
+	private static final Logger logger = LoggerFactory.getLogger(RetryTopicLegacyFactoryConfigurerIntegrationTests.class);
+
+	public final static String FIRST_TOPIC = "myRetryTopic1";
+
+	@Autowired
+	private KafkaTemplate<String, String> sendKafkaTemplate;
+
+	@Autowired
+	private CountDownLatchContainer latchContainer;
+
+	@Test
+	void shouldRetryFirstAndSecondTopics() {
+		logger.debug("Sending message to topic " + FIRST_TOPIC);
+		sendKafkaTemplate.send(FIRST_TOPIC, "Testing topic 1");
+		assertThat(awaitLatch(latchContainer.countDownLatch1)).isTrue();
+		assertThat(awaitLatch(latchContainer.countDownLatchDltOne)).isTrue();
+	}
+
+	private boolean awaitLatch(CountDownLatch latch) {
+		try {
+			return latch.await(150, TimeUnit.SECONDS);
+		}
+		catch (Exception e) {
+			fail(e.getMessage());
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Component
+	static class RetryableKafkaListener {
+
+		@Autowired
+		CountDownLatchContainer countDownLatchContainer;
+
+		@RetryableTopic(
+				attempts = "4",
+				backoff = @Backoff(delay = 1000, multiplier = 2.0),
+				autoCreateTopics = "false",
+				topicSuffixingStrategy = TopicSuffixingStrategy.SUFFIX_WITH_INDEX_VALUE)
+		@KafkaListener(topics = RetryTopicLegacyFactoryConfigurerIntegrationTests.FIRST_TOPIC)
+		public void listen(String in, @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
+			countDownLatchContainer.countDownLatch1.countDown();
+			logger.warn(in + " from " + topic);
+			throw new RuntimeException("test");
+		}
+
+		@DltHandler
+		public void dlt(String in, @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
+			countDownLatchContainer.countDownLatchDltOne.countDown();
+			logger.warn(in + " from " + topic);
+		}
+	}
+
+	@Component
+	static class CountDownLatchContainer {
+
+		CountDownLatch countDownLatch1 = new CountDownLatch(4);
+		CountDownLatch countDownLatchDltOne = new CountDownLatch(1);
+		CountDownLatch customizerLatch = new CountDownLatch(6);
+	}
+
+	@EnableKafka
+	@Configuration
+	static class Config {
+
+		@Autowired
+		EmbeddedKafkaBroker broker;
+
+		@Bean
+		CountDownLatchContainer latchContainer() {
+			return new CountDownLatchContainer();
+		}
+
+		@Bean
+		RetryableKafkaListener retryableKafkaListener() {
+			return new RetryableKafkaListener();
+		}
+
+		@Bean
+		public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory(
+				ConsumerFactory<String, String> consumerFactory, CountDownLatchContainer latchContainer) {
+
+			ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+			factory.setConsumerFactory(consumerFactory);
+			ContainerProperties props = factory.getContainerProperties();
+			props.setIdleEventInterval(100L);
+			props.setPollTimeout(50L);
+			props.setIdlePartitionEventInterval(100L);
+			factory.setConsumerFactory(consumerFactory);
+			factory.setConcurrency(1);
+			factory.setContainerCustomizer(
+					container -> latchContainer.customizerLatch.countDown());
+			return factory;
+		}
+
+		@Bean
+		public ProducerFactory<String, String> producerFactory() {
+			Map<String, Object> configProps = new HashMap<>();
+			configProps.put(
+					ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
+					this.broker.getBrokersAsString());
+			configProps.put(
+					ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+					StringSerializer.class);
+			configProps.put(
+					ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+					StringSerializer.class);
+			return new DefaultKafkaProducerFactory<>(configProps);
+		}
+
+		@Bean
+		public KafkaTemplate<String, String> kafkaTemplate() {
+			return new KafkaTemplate<>(producerFactory());
+		}
+
+		@Bean(name = RetryTopicInternalBeanNames.RETRY_TOPIC_CONFIGURER)
+		public RetryTopicConfigurer retryTopicConfigurer(DestinationTopicProcessor destinationTopicProcessor,
+														ListenerContainerFactoryResolver containerFactoryResolver,
+														ListenerContainerFactoryConfigurer listenerContainerFactoryConfigurer,
+														BeanFactory beanFactory,
+														RetryTopicNamesProviderFactory retryTopicNamesProviderFactory) {
+			RetryTopicConfigurer retryTopicConfigurer = new RetryTopicConfigurer(destinationTopicProcessor, containerFactoryResolver, listenerContainerFactoryConfigurer, beanFactory, retryTopicNamesProviderFactory);
+			retryTopicConfigurer.useLegacyFactoryConfigurer(true);
+			return retryTopicConfigurer;
+		}
+
+		@Bean
+		public ConsumerFactory<String, String> consumerFactory() {
+			Map<String, Object> props = new HashMap<>();
+			props.put(
+					ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
+					this.broker.getBrokersAsString());
+			props.put(
+					ConsumerConfig.GROUP_ID_CONFIG,
+					"groupId");
+			props.put(
+					ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+					StringDeserializer.class);
+			props.put(
+					ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+					StringDeserializer.class);
+			props.put(
+					ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG, false);
+			props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+			return new DefaultKafkaConsumerFactory<>(props);
+		}
+	}
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicSameContainerFactoryIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicSameContainerFactoryIntegrationTests.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2021-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.retrytopic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.DltHandler;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.annotation.RetryableTopic;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.stereotype.Component;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.util.backoff.FixedBackOff;
+
+/**
+ * @author Tomaz Fernandes
+ * @since 2.8.3
+ */
+@SpringJUnitConfig
+@DirtiesContext
+@EmbeddedKafka(topics = { RetryTopicSameContainerFactoryIntegrationTests.FIRST_TOPIC,
+		RetryTopicSameContainerFactoryIntegrationTests.SECOND_TOPIC}, partitions = 1)
+public class RetryTopicSameContainerFactoryIntegrationTests {
+
+	private static final Logger logger = LoggerFactory.getLogger(RetryTopicSameContainerFactoryIntegrationTests.class);
+
+	public final static String FIRST_TOPIC = "myRetryTopic1";
+
+	public final static String SECOND_TOPIC = "myRetryTopic2";
+
+	@Autowired
+	private KafkaTemplate<String, String> sendKafkaTemplate;
+
+	@Autowired
+	private CountDownLatchContainer latchContainer;
+
+	@Test
+	void shouldRetryFirstAndSecondTopics() {
+		logger.debug("Sending message to topic " + FIRST_TOPIC);
+		sendKafkaTemplate.send(FIRST_TOPIC, "Testing topic 1");
+		logger.debug("Sending message to topic " + SECOND_TOPIC);
+		sendKafkaTemplate.send(SECOND_TOPIC, "Testing topic 2");
+		assertThat(awaitLatch(latchContainer.countDownLatch1)).isTrue();
+		assertThat(awaitLatch(latchContainer.countDownLatchDltOne)).isTrue();
+		assertThat(awaitLatch(latchContainer.countDownLatch2)).isTrue();
+		assertThat(awaitLatch(latchContainer.customizerLatch)).isTrue();
+	}
+
+	private boolean awaitLatch(CountDownLatch latch) {
+		try {
+			return latch.await(150, TimeUnit.SECONDS);
+		}
+		catch (Exception e) {
+			fail(e.getMessage());
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Component
+	static class RetryableKafkaListener {
+
+		@Autowired
+		CountDownLatchContainer countDownLatchContainer;
+
+		@RetryableTopic(
+				attempts = "4",
+				backoff = @Backoff(delay = 1000, multiplier = 2.0),
+				autoCreateTopics = "false",
+				topicSuffixingStrategy = TopicSuffixingStrategy.SUFFIX_WITH_INDEX_VALUE)
+		@KafkaListener(topics = RetryTopicSameContainerFactoryIntegrationTests.FIRST_TOPIC)
+		public void listen(String in, @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
+			countDownLatchContainer.countDownLatch1.countDown();
+			logger.warn(in + " from " + topic);
+			throw new RuntimeException("test");
+		}
+
+		@DltHandler
+		public void dlt(String in, @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
+			countDownLatchContainer.countDownLatchDltOne.countDown();
+			logger.warn(in + " from " + topic);
+		}
+	}
+
+	@Component
+	static class BasicKafkaListener {
+
+		@Autowired
+		CountDownLatchContainer countDownLatchContainer;
+
+		@KafkaListener(topics = RetryTopicSameContainerFactoryIntegrationTests.SECOND_TOPIC)
+		public void listen(String in, @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
+			logger.info(in + " from " + topic);
+			throw new RuntimeException("another test");
+		}
+	}
+
+	@Component
+	static class CountDownLatchContainer {
+
+		CountDownLatch countDownLatch1 = new CountDownLatch(4);
+		CountDownLatch countDownLatch2 = new CountDownLatch(1);
+		CountDownLatch countDownLatchDltOne = new CountDownLatch(1);
+		CountDownLatch customizerLatch = new CountDownLatch(6);
+	}
+
+	@EnableKafka
+	@Configuration
+	static class Config {
+
+		@Autowired
+		EmbeddedKafkaBroker broker;
+
+		@Bean
+		CountDownLatchContainer latchContainer() {
+			return new CountDownLatchContainer();
+		}
+
+		@Bean
+		RetryableKafkaListener retryableKafkaListener() {
+			return new RetryableKafkaListener();
+		}
+
+		@Bean
+		BasicKafkaListener basicKafkaListener() {
+			return new BasicKafkaListener();
+		}
+
+		@Bean
+		public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory(
+				ConsumerFactory<String, String> consumerFactory, CountDownLatchContainer latchContainer) {
+
+			ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+			factory.setConsumerFactory(consumerFactory);
+			ContainerProperties props = factory.getContainerProperties();
+			props.setIdleEventInterval(100L);
+			props.setPollTimeout(50L);
+			props.setIdlePartitionEventInterval(100L);
+			factory.setConsumerFactory(consumerFactory);
+			DefaultErrorHandler errorHandler = new DefaultErrorHandler(
+					(cr, ex) -> latchContainer.countDownLatch2.countDown(),
+					new FixedBackOff(0, 2));
+			factory.setCommonErrorHandler(errorHandler);
+			factory.setConcurrency(1);
+			factory.setContainerCustomizer(
+					container -> latchContainer.customizerLatch.countDown());
+			return factory;
+		}
+
+		@Bean
+		public ProducerFactory<String, String> producerFactory() {
+			Map<String, Object> configProps = new HashMap<>();
+			configProps.put(
+					ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
+					this.broker.getBrokersAsString());
+			configProps.put(
+					ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+					StringSerializer.class);
+			configProps.put(
+					ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+					StringSerializer.class);
+			return new DefaultKafkaProducerFactory<>(configProps);
+		}
+
+		@Bean
+		public KafkaTemplate<String, String> kafkaTemplate() {
+			return new KafkaTemplate<>(producerFactory());
+		}
+
+		@Bean
+		public ConsumerFactory<String, String> consumerFactory() {
+			Map<String, Object> props = new HashMap<>();
+			props.put(
+					ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
+					this.broker.getBrokersAsString());
+			props.put(
+					ConsumerConfig.GROUP_ID_CONFIG,
+					"groupId");
+			props.put(
+					ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+					StringDeserializer.class);
+			props.put(
+					ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+					StringDeserializer.class);
+			props.put(
+					ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG, false);
+			props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+			return new DefaultKafkaConsumerFactory<>(props);
+		}
+	}
+}


### PR DESCRIPTION
Resolves #2069 

This solution uses a decorator to only interfere with container properties when we're in retryable topic logic.

As a result we only change two existing classes, instead of almost 10 from the other PR. I think this should be easier to review and has less chance of interfering with existing logic, while also keeping all retryable topic's factory configuration logic in one class.

I also deprecated two methods in the `ListenerContainerFactoryConfigurer` class, added the possibility of reverting back the behavior, and described this in the documentation. Since we're going to 3.0.0 and I see deprecations are being removed, I can remove these after and if we merge this code to 2.8.x.

Of course, we can still reopen the other PR if you prefer the other solution, no worries. And please let me know if there's anything to be changed.

Thanks!