### PR TITLE
GH-2109: Increase EKB Zookeeper Timeouts

### DIFF
--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaBroker.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaBroker.java
@@ -115,9 +115,9 @@ public class EmbeddedKafkaBroker implements InitializingBean, DisposableBean {
 
 	private static final Duration DEFAULT_ADMIN_TIMEOUT = Duration.ofSeconds(10);
 
-	public static final int DEFAULT_ZK_CONNECTION_TIMEOUT = 6000;
+	public static final int DEFAULT_ZK_SESSION_TIMEOUT = 18000;
 
-	public static final int DEFAULT_ZK_SESSION_TIMEOUT = 6000;
+	public static final int DEFAULT_ZK_CONNECTION_TIMEOUT = DEFAULT_ZK_SESSION_TIMEOUT;
 
 	private static final Method GET_BROKER_STATE_METHOD;
 


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2109

Increase default session timeout to 18 seconds to align with Kafka itself.
Also make connection timeout the same, similar to Kafka's default behavior.

**cherry-pick to 2.8.x, 2.7.x**
