### PR TITLE
Change Spring repositories to official

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,9 +109,10 @@ allprojects {
 
 	repositories {
 		mavenCentral()
-		maven { url 'https://repo.spring.io/libs-milestone' }
+		maven { url 'https://repo.spring.io/release' }
+		maven { url 'https://repo.spring.io/milestone' }
 		if (version.endsWith('SNAPSHOT')) {
-			maven { url 'https://repo.spring.io/libs-snapshot' }
+			maven { url 'https://repo.spring.io/snapshot' }
 		}
 //		maven { url 'https://repository.apache.org/content/groups/staging/' }
 	}


### PR DESCRIPTION
The `/libs-*` repos require an authentication to download artifacts

**Cherry-pick to `2.8.x` & `2.7.x`**

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
