### PR TITLE
GH-2049: Spring Managed Producer Interceptors

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/index.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/index.adoc
@@ -5,7 +5,7 @@
 :numbered:
 :icons: font
 :hide-uri-scheme:
-Gary Russell; Artem Bilan; Biju Kunjummen; Jay Bryant
+Gary Russell; Artem Bilan; Biju Kunjummen; Jay Bryant; Soby Chacko
 
 ifdef::backend-html5[]
 *{project-version}*
@@ -17,7 +17,7 @@ ifdef::backend-pdf[]
 NOTE: This documentation is also available as https://docs.spring.io/spring-kafka/docs/{project-version}/reference/html/index.html[HTML].
 endif::[]
 
-(C) 2016 - 2021 VMware, Inc.
+(C) 2016 - 2022 VMware, Inc.
 
 Copies of this document may be made for your own use and for distribution to others, provided that you do not charge any fee for such copies and further provided that each copy contains this Copyright Notice, whether distributed in print or electronically.
 

--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -3736,7 +3736,7 @@ Received test
 
 ==== Producer Interceptor Managed in Spring
 
-Staring with version 3.0.0, when it comes to a producer interceptor, you can let Spring manage it directly as a bean instead of providing the class name of the interceptor to the Kafka producer configuration.
+Staring with version 3.0.0, when it comes to a producer interceptor, you can let Spring manage it directly as a bean instead of providing the class name of the interceptor to the Apache Kafka producer configuration.
 If you go with this approach, then you need to set this producer interceptor on `KafkaTemplate`.
 Following is an example using the same `MyProducerInterceptor` from above, but changed to not use the internal config property.
 

--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -3734,6 +3734,67 @@ Received test
 ----
 ====
 
+==== Producer Interceptor Managed in Spring
+
+Staring with version 3.0.0, when it comes to a producer interceptor, you can let Spring manage it directly as a bean instead of providing the class name of the interceptor to the Kafka producer configuration.
+If you go with this approach, then you need to set this producer interceptor on `KafkaTemplate`.
+Following is an example using the same `MyProducerInterceptor` from above, but changed to not use the internal config property.
+
+====
+[source]
+----
+public class MyProducerInterceptor implements ProducerInterceptor<String, String> {
+
+    private final SomeBean bean;
+
+    public MyProducerInterceptor(SomeBean bean) {
+        this.bean = bean;
+    }
+
+    @Override
+    public void configure(Map<String, ?> configs) {
+
+    }
+
+    @Override
+    public ProducerRecord<String, String> onSend(ProducerRecord<String, String> record) {
+        this.bean.someMethod("producer interceptor");
+        return record;
+    }
+
+    @Override
+    public void onAcknowledgement(RecordMetadata metadata, Exception exception) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+}
+----
+====
+
+====
+[source]
+----
+
+@Bean
+public MyProducerInterceptor myProducerInterceptor(SomeBean someBean) {
+  return new MyProducerInterceptor(someBean);
+}
+
+@Bean
+public KafkaTemplate<String, String> kafkaTemplate(ProducerFactory<String, String> pf, MyProducerInterceptor myProducerInterceptor) {
+   KafkaTemplate<String, String> kafkaTemplate = new KafkaTemplate<String, String>(pf);
+   kafkaTemplate.setProducerInterceptor(myProducerInterceptor);
+}
+----
+====
+
+Right before the records are sent, the `onSend` method of the producer interceptor is invoked.
+Once the server sends an acknowledgement on publishing the data, then the `onAcknowledgement` method is invoked.
+The `onAcknowledgement` is called right before the producer invokes any user callbacks.
+
 [[pause-resume]]
 ==== Pausing and Resuming Listener Containers
 

--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -3736,7 +3736,7 @@ Received test
 
 ==== Producer Interceptor Managed in Spring
 
-Staring with version 3.0.0, when it comes to a producer interceptor, you can let Spring manage it directly as a bean instead of providing the class name of the interceptor to the Apache Kafka producer configuration.
+Starting with version 3.0.0, when it comes to a producer interceptor, you can let Spring manage it directly as a bean instead of providing the class name of the interceptor to the Apache Kafka producer configuration.
 If you go with this approach, then you need to set this producer interceptor on `KafkaTemplate`.
 Following is an example using the same `MyProducerInterceptor` from above, but changed to not use the internal config property.
 

--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -3795,6 +3795,10 @@ Right before the records are sent, the `onSend` method of the producer intercept
 Once the server sends an acknowledgement on publishing the data, then the `onAcknowledgement` method is invoked.
 The `onAcknowledgement` is called right before the producer invokes any user callbacks.
 
+If you have multiple such producer interceptors managed through Spring that need to be applied on the `KafkaTemplate`, you need to use `CompositeProducerInterceptor` instead.
+`CompositeProducerInterceptor` allows individual producer interceptors to be added in order.
+The methods from the underlying `ProducerInterceptor` implementations are invoked in the order as they were added to the `CompositeProducerInterceptor`.
+
 [[pause-resume]]
 ==== Pausing and Resuming Listener Containers
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
@@ -37,6 +37,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerInterceptor;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.Metric;
@@ -87,6 +88,7 @@ import org.springframework.util.concurrent.SettableListenableFuture;
  * @author Biju Kunjummen
  * @author Endika Gutierrez
  * @author Thomas Strauß
+ * @author Soby Chacko
  */
 public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationContextAware, BeanNameAware,
 		ApplicationListener<ContextStoppedEvent>, DisposableBean {
@@ -128,6 +130,8 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 	private volatile boolean micrometerEnabled = true;
 
 	private volatile MicrometerHolder micrometerHolder;
+
+	private ProducerInterceptor<K, V> producerInterceptor;
 
 	/**
 	 * Create an instance using the supplied producer factory and autoFlush false.
@@ -368,6 +372,24 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 	 */
 	public void setConsumerFactory(ConsumerFactory<K, V> consumerFactory) {
 		this.consumerFactory = consumerFactory;
+	}
+
+	/**
+	 * Returns the producer interceptor associated with this template.
+	 * @return {@link ProducerInterceptor}
+	 * @since 3.0.x
+	 */
+	public ProducerInterceptor<K, V> getProducerInterceptor() {
+		return this.producerInterceptor;
+	}
+
+	/**
+	 * Set a producer interceptor or this template.
+	 * @param producerInterceptor the producer interceptor
+	 * @since 3.0.x
+	 */
+	public void setProducerInterceptor(ProducerInterceptor<K, V> producerInterceptor) {
+		this.producerInterceptor = producerInterceptor;
 	}
 
 	@Override
@@ -631,6 +653,9 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 		if (this.micrometerHolder != null) {
 			sample = this.micrometerHolder.start();
 		}
+		if (this.producerInterceptor != null) {
+			this.producerInterceptor.onSend(producerRecord);
+		}
 		Future<RecordMetadata> sendFuture =
 				producer.send(producerRecord, buildCallback(producerRecord, producer, future, sample));
 		// May be an immediate failure
@@ -657,6 +682,9 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 			final SettableListenableFuture<SendResult<K, V>> future, @Nullable Object sample) {
 
 		return (metadata, exception) -> {
+			if (this.producerInterceptor != null) {
+				this.producerInterceptor.onAcknowledgement(metadata, exception);
+			}
 			try {
 				if (exception == null) {
 					if (sample != null) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
@@ -375,18 +375,9 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 	}
 
 	/**
-	 * Returns the producer interceptor associated with this template.
-	 * @return {@link ProducerInterceptor}
-	 * @since 3.0.x
-	 */
-	public ProducerInterceptor<K, V> getProducerInterceptor() {
-		return this.producerInterceptor;
-	}
-
-	/**
-	 * Set a producer interceptor or this template.
+	 * Set a producer interceptor on this template.
 	 * @param producerInterceptor the producer interceptor
-	 * @since 3.0.x
+	 * @since 3.0
 	 */
 	public void setProducerInterceptor(ProducerInterceptor<K, V> producerInterceptor) {
 		this.producerInterceptor = producerInterceptor;

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
@@ -673,8 +673,13 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 			final SettableListenableFuture<SendResult<K, V>> future, @Nullable Object sample) {
 
 		return (metadata, exception) -> {
-			if (this.producerInterceptor != null) {
-				this.producerInterceptor.onAcknowledgement(metadata, exception);
+			try {
+				if (this.producerInterceptor != null) {
+					this.producerInterceptor.onAcknowledgement(metadata, exception);
+				}
+			}
+			catch (Exception e) {
+				KafkaTemplate.this.logger.warn(e, () ->  "Error executing interceptor onAcknowledgement callback");
 			}
 			try {
 				if (exception == null) {
@@ -781,6 +786,9 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 		}
 		if (this.customProducerFactory) {
 			((DefaultKafkaProducerFactory<K, V>) this.producerFactory).destroy();
+		}
+		if (this.producerInterceptor != null) {
+			this.producerInterceptor.close();
 		}
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/CompositeProducerInterceptor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/CompositeProducerInterceptor.java
@@ -74,7 +74,8 @@ public class CompositeProducerInterceptor<K, V> implements ProducerInterceptor<K
 									record.topic(), record.partition()));
 				}
 				else {
-					CompositeProducerInterceptor.this.logger.warn(e, () -> "Error executing interceptor onSend callback");
+					CompositeProducerInterceptor.this.logger.warn(e, () -> "Error executing interceptor onSend callback: "
+							+ interceptor.toString());
 				}
 			}
 		}
@@ -89,7 +90,8 @@ public class CompositeProducerInterceptor<K, V> implements ProducerInterceptor<K
 			}
 			catch (Exception e) {
 				// do not propagate interceptor exceptions, just log
-				CompositeProducerInterceptor.this.logger.warn(e, () ->  "Error executing interceptor onAcknowledgement callback");
+				CompositeProducerInterceptor.this.logger.warn(e, () ->  "Error executing interceptor onAcknowledgement callback: "
+						+ interceptor.toString());
 			}
 		}
 	}
@@ -101,7 +103,8 @@ public class CompositeProducerInterceptor<K, V> implements ProducerInterceptor<K
 				interceptor.close();
 			}
 			catch (Exception e) {
-				CompositeProducerInterceptor.this.logger.warn(e, () -> "Failed to close producer interceptor");
+				CompositeProducerInterceptor.this.logger.warn(e, () -> "Failed to close producer interceptor: "
+						+ interceptor.toString());
 			}
 		}
 	}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/CompositeProducerInterceptor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/CompositeProducerInterceptor.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support;
+
+import java.io.Closeable;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.logging.LogFactory;
+import org.apache.kafka.clients.producer.ProducerInterceptor;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+
+import org.springframework.core.log.LogAccessor;
+import org.springframework.util.Assert;
+
+/**
+ * A {@link ProducerInterceptor} that delegates to a collection of interceptors.
+ *
+ * @param <K> the key type.
+ * @param <V> the value type.
+ *
+ * @author Soby Chacko
+ *
+ * @since 3.0
+ *
+ */
+public class CompositeProducerInterceptor<K, V> implements ProducerInterceptor<K, V>, Closeable {
+
+	private final LogAccessor logger = new LogAccessor(LogFactory.getLog(this.getClass())); //NOSONAR
+
+	private final List<ProducerInterceptor<K, V>> delegates = new ArrayList<>();
+
+	/**
+	 * Construct an instance with the provided delegates to {@link ProducerInterceptor}s.
+	 * @param delegates the delegates.
+	 */
+	@SafeVarargs
+	@SuppressWarnings("varargs")
+	public CompositeProducerInterceptor(ProducerInterceptor<K, V>... delegates) {
+		Assert.notNull(delegates, "'delegates' cannot be null");
+		Assert.noNullElements(delegates, "'delegates' cannot have null entries");
+		this.delegates.addAll(Arrays.asList(delegates));
+	}
+
+	@Override
+	public ProducerRecord<K, V> onSend(ProducerRecord<K, V> record) {
+		ProducerRecord<K, V> interceptRecord = record;
+		for (ProducerInterceptor<K, V> interceptor : this.delegates) {
+			try {
+				interceptRecord = interceptor.onSend(interceptRecord);
+			}
+			catch (Exception e) {
+				// if exception thrown, log and continue calling other interceptors.
+				if (record != null) {
+					CompositeProducerInterceptor.this.logger.warn(e, () ->
+							String.format("Error executing interceptor onSend callback for topic: %s, partition: %d",
+									record.topic(), record.partition()));
+				}
+				else {
+					CompositeProducerInterceptor.this.logger.warn(e, () -> "Error executing interceptor onSend callback");
+				}
+			}
+		}
+		return interceptRecord;
+	}
+
+	@Override
+	public void onAcknowledgement(RecordMetadata metadata, Exception exception) {
+		for (ProducerInterceptor<K, V> interceptor : this.delegates) {
+			try {
+				interceptor.onAcknowledgement(metadata, exception);
+			}
+			catch (Exception e) {
+				// do not propagate interceptor exceptions, just log
+				CompositeProducerInterceptor.this.logger.warn(e, () ->  "Error executing interceptor onAcknowledgement callback");
+			}
+		}
+	}
+
+	@Override
+	public void close() {
+		for (ProducerInterceptor<K, V> interceptor : this.delegates) {
+			try {
+				interceptor.close();
+			}
+			catch (Exception e) {
+				CompositeProducerInterceptor.this.logger.warn(e, () -> "Failed to close producer interceptor");
+			}
+		}
+	}
+
+	@Override
+	public void configure(Map<String, ?> configs) {
+		this.delegates.forEach(delegate -> delegate.configure(configs));
+	}
+}


### PR DESCRIPTION
Allow producer interceptors to be managed by Spring so that
they can be used in KafkaTemplate instead of providing the classname
of the interceptor to Kafka configuraiton.

Adding tests and docs.

Resolves https://github.com/spring-projects/spring-kafka/issues/2049

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
