### PR TITLE
GH-2117: Make ListenerContainerFactoryConfigurer ctor public

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
@@ -373,7 +373,8 @@ public class RetryTopicConfigurer {
 				? this.listenerContainerFactoryConfigurer
 				.configureWithoutBackOffValues(resolvedFactory, configuration.forContainerFactoryConfigurer())
 				: this.listenerContainerFactoryConfigurer
-					.decorateFactoryWithoutBackOffValues(resolvedFactory, configuration.forContainerFactoryConfigurer());
+					.decorateFactoryWithoutSettingContainerProperties(resolvedFactory,
+							configuration.forContainerFactoryConfigurer());
 	}
 
 	private KafkaListenerContainerFactory<?> resolveAndConfigureFactoryForRetryEndpoint(

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurerTests.java
@@ -226,7 +226,7 @@ class RetryTopicConfigurerTests {
 				defaultFactoryBeanName, factoryResolverConfig);
 		willReturn(containerFactory).given(this.listenerContainerFactoryConfigurer).decorateFactory(containerFactory,
 				lcfcConfiguration);
-		willReturn(containerFactory).given(this.listenerContainerFactoryConfigurer).decorateFactoryWithoutBackOffValues(containerFactory,
+		willReturn(containerFactory).given(this.listenerContainerFactoryConfigurer).decorateFactoryWithoutSettingContainerProperties(containerFactory,
 				lcfcConfiguration);
 
 		RetryTopicConfigurer configurer = new RetryTopicConfigurer(destinationTopicProcessor, containerFactoryResolver,


### PR DESCRIPTION
Resolves GH-2117

In order to make keeping this class' APIs compatibility easier in the future, I reviewed the methods signatures to future proof them. I've been dealing a lot with that lately.

Basically what I did was pass the Configuration object around so all methods have access to it when we add new features, without having to deprecate or overload them. I actually have one feature in mind that would require this soon.

The public method I renamed is from my previous PR and hasn't been released yet, so I hope that's ok.

I acknowledge that this may be too much for a quick review - I'm ok with only opening up the ctor and leaving the visibility opening / refactor for the next version and can provide a PR with that if that's the case.

Of course, if you think it's better to just open up the methods as they are that's ok too, just let me know.

Thanks