### PR TITLE
GH-2118: Make DLPR skip same topic fatal ex optional

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
@@ -103,6 +103,8 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 
 	private boolean stripPreviousExceptionHeaders = true;
 
+	private boolean skipSameTopicFatalExceptions = true;
+
 	/**
 	 * Create an instance with the provided template and a default destination resolving
 	 * function that returns a TopicPartition based on the original topic (appended with ".DLT")
@@ -314,6 +316,16 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 		this.stripPreviousExceptionHeaders = stripPreviousExceptionHeaders;
 	}
 
+	/**
+	 * Set to false if you want to forward the record to the same topic even though
+	 * the exception is fatal by this class' classification, e.g. to handle this scenario
+	 * in a different layer.
+	 * @param skipSameTopicFatalExceptions false to forward in this scenario.
+	 */
+	public void setSkipSameTopicFatalExceptions(boolean skipSameTopicFatalExceptions) {
+		this.skipSameTopicFatalExceptions = skipSameTopicFatalExceptions;
+	}
+
 	@SuppressWarnings("unchecked")
 	@Override
 	public void accept(ConsumerRecord<?, ?> record, @Nullable Consumer<?, ?> consumer, Exception exception) {
@@ -324,7 +336,9 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 					+ " skipped because destination resolver returned null");
 			return;
 		}
-		if (tp.topic().equals(record.topic()) && !getClassifier().classify(exception)) {
+		if (this.skipSameTopicFatalExceptions
+				&& tp.topic().equals(record.topic())
+				&& !getClassifier().classify(exception)) {
 			this.logger.error("Recovery of " + ListenerUtils.recordToString(record, true)
 					+ " skipped because not retryable exception " + exception.toString()
 					+ " and the destination resolver routed back to the same topic");

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DeadLetterPublishingRecovererFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DeadLetterPublishingRecovererFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -140,9 +140,10 @@ public class DeadLetterPublishingRecovererFactory {
 		recoverer.setFailIfSendResultIsError(true);
 		recoverer.setAppendOriginalHeaders(false);
 		recoverer.setThrowIfNoDestinationReturned(false);
+		recoverer.setSkipSameTopicFatalExceptions(false);
 		this.recovererCustomizer.accept(recoverer);
-		this.fatalExceptions.forEach(ex -> recoverer.addNotRetryableExceptions(ex));
-		this.nonFatalExceptions.forEach(ex -> recoverer.removeNotRetryableException(ex));
+		this.fatalExceptions.forEach(recoverer::addNotRetryableExceptions);
+		this.nonFatalExceptions.forEach(recoverer::removeNotRetryableException);
 		return recoverer;
 	}
 


### PR DESCRIPTION
Fixes GH-2118

The logic introduced to stop endless loops in DLPR processing for fatal exceptions interferes with RT's single-topic strategy.
Make it optional and set the default to false in DLPRF for RT.
The loop is now addressed in DefaultDestinationTopicResolver as in GH-2113.