### PR TITLE
GH-2113: Add ex classification to DDTopicResolver

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/retrytopic.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/retrytopic.adoc
@@ -306,6 +306,28 @@ public RetryTopicConfiguration myRetryTopic(KafkaTemplate<String, MyOtherPojo> t
 
 NOTE: The default behavior is retrying on all exceptions and not traversing causes.
 
+Since 2.8.3 there's a global list of fatal exceptions which will cause the record to be sent to the DLT without any retries.
+See <<default-eh, DefaultErrorHandler>> for the default list of fatal exceptions.
+You can add or remove exceptions with:
+
+====
+[source, java]
+----
+@Bean(name = RetryTopicInternalBeanNames.DESTINATION_TOPIC_CONTAINER_NAME)
+public DefaultDestinationTopicResolver topicResolver(ApplicationContext applicationContext,
+                                               @Qualifier(RetryTopicInternalBeanNames
+                                                       .INTERNAL_BACKOFF_CLOCK_BEAN_NAME) Clock clock) {
+    DefaultDestinationTopicResolver ddtr = new DefaultDestinationTopicResolver(clock, applicationContext);
+    ddtr.addNotRetryableExceptions(MyFatalException.class);
+    ddtr.removeNotRetryableException(ConversionException.class);
+    return ddtr;
+}
+----
+====
+
+NOTE: To disable fatal exceptions' classification, clear the default list using the `setClassifications` method in `DefaultDestinationTopicResolver`.
+
+
 ===== Include and Exclude Topics
 
 You can decide which topics will and will not be handled by a `RetryTopicConfiguration` bean via the .includeTopic(String topic), .includeTopics(Collection<String> topics) .excludeTopic(String topic) and .excludeTopics(Collection<String> topics) methods.

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DestinationTopicTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DestinationTopicTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,15 +62,15 @@ public class DestinationTopicTests {
 
 	protected DestinationTopic.Properties mainTopicProps =
 			new DestinationTopic.Properties(0, "", DestinationTopic.Type.RETRY, 4, 1,
-					DltStrategy.FAIL_ON_ERROR, kafkaOperations1, getShouldRetryOn(), noTimeout);
+					DltStrategy.FAIL_ON_ERROR, kafkaOperations1, getShouldRetryOnDenyList(), noTimeout);
 
 	protected DestinationTopic.Properties firstRetryProps =
 			new DestinationTopic.Properties(1000, retrySuffix + "-1000", DestinationTopic.Type.RETRY, 4, 1,
-					DltStrategy.FAIL_ON_ERROR, kafkaOperations1, getShouldRetryOn(), noTimeout);
+					DltStrategy.FAIL_ON_ERROR, kafkaOperations1, getShouldRetryOnDenyList(), noTimeout);
 
 	protected DestinationTopic.Properties secondRetryProps =
 			new DestinationTopic.Properties(2000, retrySuffix + "-2000", DestinationTopic.Type.RETRY, 4, 1,
-					DltStrategy.FAIL_ON_ERROR, kafkaOperations1, getShouldRetryOn(), noTimeout);
+					DltStrategy.FAIL_ON_ERROR, kafkaOperations1, getShouldRetryOnDenyList(), noTimeout);
 
 	protected DestinationTopic.Properties dltTopicProps =
 			new DestinationTopic.Properties(0, dltSuffix, DestinationTopic.Type.DLT, 4, 1,
@@ -218,11 +218,18 @@ public class DestinationTopicTests {
 
 	// Classifiers
 
-	private final BinaryExceptionClassifier classifier = new BinaryExceptionClassifierBuilder()
+	private final BinaryExceptionClassifier allowListClassifier = new BinaryExceptionClassifierBuilder()
 			.retryOn(IllegalArgumentException.class).build();
 
+	private final BinaryExceptionClassifier denyListClassifier = new BinaryExceptionClassifierBuilder()
+			.notRetryOn(IllegalArgumentException.class).build();
+
 	private BiPredicate<Integer, Throwable> getShouldRetryOn() {
-		return (a, e) -> a < maxAttempts && classifier.classify(e);
+		return (a, e) -> a < maxAttempts && allowListClassifier.classify(e);
+	}
+
+	private BiPredicate<Integer, Throwable> getShouldRetryOnDenyList() {
+		return (a, e) -> a < maxAttempts && denyListClassifier.classify(e);
 	}
 
 	class PropsHolder {


### PR DESCRIPTION
Resolves GH-2113

Adds exception classification to DefaultDestinationTopicResolver so that fatal exceptions makes records go straight to the DLT.

Also stop DLT processing if such an exception is found (see GH-2118).

Add documentation on this feature.