### PR TITLE
GH-2132: Producer Record Log Formatting

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
@@ -635,7 +635,7 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 	 */
 	protected ListenableFuture<SendResult<K, V>> doSend(final ProducerRecord<K, V> producerRecord) {
 		final Producer<K, V> producer = getTheProducer(producerRecord.topic());
-		this.logger.trace(() -> "Sending: " + producerRecord);
+		this.logger.trace(() -> "Sending: " + KafkaUtils.format(producerRecord));
 		final SettableListenableFuture<SendResult<K, V>> future = new SettableListenableFuture<>();
 		Object sample = null;
 		if (this.micrometerEnabled && this.micrometerHolder == null) {
@@ -665,7 +665,7 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 		if (this.autoFlush) {
 			flush();
 		}
-		this.logger.trace(() -> "Sent: " + producerRecord);
+		this.logger.trace(() -> "Sent: " + KafkaUtils.format(producerRecord));
 		return future;
 	}
 
@@ -690,7 +690,8 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 					if (KafkaTemplate.this.producerListener != null) {
 						KafkaTemplate.this.producerListener.onSuccess(producerRecord, metadata);
 					}
-					KafkaTemplate.this.logger.trace(() -> "Sent ok: " + producerRecord + ", metadata: " + metadata);
+					KafkaTemplate.this.logger.trace(() -> "Sent ok: " + KafkaUtils.format(producerRecord)
+							+ ", metadata: " + metadata);
 				}
 				else {
 					if (sample != null) {
@@ -700,7 +701,8 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 					if (KafkaTemplate.this.producerListener != null) {
 						KafkaTemplate.this.producerListener.onError(producerRecord, metadata, exception);
 					}
-					KafkaTemplate.this.logger.debug(exception, () -> "Failed to send: " + producerRecord);
+					KafkaTemplate.this.logger.debug(exception, () -> "Failed to send: "
+							+ KafkaUtils.format(producerRecord));
 				}
 			}
 			finally {

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ListenerUtils.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ListenerUtils.java
@@ -27,6 +27,7 @@ import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 
 import org.springframework.core.log.LogAccessor;
+import org.springframework.kafka.support.KafkaUtils;
 import org.springframework.kafka.support.serializer.DeserializationException;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
@@ -44,8 +45,6 @@ public final class ListenerUtils {
 
 	private ListenerUtils() {
 	}
-
-	private static final ThreadLocal<Boolean> LOG_METADATA_ONLY = new ThreadLocal<>();
 
 	private static final int DEFAULT_SLEEP_INTERVAL = 100;
 
@@ -151,7 +150,7 @@ public final class ListenerUtils {
 	 * @see #recordToString(ConsumerRecord)
 	 */
 	public static void setLogOnlyMetadata(boolean onlyMeta) {
-		LOG_METADATA_ONLY.set(onlyMeta);
+		KafkaUtils.setLogOnlyMetadata(onlyMeta);
 	}
 
 	/**
@@ -163,12 +162,7 @@ public final class ListenerUtils {
 	 * @see #setLogOnlyMetadata(boolean)
 	 */
 	public static String recordToString(ConsumerRecord<?, ?> record) {
-		if (Boolean.TRUE.equals(LOG_METADATA_ONLY.get())) {
-			return record.topic() + "-" + record.partition() + "@" + record.offset();
-		}
-		else {
-			return record.toString();
-		}
+		return KafkaUtils.recordToString(record);
 	}
 
 	/**
@@ -180,12 +174,7 @@ public final class ListenerUtils {
 	 * @since 2.5.4
 	 */
 	public static String recordToString(ConsumerRecord<?, ?> record, boolean meta) {
-		if (meta) {
-			return record.topic() + "-" + record.partition() + "@" + record.offset();
-		}
-		else {
-			return record.toString();
-		}
+		return KafkaUtils.recordToString(record, meta);
 	}
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/requestreply/AggregatingReplyingKafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/requestreply/AggregatingReplyingKafkaTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ import org.springframework.kafka.listener.BatchConsumerAwareMessageListener;
 import org.springframework.kafka.listener.ContainerProperties.AckMode;
 import org.springframework.kafka.listener.GenericMessageListenerContainer;
 import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.kafka.support.KafkaUtils;
 import org.springframework.util.Assert;
 
 /**
@@ -126,7 +127,7 @@ public class AggregatingReplyingKafkaTemplate<K, V, R>
 		data.forEach(record -> {
 			Header correlation = record.headers().lastHeader(KafkaHeaders.CORRELATION_ID);
 			if (correlation == null) {
-				this.logger.error(() -> "No correlationId found in reply: " + record
+				this.logger.error(() -> "No correlationId found in reply: " + KafkaUtils.recordToString(record)
 						+ " - to use request/reply semantics, the responding server must return the correlation id "
 						+ " in the '" + KafkaHeaders.CORRELATION_ID + "' header");
 			}


### PR DESCRIPTION
Partial solution for  https://github.com/spring-projects/spring-kafka/issues/2132

Allow the user to provide a function for formatting producer records.

Also move consumer record formatting to `KafkaUtils` will deprecate
`ListenerUtils` versions later.

There will be more polising in this area for 3.0 only (separate PR).

**cherry-pick to 2.8.x, 2.7.x**

