### PR TITLE
GH-2135: Support array for JsonDeserializer type mapping 

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java
@@ -531,8 +531,9 @@ public class JsonDeserializer<T> implements Deserializer<T> {
 
 	private void addMappingsToTrusted(Map<String, Class<?>> mappings) {
 		mappings.values().forEach(clazz -> {
-			doAddTrustedPackages(clazz.getPackage().getName());
-			doAddTrustedPackages(clazz.getPackage().getName() + ".*");
+			String packageName = clazz.isArray() ? clazz.getComponentType().getPackage().getName() : clazz.getPackage().getName();
+			doAddTrustedPackages(packageName);
+			doAddTrustedPackages(packageName + ".*");
 		});
 	}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/JsonSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/JsonSerializationTests.java
@@ -309,6 +309,19 @@ public class JsonSerializationTests {
 		assertThat(KafkaTestUtils.getPropertyValue(deser, "typeMapper.trustedPackages", Set.class))
 			.contains(Foo.class.getPackageName() + ".*");
 	}
+	
+	@SuppressWarnings("unchecked")
+	@Test
+	void testTrustMappingPackagesForArray() {
+		JsonDeserializer<Object> deser = new JsonDeserializer<>();
+		Map<String, Object> props = Collections.singletonMap(JsonDeserializer.TYPE_MAPPINGS,
+				"foo:" + Foo[].class.getName());
+		deser.configure(props, false);
+		assertThat(KafkaTestUtils.getPropertyValue(deser, "typeMapper.trustedPackages", Set.class))
+				.contains(Foo.class.getPackageName());
+		assertThat(KafkaTestUtils.getPropertyValue(deser, "typeMapper.trustedPackages", Set.class))
+			.contains(Foo.class.getPackageName() + ".*");
+	}
 
 	@SuppressWarnings("unchecked")
 	@Test


### PR DESCRIPTION
See #2135:
Fixes NullPointerException that is thrown when configuring an array for the JsonDeserializer type mappings.

This pull requests contains a proposal for a fix and a test that covers the case.

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
