### PR TITLE
GH-2134: Add filter to @KafkaListener

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -2315,7 +2315,7 @@ In addition, a `FilteringBatchMessageListenerAdapter` is provided, for when you 
 
 IMPORTANT: The `FilteringBatchMessageListenerAdapter` is ignored if your `@KafkaListener` receives a `ConsumerRecords<?, ?>` instead of `List<ConsumerRecord<?, ?>>`, because `ConsumerRecords` is immutable.
 
-Starting with version 2.8.4, you can override the listener container factory's default `RecordFilterStrategy` by using the `filter` property on the listner.
+Starting with version 2.8.4, you can override the listener container factory's default `RecordFilterStrategy` by using the `filter` property on the listener annotations.
 
 ====
 [source, java]

--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -2606,6 +2606,7 @@ Mutually exclusive; at least one must be provided; enforced by `ContainerPropert
 |See <<transactions>>.
 |===
 
+[[alc-props]]
 .`AbstractListenerContainer` Properties
 [cols="9,10,16", options="header"]
 |===
@@ -2662,6 +2663,12 @@ See <<error-handlers>>.
 |[[listenerId]]<<listenerId,`listenerId`>>
 |See desc.
 |The bean name for user-configured containers or the `id` attribute of `@KafkaListener` s.
+
+|[[listenerInfo]]<<listenerInfo,`listenerInfo`>>
+|null
+|A value to populate in the `KafkaHeaders.LISTENER_INFO` header.
+With `@KafkaListener`, this value is obtained from the `info` attribute.
+This header can be used in various places, such as a `RecordInterceptor`, `RecordFilterStrategy` and in the listener code itself.
 
 |[[pauseRequested]]<<pauseRequested,`pauseRequested`>>
 |(read only)
@@ -5555,6 +5562,30 @@ To enable population of this header, set the container property `deliveryAttempt
 It is disabled by default to avoid the (small) overhead of looking up the state for each record and adding the header.
 
 The `DefaultErrorHandler` and `DefaultAfterRollbackProcessor` support this feature.
+
+[[li-header]]
+===== Listener Info Header
+
+In some cases, it is useful to be able to know which container a listener is running in.
+
+Starting with version 2.8.4, you can now set the `listenerInfo` property on the listener container, or set the `info` attribute on the `@KafkaListener` annotation.
+Then, the container will add this in the `KafkaListener.LISTENER_INFO` header to all incoming messages; it can then be used in record interceptors, filters, etc., or in the listener itself.
+
+====
+[source, java]
+----
+@KafkaListener(id = "something", topic = "topic", filter = "someFilter",
+        info = "this is the something listener")
+public void listen2(@Payload Thing thing,
+        @Header(KafkaHeaders.LISTENER_INFO) String listenerInfo) {
+...
+}
+----
+====
+
+When used in a `RecordInterceptor` or `RecordFilterStrategy` implementation, the header is in the consumer record as a byte array, converted using the `KafkaListenerAnnotationBeanPostProcessor` 's `charSet` property.
+
+The header mappers also convert to `String` when creating `MessageHeaders` from the consumer record and never map this header on an outbound record.
 
 [[dead-letters]]
 ===== Publishing Dead-letter Records

--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -2315,6 +2315,18 @@ In addition, a `FilteringBatchMessageListenerAdapter` is provided, for when you 
 
 IMPORTANT: The `FilteringBatchMessageListenerAdapter` is ignored if your `@KafkaListener` receives a `ConsumerRecords<?, ?>` instead of `List<ConsumerRecord<?, ?>>`, because `ConsumerRecords` is immutable.
 
+Starting with version 2.8.4, you can override the listener container factory's default `RecordFilterStrategy` by using the `filter` property on the listner.
+
+====
+[source, java]
+----
+@KafkaListener(id = "filtered", topics = "topic", filter = "differentFilter")
+public void listen(Thing thing) {
+    ...
+}
+----
+====
+
 [[retrying-deliveries]]
 ===== Retrying Deliveries
 

--- a/spring-kafka-docs/src/main/asciidoc/whats-new.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/whats-new.adoc
@@ -44,6 +44,8 @@ See <<batch-listener-conv-errors>> for more information.
 `RecordFilterStrategy`, when used with batch listeners, can now filter the entire batch in one call.
 See the note at the end of <<batch-listeners>> for more information.
 
+The `@KafkaListener` annotation now has the `filter` attribute, to override the container factory's `RecordFilterStrategy` for just this listener.
+
 [[x28-template]]
 ==== `KafkaTemplate` Changes
 

--- a/spring-kafka-docs/src/main/asciidoc/whats-new.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/whats-new.adoc
@@ -46,6 +46,10 @@ See the note at the end of <<batch-listeners>> for more information.
 
 The `@KafkaListener` annotation now has the `filter` attribute, to override the container factory's `RecordFilterStrategy` for just this listener.
 
+The `@KafkaListener` annotation now the "info" attribute; this is used to populate the new listener container property `listenerInfo`.
+This is then used to populate a `KafkaHeaders.LISTENER_INFO` header in each record which can be used in `RecordInterceptor`, `RecordFilterStrategy`, or the listener itself.
+See <<li-header>> and <<alc-props,Abstract Listener Container Properties>> for more information.
+
 [[x28-template]]
 ==== `KafkaTemplate` Changes
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
@@ -308,4 +308,20 @@ public @interface KafkaListener {
 	 */
 	String filter() default "";
 
+	/**
+	 * Static information that will be added as a header with key
+	 * {@link org.springframework.kafka.support.KafkaHeaders#LISTENER_INFO}. This can be used, for example, in a
+	 * {@link org.springframework.kafka.listener.RecordInterceptor}, {@link RecordFiorg.springframework.kafka.listener.adapter.RecordFilterStrategylterStrategy} or the listener itself, for
+	 * any purposes.
+	 * <p>
+	 * SpEL {@code #{...}} and property place holders {@code ${...}} are supported, but it
+	 * must resolve to a String or `byte[]`.
+	 * <p>
+	 * This header will be stripped out if an outbound record is created with the headers
+	 * from an input record.
+	 * @return the info.
+	 * @since 2.8.4
+	 */
+	String info() default "";
+
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 the original author or authors.
+ * Copyright 2016-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -296,5 +296,16 @@ public @interface KafkaListener {
 	 * @see Boolean#parseBoolean(String)
 	 */
 	String batch() default "";
+
+	/**
+	 * Set an {@link org.springframework.kafka.listener.adapter.RecordFilterStrategy} bean
+	 * name to override the strategy configured on the container factory. If a SpEL
+	 * expression is provided ({@code #{...}}), the expression can either evaluate to a
+	 * {@link org.springframework.kafka.listener.adapter.RecordFilterStrategy} instance or
+	 * a bean name.
+	 * @return the error handler.
+	 * @since 2.8.4
+	 */
+	String filter() default "";
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
@@ -490,7 +490,7 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 		}
 
 		RetryTopicConfigurer.EndpointProcessor endpointProcessor = endpointToProcess ->
-				this.processKafkaListenerAnnotationForRetryTopic(endpointToProcess, kafkaListener, bean, topics, tps);
+				this.processKafkaListenerAnnotation(endpointToProcess, kafkaListener, bean, topics, tps);
 
 		KafkaListenerContainerFactory<?> factory =
 				resolveContainerFactory(kafkaListener, resolve(kafkaListener.containerFactory()), beanName);
@@ -561,7 +561,7 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 	protected void processListener(MethodKafkaListenerEndpoint<?, ?> endpoint, KafkaListener kafkaListener,
 								Object bean, String beanName, String[] topics, TopicPartitionOffset[] tps) {
 
-		processKafkaListenerAnnotationBeforeRegistration(endpoint, kafkaListener, bean, topics, tps);
+		processKafkaListenerAnnotation(endpoint, kafkaListener, bean, topics, tps);
 
 		String containerFactory = resolve(kafkaListener.containerFactory());
 		KafkaListenerContainerFactory<?> listenerContainerFactory = resolveContainerFactory(kafkaListener,
@@ -570,13 +570,7 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 		this.registrar.registerEndpoint(endpoint, listenerContainerFactory);
 	}
 
-	private void processKafkaListenerAnnotationForRetryTopic(MethodKafkaListenerEndpoint<?, ?> endpoint,
-			KafkaListener kafkaListener, Object bean, String[] topics, TopicPartitionOffset[] tps) {
-
-		processKafkaListenerAnnotationBeforeRegistration(endpoint, kafkaListener, bean, topics, tps);
-	}
-
-	private void processKafkaListenerAnnotationBeforeRegistration(MethodKafkaListenerEndpoint<?, ?> endpoint,
+	private void processKafkaListenerAnnotation(MethodKafkaListenerEndpoint<?, ?> endpoint,
 			KafkaListener kafkaListener, Object bean, String[] topics, TopicPartitionOffset[] tps) {
 
 		endpoint.setBean(bean);

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
@@ -369,7 +369,6 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 		return instance;
 	}
 
-	@SuppressWarnings("deprecation")
 	private void configureEndpoint(AbstractKafkaListenerEndpoint<K, V> aklEndpoint) {
 		if (aklEndpoint.getRecordFilterStrategy() == null) {
 			JavaUtils.INSTANCE
@@ -433,7 +432,8 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 				.acceptIfHasText(endpoint.getGroupId(), instance.getContainerProperties()::setGroupId)
 				.acceptIfHasText(endpoint.getClientIdPrefix(), instance.getContainerProperties()::setClientId)
 				.acceptIfNotNull(endpoint.getConsumerProperties(),
-						instance.getContainerProperties()::setKafkaConsumerProperties);
+						instance.getContainerProperties()::setKafkaConsumerProperties)
+				.acceptIfNotNull(endpoint.getListenerInfo(), instance::setListenerInfo);
 	}
 
 	private void customizeContainer(C instance) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
@@ -371,8 +371,11 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 
 	@SuppressWarnings("deprecation")
 	private void configureEndpoint(AbstractKafkaListenerEndpoint<K, V> aklEndpoint) {
+		if (aklEndpoint.getRecordFilterStrategy() == null) {
+			JavaUtils.INSTANCE
+					.acceptIfNotNull(this.recordFilterStrategy, aklEndpoint::setRecordFilterStrategy);
+		}
 		JavaUtils.INSTANCE
-				.acceptIfNotNull(this.recordFilterStrategy, aklEndpoint::setRecordFilterStrategy)
 				.acceptIfNotNull(this.ackDiscarded, aklEndpoint::setAckDiscarded)
 				.acceptIfNotNull(this.statefulRetry, aklEndpoint::setStatefulRetry)
 				.acceptIfNotNull(this.replyTemplate, aklEndpoint::setReplyTemplate)
@@ -381,7 +384,6 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 		if (aklEndpoint.getBatchListener() == null) {
 			JavaUtils.INSTANCE
 					.acceptIfNotNull(this.batchListener, aklEndpoint::setBatchListener);
-
 		}
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
@@ -116,6 +116,8 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 
 	private BatchToRecordAdapter<K, V> batchToRecordAdapter;
 
+	private byte[] listenerInfo;
+
 	@Override
 	public void setBeanFactory(BeanFactory beanFactory) throws BeansException {
 		this.beanFactory = beanFactory;
@@ -432,6 +434,21 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 		this.splitIterables = splitIterables;
 	}
 
+	@Override
+	@Nullable
+	public byte[] getListenerInfo() {
+		return this.listenerInfo; // NOSONAR
+	}
+
+	/**
+	 * Set the listener info to insert in the record header.
+	 * @param listenerInfo the info.
+	 * @since 2.8.4
+	 */
+	public void setListenerInfo(@Nullable byte[] listenerInfo) {  // NOSONAR
+		this.listenerInfo = listenerInfo; // NOSONAR
+	}
+
 	@Nullable
 	protected BatchToRecordAdapter<K, V> getBatchToRecordAdapter() {
 		return this.batchToRecordAdapter;
@@ -445,6 +462,7 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 	public void setBatchToRecordAdapter(BatchToRecordAdapter<K, V> batchToRecordAdapter) {
 		this.batchToRecordAdapter = batchToRecordAdapter;
 	}
+
 
 	@Override
 	public void afterPropertiesSet() {

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2020 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -144,5 +144,15 @@ public interface KafkaListenerEndpoint {
 	 * @since 2.3.5
 	 */
 	boolean isSplitIterables();
+
+	/**
+	 * Get the listener info to insert in the record header.
+	 * @return the info.
+	 * @since 2.8.4
+	 */
+	@Nullable
+	default byte[] getListenerInfo() {
+		return null;
+	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
@@ -46,6 +46,7 @@ import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.core.log.LogAccessor;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.event.ContainerStoppedEvent;
+import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.support.TopicPartitionOffset;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
@@ -82,6 +83,8 @@ public abstract class AbstractMessageListenerContainer<K, V>
 
 	protected final Object lifecycleMonitor = new Object(); // NOSONAR
 
+	private final Set<TopicPartition> pauseRequestedPartitions = ConcurrentHashMap.newKeySet();
+
 	private String beanName;
 
 	private ApplicationEventPublisher applicationEventPublisher;
@@ -106,13 +109,13 @@ public abstract class AbstractMessageListenerContainer<K, V>
 
 	private boolean interceptBeforeTx = true;
 
-	private volatile boolean running = false;
-
-	private volatile boolean paused;
+	private byte[] listenerInfo;
 
 	private ApplicationContext applicationContext;
 
-	private final Set<TopicPartition> pauseRequestedPartitions = ConcurrentHashMap.newKeySet();
+	private volatile boolean running = false;
+
+	private volatile boolean paused;
 
 	private volatile boolean stoppedNormally = true;
 
@@ -371,6 +374,27 @@ public abstract class AbstractMessageListenerContainer<K, V>
 	@Nullable
 	public String getListenerId() {
 		return this.beanName; // the container factory sets the bean name to the id attribute
+	}
+
+	/**
+	 * Get arbitrary static information that will be added to the
+	 * {@link KafkaHeaders#LISTENER_INFO} header of all records.
+	 * @return the info.
+	 * @since 2.8.4
+	 */
+	@Nullable
+	public byte[] getListenerInfo() {
+		return this.listenerInfo != null ? Arrays.copyOf(this.listenerInfo, this.listenerInfo.length) : null;
+	}
+
+	/**
+	 * Set arbitrary information that will be added to the
+	 * {@link KafkaHeaders#LISTENER_INFO} header of all records.
+	 * @param listenerInfo the info.
+	 * @since 2.8.4
+	 */
+	public void setListenerInfo(@Nullable byte[] listenerInfo) {
+		this.listenerInfo = listenerInfo != null ? Arrays.copyOf(listenerInfo, listenerInfo.length) : null;
 	}
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
@@ -232,6 +232,7 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 		container.setRecordInterceptor(getRecordInterceptor());
 		container.setBatchInterceptor(getBatchInterceptor());
 		container.setInterceptBeforeTx(isInterceptBeforeTx());
+		container.setListenerInfo(getListenerInfo());
 		container.setEmergencyStop(() -> {
 			stopAbnormally(() -> {
 			});

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/AbstractKafkaHeaderMapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/AbstractKafkaHeaderMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,6 +55,10 @@ public abstract class AbstractKafkaHeaderMapper implements KafkaHeaderMapper {
 
 	private final Map<String, Boolean> rawMappedHeaders = new HashMap<>();
 
+	{
+		this.rawMappedHeaders.put(KafkaHeaders.LISTENER_INFO, true);
+	}
+
 	private boolean mapAllStringsOut;
 
 	private Charset charset = StandardCharsets.UTF_8;
@@ -77,6 +81,8 @@ public abstract class AbstractKafkaHeaderMapper implements KafkaHeaderMapper {
 				KafkaHeaders.BATCH_CONVERTED_HEADERS,
 				KafkaHeaders.NATIVE_HEADERS,
 				KafkaHeaders.TOPIC,
+				KafkaHeaders.DELIVERY_ATTEMPT,
+				KafkaHeaders.LISTENER_INFO,
 				KafkaHeaders.GROUP_ID));
 		for (String pattern : patterns) {
 			this.matchers.add(new SimplePatternBasedHeaderMatcher(pattern));

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/DefaultKafkaHeaderMapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/DefaultKafkaHeaderMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2020 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -245,7 +245,7 @@ public class DefaultKafkaHeaderMapper extends AbstractKafkaHeaderMapper {
 		final Map<String, String> jsonHeaders = new HashMap<>();
 		final ObjectMapper headerObjectMapper = getObjectMapper();
 		headers.forEach((key, rawValue) -> {
-			if (!key.equals(KafkaHeaders.DELIVERY_ATTEMPT) && matches(key, rawValue)) {
+			if (matches(key, rawValue)) {
 				Object valueToAdd = headerValueToAddOut(key, rawValue);
 				if (valueToAdd instanceof byte[]) {
 					target.add(new RecordHeader(key, (byte[]) valueToAdd));
@@ -290,6 +290,9 @@ public class DefaultKafkaHeaderMapper extends AbstractKafkaHeaderMapper {
 		source.forEach(header -> {
 			if (header.key().equals(KafkaHeaders.DELIVERY_ATTEMPT)) {
 				headers.put(header.key(), ByteBuffer.wrap(header.value()).getInt());
+			}
+			else if (header.key().equals(KafkaHeaders.LISTENER_INFO)) {
+				headers.put(header.key(), new String(header.value(), getCharset()));
 			}
 			else if (!(header.key().equals(JSON_TYPES))) {
 				if (jsonTypes != null && jsonTypes.containsKey(header.key())) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/KafkaHeaders.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/KafkaHeaders.java
@@ -324,6 +324,7 @@ public abstract class KafkaHeaders {
 
 	/**
 	 * Arbitrary static information about the listener receiving this record.
+	 * @since 2.8.4
 	 */
 	public static final String LISTENER_INFO = PREFIX + "listenerInfo";
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/KafkaHeaders.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/KafkaHeaders.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2021 the original author or authors.
+ * Copyright 2014-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -321,5 +321,10 @@ public abstract class KafkaHeaders {
 	 * @since 2.8
 	 */
 	public static final String CONVERSION_FAILURES = PREFIX + "conversionFailures";
+
+	/**
+	 * Arbitrary static information about the listener receiving this record.
+	 */
+	public static final String LISTENER_INFO = PREFIX + "listenerInfo";
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/SimpleKafkaHeaderMapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/SimpleKafkaHeaderMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,9 @@
 package org.springframework.kafka.support;
 
 import java.nio.ByteBuffer;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeader;
@@ -37,6 +39,14 @@ import org.springframework.messaging.MessageHeaders;
  *
  */
 public class SimpleKafkaHeaderMapper extends AbstractKafkaHeaderMapper {
+
+	private static final Set<String> NEVER;
+
+	static {
+		NEVER = new HashSet<>();
+		NEVER.add(KafkaHeaders.DELIVERY_ATTEMPT);
+		NEVER.add(KafkaHeaders.LISTENER_INFO);
+	}
 
 	/**
 	 * Construct an instance with the default object mapper and default header patterns
@@ -69,7 +79,7 @@ public class SimpleKafkaHeaderMapper extends AbstractKafkaHeaderMapper {
 	@Override
 	public void fromHeaders(MessageHeaders headers, Headers target) {
 		headers.forEach((key, value) -> {
-			if (!key.equals(KafkaHeaders.DELIVERY_ATTEMPT)) {
+			if (!NEVER.contains(key)) {
 				Object valueToAdd = headerValueToAddOut(key, value);
 				if (valueToAdd instanceof byte[] && matches(key, valueToAdd)) {
 					target.add(new RecordHeader(key, (byte[]) valueToAdd));

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -270,6 +270,7 @@ public class EnableKafkaIntegrationTests {
 		assertThat(this.listener.latch1.await(60, TimeUnit.SECONDS)).isTrue();
 		assertThat(this.config.globalErrorThrowable).isNotNull();
 		assertThat(this.listener.receivedGroupId).isEqualTo("foo");
+		assertThat(this.listener.listenerInfo).isEqualTo("fee fi fo fum");
 		assertThat(this.listener.latch1Batch.await(60, TimeUnit.SECONDS)).isTrue();
 		assertThat(this.listener.batchOverrideStackTrace).contains("BatchMessagingMessageListenerAdapter");
 
@@ -279,7 +280,7 @@ public class EnableKafkaIntegrationTests {
 		assertThat(this.listener.partition).isNotNull();
 		assertThat(this.listener.topic).isEqualTo("annotated2");
 		assertThat(this.listener.receivedGroupId).isEqualTo("bar");
-
+		assertThat(this.listener.listenerInfo).isEqualTo("info for the bar listener");
 		assertThat(this.meterRegistry.get("spring.kafka.template")
 				.tag("name", "template")
 				.tag("extraTag", "bar")
@@ -1701,6 +1702,11 @@ public class EnableKafkaIntegrationTests {
 			return rec -> false;
 		}
 
+		@Bean
+		String barInfo() {
+			return "info for the bar listener";
+		}
+
 	}
 
 	@Component
@@ -1814,6 +1820,8 @@ public class EnableKafkaIntegrationTests {
 
 		volatile String receivedGroupId;
 
+		volatile String listenerInfo;
+
 		volatile String username;
 
 		volatile String name;
@@ -1834,9 +1842,11 @@ public class EnableKafkaIntegrationTests {
 		private final AtomicBoolean reposition1 = new AtomicBoolean();
 
 		@KafkaListener(id = "foo", topics = "#{'${topicOne:annotated1,foo}'.split(',')}",
-				filter = "lambdaAll")
-		public void listen1(String foo, @Header(value = KafkaHeaders.GROUP_ID, required = false) String groupId) {
+				filter = "lambdaAll", info = "fee fi fo fum")
+		public void listen1(String foo, @Header(value = KafkaHeaders.GROUP_ID, required = false) String groupId,
+				@Header(KafkaHeaders.LISTENER_INFO) String listenerInfo) {
 			this.receivedGroupId = groupId;
+			this.listenerInfo = listenerInfo;
 			if (this.reposition1.compareAndSet(false, true)) {
 				throw new RuntimeException("reposition");
 			}
@@ -1852,16 +1862,19 @@ public class EnableKafkaIntegrationTests {
 			foo.forEach(s ->  this.latch1Batch.countDown());
 		}
 
-		@KafkaListener(id = "bar", topicPattern = "${topicTwo:annotated2}", filter = "#{@lambdaAll}")
+		@KafkaListener(id = "bar", topicPattern = "${topicTwo:annotated2}", filter = "#{@lambdaAll}",
+				info = "#{@barInfo}")
 		public void listen2(@Payload String foo,
 				@Header(KafkaHeaders.GROUP_ID) String groupId,
 				@Header(KafkaHeaders.RECEIVED_MESSAGE_KEY) Integer key,
 				@Header(KafkaHeaders.RECEIVED_PARTITION_ID) int partition,
-				@Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
+				@Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
+				@Header(KafkaHeaders.LISTENER_INFO) String listenerInfo) {
 			this.key = key;
 			this.partition = partition;
 			this.topic = topic;
 			this.receivedGroupId = groupId;
+			this.listenerInfo = listenerInfo;
 			this.latch2.countDown();
 			if (this.latch2.getCount() > 0) {
 				this.seekCallBack.get().seek(topic, partition, 0);

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/DefaultKafkaHeaderMapperTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/DefaultKafkaHeaderMapperTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -286,6 +286,19 @@ public class DefaultKafkaHeaderMapperTests {
 		headers = new RecordHeaders();
 		mapper.fromHeaders(new MessageHeaders(springHeaders), headers);
 		assertThat(headers.lastHeader(KafkaHeaders.DELIVERY_ATTEMPT)).isNull();
+	}
+
+	@Test
+	void listenerInfo() {
+		DefaultKafkaHeaderMapper mapper = new DefaultKafkaHeaderMapper();
+		Headers headers = new RecordHeaders(
+				new Header[] { new RecordHeader(KafkaHeaders.LISTENER_INFO, "info".getBytes()) });
+		Map<String, Object> springHeaders = new HashMap<>();
+		mapper.toHeaders(headers, springHeaders);
+		assertThat(springHeaders.get(KafkaHeaders.LISTENER_INFO)).isEqualTo("info");
+		headers = new RecordHeaders();
+		mapper.fromHeaders(new MessageHeaders(springHeaders), headers);
+		assertThat(headers.lastHeader(KafkaHeaders.LISTENER_INFO)).isNull();
 	}
 
 	public static final class Foo {

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/SimpleKafkaHeaderMapperTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/SimpleKafkaHeaderMapperTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -144,6 +144,19 @@ public class SimpleKafkaHeaderMapperTests {
 		headers = new RecordHeaders();
 		mapper.fromHeaders(new MessageHeaders(springHeaders), headers);
 		assertThat(headers.lastHeader(KafkaHeaders.DELIVERY_ATTEMPT)).isNull();
+	}
+
+	@Test
+	void listenerInfo() {
+		SimpleKafkaHeaderMapper mapper = new SimpleKafkaHeaderMapper();
+		Headers headers = new RecordHeaders(
+				new Header[] { new RecordHeader(KafkaHeaders.LISTENER_INFO, "info".getBytes()) });
+		Map<String, Object> springHeaders = new HashMap<>();
+		mapper.toHeaders(headers, springHeaders);
+		assertThat(springHeaders.get(KafkaHeaders.LISTENER_INFO)).isEqualTo("info");
+		headers = new RecordHeaders();
+		mapper.fromHeaders(new MessageHeaders(springHeaders), headers);
+		assertThat(headers.lastHeader(KafkaHeaders.LISTENER_INFO)).isNull();
 	}
 
 }


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2134

Also clean up parsing of `errorHandler` and `contentTypeConverter`.

Add `info` property to `@KafkaListener`.

**cherry-pick to 2.8.x**