### PR TITLE
Add getter for StreamsUncaughtExceptionHandler

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/config/StreamsBuilderFactoryBean.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/StreamsBuilderFactoryBean.java
@@ -202,6 +202,7 @@ public class StreamsBuilderFactoryBean extends AbstractFactoryBean<StreamsBuilde
 	/**
 	 * Retrieves the current {@link StreamsUncaughtExceptionHandler} set on this factory bean.
 	 * @return {@link StreamsUncaughtExceptionHandler}
+	 * @since 2.8.4
 	 */
 	public StreamsUncaughtExceptionHandler getStreamsUncaughtExceptionHandler() {
 		return this.streamsUncaughtExceptionHandler;

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/StreamsBuilderFactoryBean.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/StreamsBuilderFactoryBean.java
@@ -199,6 +199,14 @@ public class StreamsBuilderFactoryBean extends AbstractFactoryBean<StreamsBuilde
 		this.streamsUncaughtExceptionHandler = streamsUncaughtExceptionHandler; // NOSONAR (sync)
 	}
 
+	/**
+	 * Retrieves the current {@link StreamsUncaughtExceptionHandler} set on this factory bean.
+	 * @return {@link StreamsUncaughtExceptionHandler}
+	 */
+	public StreamsUncaughtExceptionHandler getStreamsUncaughtExceptionHandler() {
+		return this.streamsUncaughtExceptionHandler;
+	}
+
 	public void setStateRestoreListener(StateRestoreListener stateRestoreListener) {
 		this.stateRestoreListener = stateRestoreListener; // NOSONAR (sync)
 	}


### PR DESCRIPTION
StreamsBuilderFactoryBean needs a getter for StreamsUncaughtExceptionHandler.

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
