### PR TITLE
GH-2149: Expose API for providing BackOffPolicies

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/BackOffPolicyProvider.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/BackOffPolicyProvider.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.retrytopic;
+
+import org.springframework.retry.backoff.BackOffPolicy;
+import org.springframework.retry.backoff.ExponentialBackOffPolicy;
+import org.springframework.retry.backoff.ExponentialRandomBackOffPolicy;
+import org.springframework.retry.backoff.FixedBackOffPolicy;
+import org.springframework.retry.backoff.UniformRandomBackOffPolicy;
+
+/**
+ * Provides a {@link BackOffPolicy} from the given parameters.
+ * Original logic from Spring Retry project.
+ *
+ * @author Tomaz Fernandes
+ * @since 2.8.4
+ */
+class BackOffPolicyProvider {
+
+	BackOffPolicy createBackOffPolicyFor(
+			Long min, Long max, Double multiplier, Boolean isRandom) {
+
+		if (multiplier != null && multiplier > 0) {
+			ExponentialBackOffPolicy policy = new ExponentialBackOffPolicy();
+			if (isRandom) {
+				policy = new ExponentialRandomBackOffPolicy();
+			}
+			policy.setInitialInterval(min);
+			policy.setMultiplier(multiplier);
+			policy.setMaxInterval(max > min ? max : ExponentialBackOffPolicy.DEFAULT_MAX_INTERVAL);
+			return policy;
+		}
+		if (max != null && min != null && max > min) {
+			UniformRandomBackOffPolicy policy = new UniformRandomBackOffPolicy();
+			policy.setMinBackOffPeriod(min);
+			policy.setMaxBackOffPeriod(max);
+			return policy;
+		}
+		FixedBackOffPolicy policy = new FixedBackOffPolicy();
+		if (min != null) {
+			policy.setBackOffPeriod(min);
+		}
+		return policy;
+	}
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationBuilder.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationBuilder.java
@@ -82,6 +82,10 @@ public class RetryTopicConfigurationBuilder {
 
 	private Boolean autoStartDltHandler;
 
+	/**
+	 * Creates a new instance of the builder. You can also use {@code newInstance()}.
+	 * @since 2.8.4
+	 */
 	public RetryTopicConfigurationBuilder() {
 		this.backOffPolicyProvider = new BackOffPolicyProvider();
 	}

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationBuilder.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationBuilder.java
@@ -52,6 +52,8 @@ public class RetryTopicConfigurationBuilder {
 
 	private final List<String> excludeTopicNames = new ArrayList<>();
 
+	private final BackOffPolicyProvider backOffPolicyProvider;
+
 	private int maxAttempts = RetryTopicConstants.NOT_SET;
 
 	private BackOffPolicy backOffPolicy;
@@ -79,6 +81,10 @@ public class RetryTopicConfigurationBuilder {
 	private TopicSuffixingStrategy topicSuffixingStrategy = TopicSuffixingStrategy.SUFFIX_WITH_DELAY_VALUE;
 
 	private Boolean autoStartDltHandler;
+
+	public RetryTopicConfigurationBuilder() {
+		this.backOffPolicyProvider = new BackOffPolicyProvider();
+	}
 
 	/* ---------------- DLT Behavior -------------- */
 	/**
@@ -239,6 +245,21 @@ public class RetryTopicConfigurationBuilder {
 		Assert.isNull(this.backOffPolicy, ALREADY_SELECTED);
 		Assert.notNull(backOffPolicy, "You should provide non null custom policy");
 		this.backOffPolicy = backOffPolicy;
+		return this;
+	}
+
+	/**
+	 * Sets a {@link BackOffPolicy} based on the given values.
+	 * @param min        the minimum delay value
+	 * @param max        the maximum delay value
+	 * @param multiplier the multiplier to be applied in the exponential backoff policy
+	 * @param isRandom   whether the exponential back off is random
+	 * @return the builder instance
+	 */
+	public RetryTopicConfigurationBuilder backOffFor(Long min, Long max, Double multiplier, Boolean isRandom) {
+		Assert.isNull(this.backOffPolicy, ALREADY_SELECTED);
+		this.backOffPolicy = this.backOffPolicyProvider
+				.createBackOffPolicyFor(min, max, multiplier, isRandom);
 		return this;
 	}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/BackOffPolicyProviderTest.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/BackOffPolicyProviderTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2021-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.retrytopic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.retry.backoff.BackOffPolicy;
+import org.springframework.retry.backoff.ExponentialBackOffPolicy;
+import org.springframework.retry.backoff.ExponentialRandomBackOffPolicy;
+import org.springframework.retry.backoff.FixedBackOffPolicy;
+import org.springframework.retry.backoff.UniformRandomBackOffPolicy;
+
+/**
+ * @author Tomaz Fernandes
+ * @since 2.8.4
+ */
+class BackOffPolicyProviderTest {
+
+	private final BackOffPolicyProvider provider = new BackOffPolicyProvider();
+
+	@Test
+	void shouldCreateExponentialBackOff() {
+		BackOffPolicy backOffPolicy = provider.createBackOffPolicyFor(100L, 1000L, 2.0, false);
+		assertThat(backOffPolicy).isInstanceOf(ExponentialBackOffPolicy.class);
+		ExponentialBackOffPolicy exponentialBackOffPolicy = (ExponentialBackOffPolicy) backOffPolicy;
+		assertThat(exponentialBackOffPolicy.getInitialInterval()).isEqualTo(100);
+		assertThat(exponentialBackOffPolicy.getMaxInterval()).isEqualTo(1000);
+		assertThat(exponentialBackOffPolicy.getMultiplier()).isEqualTo(2.0);
+	}
+
+	@Test
+	void shouldCreateExponentialRandomBackOff() {
+		BackOffPolicy backOffPolicy = provider.createBackOffPolicyFor(10000L, 100000L, 10.0, true);
+		assertThat(backOffPolicy).isInstanceOf(ExponentialRandomBackOffPolicy.class);
+		ExponentialBackOffPolicy exponentialRandomBackOffPolicy = (ExponentialBackOffPolicy) backOffPolicy;
+		assertThat(exponentialRandomBackOffPolicy.getInitialInterval()).isEqualTo(10000);
+		assertThat(exponentialRandomBackOffPolicy.getMaxInterval()).isEqualTo(100000L);
+		assertThat(exponentialRandomBackOffPolicy.getMultiplier()).isEqualTo(10.0);
+	}
+
+	@Test
+	void shouldCreateUniformRandomBackOffPolicy() {
+		BackOffPolicy backOffPolicy = provider.createBackOffPolicyFor(1L, 5000L, null, null);
+		assertThat(backOffPolicy).isInstanceOf(UniformRandomBackOffPolicy.class);
+		UniformRandomBackOffPolicy uniformRandomBackOffPolicy = (UniformRandomBackOffPolicy) backOffPolicy;
+		assertThat(uniformRandomBackOffPolicy.getMinBackOffPeriod()).isEqualTo(1);
+		assertThat(uniformRandomBackOffPolicy.getMaxBackOffPeriod()).isEqualTo(5000L);
+	}
+
+	@Test
+	void shouldCreateFixedBackOffPolicy() {
+		BackOffPolicy backOffPolicy = provider.createBackOffPolicyFor(5000L, null, null, null);
+		assertThat(backOffPolicy).isInstanceOf(FixedBackOffPolicy.class);
+		FixedBackOffPolicy fixedBackOffPolicy = (FixedBackOffPolicy) backOffPolicy;
+		assertThat(fixedBackOffPolicy.getBackOffPeriod()).isEqualTo(5000L);
+	}
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationBuilderTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationBuilderTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -96,7 +96,6 @@ class RetryTopicConfigurationBuilderTests {
 		assertThat(destinationTopicProperties.get(2).delay()).isEqualTo(0);
 		assertThat(destinationTopicProperties.get(3).delay()).isEqualTo(0);
 
-
 	}
 
 	@Test
@@ -118,6 +117,20 @@ class RetryTopicConfigurationBuilderTests {
 		assertThat(destinationTopicProperties.get(1).delay() < maxInterval).isTrue();
 		assertThat(minInterval < destinationTopicProperties.get(2).delay()).isTrue();
 		assertThat(destinationTopicProperties.get(2).delay() < maxInterval).isTrue();
+		assertThat(destinationTopicProperties.get(3).delay()).isEqualTo(0);
+	}
+
+	@Test
+	void shouldCreateBackOffFromValues() {
+
+		RetryTopicConfiguration configuration = RetryTopicConfigurationBuilder
+				.newInstance()
+				.backOffFor(1000L, 1500L, 2.0, false)
+				.create(this.kafkaOperations);
+		List<DestinationTopic.Properties> destinationTopicProperties = configuration.getDestinationTopicProperties();
+		assertThat(destinationTopicProperties.get(0).delay()).isEqualTo(0);
+		assertThat(destinationTopicProperties.get(1).delay()).isEqualTo(1000);
+		assertThat(destinationTopicProperties.get(2).delay()).isEqualTo(1500);
 		assertThat(destinationTopicProperties.get(3).delay()).isEqualTo(0);
 	}
 


### PR DESCRIPTION
Resolves #2149.

I chose not to change anything in the logic for creating the BackOffPolicy to make this PR cleaner, even though there are a few NPEs that need addressing there. I should submit another PR to fix that after and if this one is merged. But I can also make a new commit with the fixes to this PR if that's better.

I also chose to expose the API through the `RetryTopicConfigurationBuilder` because it allows users to externalize back off parameters, while it's also used by `RetryableTopicAnnotationProcessor` and can be used in Boot's auto configuration, so it becomes the only point of access to that logic.

Please LMK if there's anything to change, or any suggestions regarding these points.

Thanks