### PR TITLE
GH-2155: DeadLetterPublishingRecoverer Improvement

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -5641,7 +5641,7 @@ Key exceptions are only caused by `DeserializationException` s so there is no `D
 There are two mechanisms to add more headers.
 
 1. Subclass the recoverer and override `createProducerRecord()` - call `super.createProducerRecord()` and add more headers.
-2. Provide a `BiFunction` to receive the consumer record and exception, returning a `Headers` object; headers from there will be copied to the final producer record.
+2. Provide a `BiFunction` to receive the consumer record and exception, returning a `Headers` object; headers from there will be copied to the final producer record; also see <<dlpr-headers>>.
 Use `setHeadersFunction()` to set the `BiFunction`.
 
 The second is simpler to implement but the first has more information available, including the already assembled standard headers.
@@ -5735,6 +5735,35 @@ When repeatedly republishing a failed record, these headers can grow (and eventu
 The reason for the two properties is because, while you might want to retain only the last exception information, you might want to retain the history of which topic(s) the record passed through for each failure.
 
 `appendOriginalHeaders` is applied to all headers named `*ORIGINAL*` while `stripPreviousExceptionHeaders` is applied to all headers named `*EXCEPTION*`.
+
+Starting with version 2.8.4, you now can control which of the standard headers will be added to the output record.
+
+The there is a new property `whichHeaders`, which is a `BitSet`; for example, to suppress the addition of adding the stack trace header, use the following:
+
+====
+[source, java]
+----
+DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(template);
+recoverer.getWhichHeaders().clear(HeaderNames.HeadersToAdd.EX_STACKTRACE.getBit());
+----
+====
+
+See the `enum HeadersToAdd` for the bit names of the (currently) 10 standard headers that are added by default.
+
+In addition, you can completely customize the addition of exception headers by adding an `ExceptionHeadersCreator`; this also disables all standard exception headers.
+
+====
+[source, java]
+----
+DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(template);
+recoverer.setExceptionHeadersCreator((kafkaHeaders, exception, isKey, headerNames) -> {
+    kafkaHeaders.add(new RecordHeader(..., ...));
+});
+----
+====
+
+Also starting with version 2.8.4, you can now provide multiple headers functions, via the `addHeadersFunction` method.
+This allows additional functions to apply, even if another function  has already been registered, for example, when using <<retry-topic>>.
 
 Also see <<retry-headers>> with <<retry-topic>>.
 

--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -5737,18 +5737,17 @@ The reason for the two properties is because, while you might want to retain onl
 `appendOriginalHeaders` is applied to all headers named `*ORIGINAL*` while `stripPreviousExceptionHeaders` is applied to all headers named `*EXCEPTION*`.
 
 Starting with version 2.8.4, you now can control which of the standard headers will be added to the output record.
+See the `enum HeadersToAdd` for the names of the (currently) 10 standard headers that are added by default.
 
-There is a new property `whichHeaders`, which is a `BitSet`; for example, to suppress the addition of adding the stack trace header, use the following:
+To exclude headers, use the `excludeHeaders()` method; for example, to suppress adding the exception stack trace in a header, use:
 
 ====
 [source, java]
 ----
 DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(template);
-recoverer.getWhichHeaders().clear(HeaderNames.HeadersToAdd.EX_STACKTRACE.getBit());
+recoverer.excludeHeaders(HeaderNames.HeadersToAdd.EX_STACKTRACE);
 ----
 ====
-
-See the `enum HeadersToAdd` for the bit names of the (currently) 10 standard headers that are added by default.
 
 In addition, you can completely customize the addition of exception headers by adding an `ExceptionHeadersCreator`; this also disables all standard exception headers.
 

--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -5738,7 +5738,7 @@ The reason for the two properties is because, while you might want to retain onl
 
 Starting with version 2.8.4, you now can control which of the standard headers will be added to the output record.
 
-The there is a new property `whichHeaders`, which is a `BitSet`; for example, to suppress the addition of adding the stack trace header, use the following:
+There is a new property `whichHeaders`, which is a `BitSet`; for example, to suppress the addition of adding the stack trace header, use the following:
 
 ====
 [source, java]

--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -5737,7 +5737,7 @@ The reason for the two properties is because, while you might want to retain onl
 `appendOriginalHeaders` is applied to all headers named `*ORIGINAL*` while `stripPreviousExceptionHeaders` is applied to all headers named `*EXCEPTION*`.
 
 Starting with version 2.8.4, you now can control which of the standard headers will be added to the output record.
-See the `enum HeadersToAdd` for the names of the (currently) 10 standard headers that are added by default.
+See the `enum HeadersToAdd` for the generic names of the (currently) 10 standard headers that are added by default (these are not the actual header names, just an abstraction; the actual header names are set up by the `getHeaderNames()` method which subclasses can override.
 
 To exclude headers, use the `excludeHeaders()` method; for example, to suppress adding the exception stack trace in a header, use:
 

--- a/spring-kafka-docs/src/main/asciidoc/retrytopic.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/retrytopic.adoc
@@ -433,6 +433,8 @@ DeadLetterPublishingRecovererFactory factory(DestinationTopicResolver resolver) 
 ----
 ====
 
+Starting with version 2.8.4, if you wish to add custom headers (in addition to the retry information headers added by the factory, you can add a `headersFunction` to the factory - `factory.setHeadersFunction((rec, ex) -> { ... })`
+
 [[retry-topic-combine-blocking]]
 ==== Combining blocking and non-blocking retries
 

--- a/spring-kafka-docs/src/main/asciidoc/whats-new.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/whats-new.adoc
@@ -83,6 +83,8 @@ See <<delegating-serialization>> for more information.
 
 The property `stripPreviousExceptionHeaders` is now `true` by default.
 
+There are now several techniques to customize which headers are added to the output record.
+
 See <<dlpr-headers>> for more information.
 
 [[x28-retryable-topics-changes]]

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
@@ -46,7 +46,6 @@ import org.springframework.core.log.LogAccessor;
 import org.springframework.kafka.KafkaException;
 import org.springframework.kafka.core.KafkaOperations;
 import org.springframework.kafka.core.ProducerFactory;
-import org.springframework.kafka.listener.DeadLetterPublishingRecoverer.HeaderNames.HeadersToAdd;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.support.KafkaUtils;
 import org.springframework.kafka.support.SendResult;
@@ -673,7 +672,7 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 		}
 	}
 
-	private void maybeAddHeader(Headers kafkaHeaders, String header, byte[] value, HeadersToAdd hta) {
+	private void maybeAddHeader(Headers kafkaHeaders, String header, byte[] value, HeaderNames.HeadersToAdd hta) {
 		if (this.whichHeaders.contains(hta)
 				&& (this.appendOriginalHeaders || kafkaHeaders.lastHeader(header) == null)) {
 			kafkaHeaders.add(header, value);
@@ -705,7 +704,7 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 				HeaderNames.HeadersToAdd.EX_STACKTRACE);
 	}
 
-	private void appendOrReplace(Headers headers, RecordHeader header, HeadersToAdd hta) {
+	private void appendOrReplace(Headers headers, RecordHeader header, HeaderNames.HeadersToAdd hta) {
 		if (this.whichHeaders.contains(hta)) {
 			if (this.stripPreviousExceptionHeaders) {
 				headers.remove(header.key());

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
@@ -363,7 +363,6 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 	 * Clear the header inclusion bit for the header name.
 	 * @param headers the headers to clear.
 	 * @since 2.8.4
-	 * @see #getWhichHeaders()
 	 */
 	public void excludeHeader(HeaderNames.HeadersToAdd... headers) {
 		Assert.notNull(headers, "'headers' cannot be null");
@@ -377,7 +376,6 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 	 * Set the header inclusion bit for the header name.
 	 * @param headers the headers to set.
 	 * @since 2.8.4
-	 * @see #getWhichHeaders()
 	 */
 	public void includeHeader(HeaderNames.HeadersToAdd... headers) {
 		Assert.notNull(headers, "'headers' cannot be null");

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
@@ -398,8 +398,14 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 					headers1 = new RecordHeaders();
 				}
 				Headers headers2 = headersFunction.apply(rec, ex);
-				if (headers2 != null) {
-					headers2.forEach(headers1::add);
+				try {
+					if (headers2 != null) {
+						headers2.forEach(headers1::add);
+					}
+				}
+				catch (IllegalStateException isex) {
+					headers1 = new RecordHeaders(headers1);
+					headers2.forEach(headers1::add); // NO SONAR, never null here
 				}
 				return headers1;
 			};

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
@@ -405,7 +405,7 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 				}
 				catch (IllegalStateException isex) {
 					headers1 = new RecordHeaders(headers1);
-					headers2.forEach(headers1::add); // NO SONAR, never null here
+					headers2.forEach(headers1::add); // NOSONAR, never null here
 				}
 				return headers1;
 			};

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DeadLetterPublishingRecovererFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DeadLetterPublishingRecovererFactory.java
@@ -74,7 +74,7 @@ public class DeadLetterPublishingRecovererFactory {
 	 * Set a function that creates additional headers for the output record, in addition to the standard
 	 * retry headers added by this factory.
 	 * @param headersFunction the function.
-	 * @since
+	 * @since 2.8.4
 	 */
 	public void setHeadersFunction(BiFunction<ConsumerRecord<?, ?>, Exception, Headers> headersFunction) {
 		this.headersFunction = headersFunction;

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DeadLetterPublishingRecovererFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DeadLetterPublishingRecovererFactory.java
@@ -22,6 +22,7 @@ import java.time.Instant;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 
 import org.apache.commons.logging.LogFactory;
@@ -63,8 +64,20 @@ public class DeadLetterPublishingRecovererFactory {
 
 	private Consumer<DeadLetterPublishingRecoverer> recovererCustomizer = recoverer -> { };
 
+	private BiFunction<ConsumerRecord<?, ?>, Exception, Headers> headersFunction;
+
 	public DeadLetterPublishingRecovererFactory(DestinationTopicResolver destinationTopicResolver) {
 		this.destinationTopicResolver = destinationTopicResolver;
+	}
+
+	/**
+	 * Set a function that creates additional headers for the output record, in addition to the standard
+	 * retry headers added by this factory.
+	 * @param headersFunction the function.
+	 * @since
+	 */
+	public void setHeadersFunction(BiFunction<ConsumerRecord<?, ?>, Exception, Headers> headersFunction) {
+		this.headersFunction = headersFunction;
 	}
 
 	/**
@@ -137,6 +150,9 @@ public class DeadLetterPublishingRecovererFactory {
 		};
 
 		recoverer.setHeadersFunction((consumerRecord, e) -> addHeaders(consumerRecord, e, getAttempts(consumerRecord)));
+		if (this.headersFunction != null) {
+			recoverer.addHeadersFunction(this.headersFunction);
+		}
 		recoverer.setFailIfSendResultIsError(true);
 		recoverer.setAppendOriginalHeaders(false);
 		recoverer.setThrowIfNoDestinationReturned(false);

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/DeadLetterPublishingRecovererTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/DeadLetterPublishingRecovererTests.java
@@ -555,6 +555,8 @@ public class DeadLetterPublishingRecovererTests {
 	@Test
 	void noCircularRoutingIfFatal() {
 		KafkaOperations<?, ?> template = mock(KafkaOperations.class);
+		ListenableFuture<Object> future = mock(ListenableFuture.class);
+		given(template.send(any(ProducerRecord.class))).willReturn(future);
 		ConsumerRecord<String, String> record = new ConsumerRecord<>("foo", 0, 0L, "bar", null);
 		DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(template,
 				(cr, e) -> new TopicPartition("foo", 0));
@@ -615,7 +617,7 @@ public class DeadLetterPublishingRecovererTests {
 		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_MESSAGE)).isNotNull();
 		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_STACKTRACE)).isNotNull();
 
-		recoverer.getWhichHeaders().clear(HeaderNames.HeadersToAdd.TOPIC.getBit());
+		recoverer.excludeHeader(HeaderNames.HeadersToAdd.TOPIC);
 		recoverer.accept(record, new ListenerExecutionFailedException("test", "group", new RuntimeException()));
 		verify(template, atLeastOnce()).send(producerRecordCaptor.capture());
 		outRecord = producerRecordCaptor.getValue();
@@ -632,7 +634,7 @@ public class DeadLetterPublishingRecovererTests {
 		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_MESSAGE)).isNotNull();
 		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_STACKTRACE)).isNotNull();
 
-		recoverer.getWhichHeaders().clear(HeaderNames.HeadersToAdd.PARTITION.getBit());
+		recoverer.excludeHeader((HeaderNames.HeadersToAdd.PARTITION));
 		recoverer.accept(record, new ListenerExecutionFailedException("test", "group", new RuntimeException()));
 		verify(template, atLeastOnce()).send(producerRecordCaptor.capture());
 		outRecord = producerRecordCaptor.getValue();
@@ -649,7 +651,7 @@ public class DeadLetterPublishingRecovererTests {
 		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_MESSAGE)).isNotNull();
 		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_STACKTRACE)).isNotNull();
 
-		recoverer.getWhichHeaders().clear(HeaderNames.HeadersToAdd.OFFSET.getBit());
+		recoverer.excludeHeader((HeaderNames.HeadersToAdd.OFFSET));
 		recoverer.accept(record, new ListenerExecutionFailedException("test", "group", new RuntimeException()));
 		verify(template, atLeastOnce()).send(producerRecordCaptor.capture());
 		outRecord = producerRecordCaptor.getValue();
@@ -666,7 +668,7 @@ public class DeadLetterPublishingRecovererTests {
 		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_MESSAGE)).isNotNull();
 		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_STACKTRACE)).isNotNull();
 
-		recoverer.getWhichHeaders().clear(HeaderNames.HeadersToAdd.TS.getBit());
+		recoverer.excludeHeader((HeaderNames.HeadersToAdd.TS));
 		recoverer.accept(record, new ListenerExecutionFailedException("test", "group", new RuntimeException()));
 		verify(template, atLeastOnce()).send(producerRecordCaptor.capture());
 		outRecord = producerRecordCaptor.getValue();
@@ -683,7 +685,7 @@ public class DeadLetterPublishingRecovererTests {
 		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_MESSAGE)).isNotNull();
 		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_STACKTRACE)).isNotNull();
 
-		recoverer.getWhichHeaders().clear(HeaderNames.HeadersToAdd.TS_TYPE.getBit());
+		recoverer.excludeHeader((HeaderNames.HeadersToAdd.TS_TYPE));
 		recoverer.accept(record, new ListenerExecutionFailedException("test", "group", new RuntimeException()));
 		verify(template, atLeastOnce()).send(producerRecordCaptor.capture());
 		outRecord = producerRecordCaptor.getValue();
@@ -700,7 +702,7 @@ public class DeadLetterPublishingRecovererTests {
 		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_MESSAGE)).isNotNull();
 		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_STACKTRACE)).isNotNull();
 
-		recoverer.getWhichHeaders().clear(HeaderNames.HeadersToAdd.GROUP.getBit());
+		recoverer.excludeHeader((HeaderNames.HeadersToAdd.GROUP));
 		recoverer.accept(record, new ListenerExecutionFailedException("test", "group", new RuntimeException()));
 		verify(template, atLeastOnce()).send(producerRecordCaptor.capture());
 		outRecord = producerRecordCaptor.getValue();
@@ -717,7 +719,7 @@ public class DeadLetterPublishingRecovererTests {
 		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_MESSAGE)).isNotNull();
 		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_STACKTRACE)).isNotNull();
 
-		recoverer.getWhichHeaders().clear(HeaderNames.HeadersToAdd.EXCEPTION.getBit());
+		recoverer.excludeHeader((HeaderNames.HeadersToAdd.EXCEPTION));
 		recoverer.accept(record, new ListenerExecutionFailedException("test", "group", new RuntimeException()));
 		verify(template, atLeastOnce()).send(producerRecordCaptor.capture());
 		outRecord = producerRecordCaptor.getValue();
@@ -734,7 +736,7 @@ public class DeadLetterPublishingRecovererTests {
 		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_MESSAGE)).isNotNull();
 		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_STACKTRACE)).isNotNull();
 
-		recoverer.getWhichHeaders().clear(HeaderNames.HeadersToAdd.EX_CAUSE.getBit());
+		recoverer.excludeHeader((HeaderNames.HeadersToAdd.EX_CAUSE));
 		recoverer.accept(record, new ListenerExecutionFailedException("test", "group", new RuntimeException()));
 		verify(template, atLeastOnce()).send(producerRecordCaptor.capture());
 		outRecord = producerRecordCaptor.getValue();
@@ -751,7 +753,7 @@ public class DeadLetterPublishingRecovererTests {
 		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_MESSAGE)).isNotNull();
 		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_STACKTRACE)).isNotNull();
 
-		recoverer.getWhichHeaders().clear(HeaderNames.HeadersToAdd.EX_MSG.getBit());
+		recoverer.excludeHeader((HeaderNames.HeadersToAdd.EX_MSG));
 		recoverer.accept(record, new ListenerExecutionFailedException("test", "group", new RuntimeException()));
 		verify(template, atLeastOnce()).send(producerRecordCaptor.capture());
 		outRecord = producerRecordCaptor.getValue();
@@ -768,7 +770,7 @@ public class DeadLetterPublishingRecovererTests {
 		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_MESSAGE)).isNull();
 		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_STACKTRACE)).isNotNull();
 
-		recoverer.getWhichHeaders().clear(HeaderNames.HeadersToAdd.EX_STACKTRACE.getBit());
+		recoverer.excludeHeader(HeaderNames.HeadersToAdd.EX_STACKTRACE);
 		recoverer.accept(record, new ListenerExecutionFailedException("test", "group", new RuntimeException()));
 		verify(template, atLeastOnce()).send(producerRecordCaptor.capture());
 		outRecord = producerRecordCaptor.getValue();

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/DeadLetterPublishingRecovererTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/DeadLetterPublishingRecovererTests.java
@@ -25,6 +25,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.BDDMockito.willReturn;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -40,6 +41,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -63,10 +65,12 @@ import org.springframework.kafka.KafkaException;
 import org.springframework.kafka.core.KafkaOperations;
 import org.springframework.kafka.core.KafkaOperations.OperationsCallback;
 import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer.HeaderNames;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.support.SendResult;
 import org.springframework.kafka.support.serializer.DeserializationException;
 import org.springframework.kafka.support.serializer.SerializationUtils;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.util.concurrent.ListenableFuture;
 import org.springframework.util.concurrent.SettableListenableFuture;
 
@@ -584,6 +588,266 @@ public class DeadLetterPublishingRecovererTests {
 		recoverer.setFailIfSendResultIsError(false);
 		recoverer.accept(record, new IllegalStateException());
 		verify(template, times(3)).send(any(ProducerRecord.class));
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Test
+	void headerBitsTurnedOffOneByOne() {
+		KafkaOperations<?, ?> template = mock(KafkaOperations.class);
+		ListenableFuture future = mock(ListenableFuture.class);
+		given(template.send(any(ProducerRecord.class))).willReturn(future);
+		ConsumerRecord<String, String> record = new ConsumerRecord<>("foo", 0, 0L, "bar", null);
+		DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(template);
+		recoverer.accept(record, new ListenerExecutionFailedException("test", "group", new RuntimeException()));
+		ArgumentCaptor<ProducerRecord> producerRecordCaptor = ArgumentCaptor.forClass(ProducerRecord.class);
+		verify(template).send(producerRecordCaptor.capture());
+		ProducerRecord outRecord = producerRecordCaptor.getValue();
+		Headers headers = outRecord.headers();
+		assertThat(KafkaTestUtils.getPropertyValue(headers, "headers", List.class)).hasSize(10);
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TOPIC)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_PARTITION)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_OFFSET)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TIMESTAMP)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TIMESTAMP_TYPE)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_CONSUMER_GROUP)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_FQCN)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_CAUSE_FQCN)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_MESSAGE)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_STACKTRACE)).isNotNull();
+
+		recoverer.getWhichHeaders().clear(HeaderNames.HeadersToAdd.TOPIC.getBit());
+		recoverer.accept(record, new ListenerExecutionFailedException("test", "group", new RuntimeException()));
+		verify(template, atLeastOnce()).send(producerRecordCaptor.capture());
+		outRecord = producerRecordCaptor.getValue();
+		headers = outRecord.headers();
+		assertThat(KafkaTestUtils.getPropertyValue(headers, "headers", List.class)).hasSize(9);
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TOPIC)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_PARTITION)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_OFFSET)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TIMESTAMP)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TIMESTAMP_TYPE)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_CONSUMER_GROUP)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_FQCN)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_CAUSE_FQCN)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_MESSAGE)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_STACKTRACE)).isNotNull();
+
+		recoverer.getWhichHeaders().clear(HeaderNames.HeadersToAdd.PARTITION.getBit());
+		recoverer.accept(record, new ListenerExecutionFailedException("test", "group", new RuntimeException()));
+		verify(template, atLeastOnce()).send(producerRecordCaptor.capture());
+		outRecord = producerRecordCaptor.getValue();
+		headers = outRecord.headers();
+		assertThat(KafkaTestUtils.getPropertyValue(headers, "headers", List.class)).hasSize(8);
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TOPIC)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_PARTITION)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_OFFSET)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TIMESTAMP)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TIMESTAMP_TYPE)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_CONSUMER_GROUP)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_FQCN)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_CAUSE_FQCN)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_MESSAGE)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_STACKTRACE)).isNotNull();
+
+		recoverer.getWhichHeaders().clear(HeaderNames.HeadersToAdd.OFFSET.getBit());
+		recoverer.accept(record, new ListenerExecutionFailedException("test", "group", new RuntimeException()));
+		verify(template, atLeastOnce()).send(producerRecordCaptor.capture());
+		outRecord = producerRecordCaptor.getValue();
+		headers = outRecord.headers();
+		assertThat(KafkaTestUtils.getPropertyValue(headers, "headers", List.class)).hasSize(7);
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TOPIC)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_PARTITION)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_OFFSET)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TIMESTAMP)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TIMESTAMP_TYPE)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_CONSUMER_GROUP)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_FQCN)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_CAUSE_FQCN)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_MESSAGE)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_STACKTRACE)).isNotNull();
+
+		recoverer.getWhichHeaders().clear(HeaderNames.HeadersToAdd.TS.getBit());
+		recoverer.accept(record, new ListenerExecutionFailedException("test", "group", new RuntimeException()));
+		verify(template, atLeastOnce()).send(producerRecordCaptor.capture());
+		outRecord = producerRecordCaptor.getValue();
+		headers = outRecord.headers();
+		assertThat(KafkaTestUtils.getPropertyValue(headers, "headers", List.class)).hasSize(6);
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TOPIC)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_PARTITION)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_OFFSET)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TIMESTAMP)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TIMESTAMP_TYPE)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_CONSUMER_GROUP)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_FQCN)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_CAUSE_FQCN)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_MESSAGE)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_STACKTRACE)).isNotNull();
+
+		recoverer.getWhichHeaders().clear(HeaderNames.HeadersToAdd.TS_TYPE.getBit());
+		recoverer.accept(record, new ListenerExecutionFailedException("test", "group", new RuntimeException()));
+		verify(template, atLeastOnce()).send(producerRecordCaptor.capture());
+		outRecord = producerRecordCaptor.getValue();
+		headers = outRecord.headers();
+		assertThat(KafkaTestUtils.getPropertyValue(headers, "headers", List.class)).hasSize(5);
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TOPIC)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_PARTITION)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_OFFSET)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TIMESTAMP)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TIMESTAMP_TYPE)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_CONSUMER_GROUP)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_FQCN)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_CAUSE_FQCN)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_MESSAGE)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_STACKTRACE)).isNotNull();
+
+		recoverer.getWhichHeaders().clear(HeaderNames.HeadersToAdd.GROUP.getBit());
+		recoverer.accept(record, new ListenerExecutionFailedException("test", "group", new RuntimeException()));
+		verify(template, atLeastOnce()).send(producerRecordCaptor.capture());
+		outRecord = producerRecordCaptor.getValue();
+		headers = outRecord.headers();
+		assertThat(KafkaTestUtils.getPropertyValue(headers, "headers", List.class)).hasSize(4);
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TOPIC)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_PARTITION)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_OFFSET)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TIMESTAMP)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TIMESTAMP_TYPE)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_CONSUMER_GROUP)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_FQCN)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_CAUSE_FQCN)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_MESSAGE)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_STACKTRACE)).isNotNull();
+
+		recoverer.getWhichHeaders().clear(HeaderNames.HeadersToAdd.EXCEPTION.getBit());
+		recoverer.accept(record, new ListenerExecutionFailedException("test", "group", new RuntimeException()));
+		verify(template, atLeastOnce()).send(producerRecordCaptor.capture());
+		outRecord = producerRecordCaptor.getValue();
+		headers = outRecord.headers();
+		assertThat(KafkaTestUtils.getPropertyValue(headers, "headers", List.class)).hasSize(3);
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TOPIC)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_PARTITION)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_OFFSET)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TIMESTAMP)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TIMESTAMP_TYPE)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_CONSUMER_GROUP)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_FQCN)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_CAUSE_FQCN)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_MESSAGE)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_STACKTRACE)).isNotNull();
+
+		recoverer.getWhichHeaders().clear(HeaderNames.HeadersToAdd.EX_CAUSE.getBit());
+		recoverer.accept(record, new ListenerExecutionFailedException("test", "group", new RuntimeException()));
+		verify(template, atLeastOnce()).send(producerRecordCaptor.capture());
+		outRecord = producerRecordCaptor.getValue();
+		headers = outRecord.headers();
+		assertThat(KafkaTestUtils.getPropertyValue(headers, "headers", List.class)).hasSize(2);
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TOPIC)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_PARTITION)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_OFFSET)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TIMESTAMP)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TIMESTAMP_TYPE)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_CONSUMER_GROUP)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_FQCN)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_CAUSE_FQCN)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_MESSAGE)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_STACKTRACE)).isNotNull();
+
+		recoverer.getWhichHeaders().clear(HeaderNames.HeadersToAdd.EX_MSG.getBit());
+		recoverer.accept(record, new ListenerExecutionFailedException("test", "group", new RuntimeException()));
+		verify(template, atLeastOnce()).send(producerRecordCaptor.capture());
+		outRecord = producerRecordCaptor.getValue();
+		headers = outRecord.headers();
+		assertThat(KafkaTestUtils.getPropertyValue(headers, "headers", List.class)).hasSize(1);
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TOPIC)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_PARTITION)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_OFFSET)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TIMESTAMP)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TIMESTAMP_TYPE)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_CONSUMER_GROUP)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_FQCN)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_CAUSE_FQCN)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_MESSAGE)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_STACKTRACE)).isNotNull();
+
+		recoverer.getWhichHeaders().clear(HeaderNames.HeadersToAdd.EX_STACKTRACE.getBit());
+		recoverer.accept(record, new ListenerExecutionFailedException("test", "group", new RuntimeException()));
+		verify(template, atLeastOnce()).send(producerRecordCaptor.capture());
+		outRecord = producerRecordCaptor.getValue();
+		headers = outRecord.headers();
+		assertThat(KafkaTestUtils.getPropertyValue(headers, "headers", List.class)).hasSize(0);
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TOPIC)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_PARTITION)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_OFFSET)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TIMESTAMP)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TIMESTAMP_TYPE)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_CONSUMER_GROUP)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_FQCN)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_CAUSE_FQCN)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_MESSAGE)).isNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_STACKTRACE)).isNull();
+
+	}
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Test
+	void headerCreator() {
+		KafkaOperations<?, ?> template = mock(KafkaOperations.class);
+		ListenableFuture future = mock(ListenableFuture.class);
+		given(template.send(any(ProducerRecord.class))).willReturn(future);
+		ConsumerRecord<String, String> record = new ConsumerRecord<>("foo", 0, 0L, "bar", null);
+		DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(template);
+		recoverer.setExceptionHeadersCreator((kafkaHeaders, exception, isKey, headerNames) -> {
+			kafkaHeaders.add(new RecordHeader("foo", "bar".getBytes()));
+		});
+		recoverer.accept(record, new ListenerExecutionFailedException("test", "group", new RuntimeException()));
+		ArgumentCaptor<ProducerRecord> producerRecordCaptor = ArgumentCaptor.forClass(ProducerRecord.class);
+		verify(template, atLeastOnce()).send(producerRecordCaptor.capture());
+		ProducerRecord outRecord = producerRecordCaptor.getValue();
+		Headers headers = outRecord.headers();
+		assertThat(KafkaTestUtils.getPropertyValue(headers, "headers", List.class)).hasSize(7);
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TOPIC)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_PARTITION)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_OFFSET)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TIMESTAMP)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TIMESTAMP_TYPE)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_CONSUMER_GROUP)).isNotNull();
+		assertThat(headers.lastHeader("foo")).isNotNull();
+	}
+
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Test
+	void addHeaderFunctionsProcessedInOrder() {
+		KafkaOperations<?, ?> template = mock(KafkaOperations.class);
+		ListenableFuture future = mock(ListenableFuture.class);
+		given(template.send(any(ProducerRecord.class))).willReturn(future);
+		ConsumerRecord<String, String> record = new ConsumerRecord<>("foo", 0, 0L, "bar", null);
+		DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(template);
+		recoverer.setHeadersFunction((rec, ex) -> {
+			return new RecordHeaders(new RecordHeader[] { new RecordHeader("foo", "one".getBytes()) });
+		});
+		recoverer.addHeadersFunction((rec, ex) -> {
+			return new RecordHeaders(new RecordHeader[] { new RecordHeader("bar", "two".getBytes()) });
+		});
+		recoverer.addHeadersFunction((rec, ex) -> {
+			return new RecordHeaders(new RecordHeader[] { new RecordHeader("foo", "three".getBytes()) });
+		});
+		recoverer.accept(record, new ListenerExecutionFailedException("test", "group", new RuntimeException()));
+		ArgumentCaptor<ProducerRecord> producerRecordCaptor = ArgumentCaptor.forClass(ProducerRecord.class);
+		verify(template).send(producerRecordCaptor.capture());
+		ProducerRecord outRecord = producerRecordCaptor.getValue();
+		Headers headers = outRecord.headers();
+		assertThat(KafkaTestUtils.getPropertyValue(headers, "headers", List.class)).hasSize(13);
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TOPIC)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_PARTITION)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_OFFSET)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TIMESTAMP)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_TIMESTAMP_TYPE)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_ORIGINAL_CONSUMER_GROUP)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_FQCN)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_CAUSE_FQCN)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_MESSAGE)).isNotNull();
+		assertThat(headers.lastHeader(KafkaHeaders.DLT_EXCEPTION_STACKTRACE)).isNotNull();
+		assertThat(headers.headers("foo")).extracting("value").containsExactly("one".getBytes(), "three".getBytes());
+		assertThat(headers.lastHeader("bar")).extracting("value").isEqualTo("two".getBytes());
 	}
 
 }


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2155

- Add a `BitSet` property to suppress individual standard headers
- Support multiple `headersFunction`
- Allow complete customization of exception headers
- Add `setHeadersFunction` to the DLPR factory for retryable topics

**cherry-pick to 2.8.x**