### PR TITLE
GH-2174: Register Retry Topic's components earlier

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaBootstrapConfiguration.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaBootstrapConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,8 +25,11 @@ import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
 
 /**
  * An {@link ImportBeanDefinitionRegistrar} class that registers a {@link KafkaListenerAnnotationBeanPostProcessor}
- * bean capable of processing Spring's @{@link KafkaListener} annotation. Also register
+ * bean capable of processing Spring's @{@link KafkaListener} annotation and
  * a default {@link KafkaListenerEndpointRegistry}.
+ *
+ * Also registers a {@link RetryTopicRegistryPostProcessor} to
+ * bootstrap the non-blocking delayed retries feature if such configuration is found.
  *
  * <p>This configuration class is automatically imported when using the @{@link EnableKafka}
  * annotation.  See {@link EnableKafka} Javadoc for complete usage.
@@ -34,9 +37,11 @@ import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
  * @author Stephane Nicoll
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Tomaz Fernandes
  *
  * @see KafkaListenerAnnotationBeanPostProcessor
  * @see KafkaListenerEndpointRegistry
+ * @see RetryTopicRegistryPostProcessor
  * @see EnableKafka
  */
 public class KafkaBootstrapConfiguration implements ImportBeanDefinitionRegistrar {
@@ -53,6 +58,11 @@ public class KafkaBootstrapConfiguration implements ImportBeanDefinitionRegistra
 		if (!registry.containsBeanDefinition(KafkaListenerConfigUtils.KAFKA_LISTENER_ENDPOINT_REGISTRY_BEAN_NAME)) {
 			registry.registerBeanDefinition(KafkaListenerConfigUtils.KAFKA_LISTENER_ENDPOINT_REGISTRY_BEAN_NAME,
 					new RootBeanDefinition(KafkaListenerEndpointRegistry.class));
+		}
+
+		if (!registry.containsBeanDefinition(KafkaListenerConfigUtils.RETRY_TOPIC_REGISTRY_POST_PROCESSOR_NAME)) {
+			registry.registerBeanDefinition(KafkaListenerConfigUtils.RETRY_TOPIC_REGISTRY_POST_PROCESSOR_NAME,
+					new RootBeanDefinition(RetryTopicRegistryPostProcessor.class));
 		}
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
@@ -58,6 +58,8 @@ import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.beans.factory.config.Scope;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -84,6 +86,7 @@ import org.springframework.kafka.config.MultiMethodKafkaListenerEndpoint;
 import org.springframework.kafka.listener.ContainerGroupSequencer;
 import org.springframework.kafka.listener.KafkaListenerErrorHandler;
 import org.springframework.kafka.listener.adapter.RecordFilterStrategy;
+import org.springframework.kafka.retrytopic.RetryTopicBootstrapper;
 import org.springframework.kafka.retrytopic.RetryTopicConfiguration;
 import org.springframework.kafka.retrytopic.RetryTopicConfigurer;
 import org.springframework.kafka.retrytopic.RetryTopicInternalBeanNames;
@@ -500,11 +503,34 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 		KafkaListenerContainerFactory<?> factory =
 				resolveContainerFactory(kafkaListener, resolve(kafkaListener.containerFactory()), beanName);
 
-		this.beanFactory
-				.getBean(RetryTopicInternalBeanNames.RETRY_TOPIC_CONFIGURER, RetryTopicConfigurer.class)
+		getRetryTopicConfigurer()
 				.processMainAndRetryListeners(endpointProcessor, endpoint, retryTopicConfiguration,
 						this.registrar, factory, this.defaultContainerFactoryBeanName);
 		return true;
+	}
+
+	private RetryTopicConfigurer getRetryTopicConfigurer() {
+		bootstrapRetryTopicIfNecessary();
+		return this.beanFactory.getBean(RetryTopicInternalBeanNames.RETRY_TOPIC_CONFIGURER, RetryTopicConfigurer.class);
+	}
+
+	private void bootstrapRetryTopicIfNecessary() {
+		if (!(this.beanFactory instanceof BeanDefinitionRegistry)) {
+			throw new IllegalStateException("BeanFactory must be an instance of "
+					+ BeanDefinitionRegistry.class.getSimpleName()
+					+ " to bootstrap the RetryTopic functionality. Provided beanFactory: "
+					+ this.beanFactory.getClass().getSimpleName());
+		}
+		BeanDefinitionRegistry registry = (BeanDefinitionRegistry) this.beanFactory;
+		if (!registry.containsBeanDefinition(RetryTopicInternalBeanNames
+				.RETRY_TOPIC_BOOTSTRAPPER)) {
+			this.logger.warn(() -> "Could not bootstrap RetryTopic early. Bootstrapping lazily.");
+			registry.registerBeanDefinition(RetryTopicInternalBeanNames
+							.RETRY_TOPIC_BOOTSTRAPPER,
+					new RootBeanDefinition(RetryTopicBootstrapper.class));
+			this.beanFactory.getBean(RetryTopicInternalBeanNames
+					.RETRY_TOPIC_BOOTSTRAPPER, RetryTopicBootstrapper.class).bootstrapRetryTopic();
+		}
 	}
 
 	private Method checkProxy(Method methodArg, Object bean) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryTopicRegistryPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryTopicRegistryPostProcessor.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.annotation;
+
+import java.util.Arrays;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.core.Ordered;
+import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.kafka.retrytopic.RetryTopicBootstrapper;
+import org.springframework.kafka.retrytopic.RetryTopicConfiguration;
+import org.springframework.kafka.retrytopic.RetryTopicInternalBeanNames;
+
+/**
+ * A {@link BeanDefinitionRegistryPostProcessor} implementation that registers
+ * the non-blocking delayed retries feature's components' beans if a
+ * {@link RetryableTopic} annotated method or a {@link RetryTopicConfiguration}
+ * bean is found.
+ *
+ * @author Tomaz Fernandes
+ * @since 2.8.4
+ *
+ * @see RetryTopicBootstrapper
+ * @see RetryTopicConfiguration
+ * @see RetryableTopic
+ */
+public class RetryTopicRegistryPostProcessor
+		implements BeanDefinitionRegistryPostProcessor, Ordered, ApplicationContextAware {
+
+	private ApplicationContext applicationContext;
+
+	@Override
+	public void postProcessBeanDefinitionRegistry(BeanDefinitionRegistry registry) throws BeansException {
+		if (!registry.containsBeanDefinition(RetryTopicInternalBeanNames
+				.RETRY_TOPIC_BOOTSTRAPPER)) {
+
+			Arrays
+					.stream(registry.getBeanDefinitionNames())
+					.map(registry::getBeanDefinition)
+					.filter(this::hasRetryTopicConfiguration)
+					.findFirst()
+					.ifPresent(beanDef -> bootstrapRetryTopic(registry));
+		}
+	}
+
+	private boolean hasRetryTopicConfiguration(BeanDefinition beanDef) {
+		return RetryTopicConfiguration.class.isAssignableFrom(beanDef.getResolvableType().toClass())
+				|| AnnotationMetadata
+					.introspect(beanDef.getResolvableType().toClass())
+					.hasAnnotatedMethods(RetryableTopic.class.getName());
+	}
+
+	private void bootstrapRetryTopic(BeanDefinitionRegistry registry) {
+		registry.registerBeanDefinition(RetryTopicInternalBeanNames
+						.RETRY_TOPIC_BOOTSTRAPPER,
+				new RootBeanDefinition(RetryTopicBootstrapper.class));
+		this.applicationContext.getBean(RetryTopicInternalBeanNames
+						.RETRY_TOPIC_BOOTSTRAPPER, RetryTopicBootstrapper.class)
+				.bootstrapRetryTopic();
+	}
+
+	@Override
+	public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+	}
+
+	@Override
+	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+		this.applicationContext = applicationContext;
+	}
+
+	@Override
+	public int getOrder() {
+		return Ordered.LOWEST_PRECEDENCE;
+	}
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerConfigUtils.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerConfigUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ package org.springframework.kafka.config;
  *
  * @author Juergen Hoeller
  * @author Gary Russell
+ * @author Tomaz Fernandes
  */
 public abstract class KafkaListenerConfigUtils {
 
@@ -36,4 +37,9 @@ public abstract class KafkaListenerConfigUtils {
 	public static final String KAFKA_LISTENER_ENDPOINT_REGISTRY_BEAN_NAME =
 			"org.springframework.kafka.config.internalKafkaListenerEndpointRegistry";
 
+	/**
+	 * The bean name of the internally managed retry topic registry post processor.
+	 */
+	public static final String RETRY_TOPIC_REGISTRY_POST_PROCESSOR_NAME =
+			"org.springframework.kafka.config.internalRetryTopicRegistryPostProcessor";
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DefaultDestinationTopicResolver.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DefaultDestinationTopicResolver.java
@@ -33,7 +33,6 @@ import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.kafka.listener.ExceptionClassifier;
 import org.springframework.kafka.listener.ListenerExecutionFailedException;
 import org.springframework.kafka.listener.TimestampedException;
-import org.springframework.util.Assert;
 
 
 /**
@@ -66,17 +65,10 @@ public class DefaultDestinationTopicResolver extends ExceptionClassifier
 
 	private boolean contextRefreshed;
 
-	/**
-	 * Constructs a new instance.
-	 * The default {@link Clock} can be overridden via the
-	 * {@link #setClock(Clock)} method.
-	 * @see RetryTopicBootstrapper
-	 */
 	public DefaultDestinationTopicResolver() {
 		this.sourceDestinationsHolderMap = new HashMap<>();
 		this.destinationsTopicMap = new HashMap<>();
 		this.contextRefreshed = false;
-		this.clock = Clock.systemUTC();
 	}
 
 	@Deprecated
@@ -214,16 +206,7 @@ public class DefaultDestinationTopicResolver extends ExceptionClassifier
 	@Override
 	public void setApplicationContext(ApplicationContext applicationContext) {
 		this.applicationContext = applicationContext;
-	}
-
-	/**
-	 * Sets the {@link Clock} instance to be used to determine
-	 * if the retry process is past timeout.
-	 * @param clock the clock instance
-	 */
-	public void setClock(Clock clock) {
-		Assert.notNull(clock, "Clock should not be null");
-		this.clock = clock;
+		this.clock = applicationContext.getBean(RetryTopicInternalBeanNames.INTERNAL_BACKOFF_CLOCK_BEAN_NAME, Clock.class);
 	}
 
 	public static class DestinationTopicHolder {

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DefaultDestinationTopicResolver.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DefaultDestinationTopicResolver.java
@@ -33,6 +33,7 @@ import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.kafka.listener.ExceptionClassifier;
 import org.springframework.kafka.listener.ListenerExecutionFailedException;
 import org.springframework.kafka.listener.TimestampedException;
+import org.springframework.util.Assert;
 
 
 /**
@@ -78,7 +79,6 @@ public class DefaultDestinationTopicResolver extends ExceptionClassifier
 		this.clock = Clock.systemUTC();
 	}
 
-	@SuppressWarnings("deprecated")
 	@Deprecated
 	public DefaultDestinationTopicResolver(Clock clock, ApplicationContext applicationContext) {
 		this();
@@ -222,6 +222,7 @@ public class DefaultDestinationTopicResolver extends ExceptionClassifier
 	 * @param clock the clock instance
 	 */
 	public void setClock(Clock clock) {
+		Assert.notNull(clock, "Clock should not be null");
 		this.clock = clock;
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicBootstrapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicBootstrapper.java
@@ -54,7 +54,6 @@ public class RetryTopicBootstrapper implements ApplicationContextAware {
 	public RetryTopicBootstrapper() {
 	}
 
-	@SuppressWarnings("deprecated")
 	@Deprecated
 	public RetryTopicBootstrapper(ApplicationContext applicationContext, BeanFactory beanFactory) {
 		assertApplicationContextAndFactory(applicationContext, beanFactory);

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/RetryTopicRegistryPostProcessorIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/RetryTopicRegistryPostProcessorIntegrationTests.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.annotation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.retrytopic.DestinationTopicResolver;
+import org.springframework.kafka.retrytopic.RetryTopicConfiguration;
+import org.springframework.kafka.retrytopic.RetryTopicConfigurationBuilder;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+/**
+ * @author Tomaz Fernandes
+ * @since 2.8.4
+ */
+@SpringJUnitConfig
+@DirtiesContext
+@EmbeddedKafka
+class RetryTopicRegistryPostProcessorIntegrationTests {
+
+	@SpringJUnitConfig
+	@DirtiesContext
+	@EmbeddedKafka
+	static class RetryableTopicAnnotationTests {
+
+		@Test
+		void contextLoads() {
+		}
+
+		static class AnnotatedListener {
+
+			@Autowired
+			DestinationTopicResolver resolver;
+
+			@RetryableTopic
+			@KafkaListener(topics = "myTopic")
+			void listen() {
+
+			}
+		}
+
+		@EnableKafka
+		@Configuration
+		@Import(CommonConfiguration.class)
+		static class TestConfiguration {
+
+			@Bean
+			AnnotatedListener annotatedListener() {
+				return new AnnotatedListener();
+			}
+		}
+	}
+
+	@SpringJUnitConfig
+	@DirtiesContext
+	@EmbeddedKafka
+	static class RetryTopicConfigurationBeanTests {
+
+		@Test
+		void contextLoads() {
+		}
+
+		static class PlainListener {
+
+			@Autowired
+			DestinationTopicResolver resolver;
+
+			@KafkaListener(topics = "myTopic")
+			void listen() {
+
+			}
+		}
+
+		@EnableKafka
+		@Configuration
+		@Import(CommonConfiguration.class)
+		static class TestConfiguration {
+
+			@Autowired
+			KafkaTemplate<?, ?> kafkaTemplate;
+
+			@Bean
+			PlainListener annotatedListener() {
+				return new PlainListener();
+			}
+
+			@Bean
+			RetryTopicConfiguration retryTopicConfiguration() {
+				return RetryTopicConfigurationBuilder.newInstance().create(kafkaTemplate);
+			}
+		}
+	}
+
+	@SpringJUnitConfig
+	@DirtiesContext
+	@EmbeddedKafka
+	static class NoConfigurationTests {
+
+		@Autowired
+		PlainListener plainListener;
+
+		@Test
+		void contextLoadsWithoutBootstrapping() {
+			assertThat(plainListener.resolver).isNull();
+		}
+
+		static class PlainListener {
+
+			@Autowired(required = false)
+			DestinationTopicResolver resolver;
+
+			@KafkaListener(topics = "myTopic")
+			void listen() {
+
+			}
+		}
+
+		@EnableKafka
+		@Configuration
+		@Import(CommonConfiguration.class)
+		static class TestConfiguration {
+
+			@Bean
+			PlainListener annotatedListener() {
+				return new PlainListener();
+			}
+		}
+	}
+
+	@EnableKafka
+	@Configuration
+	static class CommonConfiguration {
+
+		@Autowired
+		private EmbeddedKafkaBroker broker;
+
+		@Bean
+		public ProducerFactory<String, String> producerFactory() {
+			Map<String, Object> configProps = new HashMap<>();
+			configProps.put(
+					ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
+					this.broker.getBrokersAsString());
+			configProps.put(
+					ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+					StringSerializer.class);
+			configProps.put(
+					ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+					StringSerializer.class);
+			return new DefaultKafkaProducerFactory<>(configProps);
+		}
+
+		@Bean
+		public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory(
+				ConsumerFactory<String, String> consumerFactory) {
+
+			ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+			factory.setConsumerFactory(consumerFactory);
+			factory.setConcurrency(1);
+			return factory;
+		}
+
+		@Bean
+		public ConsumerFactory<String, String> consumerFactory() {
+			Map<String, Object> props = new HashMap<>();
+			props.put(
+					ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
+					this.broker.getBrokersAsString());
+			props.put(
+					ConsumerConfig.GROUP_ID_CONFIG,
+					"groupId");
+			props.put(
+					ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+					StringDeserializer.class);
+			props.put(
+					ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+					StringDeserializer.class);
+			props.put(
+					ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG, false);
+			props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+			return new DefaultKafkaConsumerFactory<>(props);
+		}
+
+		@Bean
+		public KafkaTemplate<String, String> kafkaTemplate(ProducerFactory<String, String> producerFactory) {
+			return new KafkaTemplate<>(producerFactory);
+		}
+	}
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/RetryTopicRegistryPostProcessorTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/RetryTopicRegistryPostProcessorTests.java
@@ -16,6 +16,9 @@
 
 package org.springframework.kafka.annotation;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willReturn;
@@ -23,6 +26,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionRegistry;
@@ -35,7 +39,7 @@ import org.springframework.kafka.retrytopic.RetryTopicInternalBeanNames;
 
 /**
  * @author Tomaz Fernandes
- * @since 2.8.4
+ * @since 2.9.0
  */
 class RetryTopicRegistryPostProcessorTests {
 
@@ -45,60 +49,55 @@ class RetryTopicRegistryPostProcessorTests {
 		BeanDefinitionRegistry registry = mock(BeanDefinitionRegistry.class);
 		given(registry.containsBeanDefinition(RetryTopicInternalBeanNames
 				.RETRY_TOPIC_BOOTSTRAPPER)).willReturn(true);
+		BeanDefinition beanDef = mock(BeanDefinition.class);
+		given(registry.getBeanDefinition(RetryTopicInternalBeanNames
+				.RETRY_TOPIC_BOOTSTRAPPER)).willReturn(beanDef);
+		given(beanDef.hasAttribute(RetryTopicRegistryPostProcessor.RETRY_TOPIC_BOOTSTRAPPED_ATTRIBUTE))
+				.willReturn(true);
 		postProcessor.postProcessBeanDefinitionRegistry(registry);
 		then(registry).should(never()).getBeanDefinitionNames();
 	}
 
 	@Test
-	void testWillBootstrapIfHasRetryableTopicAnnotation() {
-		RetryTopicRegistryPostProcessor postProcessor = new RetryTopicRegistryPostProcessor();
-		ApplicationContext context = mock(ApplicationContext.class);
-		BeanDefinitionRegistry registry = mock(BeanDefinitionRegistry.class);
-		BeanDefinition beanDef = mock(BeanDefinition.class);
-		RetryTopicBootstrapper bootstrapper = mock(RetryTopicBootstrapper.class);
-		ResolvableType resolvableType = mock(ResolvableType.class);
-		postProcessor.setApplicationContext(context);
-		String beanName = "myBean";
-		String[] beanNames = {beanName};
-		given(registry.getBeanDefinitionNames()).willReturn(beanNames);
-		given(registry.getBeanDefinition(beanName)).willReturn(beanDef);
-		given(beanDef.getResolvableType()).willReturn(resolvableType);
-		willReturn(AnnotatedRetryableTopic.class).given(resolvableType).toClass();
-		given(registry.containsBeanDefinition(RetryTopicInternalBeanNames
-				.RETRY_TOPIC_BOOTSTRAPPER)).willReturn(false);
-		given(context.getBean(RetryTopicInternalBeanNames
-				.RETRY_TOPIC_BOOTSTRAPPER, RetryTopicBootstrapper.class)).willReturn(bootstrapper);
-		postProcessor.postProcessBeanDefinitionRegistry(registry);
-		then(bootstrapper).should().bootstrapRetryTopic();
-		then(registry).should().registerBeanDefinition(RetryTopicInternalBeanNames
-						.RETRY_TOPIC_BOOTSTRAPPER,
-				new RootBeanDefinition(RetryTopicBootstrapper.class));
+	void testWillBootstrapIfHasRetryTopicConfigurationBean() {
+		testBootstrappingFor(RetryTopicConfiguration.class);
 	}
 
 	@Test
-	void testWillBootstrapIfHasRetryTopicConfigurationBean() {
+	void testWillBootstrapIfHasRetryableTopicAnnotation() {
+		testBootstrappingFor(AnnotatedRetryableTopic.class);
+	}
+
+	private void testBootstrappingFor(Class<?> beanClass) {
 		RetryTopicRegistryPostProcessor postProcessor = new RetryTopicRegistryPostProcessor();
 		ApplicationContext context = mock(ApplicationContext.class);
 		BeanDefinitionRegistry registry = mock(BeanDefinitionRegistry.class);
 		BeanDefinition beanDef = mock(BeanDefinition.class);
+		BeanDefinition bootstrapperBeanDef = mock(BeanDefinition.class);
 		RetryTopicBootstrapper bootstrapper = mock(RetryTopicBootstrapper.class);
+		given(registry.containsBeanDefinition(RetryTopicInternalBeanNames
+				.RETRY_TOPIC_BOOTSTRAPPER)).willReturn(false);
 		ResolvableType resolvableType = mock(ResolvableType.class);
 		postProcessor.setApplicationContext(context);
 		String beanName = "myBean";
 		String[] beanNames = {beanName};
 		given(registry.getBeanDefinitionNames()).willReturn(beanNames);
+		given(registry.getBeanDefinition(RetryTopicInternalBeanNames
+				.RETRY_TOPIC_BOOTSTRAPPER)).willReturn(bootstrapperBeanDef);
 		given(registry.getBeanDefinition(beanName)).willReturn(beanDef);
 		given(beanDef.getResolvableType()).willReturn(resolvableType);
-		willReturn(RetryTopicConfiguration.class).given(resolvableType).toClass();
-		given(registry.containsBeanDefinition(RetryTopicInternalBeanNames
-				.RETRY_TOPIC_BOOTSTRAPPER)).willReturn(false);
+		willReturn(beanClass).given(resolvableType).toClass();
 		given(context.getBean(RetryTopicInternalBeanNames
 				.RETRY_TOPIC_BOOTSTRAPPER, RetryTopicBootstrapper.class)).willReturn(bootstrapper);
 		postProcessor.postProcessBeanDefinitionRegistry(registry);
 		then(bootstrapper).should().bootstrapRetryTopic();
-		then(registry).should().registerBeanDefinition(RetryTopicInternalBeanNames
-						.RETRY_TOPIC_BOOTSTRAPPER,
-				new RootBeanDefinition(RetryTopicBootstrapper.class));
+		ArgumentCaptor<RootBeanDefinition> captor = ArgumentCaptor.forClass(RootBeanDefinition.class);
+		then(registry).should().registerBeanDefinition(eq(RetryTopicInternalBeanNames
+						.RETRY_TOPIC_BOOTSTRAPPER),
+				captor.capture());
+		RootBeanDefinition value = captor.getValue();
+		assertThat(value.getAttribute(RetryTopicRegistryPostProcessor.RETRY_TOPIC_BOOTSTRAPPED_ATTRIBUTE))
+				.isEqualTo(Boolean.TRUE);
 	}
 
 	@Test
@@ -107,24 +106,55 @@ class RetryTopicRegistryPostProcessorTests {
 		ApplicationContext context = mock(ApplicationContext.class);
 		BeanDefinitionRegistry registry = mock(BeanDefinitionRegistry.class);
 		BeanDefinition beanDef = mock(BeanDefinition.class);
-		RetryTopicBootstrapper bootstrapper = mock(RetryTopicBootstrapper.class);
+		BeanDefinition bootstrapperBeanDef = mock(BeanDefinition.class);
+		given(registry.containsBeanDefinition(RetryTopicInternalBeanNames
+				.RETRY_TOPIC_BOOTSTRAPPER)).willReturn(false);
 		ResolvableType resolvableType = mock(ResolvableType.class);
 		postProcessor.setApplicationContext(context);
 		String beanName = "myBean";
 		String[] beanNames = {beanName};
 		given(registry.getBeanDefinitionNames()).willReturn(beanNames);
+		given(registry.getBeanDefinition(RetryTopicInternalBeanNames
+				.RETRY_TOPIC_BOOTSTRAPPER)).willReturn(bootstrapperBeanDef);
 		given(registry.getBeanDefinition(beanName)).willReturn(beanDef);
 		given(beanDef.getResolvableType()).willReturn(resolvableType);
 		willReturn(PlainBean.class).given(resolvableType).toClass();
+		postProcessor.postProcessBeanDefinitionRegistry(registry);
+		then(context).should(never()).getBean(RetryTopicInternalBeanNames
+				.RETRY_TOPIC_BOOTSTRAPPER, RetryTopicBootstrapper.class);
+	}
+
+	@Test
+	void testWillUseExistingRetryTopicBootstrapperBeanDefinition() {
+		RetryTopicRegistryPostProcessor postProcessor = new RetryTopicRegistryPostProcessor();
+		ApplicationContext context = mock(ApplicationContext.class);
+		BeanDefinitionRegistry registry = mock(BeanDefinitionRegistry.class);
+		BeanDefinition bootsTrapperBeanDef = mock(BeanDefinition.class);
+		BeanDefinition beanDef = mock(BeanDefinition.class);
+		RetryTopicBootstrapper bootstrapper = mock(RetryTopicBootstrapper.class);
 		given(registry.containsBeanDefinition(RetryTopicInternalBeanNames
-				.RETRY_TOPIC_BOOTSTRAPPER)).willReturn(false);
+				.RETRY_TOPIC_BOOTSTRAPPER)).willReturn(true);
+		given(bootsTrapperBeanDef.hasAttribute(RetryTopicRegistryPostProcessor.RETRY_TOPIC_BOOTSTRAPPED_ATTRIBUTE))
+				.willReturn(false);
+		ResolvableType resolvableType = mock(ResolvableType.class);
+		postProcessor.setApplicationContext(context);
+		String beanName = "myBean";
+		String[] beanNames = {beanName};
+		given(registry.getBeanDefinitionNames()).willReturn(beanNames);
+		given(registry.getBeanDefinition(RetryTopicInternalBeanNames
+				.RETRY_TOPIC_BOOTSTRAPPER)).willReturn(bootsTrapperBeanDef);
+		given(registry.getBeanDefinition(beanName)).willReturn(beanDef);
+		given(beanDef.getResolvableType()).willReturn(resolvableType);
+		willReturn(AnnotatedRetryableTopic.class).given(resolvableType).toClass();
 		given(context.getBean(RetryTopicInternalBeanNames
 				.RETRY_TOPIC_BOOTSTRAPPER, RetryTopicBootstrapper.class)).willReturn(bootstrapper);
 		postProcessor.postProcessBeanDefinitionRegistry(registry);
-		then(bootstrapper).should(never()).bootstrapRetryTopic();
-		then(registry).should(never()).registerBeanDefinition(RetryTopicInternalBeanNames
-						.RETRY_TOPIC_BOOTSTRAPPER,
-				new RootBeanDefinition(RetryTopicBootstrapper.class));
+		then(bootstrapper).should().bootstrapRetryTopic();
+		then(registry).should(never()).registerBeanDefinition(eq(RetryTopicInternalBeanNames
+						.RETRY_TOPIC_BOOTSTRAPPER),
+				any(RootBeanDefinition.class));
+		then(bootsTrapperBeanDef).should()
+				.setAttribute(RetryTopicRegistryPostProcessor.RETRY_TOPIC_BOOTSTRAPPED_ATTRIBUTE, true);
 	}
 
 	private static class AnnotatedRetryableTopic {

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/RetryTopicRegistryPostProcessorTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/RetryTopicRegistryPostProcessorTests.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.annotation;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.ResolvableType;
+import org.springframework.kafka.retrytopic.RetryTopicBootstrapper;
+import org.springframework.kafka.retrytopic.RetryTopicConfiguration;
+import org.springframework.kafka.retrytopic.RetryTopicInternalBeanNames;
+
+/**
+ * @author Tomaz Fernandes
+ * @since 2.8.4
+ */
+class RetryTopicRegistryPostProcessorTests {
+
+	@Test
+	void testWillNotBootstrapIfAlreadyHas() {
+		RetryTopicRegistryPostProcessor postProcessor = new RetryTopicRegistryPostProcessor();
+		BeanDefinitionRegistry registry = mock(BeanDefinitionRegistry.class);
+		given(registry.containsBeanDefinition(RetryTopicInternalBeanNames
+				.RETRY_TOPIC_BOOTSTRAPPER)).willReturn(true);
+		postProcessor.postProcessBeanDefinitionRegistry(registry);
+		then(registry).should(never()).getBeanDefinitionNames();
+	}
+
+	@Test
+	void testWillBootstrapIfHasRetryableTopicAnnotation() {
+		RetryTopicRegistryPostProcessor postProcessor = new RetryTopicRegistryPostProcessor();
+		ApplicationContext context = mock(ApplicationContext.class);
+		BeanDefinitionRegistry registry = mock(BeanDefinitionRegistry.class);
+		BeanDefinition beanDef = mock(BeanDefinition.class);
+		RetryTopicBootstrapper bootstrapper = mock(RetryTopicBootstrapper.class);
+		ResolvableType resolvableType = mock(ResolvableType.class);
+		postProcessor.setApplicationContext(context);
+		String beanName = "myBean";
+		String[] beanNames = {beanName};
+		given(registry.getBeanDefinitionNames()).willReturn(beanNames);
+		given(registry.getBeanDefinition(beanName)).willReturn(beanDef);
+		given(beanDef.getResolvableType()).willReturn(resolvableType);
+		willReturn(AnnotatedRetryableTopic.class).given(resolvableType).toClass();
+		given(registry.containsBeanDefinition(RetryTopicInternalBeanNames
+				.RETRY_TOPIC_BOOTSTRAPPER)).willReturn(false);
+		given(context.getBean(RetryTopicInternalBeanNames
+				.RETRY_TOPIC_BOOTSTRAPPER, RetryTopicBootstrapper.class)).willReturn(bootstrapper);
+		postProcessor.postProcessBeanDefinitionRegistry(registry);
+		then(bootstrapper).should().bootstrapRetryTopic();
+		then(registry).should().registerBeanDefinition(RetryTopicInternalBeanNames
+						.RETRY_TOPIC_BOOTSTRAPPER,
+				new RootBeanDefinition(RetryTopicBootstrapper.class));
+	}
+
+	@Test
+	void testWillBootstrapIfHasRetryTopicConfigurationBean() {
+		RetryTopicRegistryPostProcessor postProcessor = new RetryTopicRegistryPostProcessor();
+		ApplicationContext context = mock(ApplicationContext.class);
+		BeanDefinitionRegistry registry = mock(BeanDefinitionRegistry.class);
+		BeanDefinition beanDef = mock(BeanDefinition.class);
+		RetryTopicBootstrapper bootstrapper = mock(RetryTopicBootstrapper.class);
+		ResolvableType resolvableType = mock(ResolvableType.class);
+		postProcessor.setApplicationContext(context);
+		String beanName = "myBean";
+		String[] beanNames = {beanName};
+		given(registry.getBeanDefinitionNames()).willReturn(beanNames);
+		given(registry.getBeanDefinition(beanName)).willReturn(beanDef);
+		given(beanDef.getResolvableType()).willReturn(resolvableType);
+		willReturn(RetryTopicConfiguration.class).given(resolvableType).toClass();
+		given(registry.containsBeanDefinition(RetryTopicInternalBeanNames
+				.RETRY_TOPIC_BOOTSTRAPPER)).willReturn(false);
+		given(context.getBean(RetryTopicInternalBeanNames
+				.RETRY_TOPIC_BOOTSTRAPPER, RetryTopicBootstrapper.class)).willReturn(bootstrapper);
+		postProcessor.postProcessBeanDefinitionRegistry(registry);
+		then(bootstrapper).should().bootstrapRetryTopic();
+		then(registry).should().registerBeanDefinition(RetryTopicInternalBeanNames
+						.RETRY_TOPIC_BOOTSTRAPPER,
+				new RootBeanDefinition(RetryTopicBootstrapper.class));
+	}
+
+	@Test
+	void testWillNotBootstrapIfNoConfigurationFound() {
+		RetryTopicRegistryPostProcessor postProcessor = new RetryTopicRegistryPostProcessor();
+		ApplicationContext context = mock(ApplicationContext.class);
+		BeanDefinitionRegistry registry = mock(BeanDefinitionRegistry.class);
+		BeanDefinition beanDef = mock(BeanDefinition.class);
+		RetryTopicBootstrapper bootstrapper = mock(RetryTopicBootstrapper.class);
+		ResolvableType resolvableType = mock(ResolvableType.class);
+		postProcessor.setApplicationContext(context);
+		String beanName = "myBean";
+		String[] beanNames = {beanName};
+		given(registry.getBeanDefinitionNames()).willReturn(beanNames);
+		given(registry.getBeanDefinition(beanName)).willReturn(beanDef);
+		given(beanDef.getResolvableType()).willReturn(resolvableType);
+		willReturn(PlainBean.class).given(resolvableType).toClass();
+		given(registry.containsBeanDefinition(RetryTopicInternalBeanNames
+				.RETRY_TOPIC_BOOTSTRAPPER)).willReturn(false);
+		given(context.getBean(RetryTopicInternalBeanNames
+				.RETRY_TOPIC_BOOTSTRAPPER, RetryTopicBootstrapper.class)).willReturn(bootstrapper);
+		postProcessor.postProcessBeanDefinitionRegistry(registry);
+		then(bootstrapper).should(never()).bootstrapRetryTopic();
+		then(registry).should(never()).registerBeanDefinition(RetryTopicInternalBeanNames
+						.RETRY_TOPIC_BOOTSTRAPPER,
+				new RootBeanDefinition(RetryTopicBootstrapper.class));
+	}
+
+	private static class AnnotatedRetryableTopic {
+
+		@RetryableTopic
+		void myListener() {
+		}
+	}
+
+	private static class PlainBean {
+
+		void myListener() {
+		}
+	}
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DefaultDestinationTopicResolverTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DefaultDestinationTopicResolverTests.java
@@ -19,6 +19,7 @@ package org.springframework.kafka.retrytopic;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.mockito.BDDMockito.given;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -65,7 +66,8 @@ class DefaultDestinationTopicResolverTests extends DestinationTopicTests {
 		defaultDestinationTopicContainer.addDestinationTopics(allFirstDestinationsTopics);
 		defaultDestinationTopicContainer.addDestinationTopics(allSecondDestinationTopics);
 		defaultDestinationTopicContainer.addDestinationTopics(allThirdDestinationTopics);
-		((DefaultDestinationTopicResolver) defaultDestinationTopicContainer).setClock(this.clock);
+		given(this.applicationContext.getBean(RetryTopicInternalBeanNames.INTERNAL_BACKOFF_CLOCK_BEAN_NAME, Clock.class))
+				.willReturn(this.clock);
 		((DefaultDestinationTopicResolver) defaultDestinationTopicContainer).setApplicationContext(this.applicationContext);
 	}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DefaultDestinationTopicResolverTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DefaultDestinationTopicResolverTests.java
@@ -61,11 +61,12 @@ class DefaultDestinationTopicResolverTests extends DestinationTopicTests {
 	@BeforeEach
 	public void setup() {
 
-		defaultDestinationTopicContainer = new DefaultDestinationTopicResolver(clock, applicationContext);
+		defaultDestinationTopicContainer = new DefaultDestinationTopicResolver();
 		defaultDestinationTopicContainer.addDestinationTopics(allFirstDestinationsTopics);
 		defaultDestinationTopicContainer.addDestinationTopics(allSecondDestinationTopics);
 		defaultDestinationTopicContainer.addDestinationTopics(allThirdDestinationTopics);
-
+		((DefaultDestinationTopicResolver) defaultDestinationTopicContainer).setClock(this.clock);
+		((DefaultDestinationTopicResolver) defaultDestinationTopicContainer).setApplicationContext(this.applicationContext);
 	}
 
 	@Test

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicBootstrapperTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicBootstrapperTests.java
@@ -31,8 +31,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
 import org.springframework.beans.factory.config.SingletonBeanRegistry;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.beans.factory.support.RootBeanDefinition;
@@ -60,7 +60,7 @@ class RetryTopicBootstrapperTests {
 	private DefaultListableBeanFactory beanFactory;
 
 	@Mock
-	private BeanFactory wrongBeanFactory;
+	private AutowireCapableBeanFactory wrongBeanFactory;
 
 	@Mock
 	private DefaultDestinationTopicResolver defaultDestinationTopicResolver;
@@ -76,14 +76,16 @@ class RetryTopicBootstrapperTests {
 
 	@Test
 	void shouldThrowIfACDoesntImplementInterfaces() {
+		given(wrongApplicationContext.getAutowireCapableBeanFactory()).willReturn(beanFactory);
 		assertThatIllegalStateException()
-				.isThrownBy(() -> new RetryTopicBootstrapper(wrongApplicationContext, beanFactory));
+				.isThrownBy(() -> new RetryTopicBootstrapper().setApplicationContext(wrongApplicationContext));
 	}
 
 	@Test
 	void shouldThrowIfBFDoesntImplementInterfaces() {
+		given(applicationContext.getAutowireCapableBeanFactory()).willReturn(wrongBeanFactory);
 		assertThatIllegalStateException()
-				.isThrownBy(() -> new RetryTopicBootstrapper(applicationContext, wrongBeanFactory));
+				.isThrownBy(() -> new RetryTopicBootstrapper().setApplicationContext(applicationContext));
 	}
 
 	@Test

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicBootstrapperTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicBootstrapperTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
@@ -100,6 +101,12 @@ class RetryTopicBootstrapperTests {
 		given(this.applicationContext.getBean(
 				RetryTopicNamesProviderFactory.class))
 				.willThrow(NoSuchBeanDefinitionException.class);
+		given(this.applicationContext.getBean(
+				RetryTopicInternalBeanNames.DESTINATION_TOPIC_CONTAINER_NAME, DefaultDestinationTopicResolver.class))
+				.willReturn(defaultDestinationTopicResolver);
+		given(this.applicationContext.getAutowireCapableBeanFactory())
+				.willReturn(this.beanFactory);
+
 		// when
 		RetryTopicBootstrapper bootstrapper = new RetryTopicBootstrapper(applicationContext, beanFactory);
 		bootstrapper.bootstrapRetryTopic();
@@ -186,6 +193,11 @@ class RetryTopicBootstrapperTests {
 		given(this.applicationContext
 				.getBean(RetryTopicNamesProviderFactory.class))
 				.willThrow(NoSuchBeanDefinitionException.class);
+		given(this.applicationContext.getBean(
+				RetryTopicInternalBeanNames.DESTINATION_TOPIC_CONTAINER_NAME, DefaultDestinationTopicResolver.class))
+				.willReturn(defaultDestinationTopicResolver);
+		given(this.applicationContext.getAutowireCapableBeanFactory())
+				.willReturn(this.beanFactory);
 
 		given(kafkaBackOffManagerFactory.create()).willReturn(kafkaConsumerBackOffManager);
 
@@ -210,6 +222,10 @@ class RetryTopicBootstrapperTests {
 				.willReturn(true);
 		given(applicationContext.containsBeanDefinition(RetryTopicInternalBeanNames.KAFKA_CONSUMER_BACKOFF_MANAGER))
 				.willReturn(true);
+		given(applicationContext.getBean(RetryTopicNamesProviderFactory.class))
+				.willReturn(mock(RetryTopicNamesProviderFactory.class));
+		given(applicationContext.getBean(RetryTopicInternalBeanNames.DESTINATION_TOPIC_CONTAINER_NAME,
+				DefaultDestinationTopicResolver.class)).willReturn(this.defaultDestinationTopicResolver);
 
 		// when
 		RetryTopicBootstrapper bootstrapper = new RetryTopicBootstrapper(applicationContext, beanFactory);
@@ -238,6 +254,10 @@ class RetryTopicBootstrapperTests {
 		given(this.applicationContext.getBean(
 				RetryTopicNamesProviderFactory.class))
 				.willThrow(NoSuchBeanDefinitionException.class);
+		given(this.applicationContext.getBean(RetryTopicInternalBeanNames.DESTINATION_TOPIC_CONTAINER_NAME,
+				DefaultDestinationTopicResolver.class)).willReturn(this.defaultDestinationTopicResolver);
+		given(this.applicationContext.getAutowireCapableBeanFactory()).willReturn(this.beanFactory);
+
 		// when
 		RetryTopicBootstrapper bootstrapper = new RetryTopicBootstrapper(applicationContext, beanFactory);
 		bootstrapper.bootstrapRetryTopic();

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicBootstrapperTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicBootstrapperTests.java
@@ -108,7 +108,8 @@ class RetryTopicBootstrapperTests {
 				.willReturn(this.beanFactory);
 
 		// when
-		RetryTopicBootstrapper bootstrapper = new RetryTopicBootstrapper(applicationContext, beanFactory);
+		RetryTopicBootstrapper bootstrapper = new RetryTopicBootstrapper();
+		bootstrapper.setApplicationContext(this.applicationContext);
 		bootstrapper.bootstrapRetryTopic();
 
 		// then
@@ -149,9 +150,12 @@ class RetryTopicBootstrapperTests {
 		given(this.applicationContext.getBean(
 				RetryTopicNamesProviderFactory.class))
 				.willReturn(this.retryTopicNamesProviderFactory);
+		given(applicationContext.getAutowireCapableBeanFactory())
+				.willReturn(this.beanFactory);
 
 		// when
-		RetryTopicBootstrapper bootstrapper = new RetryTopicBootstrapper(applicationContext, beanFactory);
+		RetryTopicBootstrapper bootstrapper = new RetryTopicBootstrapper();
+		bootstrapper.setApplicationContext(this.applicationContext);
 		bootstrapper.bootstrapRetryTopic();
 
 		// then
@@ -202,7 +206,8 @@ class RetryTopicBootstrapperTests {
 		given(kafkaBackOffManagerFactory.create()).willReturn(kafkaConsumerBackOffManager);
 
 		// when
-		RetryTopicBootstrapper bootstrapper = new RetryTopicBootstrapper(applicationContext, beanFactory);
+		RetryTopicBootstrapper bootstrapper = new RetryTopicBootstrapper();
+		bootstrapper.setApplicationContext(this.applicationContext);
 		bootstrapper.bootstrapRetryTopic();
 
 		// then
@@ -226,9 +231,12 @@ class RetryTopicBootstrapperTests {
 				.willReturn(mock(RetryTopicNamesProviderFactory.class));
 		given(applicationContext.getBean(RetryTopicInternalBeanNames.DESTINATION_TOPIC_CONTAINER_NAME,
 				DefaultDestinationTopicResolver.class)).willReturn(this.defaultDestinationTopicResolver);
+		given(applicationContext.getAutowireCapableBeanFactory())
+				.willReturn(this.beanFactory);
 
 		// when
-		RetryTopicBootstrapper bootstrapper = new RetryTopicBootstrapper(applicationContext, beanFactory);
+		RetryTopicBootstrapper bootstrapper = new RetryTopicBootstrapper();
+		bootstrapper.setApplicationContext(this.applicationContext);
 		bootstrapper.bootstrapRetryTopic();
 
 		// then
@@ -259,7 +267,8 @@ class RetryTopicBootstrapperTests {
 		given(this.applicationContext.getAutowireCapableBeanFactory()).willReturn(this.beanFactory);
 
 		// when
-		RetryTopicBootstrapper bootstrapper = new RetryTopicBootstrapper(applicationContext, beanFactory);
+		RetryTopicBootstrapper bootstrapper = new RetryTopicBootstrapper();
+		bootstrapper.setApplicationContext(this.applicationContext);
 		bootstrapper.bootstrapRetryTopic();
 
 		// then

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicExceptionRoutingIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicExceptionRoutingIntegrationTests.java
@@ -37,7 +37,6 @@ import org.slf4j.LoggerFactory;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.DltHandler;
@@ -395,10 +394,8 @@ public class RetryTopicExceptionRoutingIntegrationTests {
 		}
 
 		@Bean(name = RetryTopicInternalBeanNames.DESTINATION_TOPIC_CONTAINER_NAME)
-		public DefaultDestinationTopicResolver ddtr(ApplicationContext applicationContext,
-													@Qualifier(RetryTopicInternalBeanNames
-															.INTERNAL_BACKOFF_CLOCK_BEAN_NAME) Clock clock) {
-			DefaultDestinationTopicResolver ddtr = new DefaultDestinationTopicResolver(clock, applicationContext);
+		public DefaultDestinationTopicResolver ddtr() {
+			DefaultDestinationTopicResolver ddtr = new DefaultDestinationTopicResolver();
 			ddtr.addNotRetryableExceptions(ShouldSkipBothRetriesException.class);
 			return ddtr;
 		}

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicIntegrationTests.java
@@ -160,6 +160,9 @@ public class RetryTopicIntegrationTests {
 	static class FirstTopicListener {
 
 		@Autowired
+		DefaultDestinationTopicResolver resolver;
+
+		@Autowired
 		CountDownLatchContainer container;
 
 		@KafkaListener(id = "firstTopicId", topics = FIRST_TOPIC, containerFactory = MAIN_TOPIC_CONTAINER_FACTORY,


### PR DESCRIPTION
Fixes #2174

Please let me know if there's a more adequate way of solving this, or if there's anything to be changed. Thanks. 

---

Non-blocking delayed retries feature's beans were being registered lazily, when the first @KafkaListener annotated bean had a configuration associated with it in the `KafkaListenerAnnotationBeanPostProcessor`.

With that, if any bean autowired one of the feature's components before such bootstrapping it would throw a `NoSuchBeanDefinitionException`.

Now the components are registered in the `RetryTopicRegistryPostProcessor` before singletons are instantiated, so autowiring the feature's components in beans works as expected.

Adds a few adjustments to related classes and integration and unit tests.