### PR TITLE
GH-2178: Fix CSA.onPartitionsAssigned (Manual)

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -2885,7 +2885,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			});
 			doInitialSeeks(partitions, beginnings, ends);
 			if (this.consumerSeekAwareListener != null) {
-				this.consumerSeekAwareListener.onPartitionsAssigned(partitions.keySet().stream()
+				this.consumerSeekAwareListener.onPartitionsAssigned(this.definedPartitions.keySet().stream()
 							.map(tp -> new SimpleEntry<>(tp, this.consumer.position(tp)))
 							.collect(Collectors.toMap(entry -> entry.getKey(), entry -> entry.getValue())),
 						this.seekCallback);

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
@@ -2790,7 +2790,21 @@ public class KafkaMessageListenerContainerTests {
 		containerProps.setGroupId("grp");
 		containerProps.setAckMode(AckMode.RECORD);
 		containerProps.setClientId("clientId");
-		containerProps.setMessageListener((MessageListener) r -> { });
+
+		Map<TopicPartition, Long> assigned = new HashMap<>();
+		class Listener extends AbstractConsumerSeekAware implements MessageListener {
+
+			@Override
+			public void onMessage(Object data) {
+			}
+
+			@Override
+			public void onPartitionsAssigned(Map<TopicPartition, Long> assignments, ConsumerSeekCallback callback) {
+				assigned.putAll(assignments);
+			}
+
+		}
+		containerProps.setMessageListener(new Listener());
 		containerProps.setMissingTopicsFatal(false);
 		KafkaMessageListenerContainer<Integer, String> container =
 				new KafkaMessageListenerContainer<>(cf, containerProps);
@@ -2808,6 +2822,7 @@ public class KafkaMessageListenerContainerTests {
 		verify(consumer).seek(new TopicPartition("foo", 3), Long.MAX_VALUE);
 		verify(consumer).seek(new TopicPartition("foo", 6), 42L);
 		container.stop();
+		assertThat(assigned).hasSize(8);
 	}
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2178

The wrong collection was used as the source for the `assignments` map,

`SeekPosition.BEGINNING` and `.END` entries are removed; use the
`definedPartitions` field instead.

**cherry-pick to 2.8.x, 2.7.x**

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
