### PR TITLE
GH-2197: Fix Container State After Fatal Stop

### DIFF
--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/TestOOMError.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/TestOOMError.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -127,6 +127,7 @@ public class TestOOMError {
 		container.start();
 		assertThat(stopLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(container.isRunning()).isFalse();
+		assertThat(container.isInExpectedState()).isFalse();
 	}
 
 }


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2197

When a container is stopped due to any fatal error, `isInExpectedState()`
should return false.

**cherry-pick to 2.8.x, 2.7.x**
