### PR TITLE
GH-2212: Log listener exception in retry topic flow

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/TimestampedException.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/TimestampedException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,14 +34,36 @@ public class TimestampedException extends KafkaException {
 
 	private final long timestamp;
 
+	@Deprecated
 	public TimestampedException(Exception ex, Clock clock) {
 		super(ex.getMessage(), ex);
 		this.timestamp = Instant.now(clock).toEpochMilli();
 	}
 
+	@Deprecated
 	public TimestampedException(Exception ex) {
 		super(ex.getMessage(), ex);
-		this.timestamp = Instant.now(Clock.systemDefaultZone()).toEpochMilli();
+		this.timestamp = Instant.now().toEpochMilli();
+	}
+
+	/**
+	 * Creates an instance with the timestamp of when it was thrown and its cause.
+	 * @param ex the exception cause.
+	 * @param timestamp the timestamp of when the exception was thrown.
+	 */
+	public TimestampedException(Exception ex, long timestamp) {
+		super("Exception thrown at " + Instant.ofEpochMilli(timestamp), ex);
+		this.timestamp = timestamp;
+	}
+
+	/**
+	 * Creates an instance with the timestamp of when it was thrown and its cause.
+	 * @param ex the exception cause.
+	 * @param now the Instant of when the exception was thrown.
+	 */
+	public TimestampedException(Exception ex, Instant now) {
+		super("Exception thrown at " + now, ex);
+		this.timestamp = now.toEpochMilli();
 	}
 
 	public long getTimestamp() {

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/TimestampedException.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/TimestampedException.java
@@ -53,7 +53,7 @@ public class TimestampedException extends KafkaException {
 	 * Creates an instance with the timestamp of when it was thrown and its cause.
 	 * @param ex the exception cause.
 	 * @param timestamp the millis from epoch of when the exception was thrown.
-	 * @since 2.8.5
+	 * @since 2.7.13
 	 */
 	public TimestampedException(Exception ex, long timestamp) {
 		super("Exception thrown at " + Instant.ofEpochMilli(timestamp), ex);
@@ -64,7 +64,7 @@ public class TimestampedException extends KafkaException {
 	 * Creates an instance with the Instant of when it was thrown and its cause.
 	 * @param ex the exception cause.
 	 * @param now the Instant of when the exception was thrown.
-	 * @since 2.8.5
+	 * @since 2.7.13
 	 */
 	public TimestampedException(Exception ex, Instant now) {
 		super("Exception thrown at " + now, ex);

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/TimestampedException.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/TimestampedException.java
@@ -40,16 +40,20 @@ public class TimestampedException extends KafkaException {
 		this.timestamp = Instant.now(clock).toEpochMilli();
 	}
 
-	@Deprecated
+	/**
+	 * Constructs an instance with the provided cause
+	 * and the current time.
+	 * @param ex the exception cause.
+	 */
 	public TimestampedException(Exception ex) {
-		super(ex.getMessage(), ex);
-		this.timestamp = Instant.now().toEpochMilli();
+		this(ex, Instant.now());
 	}
 
 	/**
 	 * Creates an instance with the timestamp of when it was thrown and its cause.
 	 * @param ex the exception cause.
-	 * @param timestamp the timestamp of when the exception was thrown.
+	 * @param timestamp the millis from epoch of when the exception was thrown.
+	 * @since 2.8.5
 	 */
 	public TimestampedException(Exception ex, long timestamp) {
 		super("Exception thrown at " + Instant.ofEpochMilli(timestamp), ex);
@@ -57,9 +61,10 @@ public class TimestampedException extends KafkaException {
 	}
 
 	/**
-	 * Creates an instance with the timestamp of when it was thrown and its cause.
+	 * Creates an instance with the Instant of when it was thrown and its cause.
 	 * @param ex the exception cause.
 	 * @param now the Instant of when the exception was thrown.
+	 * @since 2.8.5
 	 */
 	public TimestampedException(Exception ex, Instant now) {
 		super("Exception thrown at " + now, ex);

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/KafkaBackoffAwareMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/KafkaBackoffAwareMessageListenerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.kafka.listener.adapter;
 
 import java.math.BigInteger;
 import java.time.Clock;
+import java.time.Instant;
 import java.util.Optional;
 
 import org.apache.kafka.clients.consumer.Consumer;
@@ -96,7 +97,7 @@ public class KafkaBackoffAwareMessageListenerAdapter<K, V>
 			invokeDelegateOnMessage(consumerRecord, acknowledgment, consumer);
 		}
 		catch (Exception ex) {
-			throw new TimestampedException(ex, this.clock);
+			throw new TimestampedException(ex, Instant.now(this.clock));
 		}
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DeadLetterPublishingRecovererFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DeadLetterPublishingRecovererFactory.java
@@ -127,6 +127,7 @@ public class DeadLetterPublishingRecovererFactory {
 	/**
 	 * Never logs the listener exception.
 	 * The default is logging only after retries are exhausted.
+	 * @since 2.7.13
 	 */
 	public void neverLogListenerException() {
 		this.loggingStrategy = ListenerExceptionLoggingStrategy.NEVER;
@@ -135,6 +136,7 @@ public class DeadLetterPublishingRecovererFactory {
 	/**
 	 * Logs the listener exception at each attempt.
 	 * The default is logging only after retries are exhausted.
+	 * @since 2.7.13
 	 */
 	public void alwaysLogListenerException() {
 		this.loggingStrategy = ListenerExceptionLoggingStrategy.EACH_ATTEMPT;

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DeadLetterPublishingRecovererFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DeadLetterPublishingRecovererFactoryTests.java
@@ -101,7 +101,7 @@ class DeadLetterPublishingRecovererFactoryTests {
 	@Test
 	void shouldSendMessage() {
 		// setup
-		TimestampedException e = new TimestampedException(new RuntimeException(), this.clock);
+		TimestampedException e = new TimestampedException(new RuntimeException(), Instant.now(this.clock));
 		long failureTimestamp = e.getTimestamp();
 		given(destinationTopicResolver.resolveDestinationTopic(testTopic, 1, e, failureTimestamp)).willReturn(destinationTopic);
 		given(destinationTopic.isNoOpsTopic()).willReturn(false);
@@ -315,7 +315,7 @@ class DeadLetterPublishingRecovererFactoryTests {
 	@Test
 	void shouldSendMessageEvenIfCircularFatal() {
 		// setup
-		TimestampedException e = new TimestampedException(new IllegalStateException(), this.clock);
+		TimestampedException e = new TimestampedException(new IllegalStateException(), Instant.now(this.clock));
 		long failureTimestamp = e.getTimestamp();
 		given(destinationTopicResolver.resolveDestinationTopic(testTopic, 1, e, failureTimestamp))
 				.willReturn(destinationTopic);

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DeadLetterPublishingRecovererFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DeadLetterPublishingRecovererFactoryTests.java
@@ -19,9 +19,15 @@ package org.springframework.kafka.retrytopic;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 
 import java.math.BigInteger;
@@ -37,6 +43,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.record.TimestampType;
@@ -45,13 +52,17 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import org.springframework.core.NestedRuntimeException;
+import org.springframework.core.log.LogAccessor;
 import org.springframework.kafka.core.KafkaOperations;
 import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
 import org.springframework.kafka.listener.KafkaBackoffException;
 import org.springframework.kafka.listener.TimestampedException;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.util.concurrent.ListenableFuture;
 
 /**
@@ -61,6 +72,10 @@ import org.springframework.util.concurrent.ListenableFuture;
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings({"unchecked", "rawtypes"})
 class DeadLetterPublishingRecovererFactoryTests {
+
+	private static final boolean isDebugEnabled =
+			((LogAccessor) ReflectionTestUtils.getField(DeadLetterPublishingRecovererFactory.class, "LOGGER"))
+					.isDebugEnabled(); // NOSONAR
 
 	private final Clock clock = TestClockUtils.CLOCK;
 
@@ -336,6 +351,145 @@ class DeadLetterPublishingRecovererFactoryTests {
 
 		// then
 		then(kafkaOperations).should(times(1)).send(any(ProducerRecord.class));
+	}
+
+	@Test
+	void shouldNeverLogIfSet() {
+
+		// setup
+		RuntimeException retryException = new RuntimeException("Test exception");
+		DestinationTopicResolver resolver = mock(DestinationTopicResolver.class);
+		setupTopic(false, false, resolver, retryException);
+
+		RuntimeException dltException = new RuntimeException("Test exception");
+		setupTopic(false, true, resolver, dltException);
+
+		RuntimeException noOpsException = new RuntimeException("Test exception");
+		setupTopic(true, false, resolver, noOpsException);
+
+		ConsumerRecord recordMock = mock(ConsumerRecord.class);
+		Headers headersMock = mock(Headers.class);
+		given(recordMock.topic()).willReturn("testTopic");
+		given(recordMock.headers()).willReturn(headersMock);
+
+		DeadLetterPublishingRecovererFactory factory = new DeadLetterPublishingRecovererFactory(resolver) {
+			@Override
+			protected TopicPartition resolveTopicPartition(ConsumerRecord<?, ?> cr, DestinationTopic nextDestination) {
+				return null;
+			}
+		};
+		factory.neverLogListenerException();
+
+		// when
+		DeadLetterPublishingRecoverer deadLetterPublishingRecoverer = factory.create();
+		deadLetterPublishingRecoverer.accept(recordMock, retryException);
+		checkNever(headersMock);
+		Mockito.reset(headersMock);
+
+		deadLetterPublishingRecoverer.accept(recordMock, dltException);
+		checkNever(headersMock);
+		Mockito.reset(headersMock);
+
+		deadLetterPublishingRecoverer.accept(recordMock, noOpsException);
+		checkNever(headersMock);
+	}
+
+	@Test
+	void shouldAlwaysLogIfSet() {
+
+		// setup
+		RuntimeException retryException = new RuntimeException("Test exception");
+		DestinationTopicResolver resolver = mock(DestinationTopicResolver.class);
+		setupTopic(false, false, resolver, retryException);
+
+		RuntimeException dltException = new RuntimeException("Test exception");
+		setupTopic(false, true, resolver, dltException);
+
+		RuntimeException noOpsException = new RuntimeException("Test exception");
+		setupTopic(true, false, resolver, noOpsException);
+
+		ConsumerRecord recordMock = mock(ConsumerRecord.class);
+		Headers headersMock = mock(Headers.class);
+		given(recordMock.topic()).willReturn("testTopic");
+		given(recordMock.headers()).willReturn(headersMock);
+
+		DeadLetterPublishingRecovererFactory factory = new DeadLetterPublishingRecovererFactory(resolver) {
+			@Override
+			protected TopicPartition resolveTopicPartition(ConsumerRecord<?, ?> cr, DestinationTopic nextDestination) {
+				return null;
+			}
+		};
+		factory.alwaysLogListenerException();
+
+		// when
+		DeadLetterPublishingRecoverer deadLetterPublishingRecoverer = factory.create();
+		deadLetterPublishingRecoverer.accept(recordMock, retryException);
+		then(headersMock).should().lastHeader(KafkaHeaders.ORIGINAL_TOPIC);
+		Mockito.reset(headersMock);
+
+		deadLetterPublishingRecoverer.accept(recordMock, dltException);
+		then(headersMock).should().lastHeader(KafkaHeaders.ORIGINAL_TOPIC);
+		Mockito.reset(headersMock);
+
+		deadLetterPublishingRecoverer.accept(recordMock, noOpsException);
+		then(headersMock).should().lastHeader(KafkaHeaders.ORIGINAL_TOPIC);
+	}
+
+	@Test
+	void shouldLogAfterExhaustedByDefault() {
+
+		// setup
+		RuntimeException retryException = new RuntimeException("Test exception");
+		DestinationTopicResolver resolver = mock(DestinationTopicResolver.class);
+		setupTopic(false, false, resolver, retryException);
+
+		RuntimeException dltException = new RuntimeException("Test exception");
+		setupTopic(false, true, resolver, dltException);
+
+		RuntimeException noOpsException = new RuntimeException("Test exception");
+		setupTopic(true, false, resolver, noOpsException);
+
+		ConsumerRecord recordMock = mock(ConsumerRecord.class);
+		Headers headersMock = mock(Headers.class);
+		given(recordMock.topic()).willReturn("testTopic");
+		given(recordMock.headers()).willReturn(headersMock);
+
+		DeadLetterPublishingRecovererFactory factory = new DeadLetterPublishingRecovererFactory(resolver) {
+			@Override
+			protected TopicPartition resolveTopicPartition(ConsumerRecord<?, ?> cr, DestinationTopic nextDestination) {
+				return null;
+			}
+		};
+
+		// when
+		DeadLetterPublishingRecoverer deadLetterPublishingRecoverer = factory.create();
+		deadLetterPublishingRecoverer.accept(recordMock, retryException);
+		checkNever(headersMock);
+		Mockito.reset(headersMock);
+
+		deadLetterPublishingRecoverer.accept(recordMock, dltException);
+		then(headersMock).should().lastHeader(KafkaHeaders.ORIGINAL_TOPIC);
+		Mockito.reset(headersMock);
+
+		deadLetterPublishingRecoverer.accept(recordMock, noOpsException);
+		then(headersMock).should().lastHeader(KafkaHeaders.ORIGINAL_TOPIC);
+	}
+
+	private void setupTopic(boolean noOps, boolean dlt, DestinationTopicResolver resolver, RuntimeException noOpsException) {
+		DestinationTopic noOpsDestination = mock(DestinationTopic.class);
+		given(noOpsDestination.isNoOpsTopic()).willReturn(noOps);
+		given(noOpsDestination.isDltTopic()).willReturn(dlt);
+		given(resolver.resolveDestinationTopic(anyString(), anyInt(), eq(noOpsException),
+				anyLong())).willReturn(noOpsDestination);
+	}
+
+	private void checkNever(Headers headersMock) {
+		if (!isDebugEnabled) {
+			then(headersMock).should(never()).lastHeader(KafkaHeaders.ORIGINAL_TOPIC);
+		}
+		else {
+			then(headersMock).should().lastHeader(KafkaHeaders.ORIGINAL_TOPIC);
+		}
 	}
 
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DefaultDestinationTopicResolverTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DefaultDestinationTopicResolverTests.java
@@ -132,7 +132,7 @@ class DefaultDestinationTopicResolverTests extends DestinationTopicTests {
 	void shouldResolveRetryDestinationForWrappedTimestampedException() {
 		assertThat(defaultDestinationTopicContainer
 				.resolveDestinationTopic(mainDestinationTopic.getDestinationName(),
-						1, new TimestampedException(new RuntimeException()), originalTimestamp))
+						1, new TimestampedException(new RuntimeException(), Instant.now(this.clock)), originalTimestamp))
 				.isEqualTo(firstRetryDestinationTopic);
 	}
 


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2212

As in normal `Retry Topic` flow recovery is always successful, the exception thrown by the listener is never logged.

Now such exception is logged at `DEBUG` level for intermediate retries and `ERROR` level when retries are exhausted.

Produces messages such as:

For intermediate retries:

```log
2022-04-05 20:37:36,713 DEBUG [org.springframework.kafka.KafkaListenerEndpointContainer#1-retry-500-0-C-1] [org.springframework.kafka.retrytopic.DeadLetterPublishingRecovererFactory] - Error processing record: topic = myRetryTopic2-retry-500, partition = 0, offset = 0, main topic = myRetryTopic2 at topic myRetryTopic2-retry-500. Sending to retry topic myRetryTopic2-retry-1000.
```

For messages heading to a DLT:

```log
2022-04-05 20:37:37,738 ERROR [org.springframework.kafka.KafkaListenerEndpointContainer#2-retry-1000-0-C-1] [org.springframework.kafka.retrytopic.DeadLetterPublishingRecovererFactory] - Record: topic = myRetryTopic2-retry-1000, partition = 0, offset = 0, main topic = myRetryTopic2 threw an error at topic myRetryTopic2-retry-1000 and won't be retried. Sending to DLT with name myRetryTopic2-dlt.
```

For messages that won't be forwarded, including those thrown in a DLT handler:

```log
2022-04-05 20:37:38,250 ERROR [org.springframework.kafka.KafkaListenerEndpointContainer#3-dlt-0-C-1] [org.springframework.kafka.retrytopic.DeadLetterPublishingRecovererFactory] - Record: topic = myRetryTopic2-dlt, partition = 0, offset = 0, main topic = myRetryTopic2 threw an error at topic myRetryTopic2-dlt and won't be retried. No further action will be taken with this record.
```

Also did some polishing in `TimestampedException` as it was cluttering the stacktrace with duplicated information from cause.getMessage(). Now it logs the time when the exception occurred.