### PR TITLE
[2163] Deprecate ProducerListener in favor of ProducerInterceptor

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
@@ -244,7 +244,10 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 	 * a send operation. By default a {@link LoggingProducerListener} is configured
 	 * which logs errors only.
 	 * @param producerListener the listener; may be {@code null}.
+	 * @deprecated in favor of {@link #setProducerInterceptor(ProducerInterceptor)}
+	 * @see #setProducerInterceptor(ProducerInterceptor)
 	 */
+	@Deprecated(since = "3.0", forRemoval = true)
 	public void setProducerListener(@Nullable ProducerListener<K, V> producerListener) {
 		this.producerListener = producerListener;
 	}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/CompositeProducerListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/CompositeProducerListener.java
@@ -35,7 +35,7 @@ import org.springframework.util.Assert;
  * @author Artem Bilan
  *
  * @since 2.1.6
- * @deprecated since 3.0 in favor of {@link org.apache.kafka.clients.producer.ProducerInterceptor}
+ * @deprecated since 3.0 in favor of {@link org.springframework.kafka.support.CompositeProducerInterceptor}
  */
 
 @Deprecated(since = "3.0", forRemoval = true)

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/CompositeProducerListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/CompositeProducerListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,8 +35,10 @@ import org.springframework.util.Assert;
  * @author Artem Bilan
  *
  * @since 2.1.6
- *
+ * @deprecated since 3.0 in favor of {@link org.apache.kafka.clients.producer.ProducerInterceptor}
  */
+
+@Deprecated(since = "3.0", forRemoval = true)
 public class CompositeProducerListener<K, V> implements ProducerListener<K, V> {
 
 	private final List<ProducerListener<K, V>> delegates = new CopyOnWriteArrayList<>();

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/LoggingProducerListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/LoggingProducerListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2021 the original author or authors.
+ * Copyright 2015-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,7 +32,10 @@ import org.springframework.util.ObjectUtils;
  *
  * @author Marius Bogoevici
  * @author Gary Russell
+ * @deprecated since 3.0 in favor of {@link org.apache.kafka.clients.producer.ProducerInterceptor}
  */
+
+@Deprecated(since = "3.0", forRemoval = true)
 public class LoggingProducerListener<K, V> implements ProducerListener<K, V> {
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/ProducerListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/ProducerListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 the original author or authors.
+ * Copyright 2015-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,11 @@ import org.springframework.lang.Nullable;
  * @author Endika Gutiérrez
  *
  * @see org.apache.kafka.clients.producer.Callback
+ *
+ * @deprecated since 3.0 in favor of {@link org.apache.kafka.clients.producer.ProducerInterceptor}
  */
+
+@Deprecated(since = "3.0", forRemoval = true)
 public interface ProducerListener<K, V> {
 
 	/**


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2163

Added Deprecated annotation where ProducerListener was used and suggested using ProducerInterceptor instead

Please let me know if there's anything to be changed.

Thanks