### PR TITLE
Make `artifactoryPublish dependsOn build`

### DIFF
--- a/publish-maven.gradle
+++ b/publish-maven.gradle
@@ -58,5 +58,6 @@ publishing {
 }
 
 artifactoryPublish {
+	dependsOn build
 	publications(publishing.publications.mavenJava)
 }


### PR DESCRIPTION
Turns out Gradle 7 can run independent tasks in parallel.

* Make an `artifactoryPublish` dependent on `build` task
to ensure that tests are performed before artifacts are published
to the repository

**Cherry-pick to `2.9.x` & `2.8.x`**

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
