### PR TITLE
GH-2172: Expose Retry Topic Chain at Runtime

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/retrytopic.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/retrytopic.adoc
@@ -848,6 +848,18 @@ protected Consumer<RetryTopicConfigurer> configureRetryTopicConfigurer() {
 ----
 ====
 
+[[access-topic-info-runtime]]
+==== Accessing Topics' Information at Runtime
+
+Since 2.9, you can access information regarding the topic chain at runtime by injecting the provided `DestinationTopicContainer` bean.
+This interface provides methods to look up the next topic in the chain or the DLT for a topic if configured, as well as useful properties such as the topic's name, delay and type.
+
+As a real-world use-case example, you can use such information so a console application can resend a record from the DLT to the first retry topic in the chain after the cause of the failed processing, e.g. bug / inconsistent state, has been resolved.
+
+IMPORTANT: The `DestinationTopic` provided by the `DestinationTopicContainer#getNextDestinationTopicFor()` method corresponds to the next topic registered in the chain for the input topic.
+The actual topic the message will be forwarded to may differ due to different factors such as exception classification, number of attempts or single-topic fixed-delay strategies.
+Use the `DestinationTopicResolver` interface if you need to weigh in these factors.
+
 [[change-kboe-logging-level]]
 ==== Changing KafkaBackOffException Logging Level
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DestinationTopicContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DestinationTopicContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 the original author or authors.
+ * Copyright 2017-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package org.springframework.kafka.retrytopic;
 
 import java.util.List;
 
+import org.springframework.lang.Nullable;
+
 /**
  *
  * Provides methods to store and retrieve {@link DestinationTopic} instances.
@@ -34,10 +36,33 @@ public interface DestinationTopicContainer {
 	void addDestinationTopics(List<DestinationTopic> destinationTopics);
 
 	/**
-	 * Returns the DestinationTopic instance registered for that topic.
+	 * Returns the {@link DestinationTopic} instance registered for that topic.
 	 * @param topicName the topic name of the DestinationTopic to be returned.
 	 * @return the DestinationTopic instance registered for that topic.
 	 */
 	DestinationTopic getDestinationTopicByName(String topicName);
+
+	/**
+	 * Returns the {@link DestinationTopic} instance registered as the next
+	 * destination topic in the chain for the given topic.
+	 * Note that this might not correspond to the actual next topic a message will
+	 * be forwarded to, since that depends on different factors.
+	 *
+	 * If you need to find out the exact next topic for a message use the
+	 * {@link DestinationTopicResolver#resolveDestinationTopic(String, Integer, Exception, long)}
+	 * method instead.
+	 * @param topicName the topic name of the DestinationTopic to be returned.
+	 * @return the next DestinationTopic in the chain registered for that topic.
+	 */
+	DestinationTopic getNextDestinationTopicFor(String topicName);
+
+	/**
+	 * Returns the {@link DestinationTopic} instance registered as
+	 * DLT for the given topic, or null if none is found.
+	 * @param topicName the topic name for which to look the DLT for
+	 * @return The {@link DestinationTopic} instance corresponding to the DLT.
+	 */
+	@Nullable
+	DestinationTopic getDltFor(String topicName);
 
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DefaultDestinationTopicResolverTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DefaultDestinationTopicResolverTests.java
@@ -160,6 +160,26 @@ class DefaultDestinationTopicResolverTests extends DestinationTopicTests {
 	}
 
 	@Test
+	void shouldGetDestinationTopic() {
+		assertThat(defaultDestinationTopicContainer
+				.getDestinationTopicByName(mainDestinationTopic.getDestinationName())).isEqualTo(mainDestinationTopic);
+	}
+
+	@Test
+	void shouldGetNextDestinationTopic() {
+		assertThat(defaultDestinationTopicContainer
+				.getNextDestinationTopicFor(mainDestinationTopic.getDestinationName()))
+				.isEqualTo(firstRetryDestinationTopic);
+	}
+
+	@Test
+	void shouldGetDlt() {
+		assertThat(defaultDestinationTopicContainer
+				.getDltFor(mainDestinationTopic.getDestinationName()))
+				.isEqualTo(dltDestinationTopic);
+	}
+
+	@Test
 	void shouldThrowIfNoDestinationFound() {
 		assertThatNullPointerException().isThrownBy(() -> defaultDestinationTopicContainer.resolveDestinationTopic("Non-existing-topic", 0,
 						new IllegalArgumentException(), originalTimestamp));

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicIntegrationTests.java
@@ -107,10 +107,15 @@ public class RetryTopicIntegrationTests {
 	@Autowired
 	private CountDownLatchContainer latchContainer;
 
+	@Autowired
+	DestinationTopicContainer topicContainer;
+
 	@Test
 	void shouldRetryFirstTopic() {
 		logger.debug("Sending message to topic " + FIRST_TOPIC);
 		kafkaTemplate.send(FIRST_TOPIC, "Testing topic 1");
+		assertThat(topicContainer.getNextDestinationTopicFor(FIRST_TOPIC).getDestinationName())
+				.isEqualTo("myRetryTopic1-retry");
 		assertThat(awaitLatch(latchContainer.countDownLatch1)).isTrue();
 		assertThat(awaitLatch(latchContainer.customDltCountdownLatch)).isTrue();
 		assertThat(awaitLatch(latchContainer.customErrorHandlerCountdownLatch)).isTrue();
@@ -173,7 +178,7 @@ public class RetryTopicIntegrationTests {
 	static class FirstTopicListener {
 
 		@Autowired
-		DestinationTopicResolver resolver;
+		DestinationTopicContainer topicContainer;
 
 		@Autowired
 		CountDownLatchContainer container;


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2172

* Add methods to `DestinationTopicContainer` interface
* Reduce memory footprint of `DefaultDestinationTopicResolver`
* Add documentation

This has been ready for quite a while and I was only waiting for us to solve the dependency injection issue to push it. Pretty much only exposed logic that was already there and renamed a few methods accordingly.

Also, there was a `Map` in `DefaultDestinationTopicResolver` that wasn't necessary, so I removed it.

Please let me know if there's anything to be changed.

Thanks.