### PR TITLE
Introduce @DelayedTopic

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/DelayedTopic.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/DelayedTopic.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
+
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.kafka.config.DelayPrecision;
+import org.springframework.kafka.config.DelaySource;
+import org.springframework.kafka.config.KafkaListenerConfigUtils;
+import org.springframework.kafka.core.DelayedKafkaTemplate;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.listener.KafkaConsumerBackoffManager;
+import org.springframework.kafka.support.KafkaHeaders;
+
+
+/**
+ * <p>Delay record consumption by an arbitrary amount. The record's partition will be
+ * backed off by a {@link KafkaConsumerBackoffManager} until consumption time is due.
+ * Two {@link DelaySource}s are available, which can be combined.</p>
+ *
+ * <p>With {@link DelaySource#CONSUMER} all records will be processed after the same
+ * predetermined delay based on {@link ConsumerRecord#timestamp()}.</p>
+ *
+ * <p>With {@link DelaySource#PRODUCER}, the producer adds a {@link Header} with
+ * the due timestamp for the record. The same delay should be used for a given partition
+ * or topic, otherwise a record set to be processed further in the future may block
+ * records that should be processed earlier.</p>
+ *
+ * <p>With {@link DelaySource#BOTH}, if a due timestamp header is present,
+ * the record will be processed after the configured delay or the provided timestamp,
+ * whichever is latest. Otherwise only the configured delay will apply.
+ *
+ * <p>An example follows:</p>
+ *
+ * <pre class="code">
+ *
+ * &#064;Component
+ * public class MyConsumerDelayedListener {
+ *
+ *     &#064;DelayedTopic
+ *     &#064;KafkaListener(topics = "myConsumerDelayedTopic")
+ *     public void listen(String message) {
+ *         logger.info("Received message at " + System.currentTimeMillis());
+ *     }
+ * }
+ * </pre>
+ *
+ * <p>This will add the default delay of 30 seconds to each record, using the default
+ * {@link DelaySource#CONSUMER} strategy.</p>
+ *
+ * <p>Another possible setup is using the {@link DelaySource#PRODUCER} and
+ * {@link DelayedKafkaTemplate}, such as:</p>
+ *
+ * <pre class="code">
+ * &#064;Component
+ * public class MyProducerDelayedListener {
+ *
+ *     &#064;DelayedTopic(source = DelaySource.PRODUCER)
+ *     &#064;KafkaListener(topics = "myProducerDelayedTopic")
+ *     public void listen(String message,
+ *             &#064;Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic,
+ *             &#064;Header(KafkaHeaders.DUE_TIMESTAMP) String dueTimestamp) {
+ *         logger.info("Message {} received in topic {} with timestamp {}",
+ *                 message, receivedTopic, dueTimestamp);
+ *     }
+ * }
+ *
+ * &#064;Component
+ * public class MyDelayedProducer {
+ *
+ *     &#064;Autowired
+ *     private DelayedKafkaTemplate delayedKafkaTemplate;
+ *
+ *     public void sendDelayedMessage() {
+ *         delayedKafkaTemplate.sendDelayed("myProducerDelayedTopic",
+ *                 "My test message", Duration.ofSeconds(2));
+ *     }
+ * }
+ * </pre>
+ *
+ * This will delay message consumption by 2 seconds.
+ *
+ * @author Tomaz Fernandes
+ * @since 2.9
+ */
+@Target({ ElementType.METHOD, ElementType.TYPE, ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface DelayedTopic {
+
+	/**
+	 * The amount of time record consumption should be delayed.
+	 * Applied to {@link DelaySource#CONSUMER} and {@link DelaySource#BOTH}.
+	 * @return the delay value.
+	 */
+	@AliasFor("delay")
+	long value() default 30000;
+
+	/**
+	 * The amount of time record consumption should be delayed.
+	 * Applied to {@link DelaySource#CONSUMER} and {@link DelaySource#BOTH}.
+	 * @return the delay value.
+	 */
+	long delay() default 30000;
+
+	/**
+	 * The amount of time record consumption should be delayed.
+	 * Must resolve to a {@link Long} representing the amount of time in milliseconds.
+	 * Applied to {@link DelaySource#CONSUMER} and {@link DelaySource#BOTH}.
+	 * @return the delay value.
+	 */
+	String delayExpression() default "";
+
+	/**
+	 * The bean name of the {@link KafkaConsumerBackoffManager} to be used to back off
+	 * the partitions. If none is provided, a default
+	 * {@link KafkaListenerConfigUtils#KAFKA_CONSUMER_BACK_OFF_MANAGER_BEAN_NAME} will
+	 * be looked up, and if none is found a default one will be created and registered.
+	 * @return the {@link KafkaConsumerBackoffManager} name.
+	 */
+	String kafkaConsumerBackOffManager() default "";
+
+	/**
+	 * The delay source. See {@link DelaySource} for clarification on each value.
+	 * @return the {@link DelaySource}
+	 */
+	DelaySource source() default DelaySource.CONSUMER;
+
+	/**
+	 * The {@link Header} to be looked up containing the record's consumption due time.
+	 * Applied to {@link DelaySource#PRODUCER} and {@link DelaySource#BOTH}.
+	 * @return the due timestamp header name.
+	 */
+	String producerDueTimestampHeader() default KafkaHeaders.DUE_TIMESTAMP;
+
+	/**
+	 * The precision level for the delay. Higher precision means setting lower
+	 * {@link ContainerProperties#setIdlePartitionEventInterval} and
+	 * {@link ContainerProperties#setPollTimeout} values.
+	 *
+	 * Note that this only applies if these properties have their default values.
+	 * If a different value is set, it will not be overridden.
+	 *
+	 * @return the delay precision
+	 */
+	DelayPrecision delayPrecision() default DelayPrecision.HIGHEST;
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/DelayedTopicAnnotationProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/DelayedTopicAnnotationProcessor.java
@@ -1,0 +1,214 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.annotation;
+
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.function.Supplier;
+
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.beans.factory.config.BeanExpressionContext;
+import org.springframework.beans.factory.config.BeanExpressionResolver;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.RootBeanDefinition;
+import org.springframework.context.ApplicationContext;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.kafka.config.KafkaListenerConfigUtils;
+import org.springframework.kafka.listener.DelayedTopicContext;
+import org.springframework.kafka.listener.KafkaConsumerBackoffManager;
+import org.springframework.kafka.listener.KafkaConsumerTimingAdjuster;
+import org.springframework.kafka.listener.ListenerContainerRegistry;
+import org.springframework.kafka.listener.PartitionPausingBackoffManager;
+import org.springframework.kafka.listener.WakingKafkaConsumerTimingAdjuster;
+import org.springframework.lang.Nullable;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+
+/**
+ * Looks for and processes a {@link DelayedTopic @DelayedTopic} annotation.
+ * If such annotation is present returns the corresponding {@link DelayedTopicContext},
+ * returns null otherwise.
+ *
+ * @author Tomaz Fernandes
+ * @since 2.9
+ */
+public class DelayedTopicAnnotationProcessor {
+
+	private static final String TASK_EXECUTOR_BEAN_NAME = "kafkaConsumerBackOffManagerTaskExecutor";
+
+	private static final String THE_LEFT = "The [";
+
+	private static final String RESOLVED_TO_LEFT = "Resolved to [";
+
+	private static final String RIGHT_FOR_LEFT = "] for [";
+
+	private final ApplicationContext applicationContext;
+
+	private final BeanExpressionResolver resolver;
+
+	private final BeanExpressionContext expressionContext;
+
+	public DelayedTopicAnnotationProcessor(ApplicationContext applicationContext, BeanExpressionResolver resolver,
+			BeanExpressionContext expressionContext) {
+		this.applicationContext = applicationContext;
+		this.resolver = resolver;
+		this.expressionContext = expressionContext;
+	}
+
+	/**
+	 * Looks up {@link DelayedTopic @DelayedTopic} annotations in the provided class
+	 * and method and processes it.
+	 * @param clazz the class in which to look up the annotation.
+	 * @param method the method in which to look up the annotation.
+	 * @return the {@link DelayedTopicContext}
+	 */
+	@Nullable
+	public DelayedTopicContext processAnnotationFrom(Class<?> clazz, Method method) {
+		DelayedTopic annotation = null;
+		if (method != null) {
+			annotation = AnnotatedElementUtils.findMergedAnnotation(method, DelayedTopic.class);
+		}
+		if (annotation == null && clazz != null) {
+			annotation = AnnotatedElementUtils.findMergedAnnotation(clazz, DelayedTopic.class);
+		}
+		return annotation != null
+				? processAnnotation(annotation)
+				: null;
+	}
+
+	/**
+	 * Processes a {@link DelayedTopic} annotation.
+	 * @param annotation the annotation.
+	 * @return the {@link DelayedTopicContext}
+	 */
+	public DelayedTopicContext processAnnotation(DelayedTopic annotation) {
+		Duration delay = Duration.ofMillis(annotation.value());
+		if (StringUtils.hasText(annotation.delayExpression())) {
+			delay = resolveDelayExpression(annotation.delayExpression());
+		}
+		return DelayedTopicContext
+				.builder()
+				.delay(delay)
+				.delaySource(annotation.source())
+				.delayPrecision(annotation.delayPrecision())
+				.producerDueTimestampHeader(annotation.producerDueTimestampHeader())
+				.kafkaBackOffManager(resolveBackOffManager(annotation.kafkaConsumerBackOffManager()))
+				.build();
+	}
+
+	private Duration resolveDelayExpression(String delayExpression) {
+		Object resolved = resolveExpression(delayExpression);
+		if (resolved instanceof Duration) {
+			return (Duration) resolved;
+		}
+		else if (resolved instanceof Number) {
+			return Duration.ofMillis(((Number) resolved).longValue());
+		}
+		else {
+			String resolvedString = resolveExpressionAsString(delayExpression, "delayExpression");
+			Supplier<String> genericErrorMessage = () -> "Could not resolve value from expression " + delayExpression;
+			Assert.hasText(resolvedString, genericErrorMessage);
+			try {
+				return Duration.ofMillis(Long.parseLong(resolvedString));
+			}
+			catch (Exception e) {
+				throw new IllegalArgumentException(genericErrorMessage.get());
+			}
+		}
+	}
+
+	private KafkaConsumerBackoffManager resolveBackOffManager(String backOffManagerName) {
+		return StringUtils.hasText(backOffManagerName)
+				? resolveFromBeanName(backOffManagerName)
+				: resolveFromDefaultBeanNames();
+	}
+
+	private KafkaConsumerBackoffManager resolveFromBeanName(String backOffManagerName) {
+		Object manager = resolveExpression(backOffManagerName);
+		if (manager instanceof KafkaConsumerBackoffManager) {
+			return (KafkaConsumerBackoffManager) manager;
+		}
+		else {
+			String backOffManagerBeanName = resolveExpressionAsString(backOffManagerName, "kafkaConsumerBackOffManager");
+			if (StringUtils.hasText(backOffManagerBeanName)) {
+				return this.applicationContext.getBean(backOffManagerBeanName, KafkaConsumerBackoffManager.class);
+			}
+		}
+		throw new IllegalArgumentException("Could not resolve a KafkaConsumerBackOffManager from value: " + backOffManagerName);
+	}
+
+	private KafkaConsumerBackoffManager resolveFromDefaultBeanNames() {
+		if (this.applicationContext.containsBean(KafkaListenerConfigUtils.KAFKA_CONSUMER_BACK_OFF_MANAGER_BEAN_NAME)) {
+			return this.applicationContext.getBean(KafkaListenerConfigUtils.KAFKA_CONSUMER_BACK_OFF_MANAGER_BEAN_NAME,
+					KafkaConsumerBackoffManager.class);
+		}
+		else {
+			Assert.isAssignable(BeanDefinitionRegistry.class, this.applicationContext.getClass(),
+					"ApplicationContext needs to implement BeanDefinitionRegistry" +
+							" in order to register the default back off manager.");
+			ListenerContainerRegistry registry = this.applicationContext
+					.getBean(KafkaListenerConfigUtils.KAFKA_LISTENER_ENDPOINT_REGISTRY_BEAN_NAME,
+							ListenerContainerRegistry.class);
+			KafkaConsumerTimingAdjuster timingAdjuster =
+					new WakingKafkaConsumerTimingAdjuster(registerAndGetTaskExecutor());
+			((BeanDefinitionRegistry) this.applicationContext)
+					.registerBeanDefinition(KafkaListenerConfigUtils.KAFKA_CONSUMER_BACK_OFF_MANAGER_BEAN_NAME,
+							new RootBeanDefinition(PartitionPausingBackoffManager.class));
+			return (KafkaConsumerBackoffManager) this.applicationContext
+					.getBean(KafkaListenerConfigUtils.KAFKA_CONSUMER_BACK_OFF_MANAGER_BEAN_NAME, registry, timingAdjuster);
+		}
+	}
+
+	private TaskExecutor registerAndGetTaskExecutor() {
+		((BeanDefinitionRegistry) this.applicationContext)
+				.registerBeanDefinition(TASK_EXECUTOR_BEAN_NAME, new RootBeanDefinition(ThreadPoolTaskExecutor.class));
+		return this.applicationContext
+				.getBean(TASK_EXECUTOR_BEAN_NAME, ThreadPoolTaskExecutor.class);
+	}
+
+	private Object resolveExpression(String value) {
+		String resolved = resolve(value);
+		if (this.expressionContext != null) {
+			return this.resolver.evaluate(resolved, this.expressionContext);
+		}
+		else {
+			return value;
+		}
+	}
+
+	private String resolveExpressionAsString(String value, String attribute) {
+		Object resolved = resolveExpression(value);
+		if (resolved instanceof String && StringUtils.hasText((String) resolved)) {
+			return (String) resolved;
+		}
+		throw new IllegalStateException(THE_LEFT + attribute + "] must resolve to a String. "
+				+ RESOLVED_TO_LEFT + resolved.getClass() + RIGHT_FOR_LEFT + value + "]");
+	}
+
+	private String resolve(String value) {
+		AutowireCapableBeanFactory beanFactory = this.applicationContext.getAutowireCapableBeanFactory();
+		if (beanFactory instanceof ConfigurableBeanFactory) {
+			return ((ConfigurableBeanFactory) beanFactory).resolveEmbeddedValue(value);
+		}
+		return value;
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/DelayedTopicPropertiesProvider.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/DelayedTopicPropertiesProvider.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.annotation;
+
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.factory.config.BeanExpressionContext;
+import org.springframework.beans.factory.config.BeanExpressionResolver;
+import org.springframework.context.ApplicationContext;
+import org.springframework.kafka.config.MethodKafkaListenerEndpoint;
+import org.springframework.kafka.listener.DelayedTopicContext;
+import org.springframework.lang.Nullable;
+
+/**
+ * Provides a {@link DelayedTopicContext} for the given
+ * {@link MethodKafkaListenerEndpoint}, if there's any.
+ *
+ * @author Tomaz Fernandes
+ * @since 2.9
+ */
+public class DelayedTopicPropertiesProvider {
+
+	private final DelayedTopicAnnotationProcessor processor;
+
+	public DelayedTopicPropertiesProvider(ApplicationContext applicationContext, BeanExpressionResolver resolver,
+			BeanExpressionContext expressionContext) {
+		this.processor = createProcessor(applicationContext, resolver, expressionContext);
+	}
+
+	/**
+	 * Provide a {@link DelayedTopicContext} for a {@link MethodKafkaListenerEndpoint}.
+	 * @param endpoint the endpoint to provide a {@link DelayedTopicContext} for.
+	 * @return the {@link DelayedTopicContext}.
+	 */
+	@Nullable
+	public DelayedTopicContext getContextFor(MethodKafkaListenerEndpoint<?, ?> endpoint) {
+		return this.processor.processAnnotationFrom(AopUtils.getTargetClass(endpoint.getBean()), endpoint.getMethod());
+	}
+
+	protected DelayedTopicAnnotationProcessor createProcessor(ApplicationContext beanFactory,
+															BeanExpressionResolver resolver,
+															BeanExpressionContext expressionContext) {
+		return new DelayedTopicAnnotationProcessor(beanFactory, resolver, expressionContext);
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
@@ -58,6 +58,7 @@ import org.springframework.util.Assert;
  * @author Stephane Nicoll
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Tomaz Fernandes
  *
  * @see AbstractMessageListenerContainer
  */
@@ -388,13 +389,18 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 	protected void initializeContainer(C instance, KafkaListenerEndpoint endpoint) {
 		ContainerProperties properties = instance.getContainerProperties();
 		BeanUtils.copyProperties(this.containerProperties, properties, "topics", "topicPartitions", "topicPattern",
-				"messageListener", "ackCount", "ackTime", "subBatchPerPartition", "kafkaConsumerProperties");
+				"messageListener", "ackCount", "ackTime", "subBatchPerPartition", "kafkaConsumerProperties",
+				"idlePartitionEventInterval", "pollTimeout");
 		JavaUtils.INSTANCE
 				.acceptIfNotNull(this.afterRollbackProcessor, instance::setAfterRollbackProcessor)
 				.acceptIfCondition(this.containerProperties.getAckCount() > 0, this.containerProperties.getAckCount(),
 						properties::setAckCount)
 				.acceptIfCondition(this.containerProperties.getAckTime() > 0, this.containerProperties.getAckTime(),
 						properties::setAckTime)
+				.acceptIfCondition(this.containerProperties.getPollTimeout() != ContainerProperties.DEFAULT_POLL_TIMEOUT,
+						this.containerProperties.getPollTimeout(), properties::setPollTimeout)
+				.acceptIfNotNull(this.containerProperties.getIdlePartitionEventInterval(),
+						properties::setIdlePartitionEventInterval)
 				.acceptIfNotNull(this.containerProperties.getSubBatchPerPartition(),
 						properties::setSubBatchPerPartition)
 				.acceptIfNotNull(this.errorHandler, instance::setGenericErrorHandler)

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/DelayPrecision.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/DelayPrecision.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.config;
+
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.listener.KafkaConsumerBackoffManager;
+
+/**
+ *
+ * The delay precision to be used with the {@link KafkaConsumerBackoffManager}.
+ * The provided value will be set to
+ * {@link ContainerProperties#setIdlePartitionEventInterval} and
+ * {@link ContainerProperties#setPollTimeout} if these properties have their default
+ * values. If any of these values is manually set, it will not be overridden.
+ *
+ * @author Tomaz Fernandes
+ * @since 2.9
+ */
+public enum DelayPrecision {
+
+	/**
+	 * Lowest delay precision. Records are likely to be processed some time after
+	 * their due time in exchange for a higher poll timeout.
+	 * Better suited for larger delay values (over 20 seconds).
+	 */
+	LOWEST(5000),
+
+	/**
+	 * Medium delay precision. Better suited for medium delay values (over 5 seconds).
+	 */
+	MEDIUM(1000),
+
+	/**
+	 * Highest delay precision. Better suited for small delay values (up to 5 seconds).
+	 */
+	HIGHEST(100);
+
+	private final long delay;
+
+	DelayPrecision(long delay) {
+		this.delay = delay;
+	}
+
+	public long getDelay() {
+		return this.delay;
+	}
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/DelaySource.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/DelaySource.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.config;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+
+/**
+ * The delay source for backing off the record's partition.
+ *
+ * @author Tomaz Fernandes
+ * @since 2.9
+ */
+public enum DelaySource {
+
+	/**
+	 * The consumer backs off the partition by applying a fixed delay to
+	 * {@link ConsumerRecord#timestamp()}.
+	 */
+	CONSUMER,
+
+	/**
+	 * The consumer looks for a header added by the producer with a due timestamp
+	 * and backs the partition off until then.
+	 */
+	PRODUCER,
+
+	/**
+	 * The record will be consumed after whichever is latest -
+	 * the consumer delay value or the due timestamp header added by the producer, if any.
+	 */
+	BOTH
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DelayedKafkaOperations.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DelayedKafkaOperations.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.core;
+
+import java.time.Duration;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+
+import org.springframework.kafka.annotation.DelayedTopic;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.messaging.Message;
+import org.springframework.util.concurrent.ListenableFuture;
+
+
+/**
+ * Delayed operations. Note that to have maximum delay precision, the same amount
+ * of delay should be applied to a given partition or topic.
+ * It's up to the consumer to respect the delay semantics.
+ *
+ * @param <K> the key type.
+ * @param <V> the outbound data type.
+ *
+ * @author Tomaz Fernandes
+ * @since 2.9
+ * @see DelayedTopic
+ */
+public interface DelayedKafkaOperations<K, V> {
+
+	/**
+	 * Sends a message that won't be processed before the given delay.
+	 * @param message the message.
+	 * @param delay the delay.
+	 * @return the result future.
+	 */
+	ListenableFuture<SendResult<K, V>> sendDelayed(Message<?> message, Duration delay);
+
+	/**
+	 * Sends a {@link ProducerRecord} that won't be processed before the given delay.
+	 * @param record the record.
+	 * @param delay the delay.
+	 * @return the result future.
+	 */
+	ListenableFuture<SendResult<K, V>> sendDelayed(ProducerRecord<K, V> record, Duration delay);
+
+	/**
+	 * Sends a message to the given topic that won't be processed before
+	 * the given delay.
+	 * @param topic the topic.
+	 * @param data the data.
+	 * @param delay the delay.
+	 * @return the result future.
+	 */
+	ListenableFuture<SendResult<K, V>> sendDelayed(String topic, V data, Duration delay);
+
+	/**
+	 * Sends a message to the given topic and partition that won't be processed before
+	 * the given delay.
+	 * @param topic the topic.
+	 * @param partition the partition.
+	 * @param key the key.
+	 * @param data the data.
+	 * @param delay the delay.
+	 * @return the result future.
+	 */
+	ListenableFuture<SendResult<K, V>> sendDelayed(String topic, Integer partition, K key, V data, Duration delay);
+
+	/**
+	 * Sends a message that won't be processed before the given timestamp.
+	 * @param message the message.
+	 * @param timestamp the timestamp.
+	 * @return the result future.
+	 */
+	ListenableFuture<SendResult<K, V>> sendDueAfter(Message<?> message, long timestamp);
+
+	/**
+	 * Sends a record that won't be processed before the given timestamp.
+	 * @param record the record.
+	 * @param timestamp the timestamp.
+	 * @return the result future.
+	 */
+	ListenableFuture<SendResult<K, V>> sendDueAfter(ProducerRecord<K, V> record, long timestamp);
+
+	/**
+	 * Sends a message to the given topic that won't be processed before
+	 * the given timestamp.
+	 * @param topic the topic.
+	 * @param data the data.
+	 * @param timestamp the timestamp.
+	 * @return the result future.
+	 */
+	ListenableFuture<SendResult<K, V>> sendDueAfter(String topic, V data, long timestamp);
+
+	/**
+	 * Sends a message to the given topic and partition that won't be processed before
+	 * the given timestamp.
+	 * @param topic the topic.
+	 * @param partition the partition.
+	 * @param key the key.
+	 * @param data the data.
+	 * @param timestamp the timestamp.
+	 * @return the result future.
+	 */
+	ListenableFuture<SendResult<K, V>> sendDueAfter(String topic, Integer partition, K key, V data, long timestamp);
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DelayedKafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DelayedKafkaTemplate.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.core;
+
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.Map;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.utils.Time;
+
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.messaging.Message;
+import org.springframework.util.Assert;
+import org.springframework.util.concurrent.ListenableFuture;
+
+/**
+ *
+ * A {@link KafkaTemplate} with delay semantics.
+ * Note that due to Kafka's ordering guarantees the same delay value should be applied
+ * by partition, or topic. Otherwise, a record set to be processed further in the future
+ * might block consumption of records that should be processed earlier.
+ *
+ * @param <K> the key type.
+ * @param <V> the outbound data type.
+ *
+ * @author Tomaz Fernandes
+ * @since 2.9
+ */
+public class DelayedKafkaTemplate<K, V> extends KafkaTemplate<K, V> implements DelayedKafkaOperations<K, V> {
+
+	private String dueTimestampHeader = KafkaHeaders.DUE_TIMESTAMP;
+
+	public DelayedKafkaTemplate(ProducerFactory<K, V> producerFactory) {
+		super(producerFactory);
+	}
+
+	public DelayedKafkaTemplate(ProducerFactory<K, V> producerFactory, Map<String, Object> configOverrides) {
+		super(producerFactory, configOverrides);
+	}
+
+	public DelayedKafkaTemplate(ProducerFactory<K, V> producerFactory, boolean autoFlush) {
+		super(producerFactory, autoFlush);
+	}
+
+	public DelayedKafkaTemplate(ProducerFactory<K, V> producerFactory, boolean autoFlush, Map<String, Object> configOverrides) {
+		super(producerFactory, autoFlush, configOverrides);
+	}
+
+	@Override
+	public ListenableFuture<SendResult<K, V>> sendDelayed(Message<?> message, Duration delay) {
+		return sendDueAfter(message, getDueTimestampFor(delay));
+	}
+
+	@Override
+	public ListenableFuture<SendResult<K, V>> sendDelayed(ProducerRecord<K, V> record, Duration delay) {
+		return sendDueAfter(record, getDueTimestampFor(delay));
+	}
+
+	@Override
+	public ListenableFuture<SendResult<K, V>> sendDelayed(String topic, Integer partition, K key, V data, Duration delay) {
+		ProducerRecord<K, V> producerRecord = new ProducerRecord<>(topic, partition, key, data);
+		addTimestampHeader(producerRecord, getDueTimestampFor(delay));
+		return send(producerRecord);
+	}
+
+	@Override
+	public ListenableFuture<SendResult<K, V>> sendDelayed(String topic, V data, Duration delay) {
+		ProducerRecord<K, V> producerRecord = new ProducerRecord<>(topic, data);
+		addTimestampHeader(producerRecord, getDueTimestampFor(delay));
+		return send(producerRecord);
+	}
+
+	@Override
+	public ListenableFuture<SendResult<K, V>> sendDueAfter(Message<?> message, long timestamp) {
+		addTimestampHeader(message, timestamp);
+		return send(message);
+	}
+
+	@Override
+	public ListenableFuture<SendResult<K, V>> sendDueAfter(ProducerRecord<K, V> record, long timestamp) {
+		addTimestampHeader(record, timestamp);
+		return send(record);
+	}
+
+	@Override
+	public ListenableFuture<SendResult<K, V>> sendDueAfter(String topic, V data, long timestamp) {
+		ProducerRecord<K, V> record = new ProducerRecord<>(topic, data);
+		addTimestampHeader(record, timestamp);
+		return send(record);
+	}
+
+	@Override
+	public ListenableFuture<SendResult<K, V>> sendDueAfter(String topic, Integer partition, K key, V data, long timestamp) {
+		ProducerRecord<K, V> record = new ProducerRecord<>(topic, partition, key, data);
+		addTimestampHeader(record, timestamp);
+		return send(record);
+	}
+
+	/**
+	 * Set the dueTimestampHeader.
+	 * @param dueTimestampHeader the timestamp header.
+	 */
+	public void setDueTimestampHeader(String dueTimestampHeader) {
+		Assert.notNull(dueTimestampHeader, "dueTimestampHeader cannot be null");
+		this.dueTimestampHeader = dueTimestampHeader;
+	}
+
+	private void addTimestampHeader(Message<?> message, long timestamp) {
+		message.getHeaders().put(this.dueTimestampHeader,
+				ByteBuffer.allocate(Long.BYTES).putLong(timestamp).array());
+	}
+
+	private void addTimestampHeader(ProducerRecord<K, V> record, long timestamp) {
+		record.headers().add(this.dueTimestampHeader,
+				ByteBuffer.allocate(Long.BYTES).putLong(timestamp).array());
+	}
+
+	private long getDueTimestampFor(Duration delay) {
+		return Time.SYSTEM.milliseconds() + delay.toMillis();
+	}
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/DelayedTopicContext.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/DelayedTopicContext.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import java.time.Duration;
+
+import org.springframework.kafka.config.DelayPrecision;
+import org.springframework.kafka.config.DelaySource;
+import org.springframework.kafka.config.KafkaListenerEndpoint;
+import org.springframework.util.Assert;
+
+/**
+ * The delay context for a {@link KafkaListenerEndpoint}.
+ *
+ * @author Tomaz Fernandes
+ * @since 2.9
+ */
+public final class DelayedTopicContext {
+
+	private final Duration delay;
+
+	private final DelaySource delaySource;
+
+	private final DelayPrecision delayPrecision;
+
+	private final String producerDueTimestampHeader;
+
+	private final KafkaConsumerBackoffManager backoffManager;
+
+	private DelayedTopicContext(Duration delay, DelaySource delaySource,
+								DelayPrecision delayPrecision, String producerDueTimestampHeader,
+								KafkaConsumerBackoffManager backoffManager) {
+		this.delay = delay;
+		this.delaySource = delaySource;
+		this.delayPrecision = delayPrecision;
+		this.producerDueTimestampHeader = producerDueTimestampHeader;
+		this.backoffManager = backoffManager;
+	}
+
+	public static DelayedTopicContextBuilder builder() {
+		return new DelayedTopicContextBuilder();
+	}
+
+	public Duration getDelay() {
+		return this.delay;
+	}
+
+	public DelaySource getDelaySource() {
+		return this.delaySource;
+	}
+
+	public DelayPrecision getDelayPrecision() {
+		return this.delayPrecision;
+	}
+
+	public String getProducerDueTimestampHeader() {
+		return this.producerDueTimestampHeader;
+	}
+
+	public KafkaConsumerBackoffManager getBackoffManager() {
+		return this.backoffManager;
+	}
+
+	public static final class DelayedTopicContextBuilder {
+
+		private Duration delay;
+
+		private DelaySource delaySource;
+
+		private String producerDueTimestampHeader;
+
+		private DelayPrecision delayPrecision;
+
+		private KafkaConsumerBackoffManager backoffManager;
+
+		private DelayedTopicContextBuilder() {
+		}
+
+		public DelayedTopicContextBuilder delay(Duration delay) {
+			this.delay = delay;
+			return this;
+		}
+
+		public DelayedTopicContextBuilder delaySource(DelaySource delaySource) {
+			this.delaySource = delaySource;
+			return this;
+		}
+
+		public DelayedTopicContextBuilder delayPrecision(DelayPrecision delayPrecision) {
+			this.delayPrecision = delayPrecision;
+			return this;
+		}
+
+		public DelayedTopicContextBuilder producerDueTimestampHeader(String producerDueTimestampHeader) {
+			this.producerDueTimestampHeader = producerDueTimestampHeader;
+			return this;
+		}
+
+		public DelayedTopicContextBuilder kafkaBackOffManager(KafkaConsumerBackoffManager backoffManager) {
+			this.backoffManager = backoffManager;
+			return this;
+		}
+
+		public DelayedTopicContext build() {
+			Assert.notNull(this.delay, "delay cannot be null");
+			Assert.notNull(this.delaySource, "delaySource cannot be null");
+			Assert.notNull(this.delayPrecision, "delayPrecision cannot be null");
+			Assert.notNull(this.producerDueTimestampHeader, "producerDueTimestampHeader cannot be null");
+			Assert.notNull(this.backoffManager, "kafkaConsumerBackOffManager cannot be null");
+			return new DelayedTopicContext(this.delay, this.delaySource, this.delayPrecision,
+					this.producerDueTimestampHeader, this.backoffManager);
+		}
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordTracker.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordTracker.java
@@ -157,6 +157,9 @@ class FailedRecordTracker implements RecoveryStrategy {
 			@Nullable MessageListenerContainer container,
 			@Nullable Consumer<?, ?> consumer) throws InterruptedException {
 
+		if (SeekUtils.isBackoffException(exception)) {
+			return false;
+		}
 		if (this.noRetries) {
 			attemptRecovery(record, exception, null, consumer);
 			return true;

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/DelayedMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/DelayedMessageListenerAdapter.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener.adapter;
+
+import java.time.Duration;
+
+import org.apache.commons.logging.LogFactory;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
+
+import org.springframework.core.log.LogAccessor;
+import org.springframework.kafka.annotation.DelayedTopic;
+import org.springframework.kafka.listener.AcknowledgingConsumerAwareMessageListener;
+import org.springframework.kafka.listener.KafkaBackoffException;
+import org.springframework.kafka.listener.KafkaConsumerBackoffManager;
+import org.springframework.kafka.listener.MessageListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * An {@link AcknowledgingConsumerAwareMessageListener} implementation that delays
+ * record consumption by backing off the record's partition until a given delay
+ * past the record's creation timestamp.
+ *
+ * @param <K> the key.
+ * @param <V> the value.
+ *
+ * @author Tomaz Fernandes
+ * @since 2.9
+ *
+ * @see KafkaConsumerBackoffManager
+ * @see DelayedTopic
+ */
+public class DelayedMessageListenerAdapter<K, V>
+		extends AbstractDelegatingMessageListenerAdapter<MessageListener<K, V>>
+		implements AcknowledgingConsumerAwareMessageListener<K, V> {
+
+	private final LogAccessor logger = new LogAccessor(LogFactory.getLog(getClass()));
+
+	private static final int THIRTY = 30;
+
+	private static final Duration DEFAULT_DELAY_VALUE = Duration.ofSeconds(THIRTY);
+
+	private final String listenerId;
+
+	private final KafkaConsumerBackoffManager kafkaConsumerBackoffManager;
+
+	private volatile Duration delay = DEFAULT_DELAY_VALUE;
+
+	public DelayedMessageListenerAdapter(MessageListener<K, V> delegate,
+			KafkaConsumerBackoffManager kafkaConsumerBackoffManager, String listenerId) {
+
+		super(delegate);
+		Assert.notNull(kafkaConsumerBackoffManager, "kafkaConsumerBackoffManager cannot be null");
+		Assert.notNull(listenerId, "listenerId cannot be null");
+		this.kafkaConsumerBackoffManager = kafkaConsumerBackoffManager;
+		this.listenerId = listenerId;
+	}
+
+	@Override
+	public void onMessage(ConsumerRecord<K, V> consumerRecord, @Nullable Acknowledgment acknowledgment,
+								@Nullable Consumer<?, ?> consumer) throws KafkaBackoffException {
+
+		this.kafkaConsumerBackoffManager
+						.backOffIfNecessary(createContext(consumerRecord,
+								consumerRecord.timestamp() + this.delay.toMillis(),
+								consumer));
+		invokeDelegateOnMessage(consumerRecord, acknowledgment, consumer);
+	}
+
+	/**
+	 * Sets the amount of time the record will be delayed,
+	 * counting from its creation timestamp.
+	 *
+	 * The delay value can be changed at runtime - mind that
+	 * if consumption is already backed off, if the new value is greater than the
+	 * previous value, consumption will be backed off until the new value.
+	 *
+	 * However, if the new value is less than the current value,
+	 * the new value will be effective beginning in the next record.
+	 * @param delay the delay value.
+	 */
+	public void setDelay(Duration delay) {
+		Assert.notNull(delay, "Delay cannot be null");
+		this.logger.debug(() -> String.format("Setting delay %s for listener id %s", delay, this.listenerId));
+		this.delay = delay;
+	}
+
+	private void invokeDelegateOnMessage(ConsumerRecord<K, V> consumerRecord, Acknowledgment acknowledgment, Consumer<?, ?> consumer) {
+		switch (this.delegateType) {
+			case ACKNOWLEDGING_CONSUMER_AWARE:
+				this.delegate.onMessage(consumerRecord, acknowledgment, consumer);
+				break;
+			case ACKNOWLEDGING:
+				this.delegate.onMessage(consumerRecord, acknowledgment);
+				break;
+			case CONSUMER_AWARE:
+				this.delegate.onMessage(consumerRecord, consumer);
+				break;
+			case SIMPLE:
+				this.delegate.onMessage(consumerRecord);
+		}
+	}
+
+	private KafkaConsumerBackoffManager.Context createContext(ConsumerRecord<K, V> data, long nextExecutionTimestamp,
+			Consumer<?, ?> consumer) {
+
+		return this.kafkaConsumerBackoffManager.createContext(nextExecutionTimestamp, this.listenerId,
+				new TopicPartition(data.topic(), data.partition()), consumer);
+	}
+
+	/*
+	 * Since the container uses the delegate's type to determine which method to call, we
+	 * must implement them all.
+	 */
+	@Override
+	public void onMessage(ConsumerRecord<K, V> data) {
+		onMessage(data, null, null); // NOSONAR
+	}
+
+	@Override
+	public void onMessage(ConsumerRecord<K, V> data, Acknowledgment acknowledgment) {
+		onMessage(data, acknowledgment, null); // NOSONAR
+	}
+
+	@Override
+	public void onMessage(ConsumerRecord<K, V> data, Consumer<?, ?> consumer) {
+		onMessage(data, null, consumer);
+	}
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/KafkaBackoffAwareMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/KafkaBackoffAwareMessageListenerAdapter.java
@@ -32,6 +32,7 @@ import org.springframework.kafka.listener.MessageListener;
 import org.springframework.kafka.listener.TimestampedException;
 import org.springframework.kafka.retrytopic.RetryTopicHeaders;
 import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.lang.Nullable;
 
 /**
@@ -80,6 +81,37 @@ public class KafkaBackoffAwareMessageListenerAdapter<K, V>
 		this.kafkaConsumerBackoffManager = kafkaConsumerBackoffManager;
 		this.backoffTimestampHeader = backoffTimestampHeader;
 		this.clock = clock;
+	}
+
+	/**
+	 * The configuration for this listener adapter.
+	 *
+	 * @param delegate the MessageListener instance that will handle the messages.
+	 * @param kafkaConsumerBackoffManager the manager that will handle the back off.
+	 * @param listenerId the id of the listener container associated to this adapter.
+	 * @param backoffTimestampHeader the header name that will be looked up in the
+	 * 			incoming record to acquire the timestamp.
+	 * @since 2.7
+	 */
+	public KafkaBackoffAwareMessageListenerAdapter(MessageListener<K, V> delegate,
+												KafkaConsumerBackoffManager kafkaConsumerBackoffManager,
+												String listenerId,
+												String backoffTimestampHeader) {
+		this(delegate, kafkaConsumerBackoffManager, listenerId, backoffTimestampHeader, Clock.systemUTC());
+	}
+
+	/**
+	 * The configuration for this listener adapter.
+	 *
+	 * @param delegate the MessageListener instance that will handle the messages.
+	 * @param kafkaConsumerBackoffManager the manager that will handle the back off.
+	 * @param listenerId the id of the listener container associated to this adapter.
+	 * @since 2.9
+	 */
+	public KafkaBackoffAwareMessageListenerAdapter(MessageListener<K, V> delegate,
+												KafkaConsumerBackoffManager kafkaConsumerBackoffManager,
+												String listenerId) {
+		this(delegate, kafkaConsumerBackoffManager, listenerId, KafkaHeaders.DUE_TIMESTAMP, Clock.systemUTC());
 	}
 
 	public KafkaBackoffAwareMessageListenerAdapter(MessageListener<K, V> adapter,

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/KafkaHeaders.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/KafkaHeaders.java
@@ -23,6 +23,7 @@ package org.springframework.kafka.support;
  * @author Marius Bogoevici
  * @author Gary Russell
  * @author Biju Kunjummen
+ * @author Tomaz Fernandes
  */
 public abstract class KafkaHeaders {
 
@@ -327,5 +328,12 @@ public abstract class KafkaHeaders {
 	 * @since 2.8.4
 	 */
 	public static final String LISTENER_INFO = PREFIX + "listenerInfo";
+
+	/**
+	 * The time after which the record should be consumed.
+	 * Note that it's up to the consumer to respect the timestamp.
+	 * @since 2.9
+	 */
+	public static final String DUE_TIMESTAMP = PREFIX + "due-timestamp";
 
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/adapter/DelayedTopicIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/adapter/DelayedTopicIntegrationTests.java
@@ -1,0 +1,377 @@
+/*
+ * Copyright 2021-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener.adapter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.DelayedTopic;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.config.DelaySource;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.DelayedKafkaTemplate;
+import org.springframework.kafka.core.KafkaAdmin;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.util.StopWatch;
+
+
+
+/**
+ * @author Tomaz Fernandes
+ * @since 2.9
+ */
+@SpringJUnitConfig
+@DirtiesContext
+@EmbeddedKafka(topics = { DelayedTopicIntegrationTests.FIRST_TOPIC,
+		DelayedTopicIntegrationTests.SECOND_TOPIC,
+		DelayedTopicIntegrationTests.THIRD_TOPIC,
+		DelayedTopicIntegrationTests.FOURTH_TOPIC,
+		DelayedTopicIntegrationTests.FIFTH_TOPIC })
+@TestPropertySource(properties = "three.seconds=3000")
+public class DelayedTopicIntegrationTests {
+
+	private static final Logger logger = LoggerFactory.getLogger(DelayedTopicIntegrationTests.class);
+
+	public final static String FIRST_TOPIC = "myDelayedTopic1";
+
+	public final static String SECOND_TOPIC = "myDelayedTopic2";
+
+	public final static String THIRD_TOPIC = "myDelayedTopic3";
+
+	public final static String FOURTH_TOPIC = "myDelayedTopic4";
+
+	public final static String FIFTH_TOPIC = "myDelayedTopic5";
+
+	@Autowired
+	private KafkaTemplate<String, String> kafkaTemplate;
+
+	@Autowired
+	private DelayedKafkaTemplate<String, String> delayedKafkaTemplate;
+
+	@Autowired
+	private CountDownLatchContainer latchContainer;
+
+	@Test
+	void shouldDelayFirstTopicBy2Seconds() {
+		logger.debug("Sending message to topic " + FIRST_TOPIC);
+		StopWatch watch = new StopWatch();
+		watch.start();
+		kafkaTemplate.send(FIRST_TOPIC, "Testing topic 1");
+		assertThat(awaitLatch(latchContainer.countDownLatch1)).isTrue();
+		watch.stop();
+		logger.debug(FIRST_TOPIC + " took " + watch.getTotalTimeMillis() + " to run.");
+		assertThat(watch.getTotalTimeMillis()).isGreaterThanOrEqualTo(2000);
+	}
+
+	@Test
+	void shouldDelaySecondTopicBy2SecondsViaProducer() {
+		logger.debug("Sending message to topic " + SECOND_TOPIC);
+		StopWatch watch = new StopWatch();
+		watch.start();
+		delayedKafkaTemplate.sendDelayed(SECOND_TOPIC, "Testing topic 2", Duration.ofSeconds(2));
+		assertThat(awaitLatch(latchContainer.countDownLatch2)).isTrue();
+		watch.stop();
+		logger.debug(SECOND_TOPIC + " took " + watch.getTotalTimeMillis() + " to run.");
+		assertThat(watch.getTotalTimeMillis()).isGreaterThanOrEqualTo(2000);
+	}
+
+	@Test
+	void shouldDelayThirdTopicFor3Seconds() {
+		logger.debug("Sending message to topic " + THIRD_TOPIC);
+		StopWatch watch = new StopWatch();
+		watch.start();
+		delayedKafkaTemplate.sendDelayed(THIRD_TOPIC, "Testing topic 3", Duration.ofSeconds(2));
+		assertThat(awaitLatch(latchContainer.countDownLatch3)).isTrue();
+		watch.stop();
+		logger.debug(THIRD_TOPIC + " took " + watch.getTotalTimeMillis() + " to run.");
+		assertThat(watch.getTotalTimeMillis()).isGreaterThanOrEqualTo(3000);
+	}
+
+	@Test
+	void shouldDelayFourthTopicFor3Seconds() {
+		logger.debug("Sending message to topic " + FOURTH_TOPIC);
+		StopWatch watch = new StopWatch();
+		watch.start();
+		delayedKafkaTemplate.sendDelayed(FOURTH_TOPIC, "Testing topic 4", Duration.ofSeconds(3));
+		assertThat(awaitLatch(latchContainer.countDownLatch4)).isTrue();
+		watch.stop();
+		logger.debug(FOURTH_TOPIC + " took " + watch.getTotalTimeMillis() + " to run.");
+		assertThat(watch.getTotalTimeMillis()).isGreaterThanOrEqualTo(3000);
+	}
+
+	@Test
+	void shouldRespectDifferentDelaysForSeparatePartitions() {
+		logger.debug("Sending message to topic " + FIFTH_TOPIC);
+		StopWatch watchPartition0 = new StopWatch();
+		StopWatch watchPartition1 = new StopWatch();
+		watchPartition0.start();
+		watchPartition1.start();
+		delayedKafkaTemplate.sendDelayed(FIFTH_TOPIC, 0, null,
+				"Testing topic 5 - 0", Duration.ofSeconds(2));
+		delayedKafkaTemplate.sendDelayed(FIFTH_TOPIC, 1, null,
+				"Testing topic 5 - 1", Duration.ofSeconds(3));
+		assertThat(awaitLatch(latchContainer.countDownLatch5_0)).isTrue();
+		watchPartition0.stop();
+		assertThat(watchPartition0.getTotalTimeMillis()).isGreaterThanOrEqualTo(2000);
+		assertThat(awaitLatch(latchContainer.countDownLatch5_1)).isTrue();
+		watchPartition1.stop();
+		assertThat(watchPartition1.getTotalTimeMillis()).isGreaterThanOrEqualTo(3000);
+		logger.debug(FIFTH_TOPIC + " took " + watchPartition1.getTotalTimeMillis() + " to run.");
+	}
+
+	private boolean awaitLatch(CountDownLatch latch) {
+		try {
+			return latch.await(120, TimeUnit.SECONDS);
+		}
+		catch (Exception e) {
+			fail(e.getMessage());
+			throw new RuntimeException(e);
+		}
+	}
+
+	static class FirstTopicListener {
+
+		@Autowired
+		CountDownLatchContainer container;
+
+		@DelayedTopic(delayExpression = "${missing.property:2000}")
+		@KafkaListener(topics = FIRST_TOPIC)
+		public void listen(String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic) {
+			logger.debug("Message {} received in topic {}", message, receivedTopic);
+			container.countDownLatch1.countDown();
+		}
+	}
+
+	static class SecondTopicListener {
+
+		@Autowired
+		CountDownLatchContainer container;
+
+		@DelayedTopic(source = DelaySource.PRODUCER)
+		@KafkaListener(topics = SECOND_TOPIC)
+		public void listen(String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic,
+								@Header(KafkaHeaders.DUE_TIMESTAMP) String dueTimestamp) {
+			logger.debug("Message {} received in topic {} with timestamp {}", message, receivedTopic, dueTimestamp);
+			container.countDownLatch2.countDown();
+		}
+	}
+
+	static class ThirdTopicListener {
+
+		@Autowired
+		CountDownLatchContainer container;
+
+		@DelayedTopic(delayExpression = "${three.seconds}", source = DelaySource.BOTH)
+		@KafkaListener(topics = THIRD_TOPIC)
+		public void listen(String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic,
+								@Header(KafkaHeaders.DUE_TIMESTAMP) String dueTimestamp) {
+			logger.debug("Message {} received in topic {} with timestamp {}", message, receivedTopic, dueTimestamp);
+			container.countDownLatch3.countDown();
+		}
+	}
+
+	static class FourthTopicListener {
+
+		@Autowired
+		CountDownLatchContainer container;
+
+		@DelayedTopic(delayExpression = "#{2000}", source = DelaySource.BOTH)
+		@KafkaListener(topics = FOURTH_TOPIC)
+		public void listen(String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic,
+								@Header(KafkaHeaders.DUE_TIMESTAMP) String dueTimestamp) {
+			logger.debug("Message {} received in topic {} with timestamp {}", message, receivedTopic, dueTimestamp);
+			container.countDownLatch4.countDown();
+		}
+	}
+
+	static class FifthTopicListener {
+
+		@Autowired
+		CountDownLatchContainer container;
+
+		@DelayedTopic(source = DelaySource.PRODUCER)
+		@KafkaListener(topics = FIFTH_TOPIC)
+		public void listen(String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic,
+						@Header(KafkaHeaders.DUE_TIMESTAMP) String dueTimestamp,
+						@Header(KafkaHeaders.RECEIVED_PARTITION_ID) Integer partition) {
+			logger.debug("Message {} received in topic {} partition {} with timestamp {}", message, receivedTopic,
+					partition, dueTimestamp);
+			if (partition == 0) {
+				container.countDownLatch5_0.countDown();
+			}
+			else {
+				container.countDownLatch5_1.countDown();
+			}
+		}
+	}
+
+	static class CountDownLatchContainer {
+
+		CountDownLatch countDownLatch1 = new CountDownLatch(1);
+		CountDownLatch countDownLatch2 = new CountDownLatch(1);
+		CountDownLatch countDownLatch3 = new CountDownLatch(1);
+		CountDownLatch countDownLatch4 = new CountDownLatch(1);
+		CountDownLatch countDownLatch5_0 = new CountDownLatch(1);
+		CountDownLatch countDownLatch5_1 = new CountDownLatch(1);
+
+	}
+
+	@Configuration
+	static class DelayedTopicTestConfiguration {
+
+		@Bean
+		public FirstTopicListener firstTopicListener() {
+			return new FirstTopicListener();
+		}
+
+		@Bean
+		public SecondTopicListener secondTopicListener() {
+			return new SecondTopicListener();
+		}
+
+		@Bean
+		public ThirdTopicListener thirdTopicListener() {
+			return new ThirdTopicListener();
+		}
+
+		@Bean
+		public FourthTopicListener fourthTopicListener() {
+			return new FourthTopicListener();
+		}
+
+		@Bean
+		public FifthTopicListener fifthTopicListener() {
+			return new FifthTopicListener();
+		}
+
+		@Bean
+		CountDownLatchContainer latchContainer() {
+			return new CountDownLatchContainer();
+		}
+
+	}
+
+	@Configuration
+	public static class KafkaProducerConfig {
+
+		@Autowired
+		EmbeddedKafkaBroker broker;
+
+		@Bean
+		public ProducerFactory<String, String> producerFactory() {
+			Map<String, Object> configProps = new HashMap<>();
+			configProps.put(
+					ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
+					this.broker.getBrokersAsString());
+			configProps.put(
+					ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+					StringSerializer.class);
+			configProps.put(
+					ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+					StringSerializer.class);
+			return new DefaultKafkaProducerFactory<>(configProps);
+		}
+
+		@Bean
+		public KafkaTemplate<String, String> kafkaTemplate() {
+			return new KafkaTemplate<>(producerFactory());
+		}
+
+		@Bean
+		public DelayedKafkaTemplate<String, String> delayedKafkaTemplate() {
+			return new DelayedKafkaTemplate<>(producerFactory());
+		}
+	}
+
+	@EnableKafka
+	@Configuration
+	public static class KafkaConsumerConfig {
+
+		@Autowired
+		EmbeddedKafkaBroker broker;
+
+		@Bean
+		public KafkaAdmin kafkaAdmin() {
+			Map<String, Object> configs = new HashMap<>();
+			configs.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, this.broker.getBrokersAsString());
+			return new KafkaAdmin(configs);
+		}
+
+		@Bean
+		public ConsumerFactory<String, String> consumerFactory() {
+			Map<String, Object> props = new HashMap<>();
+			props.put(
+					ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
+					this.broker.getBrokersAsString());
+			props.put(
+					ConsumerConfig.GROUP_ID_CONFIG,
+					"groupId");
+			props.put(
+					ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+					StringDeserializer.class);
+			props.put(
+					ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+					StringDeserializer.class);
+			props.put(
+					ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG, false);
+			props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+			return new DefaultKafkaConsumerFactory<>(props);
+		}
+
+		@Bean
+		public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory(
+				ConsumerFactory<String, String> consumerFactory) {
+
+			ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+			factory.setConsumerFactory(consumerFactory);
+			factory.setConcurrency(1);
+			return factory;
+		}
+	}
+
+}


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2247

Now that we have the `KafkaConsumerBackOffManager`, we can build an arbitrary delay mechanism for topics.

I realize this is quite a bit of code - I meant to present it much smaller, but the configuration issues took some time and I kept working on this in parallel and it got bigger. So no hurry.

The `@DelayedTopic`'s  javadoc and `DelayedTopicIntegrationTests` should do a good job in showing around what we have, so I won't bother writing too much here - I think you prefer looking into the code.

So that's it, hope you enjoy this, and please let me know what you think. Of course, this is just a proposal and we can change things around if necessary. Anyway, I think should be helpful for our users and a good addition to our `2.9` version.

Thanks!