### PR TITLE
Add BackOffHandler to FailedRecordTracker

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/BackOffHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/BackOffHandler.java
@@ -9,18 +9,9 @@ import org.springframework.lang.Nullable;
  *
  *  @since 1.3.5
  */
+@FunctionalInterface
 public interface BackOffHandler {
 
-	default void onNextBackOff(@Nullable MessageListenerContainer container, Exception exception, long nextBackOff) {
-		try {
-			if (container == null) {
-				Thread.sleep(nextBackOff);
-			} else {
-				ListenerUtils.stoppableSleep(container, nextBackOff);
-			}
-		} catch (InterruptedException e) {
-			throw new RuntimeException(e);
-		}
-	}
+	void onNextBackOff(@Nullable MessageListenerContainer container, Exception exception, long nextBackOff);
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/BackOffHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/BackOffHandler.java
@@ -1,0 +1,26 @@
+package org.springframework.kafka.listener;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * Handler for the provided back off time, listener container and exception.
+ *
+ *  @author Jan Marincek
+ *
+ *  @since 1.3.5
+ */
+public interface BackOffHandler {
+
+	default void onNextBackOff(@Nullable MessageListenerContainer container, Exception exception, long nextBackOff) {
+		try {
+			if (container == null) {
+				Thread.sleep(nextBackOff);
+			} else {
+				ListenerUtils.stoppableSleep(container, nextBackOff);
+			}
+		} catch (InterruptedException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/BackOffHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/BackOffHandler.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.kafka.listener;
 
 import org.springframework.lang.Nullable;
@@ -6,8 +22,7 @@ import org.springframework.lang.Nullable;
  * Handler for the provided back off time, listener container and exception.
  *
  *  @author Jan Marincek
- *
- *  @since 1.3.5
+ *  @since 2.9
  */
 @FunctionalInterface
 public interface BackOffHandler {

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/DefaultAfterRollbackProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/DefaultAfterRollbackProcessor.java
@@ -42,8 +42,11 @@ import org.springframework.util.backoff.BackOffExecution;
  *
  * @param <K> the key type.
  * @param <V> the value type.
+ *
  * @author Gary Russell
+ *
  * @since 1.3.5
+ *
  */
 public class DefaultAfterRollbackProcessor<K, V> extends FailedRecordProcessor
 		implements AfterRollbackProcessor<K, V> {
@@ -60,7 +63,6 @@ public class DefaultAfterRollbackProcessor<K, V> extends FailedRecordProcessor
 	 * Construct an instance with the default recoverer which simply logs the record after
 	 * {@value SeekUtils#DEFAULT_MAX_FAILURES} (maxFailures) have occurred for a
 	 * topic/partition/offset.
-	 *
 	 * @since 2.2
 	 */
 	public DefaultAfterRollbackProcessor() {
@@ -70,7 +72,6 @@ public class DefaultAfterRollbackProcessor<K, V> extends FailedRecordProcessor
 	/**
 	 * Construct an instance with the default recoverer which simply logs the record after
 	 * the backOff returns STOP for a topic/partition/offset.
-	 *
 	 * @param backOff the {@link BackOff}.
 	 * @since 2.3
 	 */
@@ -82,7 +83,6 @@ public class DefaultAfterRollbackProcessor<K, V> extends FailedRecordProcessor
 	 * Construct an instance with the provided recoverer which will be called after
 	 * {@value SeekUtils#DEFAULT_MAX_FAILURES} (maxFailures) have occurred for a
 	 * topic/partition/offset.
-	 *
 	 * @param recoverer the recoverer.
 	 * @since 2.2
 	 */
@@ -93,13 +93,12 @@ public class DefaultAfterRollbackProcessor<K, V> extends FailedRecordProcessor
 	/**
 	 * Construct an instance with the provided recoverer which will be called after
 	 * the backOff returns STOP for a topic/partition/offset.
-	 *
 	 * @param recoverer the recoverer; if null, the default (logging) recoverer is used.
-	 * @param backOff   the {@link BackOff}.
+	 * @param backOff the {@link BackOff}.
 	 * @since 2.3
 	 */
 	public DefaultAfterRollbackProcessor(@Nullable BiConsumer<ConsumerRecord<?, ?>, Exception> recoverer,
-										 BackOff backOff) {
+			BackOff backOff) {
 
 		this(recoverer, backOff, null, false);
 	}
@@ -107,13 +106,12 @@ public class DefaultAfterRollbackProcessor<K, V> extends FailedRecordProcessor
 	/**
 	 * Construct an instance with the provided recoverer which will be called after the
 	 * backOff returns STOP for a topic/partition/offset.
-	 *
 	 * @param recoverer       the recoverer; if null, the default (logging) recoverer is used.
 	 * @param backOff         the {@link BackOff}.
 	 * @param kafkaOperations for sending the recovered offset to the transaction.
 	 * @param commitRecovered true to commit the recovered record's offset; requires a
 	 *                        {@link KafkaOperations}.
-	 * @since 2.5.3
+	 * @since 2.9
 	 */
 	public DefaultAfterRollbackProcessor(@Nullable BiConsumer<ConsumerRecord<?, ?>, Exception> recoverer,
 										 BackOff backOff, @Nullable KafkaOperations<?, ?> kafkaOperations, boolean commitRecovered) {
@@ -124,14 +122,13 @@ public class DefaultAfterRollbackProcessor<K, V> extends FailedRecordProcessor
 	/**
 	 * Construct an instance with the provided recoverer which will be called after the
 	 * backOff returns STOP for a topic/partition/offset.
-	 *
 	 * @param recoverer       the recoverer; if null, the default (logging) recoverer is used.
 	 * @param backOff         the {@link BackOff}.
 	 * @param backOffHandler  the {@link BackOffHandler}.
 	 * @param kafkaOperations for sending the recovered offset to the transaction.
 	 * @param commitRecovered true to commit the recovered record's offset; requires a
 	 *                        {@link KafkaOperations}.
-	 * @since 2.5.8
+	 * @since 2.5.9
 	 */
 	public DefaultAfterRollbackProcessor(@Nullable BiConsumer<ConsumerRecord<?, ?>, Exception> recoverer,
 										 BackOff backOff, @Nullable BackOffHandler backOffHandler, @Nullable KafkaOperations<?, ?> kafkaOperations, boolean commitRecovered) {
@@ -148,14 +145,14 @@ public class DefaultAfterRollbackProcessor<K, V> extends FailedRecordProcessor
 				"A KafkaOperations is required when 'commitRecovered' is true");
 	}
 
-	@SuppressWarnings({"unchecked", "rawtypes", "deprecation"})
+	@SuppressWarnings({ "unchecked", "rawtypes", "deprecation" })
 	@Override
 	public void process(List<ConsumerRecord<K, V>> records, Consumer<K, V> consumer,
-						@Nullable MessageListenerContainer container, Exception exception, boolean recoverable, EOSMode eosMode) {
+			@Nullable MessageListenerContainer container, Exception exception, boolean recoverable, EOSMode eosMode) {
 
 		if (SeekUtils.doSeeks((List) records, consumer, exception, recoverable,
 				getFailureTracker()::recovered, container, this.logger)
-				&& isCommitRecovered() && this.kafkaTemplate.isTransactional()) {
+					&& isCommitRecovered() && this.kafkaTemplate.isTransactional()) {
 			ConsumerRecord<K, V> skipped = records.get(0);
 			this.kafkaTemplate.sendOffsetsToTransaction(
 					Collections.singletonMap(new TopicPartition(skipped.topic(), skipped.partition()),
@@ -165,7 +162,8 @@ public class DefaultAfterRollbackProcessor<K, V> extends FailedRecordProcessor
 		if (!recoverable && this.backOff != null) {
 			try {
 				ListenerUtils.unrecoverableBackOff(this.backOff, this.backOffs, this.lastIntervals, container);
-			} catch (InterruptedException e) {
+			}
+			catch (InterruptedException e) {
 				Thread.currentThread().interrupt();
 			}
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/DefaultAfterRollbackProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/DefaultAfterRollbackProcessor.java
@@ -113,9 +113,7 @@ public class DefaultAfterRollbackProcessor<K, V> extends FailedRecordProcessor
 	 *                        {@link KafkaOperations}.
 	 * @since 2.9
 	 */
-	public DefaultAfterRollbackProcessor(@Nullable BiConsumer<ConsumerRecord<?, ?>, Exception> recoverer,
-										 BackOff backOff, @Nullable KafkaOperations<?, ?> kafkaOperations, boolean commitRecovered) {
-
+	public DefaultAfterRollbackProcessor(@Nullable BiConsumer<ConsumerRecord<?, ?>, Exception> recoverer, BackOff backOff, @Nullable KafkaOperations<?, ?> kafkaOperations, boolean commitRecovered) {
 		this(recoverer, backOff, null, kafkaOperations, commitRecovered);
 	}
 
@@ -130,9 +128,7 @@ public class DefaultAfterRollbackProcessor<K, V> extends FailedRecordProcessor
 	 *                        {@link KafkaOperations}.
 	 * @since 2.5.9
 	 */
-	public DefaultAfterRollbackProcessor(@Nullable BiConsumer<ConsumerRecord<?, ?>, Exception> recoverer,
-										 BackOff backOff, @Nullable BackOffHandler backOffHandler, @Nullable KafkaOperations<?, ?> kafkaOperations, boolean commitRecovered) {
-
+	public DefaultAfterRollbackProcessor(@Nullable BiConsumer<ConsumerRecord<?, ?>, Exception> recoverer, BackOff backOff, @Nullable BackOffHandler backOffHandler, @Nullable KafkaOperations<?, ?> kafkaOperations, boolean commitRecovered) {
 		super(recoverer, backOff, backOffHandler);
 		this.kafkaTemplate = kafkaOperations;
 		super.setCommitRecovered(commitRecovered);

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/DefaultErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/DefaultErrorHandler.java
@@ -94,6 +94,7 @@ public class DefaultErrorHandler extends FailedBatchProcessor implements CommonE
 	 * the backOff returns STOP for a topic/partition/offset.
 	 * @param recoverer the recoverer; if null, the default (logging) recoverer is used.
 	 * @param backOff the {@link BackOff}.
+	 * @param backOffHandler the {@link BackOffHandler}.
 	 */
 	public DefaultErrorHandler(@Nullable ConsumerRecordRecoverer recoverer, BackOff backOff, @Nullable BackOffHandler backOffHandler) {
 		super(recoverer, backOff, backOffHandler, createFallback(backOff, recoverer));

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/DefaultErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/DefaultErrorHandler.java
@@ -86,7 +86,17 @@ public class DefaultErrorHandler extends FailedBatchProcessor implements CommonE
 	 * @param backOff the {@link BackOff}.
 	 */
 	public DefaultErrorHandler(@Nullable ConsumerRecordRecoverer recoverer, BackOff backOff) {
-		super(recoverer, backOff, createFallback(backOff, recoverer));
+		this(recoverer, backOff, null);
+	}
+
+	/**
+	 * Construct an instance with the provided recoverer which will be called after
+	 * the backOff returns STOP for a topic/partition/offset.
+	 * @param recoverer the recoverer; if null, the default (logging) recoverer is used.
+	 * @param backOff the {@link BackOff}.
+	 */
+	public DefaultErrorHandler(@Nullable ConsumerRecordRecoverer recoverer, BackOff backOff, @Nullable BackOffHandler backOffHandler) {
+		super(recoverer, backOff, backOffHandler, createFallback(backOff, recoverer));
 	}
 
 	private static CommonErrorHandler createFallback(BackOff backOff, @Nullable ConsumerRecordRecoverer recoverer) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedBatchProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedBatchProcessor.java
@@ -63,9 +63,21 @@ public abstract class FailedBatchProcessor extends FailedRecordProcessor {
 	 * @param fallbackHandler the fall back handler.
 	 */
 	public FailedBatchProcessor(@Nullable BiConsumer<ConsumerRecord<?, ?>, Exception> recoverer, BackOff backOff,
-			CommonErrorHandler fallbackHandler) {
+								CommonErrorHandler fallbackHandler) {
 
-		super(recoverer, backOff);
+		this(recoverer, backOff, null, fallbackHandler);
+	}
+
+	/**
+	 * Construct an instance with the provided properties.
+	 * @param recoverer the recoverer.
+	 * @param backOff the back off.
+	 * @param fallbackHandler the fall back handler.
+	 */
+	public FailedBatchProcessor(@Nullable BiConsumer<ConsumerRecord<?, ?>, Exception> recoverer, BackOff backOff,
+								@Nullable BackOffHandler backOffHandler, CommonErrorHandler fallbackHandler) {
+
+		super(recoverer, backOff, backOffHandler);
 		this.fallbackBatchHandler = fallbackHandler;
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedBatchProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedBatchProcessor.java
@@ -72,6 +72,7 @@ public abstract class FailedBatchProcessor extends FailedRecordProcessor {
 	 * Construct an instance with the provided properties.
 	 * @param recoverer the recoverer.
 	 * @param backOff the back off.
+	 * @param backOffHandler the {@link BackOffHandler}
 	 * @param fallbackHandler the fall back handler.
 	 */
 	public FailedBatchProcessor(@Nullable BiConsumer<ConsumerRecord<?, ?>, Exception> recoverer, BackOff backOff,

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordProcessor.java
@@ -61,7 +61,11 @@ public abstract class FailedRecordProcessor extends ExceptionClassifier implemen
 	private boolean seekAfterError = true;
 
 	protected FailedRecordProcessor(@Nullable BiConsumer<ConsumerRecord<?, ?>, Exception> recoverer, BackOff backOff) {
-		this.failureTracker = new FailedRecordTracker(recoverer, backOff, this.logger);
+		this(recoverer, backOff, null);
+	}
+
+	protected FailedRecordProcessor(@Nullable BiConsumer<ConsumerRecord<?, ?>, Exception> recoverer, BackOff backOff, @Nullable BackOffHandler backOffHandler) {
+		this.failureTracker = new FailedRecordTracker(recoverer, backOff, this.logger, backOffHandler);
 		this.failureTracker.setBackOffFunction(this.noRetriesForClassified);
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordProcessor.java
@@ -65,7 +65,7 @@ public abstract class FailedRecordProcessor extends ExceptionClassifier implemen
 	}
 
 	protected FailedRecordProcessor(@Nullable BiConsumer<ConsumerRecord<?, ?>, Exception> recoverer, BackOff backOff, @Nullable BackOffHandler backOffHandler) {
-		this.failureTracker = new FailedRecordTracker(recoverer, backOff, this.logger, backOffHandler);
+		this.failureTracker = new FailedRecordTracker(recoverer, backOff, backOffHandler, this.logger);
 		this.failureTracker.setBackOffFunction(this.noRetriesForClassified);
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordTracker.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordTracker.java
@@ -182,7 +182,7 @@ class FailedRecordTracker implements RecoveryStrategy {
 				rl.failedDelivery(record, exception, failedRecord.getDeliveryAttempts().get()));
 		long nextBackOff = failedRecord.getBackOffExecution().nextBackOff();
 		if (nextBackOff != BackOffExecution.STOP) {
-			backOffHandler.onNextBackOff(container, exception, nextBackOff);
+			this.backOffHandler.onNextBackOff(container, exception, nextBackOff);
 			return false;
 		}
 		else {
@@ -311,10 +311,12 @@ class FailedRecordTracker implements RecoveryStrategy {
 			try {
 				if (container == null) {
 					Thread.sleep(nextBackOff);
-				} else {
+				}
+				else {
 					ListenerUtils.stoppableSleep(container, nextBackOff);
 				}
-			} catch (InterruptedException e) {
+			}
+			catch (InterruptedException e) {
 				throw new RuntimeException(e);
 			}
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ListenerContainerPauseService.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ListenerContainerPauseService.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2014-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.logging.LogFactory;
+
+import org.springframework.core.log.LogAccessor;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+
+/**
+ * Service for pausing and resuming of {@link MessageListenerContainer}.
+ *
+ * @author Jan Marincek
+ * @since 2.9
+ */
+public class ListenerContainerPauseService {
+
+	private static final LogAccessor LOGGER = new LogAccessor(LogFactory.getLog(ListenerContainerPauseService.class));
+	private final ListenerContainerRegistry registry;
+	private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+
+	public ListenerContainerPauseService(ListenerContainerRegistry registry) {
+		this.registry = registry;
+	}
+
+	/**
+	 * Pause the listener by given id.
+	 * Checks if the listener has already been requested to pause.
+	 *
+	 * @param listenerId the id of the listener
+	 */
+	public void pause(String listenerId) {
+		getListenerContainer(listenerId).ifPresent(this::pause);
+	}
+
+	/**
+	 * Pause the listener by given id.
+	 * Checks if the listener has already been requested to pause.
+	 * Sets executor schedule for resuming the same listener after pauseDuration.
+	 *
+	 * @param listenerId    the id of the listener
+	 * @param pauseDuration duration between pause() and resume() actions
+	 */
+	public void pause(String listenerId, Duration pauseDuration) {
+		getListenerContainer(listenerId)
+				.ifPresent(messageListenerContainer -> pause(messageListenerContainer, pauseDuration));
+	}
+
+	/**
+	 * Pause the listener by given container instance.
+	 * Checks if the listener has already been requested to pause.
+	 *
+	 * @param messageListenerContainer the listener container
+	 */
+	public void pause(@NonNull MessageListenerContainer messageListenerContainer) {
+		pause(messageListenerContainer, null);
+	}
+
+	/**
+	 * Pause the listener by given container instance.
+	 * Checks if the listener has already been requested to pause.
+	 * Sets executor schedule for resuming the same listener after pauseDuration.
+	 *
+	 * @param messageListenerContainer the listener container
+	 * @param pauseDuration            duration between pause() and resume() actions
+	 */
+	public void pause(@NonNull MessageListenerContainer messageListenerContainer, @Nullable Duration pauseDuration) {
+		if (messageListenerContainer.isPauseRequested()) {
+			LOGGER.debug(() -> "Container " + messageListenerContainer + " already has pause requested");
+		}
+		else {
+			LOGGER.debug(() -> "Pausing container " + messageListenerContainer);
+			messageListenerContainer.pause();
+			if (messageListenerContainer.getListenerId() != null && pauseDuration != null) {
+				LOGGER.debug(() -> "Resuming of container " + messageListenerContainer + " scheduled for " + LocalDateTime.now().plus(pauseDuration));
+				this.executor.schedule(() -> resume(messageListenerContainer.getListenerId()), pauseDuration.toMillis(), TimeUnit.MILLISECONDS);
+			}
+		}
+	}
+
+	/**
+	 * Resume the listener by given id.
+	 *
+	 * @param listenerId the id of the listener
+	 */
+	public void resume(@NonNull String listenerId) {
+		getListenerContainer(listenerId).ifPresent(this::resume);
+	}
+
+	/**
+	 * Resume the listener.
+	 *
+	 * @param messageListenerContainer the listener container
+	 */
+	public void resume(@NonNull MessageListenerContainer messageListenerContainer) {
+		if (messageListenerContainer.isContainerPaused()) {
+			LOGGER.debug(() -> "Resuming container " + messageListenerContainer);
+			messageListenerContainer.resume();
+		}
+		else {
+			LOGGER.debug(() -> "Container " + messageListenerContainer + " was not paused");
+		}
+	}
+
+	private Optional<MessageListenerContainer> getListenerContainer(String listenerId) {
+		MessageListenerContainer messageListenerContainer = this.registry.getListenerContainer(listenerId);
+		if (messageListenerContainer == null) {
+			LOGGER.warn(() -> "MessageListenerContainer " + listenerId + " does not exists");
+		}
+
+		return Optional.ofNullable(messageListenerContainer);
+	}
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ListenerContainerPauseServiceTest.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ListenerContainerPauseServiceTest.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2014-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit test for {@link ListenerContainerPauseService}.
+ *
+ * @author Jan Marincek
+ * @since 2.9
+ */
+@ExtendWith(MockitoExtension.class)
+class ListenerContainerPauseServiceTest {
+	@Mock
+	private ListenerContainerRegistry listenerContainerRegistry;
+
+	@InjectMocks
+	private ListenerContainerPauseService kafkaPausableListenersService;
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void testPausingAndResumingListener() throws InterruptedException {
+		long timeToBePausedInSec = 2;
+		KafkaMessageListenerContainer<Object, Object> messageListenerContainer = mock(KafkaMessageListenerContainer.class);
+
+		given(messageListenerContainer.isPauseRequested()).willReturn(false);
+		given(messageListenerContainer.isContainerPaused()).willReturn(true);
+		given(messageListenerContainer.getListenerId()).willReturn("test-listener");
+		given(listenerContainerRegistry.getListenerContainer("test-listener")).willReturn(messageListenerContainer);
+
+		kafkaPausableListenersService.pause("test-listener", Duration.ofSeconds(timeToBePausedInSec));
+
+		then(messageListenerContainer).should(times(1)).pause();
+
+		TimeUnit.SECONDS.sleep(timeToBePausedInSec + 1);
+
+		then(messageListenerContainer).should(times(1)).resume();
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void testPausingListener() {
+		KafkaMessageListenerContainer<Object, Object> messageListenerContainer = mock(KafkaMessageListenerContainer.class);
+
+		given(messageListenerContainer.getListenerId()).willReturn("test-listener");
+		given(listenerContainerRegistry.getListenerContainer("test-listener")).willReturn(messageListenerContainer);
+
+		kafkaPausableListenersService.pause("test-listener");
+
+		then(messageListenerContainer).should(times(1)).pause();
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void testPausingNonExistingListener() {
+		long timeToBePausedInSec = 2;
+
+		KafkaMessageListenerContainer<Object, Object> messageListenerContainer = mock(KafkaMessageListenerContainer.class);
+		given(listenerContainerRegistry.getListenerContainer("test-listener")).willReturn(null);
+
+		kafkaPausableListenersService.pause("test-listener", Duration.ofSeconds(timeToBePausedInSec));
+
+		then(messageListenerContainer).should(never()).pause();
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void testResmingNotPausedListener() throws InterruptedException {
+		long timeToBePausedInSec = 2;
+		KafkaMessageListenerContainer<Object, Object> messageListenerContainer = mock(KafkaMessageListenerContainer.class);
+
+		given(messageListenerContainer.isPauseRequested()).willReturn(false);
+		given(messageListenerContainer.isContainerPaused()).willReturn(false);
+		given(messageListenerContainer.getListenerId()).willReturn("test-listener");
+		given(listenerContainerRegistry.getListenerContainer("test-listener")).willReturn(messageListenerContainer);
+
+		kafkaPausableListenersService.pause("test-listener", Duration.ofSeconds(timeToBePausedInSec));
+
+		then(messageListenerContainer).should(times(1)).pause();
+
+		TimeUnit.SECONDS.sleep(timeToBePausedInSec + 1);
+
+		then(messageListenerContainer).should(never()).resume();
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void testAlreadyPausedListener() {
+		KafkaMessageListenerContainer<Object, Object> messageListenerContainer = mock(KafkaMessageListenerContainer.class);
+
+		given(messageListenerContainer.isPauseRequested()).willReturn(true);
+		given(listenerContainerRegistry.getListenerContainer("test-listener")).willReturn(messageListenerContainer);
+
+		kafkaPausableListenersService.pause("test-listener", Duration.ofSeconds(30));
+
+		then(messageListenerContainer).should(never()).pause();
+	}
+}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
Added new BackOffHandler interface. The idea is to decouple the FailedRecordTracker with the behavior on next back off time. 
Currently the FailedRecordTracker is sleeping the thread, and there is now way to change that behaviour.

Related issue : https://github.com/spring-projects/spring-kafka/issues/2262