### PR TITLE
GH-2195: Fix No Seek Retry Mode

### DIFF
--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/DefaultErrorHandlerSeekAfterCommitException.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/DefaultErrorHandlerSeekAfterCommitException.java
@@ -18,19 +18,22 @@ package org.springframework.kafka.listener;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willAnswer;
-import static org.mockito.BDDMockito.willReturn;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,13 +43,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.kafka.clients.consumer.CommitFailedException;
 import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
-import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
-import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.record.TimestampType;
@@ -61,8 +62,10 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
 import org.springframework.kafka.core.ConsumerFactory;
-import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.listener.ContainerProperties.AckMode;
+import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
@@ -73,18 +76,11 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
  */
 @SpringJUnitConfig
 @DirtiesContext
-@SuppressWarnings("deprecation")
-public class DefaultErrorHandlerNoSeeksBatchListenerTests {
-
-	private static final String CONTAINER_ID = "container";
+public class DefaultErrorHandlerSeekAfterCommitException {
 
 	@SuppressWarnings("rawtypes")
 	@Autowired
 	private Consumer consumer;
-
-	@SuppressWarnings("rawtypes")
-	@Autowired
-	private Producer producer;
 
 	@Autowired
 	private Config config;
@@ -93,59 +89,57 @@ public class DefaultErrorHandlerNoSeeksBatchListenerTests {
 	private KafkaListenerEndpointRegistry registry;
 
 	/*
-	 * Deliver 6 records from three partitions, fail on the second record second
-	 * partition.
+	 * Fail with commit exception - always seek.
 	 */
 	@SuppressWarnings("unchecked")
 	@Test
-	void retriesWithNoSeeksBatchListener() throws Exception {
+	public void forceSeeksWithCommitException() throws Exception {
 		assertThat(this.config.deliveryLatch.await(10, TimeUnit.SECONDS)).isTrue();
-		assertThat(this.config.pollLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(this.config.commitLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(this.config.pollLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		this.registry.stop();
 		assertThat(this.config.closeLatch.await(10, TimeUnit.SECONDS)).isTrue();
-		InOrder inOrder = inOrder(this.consumer, this.producer);
-		inOrder.verify(this.consumer).subscribe(any(Collection.class), any(ConsumerRebalanceListener.class));
+		InOrder inOrder = inOrder(this.consumer, this.config.eh);
+		inOrder.verify(this.consumer).assign(any(Collection.class));
 		inOrder.verify(this.consumer).poll(Duration.ofMillis(ContainerProperties.DEFAULT_POLL_TIMEOUT));
-		Map<TopicPartition, OffsetAndMetadata> offsets = new LinkedHashMap<>();
-		offsets.put(new TopicPartition("foo", 0), new OffsetAndMetadata(2L));
-		offsets.put(new TopicPartition("foo", 1), new OffsetAndMetadata(1L));
-		inOrder.verify(this.consumer).commitSync(offsets, Duration.ofSeconds(60));
-		inOrder.verify(this.consumer).pause(any());
-		offsets = new LinkedHashMap<>();
-		offsets.put(new TopicPartition("foo", 1), new OffsetAndMetadata(2L));
-		offsets.put(new TopicPartition("foo", 2), new OffsetAndMetadata(2L));
-		inOrder.verify(this.consumer).commitSync(offsets, Duration.ofSeconds(60));
-		inOrder.verify(this.consumer).resume(any());
-		assertThat(this.config.ehException).isInstanceOf(ListenerExecutionFailedException.class);
-		assertThat(((ListenerExecutionFailedException) this.config.ehException).getGroupId()).isEqualTo(CONTAINER_ID);
-		assertThat(this.config.contents).contains("foo", "bar", "baz", "qux", "qux", "qux", "fiz", "buz");
+		inOrder.verify(this.consumer).commitSync(
+				Collections.singletonMap(new TopicPartition("foo", 0), new OffsetAndMetadata(1L)),
+				Duration.ofSeconds(60));
+		inOrder.verify(this.config.eh).handleRemaining(any(), any(), any(), any());
+		verify(this.consumer, times(3)).seek(any(), anyLong());
 	}
 
 	@Configuration
 	@EnableKafka
 	public static class Config {
 
-		final CountDownLatch pollLatch = new CountDownLatch(1);
+		final List<String> contents = new ArrayList<>();
 
-		final CountDownLatch deliveryLatch = new CountDownLatch(2);
+		final List<Integer> deliveries = new ArrayList<>();
+
+		final CountDownLatch pollLatch = new CountDownLatch(4);
+
+		final CountDownLatch deliveryLatch = new CountDownLatch(1);
 
 		final CountDownLatch closeLatch = new CountDownLatch(1);
 
-		final CountDownLatch commitLatch = new CountDownLatch(2);
+		final CountDownLatch commitLatch = new CountDownLatch(1);
 
-		final AtomicBoolean fail = new AtomicBoolean(true);
+		DefaultErrorHandler eh;
 
-		final List<String> contents = new ArrayList<>();
+		int count;
 
-		volatile Exception ehException;
+		volatile org.apache.kafka.common.header.Header deliveryAttempt;
 
-		@KafkaListener(id = CONTAINER_ID, topics = "foo")
-		public void foo(List<String> in) {
-			this.contents.addAll(in);
+		@KafkaListener(groupId = "grp",
+				topicPartitions = @org.springframework.kafka.annotation.TopicPartition(topic = "foo",
+						partitions = "#{'0,1,2'.split(',')}"))
+		public void foo(String in, @Header(KafkaHeaders.DELIVERY_ATTEMPT) int delivery) {
+			this.contents.add(in);
+			this.deliveries.add(delivery);
 			this.deliveryLatch.countDown();
-			if (this.fail.getAndSet(false)) {
-				throw new BatchListenerFailedException("test", 3);
+			if (++this.count == 4 || this.count == 5) { // part 1, offset 1, first and second times
+				throw new RuntimeException("foo");
 			}
 		}
 
@@ -154,7 +148,7 @@ public class DefaultErrorHandlerNoSeeksBatchListenerTests {
 		public ConsumerFactory consumerFactory() {
 			ConsumerFactory consumerFactory = mock(ConsumerFactory.class);
 			final Consumer consumer = consumer();
-			given(consumerFactory.createConsumer(CONTAINER_ID, "", "-0", KafkaTestUtils.defaultPropertyOverrides()))
+			given(consumerFactory.createConsumer("grp", "", "-0", KafkaTestUtils.defaultPropertyOverrides()))
 				.willReturn(consumer);
 			return consumerFactory;
 		}
@@ -166,11 +160,6 @@ public class DefaultErrorHandlerNoSeeksBatchListenerTests {
 			final TopicPartition topicPartition0 = new TopicPartition("foo", 0);
 			final TopicPartition topicPartition1 = new TopicPartition("foo", 1);
 			final TopicPartition topicPartition2 = new TopicPartition("foo", 2);
-			willAnswer(i -> {
-				((ConsumerRebalanceListener) i.getArgument(1)).onPartitionsAssigned(
-						Collections.singletonList(topicPartition1));
-				return null;
-			}).given(consumer).subscribe(any(Collection.class), any(ConsumerRebalanceListener.class));
 			Map<TopicPartition, List<ConsumerRecord>> records1 = new LinkedHashMap<>();
 			records1.put(topicPartition0, Arrays.asList(
 					new ConsumerRecord("foo", 0, 0L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, null, "foo",
@@ -203,54 +192,48 @@ public class DefaultErrorHandlerNoSeeksBatchListenerTests {
 						return new ConsumerRecords(Collections.emptyMap());
 				}
 			}).given(consumer).poll(Duration.ofMillis(ContainerProperties.DEFAULT_POLL_TIMEOUT));
+			List<TopicPartition> paused = new ArrayList<>();
+			AtomicBoolean first = new AtomicBoolean(true);
 			willAnswer(i -> {
 				this.commitLatch.countDown();
+				if (first.getAndSet(false)) {
+					throw new CommitFailedException();
+				}
 				return null;
 			}).given(consumer).commitSync(anyMap(), any());
 			willAnswer(i -> {
 				this.closeLatch.countDown();
 				return null;
 			}).given(consumer).close();
-			willReturn(new ConsumerGroupMetadata(CONTAINER_ID)).given(consumer).groupMetadata();
+			willAnswer(i -> {
+				paused.addAll(i.getArgument(0));
+				return null;
+			}).given(consumer).pause(any());
+			willAnswer(i -> {
+				return new HashSet<>(paused);
+			}).given(consumer).paused();
+			willAnswer(i -> {
+				paused.removeAll(i.getArgument(0));
+				return null;
+			}).given(consumer).resume(any());
 			return consumer;
 		}
 
 		@SuppressWarnings({ "rawtypes", "unchecked" })
 		@Bean
-		public ConcurrentKafkaListenerContainerFactory kafkaListenerContainerFactory() {
+		ConcurrentKafkaListenerContainerFactory kafkaListenerContainerFactory() {
 			ConcurrentKafkaListenerContainerFactory factory = new ConcurrentKafkaListenerContainerFactory();
 			factory.setConsumerFactory(consumerFactory());
-			factory.setBatchListener(true);
-			DefaultErrorHandler eh = new DefaultErrorHandler() {
-
-				@Override
-				public <K, V> ConsumerRecords<K, V> handleBatchAndReturnRemaining(Exception thrownException,
-						ConsumerRecords<?, ?> data, Consumer<?, ?> consumer, MessageListenerContainer container,
-						Runnable invokeListener) {
-
-					Config.this.ehException = thrownException;
-					return super.handleBatchAndReturnRemaining(thrownException, data, consumer, container, invokeListener);
-				}
-
-			};
-			eh.setSeekAfterError(false);
+			factory.getContainerProperties().setAckMode(AckMode.RECORD);
+			factory.getContainerProperties().setDeliveryAttemptHeader(true);
+			factory.setRecordInterceptor((record, consumer) -> {
+				Config.this.deliveryAttempt = record.headers().lastHeader(KafkaHeaders.DELIVERY_ATTEMPT);
+				return record;
+			});
+			this.eh = spy(new DefaultErrorHandler());
+			this.eh.setSeekAfterError(false);
 			factory.setCommonErrorHandler(eh);
 			return factory;
-		}
-
-		@SuppressWarnings("rawtypes")
-		@Bean
-		public ProducerFactory producerFactory() {
-			ProducerFactory pf = mock(ProducerFactory.class);
-			given(pf.createProducer(isNull())).willReturn(producer());
-			given(pf.transactionCapable()).willReturn(true);
-			return pf;
-		}
-
-		@SuppressWarnings("rawtypes")
-		@Bean
-		public Producer producer() {
-			return mock(Producer.class);
 		}
 
 	}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/DefaultErrorHandlerSeekAfterCommitExceptionBatchAck.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/DefaultErrorHandlerSeekAfterCommitExceptionBatchAck.java
@@ -18,19 +18,22 @@ package org.springframework.kafka.listener;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willAnswer;
-import static org.mockito.BDDMockito.willReturn;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,13 +43,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.kafka.clients.consumer.CommitFailedException;
 import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
-import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.clients.consumer.OffsetAndMetadata;
-import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.record.TimestampType;
@@ -61,8 +61,10 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
 import org.springframework.kafka.core.ConsumerFactory;
-import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.listener.ContainerProperties.AckMode;
+import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
@@ -73,18 +75,11 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
  */
 @SpringJUnitConfig
 @DirtiesContext
-@SuppressWarnings("deprecation")
-public class DefaultErrorHandlerNoSeeksBatchListenerTests {
-
-	private static final String CONTAINER_ID = "container";
+public class DefaultErrorHandlerSeekAfterCommitExceptionBatchAck {
 
 	@SuppressWarnings("rawtypes")
 	@Autowired
 	private Consumer consumer;
-
-	@SuppressWarnings("rawtypes")
-	@Autowired
-	private Producer producer;
 
 	@Autowired
 	private Config config;
@@ -93,59 +88,58 @@ public class DefaultErrorHandlerNoSeeksBatchListenerTests {
 	private KafkaListenerEndpointRegistry registry;
 
 	/*
-	 * Deliver 6 records from three partitions, fail on the second record second
-	 * partition.
+	 * Fail with commit exception - always seek.
 	 */
 	@SuppressWarnings("unchecked")
 	@Test
-	void retriesWithNoSeeksBatchListener() throws Exception {
+	public void forceSeeksWithCommitException() throws Exception {
 		assertThat(this.config.deliveryLatch.await(10, TimeUnit.SECONDS)).isTrue();
-		assertThat(this.config.pollLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(this.config.commitLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(this.config.pollLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(this.config.handleLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		this.registry.stop();
 		assertThat(this.config.closeLatch.await(10, TimeUnit.SECONDS)).isTrue();
-		InOrder inOrder = inOrder(this.consumer, this.producer);
-		inOrder.verify(this.consumer).subscribe(any(Collection.class), any(ConsumerRebalanceListener.class));
+		InOrder inOrder = inOrder(this.consumer, this.config.eh);
+		inOrder.verify(this.consumer).assign(any(Collection.class));
 		inOrder.verify(this.consumer).poll(Duration.ofMillis(ContainerProperties.DEFAULT_POLL_TIMEOUT));
-		Map<TopicPartition, OffsetAndMetadata> offsets = new LinkedHashMap<>();
-		offsets.put(new TopicPartition("foo", 0), new OffsetAndMetadata(2L));
-		offsets.put(new TopicPartition("foo", 1), new OffsetAndMetadata(1L));
-		inOrder.verify(this.consumer).commitSync(offsets, Duration.ofSeconds(60));
-		inOrder.verify(this.consumer).pause(any());
-		offsets = new LinkedHashMap<>();
-		offsets.put(new TopicPartition("foo", 1), new OffsetAndMetadata(2L));
-		offsets.put(new TopicPartition("foo", 2), new OffsetAndMetadata(2L));
-		inOrder.verify(this.consumer).commitSync(offsets, Duration.ofSeconds(60));
-		inOrder.verify(this.consumer).resume(any());
-		assertThat(this.config.ehException).isInstanceOf(ListenerExecutionFailedException.class);
-		assertThat(((ListenerExecutionFailedException) this.config.ehException).getGroupId()).isEqualTo(CONTAINER_ID);
-		assertThat(this.config.contents).contains("foo", "bar", "baz", "qux", "qux", "qux", "fiz", "buz");
+		inOrder.verify(this.consumer).commitSync(any(), any());
+		inOrder.verify(this.config.eh).handleRemaining(any(), any(), any(), any());
+		verify(this.consumer, times(2)).seek(any(), anyLong());
 	}
 
 	@Configuration
 	@EnableKafka
 	public static class Config {
 
-		final CountDownLatch pollLatch = new CountDownLatch(1);
+		final List<String> contents = new ArrayList<>();
 
-		final CountDownLatch deliveryLatch = new CountDownLatch(2);
+		final List<Integer> deliveries = new ArrayList<>();
+
+		final CountDownLatch pollLatch = new CountDownLatch(4);
+
+		final CountDownLatch deliveryLatch = new CountDownLatch(1);
 
 		final CountDownLatch closeLatch = new CountDownLatch(1);
 
-		final CountDownLatch commitLatch = new CountDownLatch(2);
+		final CountDownLatch commitLatch = new CountDownLatch(1);
 
-		final AtomicBoolean fail = new AtomicBoolean(true);
+		final CountDownLatch handleLatch = new CountDownLatch(1);
 
-		final List<String> contents = new ArrayList<>();
+		DefaultErrorHandler eh;
 
-		volatile Exception ehException;
+		int count;
 
-		@KafkaListener(id = CONTAINER_ID, topics = "foo")
-		public void foo(List<String> in) {
-			this.contents.addAll(in);
+		volatile org.apache.kafka.common.header.Header deliveryAttempt;
+
+		@KafkaListener(groupId = "grp",
+				topicPartitions = @org.springframework.kafka.annotation.TopicPartition(topic = "foo",
+						partitions = "#{'0,1,2'.split(',')}"))
+		public void foo(String in, @Header(KafkaHeaders.DELIVERY_ATTEMPT) int delivery) {
+			this.contents.add(in);
+			this.deliveries.add(delivery);
 			this.deliveryLatch.countDown();
-			if (this.fail.getAndSet(false)) {
-				throw new BatchListenerFailedException("test", 3);
+			if (++this.count == 4 || this.count == 5) { // part 1, offset 1, first and second times
+				throw new RuntimeException("foo");
 			}
 		}
 
@@ -154,7 +148,7 @@ public class DefaultErrorHandlerNoSeeksBatchListenerTests {
 		public ConsumerFactory consumerFactory() {
 			ConsumerFactory consumerFactory = mock(ConsumerFactory.class);
 			final Consumer consumer = consumer();
-			given(consumerFactory.createConsumer(CONTAINER_ID, "", "-0", KafkaTestUtils.defaultPropertyOverrides()))
+			given(consumerFactory.createConsumer("grp", "", "-0", KafkaTestUtils.defaultPropertyOverrides()))
 				.willReturn(consumer);
 			return consumerFactory;
 		}
@@ -166,11 +160,6 @@ public class DefaultErrorHandlerNoSeeksBatchListenerTests {
 			final TopicPartition topicPartition0 = new TopicPartition("foo", 0);
 			final TopicPartition topicPartition1 = new TopicPartition("foo", 1);
 			final TopicPartition topicPartition2 = new TopicPartition("foo", 2);
-			willAnswer(i -> {
-				((ConsumerRebalanceListener) i.getArgument(1)).onPartitionsAssigned(
-						Collections.singletonList(topicPartition1));
-				return null;
-			}).given(consumer).subscribe(any(Collection.class), any(ConsumerRebalanceListener.class));
 			Map<TopicPartition, List<ConsumerRecord>> records1 = new LinkedHashMap<>();
 			records1.put(topicPartition0, Arrays.asList(
 					new ConsumerRecord("foo", 0, 0L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, null, "foo",
@@ -203,54 +192,57 @@ public class DefaultErrorHandlerNoSeeksBatchListenerTests {
 						return new ConsumerRecords(Collections.emptyMap());
 				}
 			}).given(consumer).poll(Duration.ofMillis(ContainerProperties.DEFAULT_POLL_TIMEOUT));
+			List<TopicPartition> paused = new ArrayList<>();
+			AtomicBoolean first = new AtomicBoolean(true);
 			willAnswer(i -> {
 				this.commitLatch.countDown();
+				if (first.getAndSet(false)) {
+					throw new CommitFailedException();
+				}
 				return null;
 			}).given(consumer).commitSync(anyMap(), any());
 			willAnswer(i -> {
 				this.closeLatch.countDown();
 				return null;
 			}).given(consumer).close();
-			willReturn(new ConsumerGroupMetadata(CONTAINER_ID)).given(consumer).groupMetadata();
+			willAnswer(i -> {
+				paused.addAll(i.getArgument(0));
+				return null;
+			}).given(consumer).pause(any());
+			willAnswer(i -> {
+				return new HashSet<>(paused);
+			}).given(consumer).paused();
+			willAnswer(i -> {
+				paused.removeAll(i.getArgument(0));
+				return null;
+			}).given(consumer).resume(any());
 			return consumer;
 		}
 
 		@SuppressWarnings({ "rawtypes", "unchecked" })
 		@Bean
-		public ConcurrentKafkaListenerContainerFactory kafkaListenerContainerFactory() {
+		ConcurrentKafkaListenerContainerFactory kafkaListenerContainerFactory() {
 			ConcurrentKafkaListenerContainerFactory factory = new ConcurrentKafkaListenerContainerFactory();
 			factory.setConsumerFactory(consumerFactory());
-			factory.setBatchListener(true);
-			DefaultErrorHandler eh = new DefaultErrorHandler() {
-
-				@Override
-				public <K, V> ConsumerRecords<K, V> handleBatchAndReturnRemaining(Exception thrownException,
-						ConsumerRecords<?, ?> data, Consumer<?, ?> consumer, MessageListenerContainer container,
-						Runnable invokeListener) {
-
-					Config.this.ehException = thrownException;
-					return super.handleBatchAndReturnRemaining(thrownException, data, consumer, container, invokeListener);
+			factory.getContainerProperties().setAckMode(AckMode.BATCH);
+			factory.getContainerProperties().setDeliveryAttemptHeader(true);
+			factory.setRecordInterceptor((record, consumer) -> {
+				Config.this.deliveryAttempt = record.headers().lastHeader(KafkaHeaders.DELIVERY_ATTEMPT);
+				return record;
+			});
+			this.eh = spy(new DefaultErrorHandler());
+			this.eh.setSeekAfterError(false);
+			willAnswer(inv -> {
+				try {
+					inv.callRealMethod();
 				}
-
-			};
-			eh.setSeekAfterError(false);
+				finally {
+					this.handleLatch.countDown();
+				}
+				return null;
+			}).given(this.eh).handleRemaining(any(), any(), any(), any());
 			factory.setCommonErrorHandler(eh);
 			return factory;
-		}
-
-		@SuppressWarnings("rawtypes")
-		@Bean
-		public ProducerFactory producerFactory() {
-			ProducerFactory pf = mock(ProducerFactory.class);
-			given(pf.createProducer(isNull())).willReturn(producer());
-			given(pf.transactionCapable()).willReturn(true);
-			return pf;
-		}
-
-		@SuppressWarnings("rawtypes")
-		@Bean
-		public Producer producer() {
-			return mock(Producer.class);
 		}
 
 	}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/DefaultErrorHandlerSeekAfterCommitExceptionBatchAckTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/DefaultErrorHandlerSeekAfterCommitExceptionBatchAckTests.java
@@ -75,7 +75,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
  */
 @SpringJUnitConfig
 @DirtiesContext
-public class DefaultErrorHandlerSeekAfterCommitExceptionBatchAck {
+public class DefaultErrorHandlerSeekAfterCommitExceptionBatchAckTests {
 
 	@SuppressWarnings("rawtypes")
 	@Autowired

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/DefaultErrorHandlerSeekAfterCommitExceptionTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/DefaultErrorHandlerSeekAfterCommitExceptionTests.java
@@ -76,7 +76,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
  */
 @SpringJUnitConfig
 @DirtiesContext
-public class DefaultErrorHandlerSeekAfterCommitException {
+public class DefaultErrorHandlerSeekAfterCommitExceptionTests {
 
 	@SuppressWarnings("rawtypes")
 	@Autowired


### PR DESCRIPTION
- Revert to seeking when `CommitFailedException` - due to a rebalance
- For batch listeners, move committing to the try block
- For record listeners, `AckMode.RECORD` already commits in the try block
- With `AckMode.BATCH`, detect a no-seek retry and call the error handler `handleRemaining`

**cherry-pick to 2.9.x**

