### PR TITLE
Changed log level to improve troubleshooting

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -3058,7 +3058,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 				doCommitSync(commits, retries + 1);
 			}
 			catch (RebalanceInProgressException e) {
-				this.logger.debug(e, "Non-fatal commit failure");
+				this.logger.warn(e, "Non-fatal commit failure");
 				this.commitsDuringRebalance.putAll(commits);
 			}
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -3066,7 +3066,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 				doCommitSync(commits, retries + 1);
 			}
 			catch (RebalanceInProgressException e) {
-				this.logger.warn(e, "Non-fatal commit failure");
+				this.logger.debug(e, "Non-fatal commit failure");
 				this.commitsDuringRebalance.putAll(commits);
 			}
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -1552,12 +1552,12 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 						.filter(entry -> this.assignedPartitions.contains(entry.getKey()))
 						.collect(Collectors.toMap(Entry::getKey, Entry::getValue));
 
-			   Map<TopicPartition, OffsetAndMetadata> uncommitted = this.commitsDuringRebalance.entrySet()
-					   .stream()
-					   .filter(entry -> !this.assignedPartitions.contains(entry.getKey()))
-					   .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
-			   this.logger.warn(() -> "These offsets could not be committed; partition(s) lost during rebalance: "
-							   + uncommitted);
+				Map<TopicPartition, OffsetAndMetadata> uncommitted = this.commitsDuringRebalance.entrySet()
+						.stream()
+						.filter(entry -> !this.assignedPartitions.contains(entry.getKey()))
+						.collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+				this.logger.warn(() -> "These offsets could not be committed; partition(s) lost during rebalance: "
+								+ uncommitted);
 
 				this.commitsDuringRebalance.clear();
 				this.logger.debug(() -> "Commit list: " + commits);

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -1550,7 +1550,15 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 				Map<TopicPartition, OffsetAndMetadata> commits = this.commitsDuringRebalance.entrySet()
 						.stream()
 						.filter(entry -> this.assignedPartitions.contains(entry.getKey()))
-						.collect(Collectors.toMap(entry -> entry.getKey(), entry -> entry.getValue()));
+						.collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+
+			   Map<TopicPartition, OffsetAndMetadata> uncommitted = this.commitsDuringRebalance.entrySet()
+					   .stream()
+					   .filter(entry -> !this.assignedPartitions.contains(entry.getKey()))
+					   .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+			   this.logger.warn(() -> "These offsets could not be committed; partition(s) lost during rebalance: "
+							   + uncommitted);
+
 				this.commitsDuringRebalance.clear();
 				this.logger.debug(() -> "Commit list: " + commits);
 				commitSync(commits);


### PR DESCRIPTION
I think that it will be useful to change the log level from debug to warn in case of RebalanceInProgressException in order to improve troubleshooting.
because we may have a situation when the same message may be processed multiple times. This is not a common situation and users should be able to understand it by reading the logs easily.
For example:

1. Concurrent Kafka listener received a message
2. Rebalancing started for some reasons
3. Kafka listener processed message successfully
4. Kafka listener tries to commit offset but failed because of rebalancing in progress 
5. Another consumer receive this message after competition of rebalancing 
6. No information in the logs that something was wrong and why offset was not committed

I mean this message should see users

` o.s.k.l.KafkaMessageListenerContainer    : Non-fatal commit failure

org.apache.kafka.common.errors.RebalanceInProgressException: Offset commit cannot be completed since the consumer is undergoing a rebalance for auto partition assignment. You can try completing the rebalance by calling poll() and then retry the operation.`

