### PR TITLE
GH-2297: Add KLERegistry.alwaysStartAfterRefresh

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -1953,6 +1953,10 @@ A collection of managed containers can be obtained by calling the registry's `ge
 Version 2.2.5 added a convenience method `getAllListenerContainers()`, which returns a collection of all containers, including those managed by the registry and those declared as beans.
 The collection returned will include any prototype beans that have been initialized, but it will not initialize any lazy bean declarations.
 
+IMPORTANT: Endpoints registered after the application context has been refreshed will start immediately, regardless of their `autoStartup` property, to comply with the `SmartLifecycle` contract, where `autoStartup` is only considered during application context initialization.
+An example of late registration is a bean with a `@KafkaListener` in prototype scope where an instance is created after the context is initialized.
+Starting with version 2.8.7, you can set the registry's `alwaysStartAfterRefresh` property to `false` and then the container's `autoStartup` property will define whether or not the container is started.
+
 [[kafka-validation]]
 ===== `@KafkaListener` `@Payload` Validation
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -71,9 +71,12 @@ import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Role;
+import org.springframework.context.annotation.Scope;
 import org.springframework.context.event.EventListener;
 import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
 import org.springframework.core.MethodParameter;
@@ -179,7 +182,7 @@ import jakarta.validation.constraints.Max;
 		"annotated25", "annotated25reply1", "annotated25reply2", "annotated26", "annotated27", "annotated28",
 		"annotated29", "annotated30", "annotated30reply", "annotated31", "annotated32", "annotated33",
 		"annotated34", "annotated35", "annotated36", "annotated37", "foo", "manualStart", "seekOnIdle",
-		"annotated38", "annotated38reply", "annotated39", "annotated40", "annotated41" })
+		"annotated38", "annotated38reply", "annotated39", "annotated40", "annotated41", "annotated42" })
 @TestPropertySource(properties = "spel.props=fetch.min.bytes=420000,max.poll.records=10")
 public class EnableKafkaIntegrationTests {
 
@@ -981,6 +984,14 @@ public class EnableKafkaIntegrationTests {
 		assertThat(this.listener.contentFoo).isEqualTo(new Foo("bar"));
 	}
 
+	@Test
+	void proto(@Autowired ApplicationContext context) {
+		this.registry.setAlwaysStartAfterRefresh(false);
+		context.getBean(ProtoListener.class);
+		assertThat(this.registry.getListenerContainer("proto").isRunning()).isFalse();
+		this.registry.setAlwaysStartAfterRefresh(true);
+	}
+
 	@Configuration
 	@EnableKafka
 	@EnableTransactionManagement(proxyTargetClass = true)
@@ -1708,6 +1719,20 @@ public class EnableKafkaIntegrationTests {
 		@Bean
 		String barInfo() {
 			return "info for the bar listener";
+		}
+
+		@Bean
+		@Scope(ConfigurableBeanFactory.SCOPE_PROTOTYPE)
+		ProtoListener proto() {
+			return new ProtoListener();
+		}
+
+	}
+
+	static class ProtoListener {
+
+		@KafkaListener(id = "proto", topics = "annotated-42", autoStartup = "false")
+		public void listen(String in) {
 		}
 
 	}


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2297

Add an option to apply `autoStartup` semantics to late registrations.

**cherry-pick to 2.9.x, 2.8.x**

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
