### PR TITLE
GH-2304: Fix SendTo on Interface Etc.

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/config/MethodKafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/MethodKafkaListenerEndpoint.java
@@ -25,7 +25,7 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.config.BeanExpressionContext;
 import org.springframework.beans.factory.config.BeanExpressionResolver;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
-import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.log.LogAccessor;
 import org.springframework.expression.BeanResolver;
 import org.springframework.kafka.listener.KafkaListenerErrorHandler;
@@ -132,7 +132,7 @@ public class MethodKafkaListenerEndpoint<K, V> extends AbstractKafkaListenerEndp
 	private String getReplyTopic() {
 		Method replyingMethod = getMethod();
 		if (replyingMethod != null) {
-			SendTo ann = AnnotationUtils.getAnnotation(replyingMethod, SendTo.class);
+			SendTo ann = AnnotatedElementUtils.findMergedAnnotation(replyingMethod, SendTo.class);
 			if (ann != null) {
 				if (replyingMethod.getReturnType().equals(void.class)) {
 					this.logger.warn(() -> "Method "

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/DelegatingInvocableHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/DelegatingInvocableHandler.java
@@ -31,7 +31,7 @@ import org.springframework.beans.factory.config.BeanExpressionContext;
 import org.springframework.beans.factory.config.BeanExpressionResolver;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.core.MethodParameter;
-import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.expression.Expression;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.kafka.KafkaException;
@@ -193,12 +193,12 @@ public class DelegatingInvocableHandler {
 		Method method = handler.getMethod();
 		SendTo ann = null;
 		if (method != null) {
-			ann = AnnotationUtils.getAnnotation(method, SendTo.class);
+			ann = AnnotatedElementUtils.findMergedAnnotation(method, SendTo.class);
 			replyTo = extractSendTo(method.toString(), ann);
 		}
 		if (ann == null) {
 			Class<?> beanType = handler.getBeanType();
-			ann = AnnotationUtils.getAnnotation(beanType, SendTo.class);
+			ann = AnnotatedElementUtils.findMergedAnnotation(beanType, SendTo.class);
 			replyTo = extractSendTo(beanType.getSimpleName(), ann);
 		}
 		if (ann != null && replyTo == null) {


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2304

`@SendTo` was only detected on the concrete listener method.

Use `AnnotatedElementUtils.findMergedAnnotation()` instead.

**cherry-pick to 2.9.x, 2.8.x**
