### PR TITLE
GH-2195: Polishing

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -782,6 +782,8 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 
 		private ConsumerRecords<K, V> pendingRecordsAfterError;
 
+		private boolean pauseForPending;
+
 		private volatile boolean consumerPaused;
 
 		private volatile Thread consumerThread;
@@ -1566,7 +1568,10 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 								+ "after an error; emergency stop invoked to avoid message loss", howManyRecords));
 						KafkaMessageListenerContainer.this.emergencyStop.run();
 					}
-					if (!isPartitionPaused(this.pendingRecordsAfterError.partitions().iterator().next())) {
+					TopicPartition firstPart = this.pendingRecordsAfterError.partitions().iterator().next();
+					boolean isPaused = isPartitionPauseRequested(firstPart);
+					logger.debug(() -> "First pending after error: " + firstPart + "; paused: " + isPaused);
+					if (!isPaused) {
 						records = this.pendingRecordsAfterError;
 						this.pendingRecordsAfterError = null;
 					}
@@ -1682,10 +1687,11 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 				this.logger.debug(() -> "Pausing for incomplete async acks: " + this.offsetsInThisBatch);
 			}
 			if (!this.consumerPaused && (isPaused() || this.pausedForAsyncAcks)
-					|| this.pendingRecordsAfterError != null) {
+					|| this.pauseForPending) {
 
 				this.consumer.pause(this.consumer.assignment());
 				this.consumerPaused = true;
+				this.pauseForPending = false;
 				this.logger.debug(() -> "Paused consumption from: " + this.consumer.paused());
 				publishConsumerPausedEvent(this.consumer.assignment());
 			}
@@ -2385,6 +2391,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 						() -> invokeBatchOnMessageWithRecordsOrList(records, list));
 				if (!afterHandling.isEmpty()) {
 					this.pendingRecordsAfterError = afterHandling;
+					this.pauseForPending = true;
 				}
 			}
 		}
@@ -2778,6 +2785,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 				}
 				if (records.size() > 0) {
 					this.pendingRecordsAfterError = new ConsumerRecords<>(records);
+					this.pauseForPending = true;
 				}
 			}
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -1570,7 +1570,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 					}
 					TopicPartition firstPart = this.pendingRecordsAfterError.partitions().iterator().next();
 					boolean isPaused = isPartitionPauseRequested(firstPart);
-					logger.debug(() -> "First pending after error: " + firstPart + "; paused: " + isPaused);
+					this.logger.debug(() -> "First pending after error: " + firstPart + "; paused: " + isPaused);
 					if (!isPaused) {
 						records = this.pendingRecordsAfterError;
 						this.pendingRecordsAfterError = null;


### PR DESCRIPTION
Related to https://github.com/spring-projects/spring-kafka/issues/2195

- check `isPartitionPauseRequested()` instead of `isPartitionPaused()`
- add diagnostic debug logging
- prevent re-pausing the entire consumer each time a poll exits but the first
  partition is still paused.

**cherry-pick to 2.9.x**
