### PR TITLE
GH-2340: Fix Retrying Batch Error Handling

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonErrorHandler.java
@@ -16,12 +16,14 @@
 
 package org.springframework.kafka.listener;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
 
 import org.springframework.kafka.support.TopicPartitionOffset;
 
@@ -210,6 +212,15 @@ public interface CommonErrorHandler extends DeliveryAttemptAware {
 	 */
 	default void setAckAfterHandle(boolean ack) {
 		throw new UnsupportedOperationException("This error handler does not support setting this property");
+	}
+
+	/**
+	 * Called when partitions are assigned.
+	 * @param consumer the consumer.
+	 * @param partitions the newly assigned partitions.
+	 * @since 2.8.8
+	 */
+	default void onPartitionsAssigned(Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {
 	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/DefaultErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/DefaultErrorHandler.java
@@ -16,11 +16,13 @@
 
 package org.springframework.kafka.listener;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.SerializationException;
 
 import org.springframework.kafka.support.KafkaUtils;
@@ -197,6 +199,11 @@ public class DefaultErrorHandler extends FailedBatchProcessor implements CommonE
 					+ thrownException.getClass().getName()
 					+ "'s; no record information is available", thrownException);
 		}
+	}
+
+	@Override
+	public void onPartitionsAssigned(Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {
+		getFallbackBatchHandler().onPartitionsAssigned(consumer, partitions);
 	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ErrorHandlerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ErrorHandlerAdapter.java
@@ -16,12 +16,14 @@
 
 package org.springframework.kafka.listener;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
 
 import org.springframework.kafka.support.TopicPartitionOffset;
 import org.springframework.util.Assert;
@@ -157,6 +159,13 @@ class ErrorHandlerAdapter implements CommonErrorHandler {
 		}
 		else {
 			CommonErrorHandler.super.handleBatch(thrownException, data, consumer, container, invokeListener);
+		}
+	}
+
+	@Override
+	public void onPartitionsAssigned(Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {
+		if (this.batchErrorHandler instanceof FallbackBatchErrorHandler) {
+			((FallbackBatchErrorHandler) this.batchErrorHandler).onPartitionsAssigned(consumer, partitions);
 		}
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedBatchProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedBatchProcessor.java
@@ -70,6 +70,16 @@ public abstract class FailedBatchProcessor extends FailedRecordProcessor {
 	}
 
 	/**
+	 * Return the fallback batch error handler.
+	 * @return the handler.
+	 * @since 2.8.8
+	 */
+	protected CommonErrorHandler getFallbackBatchHandler() {
+		return this.fallbackBatchHandler;
+	}
+
+
+	/**
 	 * Construct an instance with the provided properties.
 	 * @param recoverer the recoverer.
 	 * @param backOff the back off.

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FallbackBatchErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FallbackBatchErrorHandler.java
@@ -16,11 +16,13 @@
 
 package org.springframework.kafka.listener;
 
+import java.util.Collection;
 import java.util.function.BiConsumer;
 
 import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
 
 import org.springframework.core.log.LogAccessor;
 import org.springframework.lang.Nullable;
@@ -53,6 +55,8 @@ class FallbackBatchErrorHandler extends KafkaExceptionLogLevelAware
 	private final CommonErrorHandler seeker = new ErrorHandlerAdapter(new SeekToCurrentBatchErrorHandler());
 
 	private boolean ackAfterHandle = true;
+
+	private boolean retrying;
 
 	/**
 	 * Construct an instance with a default {@link FixedBackOff} (unlimited attempts with
@@ -99,8 +103,16 @@ class FallbackBatchErrorHandler extends KafkaExceptionLogLevelAware
 			this.logger.error(thrownException, "Called with no records; consumer exception");
 			return;
 		}
+		this.retrying = true;
 		ErrorHandlingUtils.retryBatch(thrownException, records, consumer, container, invokeListener, this.backOff,
 				this.seeker, this.recoverer, this.logger, getLogLevel());
+		this.retrying = false;
+	}
+
+	public void onPartitionsAssigned(Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {
+		if (this.retrying) {
+			consumer.pause(consumer.assignment());
+		}
 	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -3464,6 +3464,10 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 					ListenerConsumer.this.firstPoll = true;
 					ListenerConsumer.this.consumerSeekAwareListener.onFirstPoll();
 				}
+				if (ListenerConsumer.this.commonErrorHandler != null) {
+					ListenerConsumer.this.commonErrorHandler.onPartitionsAssigned(ListenerConsumer.this.consumer,
+							partitions);
+				}
 			}
 
 			private void repauseIfNeeded(Collection<TopicPartition> partitions) {


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2340

The `RetryingBatchErrorHandler` - now called the `FallbackBatchErrorHandler`
pauses and resumes the consumer during retries, to allow it to poll the
consumer to avoid a forced rebalance.

However, if a normal rebalance occurs, for example if a new member joins,
the error handler does not re-pause the consumer and silently consumes
new records.

Add a mechanism to always re-pause the consume when in this retry mode.

**cherry-pick to 2.9.x, 2.8.x**

As well as the unit test, tested proper functionality by running two copies of a Boot app.