### PR TITLE
Remove `provided` deps from the target POM

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -234,12 +234,6 @@ subprojects { subproject ->
 					def pomDeps = asNode().dependencies.first()
 					subproject.configurations.providedImplementation.allDependencies.each { dep ->
 						pomDeps.remove(pomDeps.'*'.find { it.artifactId.text() == dep.name })
-						pomDeps.appendNode('dependency').with {
-							it.appendNode('groupId', dep.group)
-							it.appendNode('artifactId', dep.name)
-							it.appendNode('version', dep.version)
-							it.appendNode('scope', 'provided')
-						}
 					}
 				}
 			}


### PR DESCRIPTION
Related to https://github.com/spring-projects/spring-framework/issues/23486

We have this `providedApi 'org.junit.platform:junit-platform-launcher'`
where its `version` is resolved from `mavenBom "org.junit:junit-bom:$junitJupiterVersion"`.
When we generate a Maven POM, this kind of dependency is present as an `optional` by default.
We previously have overridden this to the `provided`, but it comes without a `version`.

According to Spring Framework decision this kind of transitive dependencies are misleading.

* Remove any `provided` deps in Gradle from the target POM altogether

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
