### PR TITLE
GH-2239: Fix Boot AutoConfiguration

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractKafkaBackOffManagerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractKafkaBackOffManagerFactory.java
@@ -87,7 +87,7 @@ public abstract class AbstractKafkaBackOffManagerFactory
 	}
 
 	@Override
-	public void setApplicationContext(ApplicationContext applicationContext) {
+	public final void setApplicationContext(ApplicationContext applicationContext) {
 		this.applicationContext = applicationContext;
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerPartitionPausingBackOffManagerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerPartitionPausingBackOffManagerFactory.java
@@ -16,6 +16,7 @@
 
 package org.springframework.kafka.listener;
 
+import org.springframework.context.ApplicationContext;
 import org.springframework.util.Assert;
 
 /**
@@ -32,9 +33,13 @@ public class ContainerPartitionPausingBackOffManagerFactory extends AbstractKafk
 	/**
 	 * Construct an instance with the provided properties.
 	 * @param listenerContainerRegistry the registry.
+	 * @param applicationContext the application context.
 	 */
-	public ContainerPartitionPausingBackOffManagerFactory(ListenerContainerRegistry listenerContainerRegistry) {
+	public ContainerPartitionPausingBackOffManagerFactory(ListenerContainerRegistry listenerContainerRegistry,
+			ApplicationContext applicationContext) {
+
 		super(listenerContainerRegistry);
+		setApplicationContext(applicationContext);
 	}
 
 	@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicBeanNames.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicBeanNames.java
@@ -19,12 +19,20 @@ package org.springframework.kafka.retrytopic;
 /**
  * The bean names for the non-blocking topic-based delayed retries feature.
  * @author Tomaz Fernandes
+ * @author Gary Russell
  * @since 2.9
  */
 public final class RetryTopicBeanNames {
 
 	private RetryTopicBeanNames() {
 	}
+
+	/**
+	 * The bean name of an internally managed retry topic configuration support, if
+	 * needed.
+	 */
+	public static final String DEFAULT_RETRY_TOPIC_CONFIG_SUPPORT_BEAN_NAME =
+			"org.springframework.kafka.retrytopic.internalRetryTopicConfigurationSupport";
 
 	/**
 	 * The bean name of the internally managed retry topic configurer.
@@ -48,6 +56,12 @@ public final class RetryTopicBeanNames {
 	 * The bean name of the internally managed listener container factory.
 	 */
 	public static final String DEFAULT_KAFKA_TEMPLATE_BEAN_NAME =
+			"defaultRetryTopicKafkaTemplate";
+
+	/**
+	 * The bean name of the internally registered scheduler wrapper, if needed.
+	 */
+	public static final String DEFAULT_SCHEDULER_WRAPPER_BEAN_NAME =
 			"defaultRetryTopicKafkaTemplate";
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicComponentFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicComponentFactory.java
@@ -19,6 +19,7 @@ package org.springframework.kafka.retrytopic;
 import java.time.Clock;
 
 import org.springframework.beans.factory.BeanFactory;
+import org.springframework.context.ApplicationContext;
 import org.springframework.kafka.config.KafkaListenerContainerFactory;
 import org.springframework.kafka.config.KafkaListenerEndpoint;
 import org.springframework.kafka.listener.ContainerPartitionPausingBackOffManagerFactory;
@@ -150,10 +151,13 @@ public class RetryTopicComponentFactory {
 	 * {@link KafkaConsumerBackoffManager} instance used to back off the partitions.
 	 * @param registry the {@link ListenerContainerRegistry} used to fetch the
 	 * {@link MessageListenerContainer}.
+	 * @param applicationContext the application context.
 	 * @return the instance.
 	 */
-	public KafkaBackOffManagerFactory kafkaBackOffManagerFactory(ListenerContainerRegistry registry) {
-		return new ContainerPartitionPausingBackOffManagerFactory(registry);
+	public KafkaBackOffManagerFactory kafkaBackOffManagerFactory(ListenerContainerRegistry registry,
+			ApplicationContext applicationContext) {
+
+		return new ContainerPartitionPausingBackOffManagerFactory(registry, applicationContext);
 	}
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationSupport.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationSupport.java
@@ -27,6 +27,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafkaRetryTopic;
@@ -72,7 +73,7 @@ public class RetryTopicConfigurationSupport {
 
 	private final RetryTopicComponentFactory componentFactory = createComponentFactory();
 
-	protected RetryTopicConfigurationSupport() {
+	public RetryTopicConfigurationSupport() {
 		Assert.state(ONLY_ONE_ALLOWED.getAndSet(false), "Only one 'RetryTopicConfigurationSupport' is allowed");
 	}
 
@@ -266,6 +267,7 @@ public class RetryTopicConfigurationSupport {
 	 * To provide a custom implementation, either override this method, or
 	 * override the {@link RetryTopicComponentFactory#kafkaBackOffManagerFactory} method
 	 * and return a different {@link KafkaBackOffManagerFactory}.
+	 * @param applicationContext the application context.
 	 * @param registry the {@link ListenerContainerRegistry} to be used to fetch the
 	 * {@link MessageListenerContainer} at runtime to be backed off.
 	 * @param wrapper a {@link RetryTopicSchedulerWrapper}.
@@ -273,13 +275,13 @@ public class RetryTopicConfigurationSupport {
 	 * @return the instance.
 	 */
 	@Bean(name = KafkaListenerConfigUtils.KAFKA_CONSUMER_BACK_OFF_MANAGER_BEAN_NAME)
-	public KafkaConsumerBackoffManager kafkaConsumerBackoffManager(
+	public KafkaConsumerBackoffManager kafkaConsumerBackoffManager(ApplicationContext applicationContext,
 			@Qualifier(KafkaListenerConfigUtils.KAFKA_LISTENER_ENDPOINT_REGISTRY_BEAN_NAME)
 					ListenerContainerRegistry registry, @Nullable RetryTopicSchedulerWrapper wrapper,
 					@Nullable TaskScheduler taskScheduler) {
 
 		KafkaBackOffManagerFactory backOffManagerFactory =
-				this.componentFactory.kafkaBackOffManagerFactory(registry);
+				this.componentFactory.kafkaBackOffManagerFactory(registry, applicationContext);
 		JavaUtils.INSTANCE.acceptIfInstanceOf(ContainerPartitionPausingBackOffManagerFactory.class, backOffManagerFactory,
 				factory -> configurePartitionPausingFactory(factory, registry,
 						wrapper != null ? wrapper.getScheduler() : taskScheduler));

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationSupportTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationSupportTests.java
@@ -35,6 +35,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 import org.springframework.beans.factory.BeanFactory;
+import org.springframework.context.ApplicationContext;
 import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
 import org.springframework.kafka.listener.ContainerPartitionPausingBackOffManagerFactory;
 import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
@@ -167,7 +168,8 @@ class RetryTopicConfigurationSupportTests {
 		KafkaConsumerBackoffManager backoffManagerMock = mock(KafkaConsumerBackoffManager.class);
 		TaskScheduler taskSchedulerMock = mock(TaskScheduler.class);
 		Clock clock = mock(Clock.class);
-		given(componentFactory.kafkaBackOffManagerFactory(registry)).willReturn(factory);
+		ApplicationContext ctx = mock(ApplicationContext.class);
+		given(componentFactory.kafkaBackOffManagerFactory(registry, ctx)).willReturn(factory);
 		given(factory.create()).willReturn(backoffManagerMock);
 		RetryTopicConfigurationSupport support = new RetryTopicConfigurationSupport() {
 
@@ -177,10 +179,10 @@ class RetryTopicConfigurationSupportTests {
 			}
 
 		};
-		KafkaConsumerBackoffManager backoffManager = support.kafkaConsumerBackoffManager(registry, null,
+		KafkaConsumerBackoffManager backoffManager = support.kafkaConsumerBackoffManager(ctx, registry, null,
 				taskSchedulerMock);
 		assertThat(backoffManager).isEqualTo(backoffManagerMock);
-		then(componentFactory).should().kafkaBackOffManagerFactory(registry);
+		then(componentFactory).should().kafkaBackOffManagerFactory(registry, ctx);
 		then(factory).should().create();
 	}
 
@@ -188,8 +190,10 @@ class RetryTopicConfigurationSupportTests {
 	void testCreateBackOffManagerNoConfiguration() {
 		ListenerContainerRegistry registry = mock(ListenerContainerRegistry.class);
 		TaskScheduler scheduler = mock(TaskScheduler.class);
+		ApplicationContext ctx = mock(ApplicationContext.class);
 		RetryTopicConfigurationSupport support = new RetryTopicConfigurationSupport();
-		KafkaConsumerBackoffManager backoffManager = support.kafkaConsumerBackoffManager(registry, null, scheduler);
+		KafkaConsumerBackoffManager backoffManager = support.kafkaConsumerBackoffManager(ctx, registry, null,
+				scheduler);
 		assertThat(backoffManager).isNotNull();
 	}
 


### PR DESCRIPTION
See https://github.com/spring-projects/spring-kafka/issues/2239

The previous commit removed the implicit bootstrap in favor of enforcing the
user to use the `@EnableKafkaRretryTopic` or explicitly extend
`RetryTopicConfigurationSupport`.

Unfortunately, this breaks Spring Boot because it can auto configure a
`RetryTopicConfiguration` bean, which means the infrastructure beans are required.

Fallback to late binding of the infrastructure beans if a `RetryTopicConfiguration`
bean is found in the application context.

Tested with a Boot app.

**cherry-pick to main**
