### PR TITLE
GH-2345: Fix Possible NPE in KafkaAdmin

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaAdmin.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaAdmin.java
@@ -301,13 +301,12 @@ public class KafkaAdmin extends KafkaResourceFactory
 				if (topicOptional.isPresent() && topicOptional.get().configs() != null) {
 					for (Map.Entry<String, String> desiredConfigParameter : topicOptional.get().configs().entrySet()) {
 						ConfigEntry actualConfigParameter = topicConfig.getValue().get(desiredConfigParameter.getKey());
-						if (!actualConfigParameter.value().equals(desiredConfigParameter.getValue())) {
+						if (!desiredConfigParameter.getValue().equals(actualConfigParameter.value())) {
 							configMismatchesEntries.add(actualConfigParameter);
 						}
-
-						if (configMismatchesEntries.size() > 0) {
-							configMismatches.put(topicConfig.getKey(), configMismatchesEntries);
-						}
+					}
+					if (configMismatchesEntries.size() > 0) {
+						configMismatches.put(topicConfig.getKey(), configMismatchesEntries);
 					}
 				}
 			}


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2345

I haven't been able to reproduce it since, but I saw one occasion where
the existing config property returned null.

Protect against an NPE in that case and add the property to the change
candidates.

Also move the map entry out of the for loop.

**cherry-pick to 2.9.x, 2.8.x**

