### PR TITLE
GH-2344: AggReplyingKT Support Custom Correlation

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/requestreply/ReplyingKafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/requestreply/ReplyingKafkaTemplate.java
@@ -252,6 +252,15 @@ public class ReplyingKafkaTemplate<K, V, R> extends KafkaTemplate<K, V> implemen
 	}
 
 	/**
+	 * Return the correlation header name.
+	 * @return the header name.
+	 * @since 2.8.8
+	 */
+	protected String getCorrelationHeaderName() {
+		return this.correlationHeaderName;
+	}
+
+	/**
 	 * Set a custom header name for the reply topic. Default
 	 * {@link KafkaHeaders#REPLY_TOPIC}.
 	 * @param replyTopicHeaderName the header name.


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2344

The `ReplyingKafkaTemplate` supports the use of a custom header name
for correlation, but the subclass `AggregatingReplyingKafkaTemplate`
was hard coded to use the default header.

Support the use of a custom header name in the subclass.

**cherry-pick to 2.9.x, 2.8.x**
