### PR TITLE
GH-2357: Switch to CompletableFuture

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -210,6 +210,21 @@ interface ProducerCallback<K, V, T> {
 
 See the https://docs.spring.io/spring-kafka/api/org/springframework/kafka/core/KafkaTemplate.html[Javadoc] for more detail.
 
+IMPORTANT: In version 3.0, the methods that return `ListenableFuture` will be changed to return `CompletableFuture`.
+To facilitate the migration, the 2.9 version has a method `.usingCompletableFuture()` which will provide the same methods with `CompletableFuture` return types.
+
+====
+[source, java]
+----
+KafkaOperations2<String, String> template = new KafkaTemplate<>().usingCompletableFuture();
+CompletableFuture<SendResult<String, String>> future = template.send(topic1, 0, 0, "buz")
+        .whenComplete((sr, thrown) -> {
+            ...
+         });
+)
+----
+====
+
 The `sendDefault` API requires that a default topic has been provided to the template.
 
 The API takes in a `timestamp` as a parameter and stores this timestamp in the record.
@@ -553,6 +568,9 @@ The result is a `ListenableFuture` that is asynchronously populated with the res
 The result also has a `sendFuture` property, which is the result of calling `KafkaTemplate.send()`.
 You can use this future to determine the result of the send operation.
 
+IMPORTANT: In version 3.0, the futures returned by these methods (and their `sendFuture` properties) will be `CompletableFuture` s instead of `ListenableFuture` s.
+To assit in the transition, using this release, you can convert these types to a `CompleteableFuture` by calling `asCompletable()` on the returned `Future`.
+
 If the first method is used, or the `replyTimeout` argument is `null`, the template's `defaultReplyTimeout` property is used (5 seconds by default).
 
 Starting with version 2.8.8, the template has a new method `waitForAssignment`.
@@ -790,6 +808,9 @@ RequestReplyMessageFuture<K, V> sendAndReceive(Message<?> message);
 ====
 
 These will use the template's default `replyTimeout`, there are also overloaded versions that can take a timeout in the method call.
+
+IMPORTANT: In version 3.0, the futures returned by these methods (and their `sendFuture` properties) will be `CompletableFuture` s instead of `ListenableFuture` s.
+To assit in the transition, using this release, you can convert these types to a `CompleteableFuture` by calling `asCompletable()` on the returned `Future`.
 
 Use the first method if the consumer's `Deserializer` or the template's `MessageConverter` can convert the payload without any additional information, either via configuration or type metadata in the reply message.
 

--- a/spring-kafka-docs/src/main/asciidoc/whats-new.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/whats-new.adoc
@@ -35,9 +35,18 @@ You can now configure which inbound headers should be mapped.
 Also available in version 2.8.8 or later.
 See <<headers>> for more information.
 
+[[x29-template-changes]]
+==== `KafkaTemplate` Changes
+
+In 3.0, the futures returned by this class will be `CompletableFuture` s instead of `ListenableFuture` s.
+See <<kafka-template>> for assistance in transitioning when using this release.
+
 [[x29-rkt-changes]]
 ==== `ReplyingKafkaTemplate` Changes
 
 The template now provides a method to wait for assignment on the reply container, to avoid a race when sending a request before the reply container is initialized.
 Also available in version 2.8.8 or later.
 See <<replying-template>>.
+
+In 3.0, the futures returned by this class will be `CompletableFuture` s instead of `ListenableFuture` s.
+See <<replying-template>> and <<exchanging-messages>> for assistance in transitioning when using this release.

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaOperations.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaOperations.java
@@ -20,6 +20,7 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 
 import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -67,7 +68,10 @@ public interface KafkaOperations<K, V> {
 	 * Send the data to the default topic with no key or partition.
 	 * @param data The data.
 	 * @return a Future for the {@link SendResult}.
+	 * @deprecated see {@link #usingCompletableFuture()}
+	 * @see #usingCompletableFuture()
 	 */
+	@Deprecated
 	ListenableFuture<SendResult<K, V>> sendDefault(V data);
 
 	/**
@@ -75,7 +79,10 @@ public interface KafkaOperations<K, V> {
 	 * @param key the key.
 	 * @param data The data.
 	 * @return a Future for the {@link SendResult}.
+	 * @deprecated see {@link #usingCompletableFuture()}
+	 * @see #usingCompletableFuture()
 	 */
+	@Deprecated
 	ListenableFuture<SendResult<K, V>> sendDefault(K key, V data);
 
 	/**
@@ -84,7 +91,10 @@ public interface KafkaOperations<K, V> {
 	 * @param key the key.
 	 * @param data the data.
 	 * @return a Future for the {@link SendResult}.
+	 * @deprecated see {@link #usingCompletableFuture()}
+	 * @see #usingCompletableFuture()
 	 */
+	@Deprecated
 	ListenableFuture<SendResult<K, V>> sendDefault(Integer partition, K key, V data);
 
 	/**
@@ -95,7 +105,10 @@ public interface KafkaOperations<K, V> {
 	 * @param data the data.
 	 * @return a Future for the {@link SendResult}.
 	 * @since 1.3
+	 * @deprecated see {@link #usingCompletableFuture()}
+	 * @see #usingCompletableFuture()
 	 */
+	@Deprecated
 	ListenableFuture<SendResult<K, V>> sendDefault(Integer partition, Long timestamp, K key, V data);
 
 	/**
@@ -103,7 +116,10 @@ public interface KafkaOperations<K, V> {
 	 * @param topic the topic.
 	 * @param data The data.
 	 * @return a Future for the {@link SendResult}.
+	 * @deprecated see {@link #usingCompletableFuture()}
+	 * @see #usingCompletableFuture()
 	 */
+	@Deprecated
 	ListenableFuture<SendResult<K, V>> send(String topic, V data);
 
 	/**
@@ -112,7 +128,10 @@ public interface KafkaOperations<K, V> {
 	 * @param key the key.
 	 * @param data The data.
 	 * @return a Future for the {@link SendResult}.
+	 * @deprecated see {@link #usingCompletableFuture()}
+	 * @see #usingCompletableFuture()
 	 */
+	@Deprecated
 	ListenableFuture<SendResult<K, V>> send(String topic, K key, V data);
 
 	/**
@@ -122,7 +141,10 @@ public interface KafkaOperations<K, V> {
 	 * @param key the key.
 	 * @param data the data.
 	 * @return a Future for the {@link SendResult}.
+	 * @deprecated see {@link #usingCompletableFuture()}
+	 * @see #usingCompletableFuture()
 	 */
+	@Deprecated
 	ListenableFuture<SendResult<K, V>> send(String topic, Integer partition, K key, V data);
 
 	/**
@@ -134,7 +156,10 @@ public interface KafkaOperations<K, V> {
 	 * @param data the data.
 	 * @return a Future for the {@link SendResult}.
 	 * @since 1.3
+	 * @deprecated see {@link #usingCompletableFuture()}
+	 * @see #usingCompletableFuture()
 	 */
+	@Deprecated
 	ListenableFuture<SendResult<K, V>> send(String topic, Integer partition, Long timestamp, K key, V data);
 
 	/**
@@ -142,7 +167,10 @@ public interface KafkaOperations<K, V> {
 	 * @param record the record.
 	 * @return a Future for the {@link SendResult}.
 	 * @since 1.3
+	 * @deprecated see {@link #usingCompletableFuture()}
+	 * @see #usingCompletableFuture()
 	 */
+	@Deprecated
 	ListenableFuture<SendResult<K, V>> send(ProducerRecord<K, V> record);
 
 	/**
@@ -150,10 +178,13 @@ public interface KafkaOperations<K, V> {
 	 * may be converted before sending.
 	 * @param message the message to send.
 	 * @return a Future for the {@link SendResult}.
+	 * @deprecated see {@link #usingCompletableFuture()}
 	 * @see org.springframework.kafka.support.KafkaHeaders#TOPIC
 	 * @see org.springframework.kafka.support.KafkaHeaders#PARTITION
 	 * @see org.springframework.kafka.support.KafkaHeaders#KEY
+	 * @see #usingCompletableFuture()
 	 */
+	@Deprecated
 	ListenableFuture<SendResult<K, V>> send(Message<?> message);
 
 	/**
@@ -327,6 +358,148 @@ public interface KafkaOperations<K, V> {
 	 * @since 2.8
 	 */
 	ConsumerRecords<K, V> receive(Collection<TopicPartitionOffset> requested, Duration pollTimeout);
+
+	/**
+	 * Return an implementation that returns {@link CompletableFuture} instead of
+	 * {@link ListenableFuture}. The methods returning {@link ListenableFuture} will be
+	 * removed in 3.0
+	 * @return the implementation.
+	 * @since 2.9.
+	 */
+	default KafkaOperations2<K, V> usingCompletableFuture() {
+		return new KafkaOperations2<K, V>() {
+
+			KafkaOperations<K, V> ops;
+
+			@Override
+			public CompletableFuture<SendResult<K, V>> sendDefault(V data) {
+				return KafkaOperations.this.sendDefault(data).completable();
+			}
+
+			@Override
+			public CompletableFuture<SendResult<K, V>> sendDefault(K key, V data) {
+				return KafkaOperations.this.sendDefault(key, data).completable();
+			}
+
+			@Override
+			public CompletableFuture<SendResult<K, V>> sendDefault(Integer partition, K key, V data) {
+				return KafkaOperations.this.sendDefault(partition, key, data).completable();
+			}
+
+			@Override
+			public CompletableFuture<SendResult<K, V>> sendDefault(Integer partition, Long timestamp, K key, V data) {
+				return KafkaOperations.this.sendDefault(partition, timestamp, key, data).completable();
+			}
+
+			@Override
+			public CompletableFuture<SendResult<K, V>> send(String topic, V data) {
+				return KafkaOperations.this.send(topic, data).completable();
+			}
+
+			@Override
+			public CompletableFuture<SendResult<K, V>> send(String topic, K key, V data) {
+				return KafkaOperations.this.send(topic, key, data).completable();
+			}
+
+			@Override
+			public CompletableFuture<SendResult<K, V>> send(String topic, Integer partition, K key, V data) {
+				return KafkaOperations.this.send(topic, partition, key, data).completable();
+			}
+
+			@Override
+			public CompletableFuture<SendResult<K, V>> send(String topic, Integer partition, Long timestamp, K key,
+					V data) {
+				return KafkaOperations.this.send(topic, partition, timestamp, key, data).completable();
+			}
+
+			@Override
+			public CompletableFuture<SendResult<K, V>> send(ProducerRecord<K, V> record) {
+				return KafkaOperations.this.send(record).completable();
+			}
+
+			@Override
+			public CompletableFuture<SendResult<K, V>> send(Message<?> message) {
+				return KafkaOperations.this.send(message).completable();
+			}
+
+			@Override
+			public List<PartitionInfo> partitionsFor(String topic) {
+				return KafkaOperations.this.partitionsFor(topic);
+			}
+
+			@Override
+			public Map<MetricName, ? extends Metric> metrics() {
+				return KafkaOperations.this.metrics();
+			}
+
+			@Override
+			@Nullable
+			public <T> T execute(ProducerCallback<K, V, T> callback) {
+				return KafkaOperations.this.execute(callback);
+			}
+
+			@Override
+			@Nullable
+			public <T> T executeInTransaction(OperationsCallback<K, V, T> callback) {
+				return KafkaOperations.this.executeInTransaction(callback);
+			}
+
+			@Override
+			public void flush() {
+				KafkaOperations.this.flush();
+			}
+
+			@Override
+			public void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets,
+					ConsumerGroupMetadata groupMetadata) {
+				KafkaOperations.this.sendOffsetsToTransaction(offsets, groupMetadata);
+			}
+
+			@Override
+			public boolean isTransactional() {
+				return KafkaOperations.this.isTransactional();
+			}
+
+			@Override
+			public boolean isAllowNonTransactional() {
+				return KafkaOperations.this.isAllowNonTransactional();
+			}
+
+			@Override
+			public boolean inTransaction() {
+				return KafkaOperations.this.inTransaction();
+			}
+
+			@Override
+			public ProducerFactory<K, V> getProducerFactory() {
+				return KafkaOperations.this.getProducerFactory();
+			}
+
+			@Override
+			@Nullable
+			public ConsumerRecord<K, V> receive(String topic, int partition, long offset) {
+				return KafkaOperations.this.receive(topic, partition, offset);
+			}
+
+			@Override
+			@Nullable
+			public ConsumerRecord<K, V> receive(String topic, int partition, long offset, Duration pollTimeout) {
+				return KafkaOperations.this.receive(topic, partition, offset, pollTimeout);
+			}
+
+			@Override
+			public ConsumerRecords<K, V> receive(Collection<TopicPartitionOffset> requested) {
+				return KafkaOperations.this.receive(requested);
+			}
+
+			@Override
+			public ConsumerRecords<K, V> receive(Collection<TopicPartitionOffset> requested, Duration pollTimeout) {
+				return KafkaOperations.this.receive(requested, pollTimeout);
+			}
+
+		};
+
+	}
 
 	/**
 	 * A callback for executing arbitrary operations on the {@link Producer}.

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaOperations2.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaOperations2.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright 2015-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.core;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+
+import org.springframework.kafka.core.KafkaOperations.OperationsCallback;
+import org.springframework.kafka.core.KafkaOperations.ProducerCallback;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.kafka.support.TopicPartitionOffset;
+import org.springframework.lang.Nullable;
+import org.springframework.messaging.Message;
+
+/**
+ * The basic Kafka operations contract returning {@link CompletableFuture}s.
+ *
+ * @param <K> the key type.
+ * @param <V> the value type.
+ *
+ * @author Gary Russell
+ * @since 2.9
+ */
+public interface KafkaOperations2<K, V> {
+
+	/**
+	 * Default timeout for {@link #receive(String, int, long)}.
+	 */
+	Duration DEFAULT_POLL_TIMEOUT = Duration.ofSeconds(5);
+
+	/**
+	 * Send the data to the default topic with no key or partition.
+	 * @param data The data.
+	 * @return a Future for the {@link SendResult}.
+	 */
+	CompletableFuture<SendResult<K, V>> sendDefault(V data);
+
+	/**
+	 * Send the data to the default topic with the provided key and no partition.
+	 * @param key the key.
+	 * @param data The data.
+	 * @return a Future for the {@link SendResult}.
+	 */
+	CompletableFuture<SendResult<K, V>> sendDefault(K key, V data);
+
+	/**
+	 * Send the data to the default topic with the provided key and partition.
+	 * @param partition the partition.
+	 * @param key the key.
+	 * @param data the data.
+	 * @return a Future for the {@link SendResult}.
+	 */
+	CompletableFuture<SendResult<K, V>> sendDefault(Integer partition, K key, V data);
+
+	/**
+	 * Send the data to the default topic with the provided key and partition.
+	 * @param partition the partition.
+	 * @param timestamp the timestamp of the record.
+	 * @param key the key.
+	 * @param data the data.
+	 * @return a Future for the {@link SendResult}.
+	 */
+	CompletableFuture<SendResult<K, V>> sendDefault(Integer partition, Long timestamp, K key, V data);
+
+	/**
+	 * Send the data to the provided topic with no key or partition.
+	 * @param topic the topic.
+	 * @param data The data.
+	 * @return a Future for the {@link SendResult}.
+	 */
+	CompletableFuture<SendResult<K, V>> send(String topic, V data);
+
+	/**
+	 * Send the data to the provided topic with the provided key and no partition.
+	 * @param topic the topic.
+	 * @param key the key.
+	 * @param data The data.
+	 * @return a Future for the {@link SendResult}.
+	 */
+	CompletableFuture<SendResult<K, V>> send(String topic, K key, V data);
+
+	/**
+	 * Send the data to the provided topic with the provided key and partition.
+	 * @param topic the topic.
+	 * @param partition the partition.
+	 * @param key the key.
+	 * @param data the data.
+	 * @return a Future for the {@link SendResult}.
+	 */
+	CompletableFuture<SendResult<K, V>> send(String topic, Integer partition, K key, V data);
+
+	/**
+	 * Send the data to the provided topic with the provided key and partition.
+	 * @param topic the topic.
+	 * @param partition the partition.
+	 * @param timestamp the timestamp of the record.
+	 * @param key the key.
+	 * @param data the data.
+	 * @return a Future for the {@link SendResult}.
+	 */
+	CompletableFuture<SendResult<K, V>> send(String topic, Integer partition, Long timestamp, K key, V data);
+
+	/**
+	 * Send the provided {@link ProducerRecord}.
+	 * @param record the record.
+	 * @return a Future for the {@link SendResult}.
+	 */
+	CompletableFuture<SendResult<K, V>> send(ProducerRecord<K, V> record);
+
+	/**
+	 * Send a message with routing information in message headers. The message payload
+	 * may be converted before sending.
+	 * @param message the message to send.
+	 * @return a Future for the {@link SendResult}.
+	 * @see org.springframework.kafka.support.KafkaHeaders#TOPIC
+	 * @see org.springframework.kafka.support.KafkaHeaders#PARTITION
+	 * @see org.springframework.kafka.support.KafkaHeaders#KEY
+	 */
+	CompletableFuture<SendResult<K, V>> send(Message<?> message);
+
+	/**
+	 * See {@link Producer#partitionsFor(String)}.
+	 * @param topic the topic.
+	 * @return the partition info.
+	 */
+	List<PartitionInfo> partitionsFor(String topic);
+
+	/**
+	 * See {@link Producer#metrics()}.
+	 * @return the metrics.
+	 */
+	Map<MetricName, ? extends Metric> metrics();
+
+	/**
+	 * Execute some arbitrary operation(s) on the producer and return the result.
+	 * @param callback the callback.
+	 * @param <T> the result type.
+	 * @return the result.
+	 */
+	@Nullable
+	<T> T execute(ProducerCallback<K, V, T> callback);
+
+	/**
+	 * Execute some arbitrary operation(s) on the operations and return the result.
+	 * The operations are invoked within a local transaction and do not participate
+	 * in a global transaction (if present).
+	 * @param callback the callback.
+	 * @param <T> the result type.
+	 * @return the result.
+	 */
+	@Nullable
+	<T> T executeInTransaction(OperationsCallback<K, V, T> callback);
+
+	/**
+	 * Flush the producer.
+	 */
+	void flush();
+
+	/**
+	 * When running in a transaction, send the consumer offset(s) to the transaction. It
+	 * is not necessary to call this method if the operations are invoked on a listener
+	 * container thread (and the listener container is configured with a
+	 * {@link org.springframework.kafka.transaction.KafkaAwareTransactionManager}) since
+	 * the container will take care of sending the offsets to the transaction.
+	 * Use with 2.5 brokers or later.
+	 * @param offsets The offsets.
+	 * @param groupMetadata the consumer group metadata.
+	 * @see Producer#sendOffsetsToTransaction(Map, ConsumerGroupMetadata)
+	 */
+	default void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets,
+			ConsumerGroupMetadata groupMetadata) {
+
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Return true if the implementation supports transactions (has a transaction-capable
+	 * producer factory).
+	 * @return true or false.
+	 */
+	boolean isTransactional();
+
+	/**
+	 * Return true if this template, when transactional, allows non-transactional operations.
+	 * @return true to allow.
+	 */
+	default boolean isAllowNonTransactional() {
+		return false;
+	}
+
+	/**
+	 * Return true if the template is currently running in a transaction on the calling
+	 * thread.
+	 * @return true if a transaction is running.
+	 */
+	default boolean inTransaction() {
+		return false;
+	}
+
+	/**
+	 * Return the producer factory used by this template.
+	 * @return the factory.
+	 */
+	default ProducerFactory<K, V> getProducerFactory() {
+		throw new UnsupportedOperationException("This implementation does not support this operation");
+	}
+
+	/**
+	 * Receive a single record with the default poll timeout (5 seconds).
+	 * @param topic the topic.
+	 * @param partition the partition.
+	 * @param offset the offset.
+	 * @return the record or null.
+	 * @see #DEFAULT_POLL_TIMEOUT
+	 */
+	@Nullable
+	default ConsumerRecord<K, V> receive(String topic, int partition, long offset) {
+		return receive(topic, partition, offset, DEFAULT_POLL_TIMEOUT);
+	}
+
+	/**
+	 * Receive a single record.
+	 * @param topic the topic.
+	 * @param partition the partition.
+	 * @param offset the offset.
+	 * @param pollTimeout the timeout.
+	 * @return the record or null.
+	 */
+	@Nullable
+	ConsumerRecord<K, V> receive(String topic, int partition, long offset, Duration pollTimeout);
+
+	/**
+	 * Receive a multiple records with the default poll timeout (5 seconds). Only
+	 * absolute, positive offsets are supported.
+	 * @param requested a collection of record requests (topic/partition/offset).
+	 * @return the records
+	 * @see #DEFAULT_POLL_TIMEOUT
+	 */
+	default ConsumerRecords<K, V> receive(Collection<TopicPartitionOffset> requested) {
+		return receive(requested, DEFAULT_POLL_TIMEOUT);
+	}
+
+	/**
+	 * Receive multiple records. Only absolute, positive offsets are supported.
+	 * @param requested a collection of record requests (topic/partition/offset).
+	 * @param pollTimeout the timeout.
+	 * @return the record or null.
+	 */
+	ConsumerRecords<K, V> receive(Collection<TopicPartitionOffset> requested, Duration pollTimeout);
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
@@ -88,6 +88,7 @@ import org.springframework.util.concurrent.SettableListenableFuture;
  * @author Thomas Strauß
  * @author Gurps Bassi
  */
+@SuppressWarnings("deprecation")
 public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationContextAware, BeanNameAware,
 		ApplicationListener<ContextStoppedEvent>, DisposableBean {
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
@@ -337,7 +337,7 @@ public class DefaultKafkaConsumerFactoryTests {
 		KafkaTemplate<Integer, String> template = new KafkaTemplate<>(pf);
 		DefaultKafkaProducerFactory<Integer, String> pfTx = new DefaultKafkaProducerFactory<>(producerProps);
 		pfTx.setTransactionIdPrefix("fooTx.");
-		KafkaTemplate<Integer, String> templateTx = new KafkaTemplate<>(pfTx);
+		KafkaOperations2<Integer, String> templateTx = new KafkaTemplate<>(pfTx).usingCompletableFuture();
 		Map<String, Object> consumerProps = KafkaTestUtils.consumerProps("txCache1Group", "false", this.embeddedKafka);
 		DefaultKafkaConsumerFactory<Integer, String> cf = new DefaultKafkaConsumerFactory<>(consumerProps);
 		AtomicReference<Consumer<Integer, String>> wrapped = new AtomicReference<>();

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerMockTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerMockTests.java
@@ -691,6 +691,7 @@ public class ConcurrentMessageListenerContainerMockTests {
 
 			@Override
 			@Nullable
+			@SuppressWarnings("deprecation")
 			public ConsumerRecord intercept(ConsumerRecord rec) {
 				order.add("interceptor");
 				latch.get().countDown();

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/DeadLetterPublishingRecovererTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/DeadLetterPublishingRecovererTests.java
@@ -80,6 +80,7 @@ import org.springframework.util.concurrent.SettableListenableFuture;
  * @since 2.4.3
  *
  */
+@SuppressWarnings("deprecation")
 public class DeadLetterPublishingRecovererTests {
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DeadLetterPublishingRecovererFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DeadLetterPublishingRecovererFactoryTests.java
@@ -69,7 +69,7 @@ import org.springframework.util.concurrent.ListenableFuture;
  * @since 2.7
  */
 @ExtendWith(MockitoExtension.class)
-@SuppressWarnings({"unchecked", "rawtypes"})
+@SuppressWarnings({"unchecked", "rawtypes", "deprecation"})
 class DeadLetterPublishingRecovererFactoryTests {
 
 	private final Clock clock = TestClockUtils.CLOCK;


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2357

Spring Framework is planning to deprecate `ListenableFuture` in 6.0.

Add methods to the `KafkaOperations` (`KafkaTemplate`) that return
`CompletableFuture` instead; the `ListenableFuture` methods will be
removed in 3.0.

Provide mechanisms to ease the migration; allowing users to use
`CompletableFuture`s in this release, which will significantly reduce
the effort to switch in 3.0.

**2.9 Only; I will issue a separate PR for main**
