### PR TITLE
GH-2357: Switch to CompletableFuture

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/changes-since-1.0.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/changes-since-1.0.adoc
@@ -33,12 +33,21 @@ You can now configure which inbound headers should be mapped.
 Also available in version 2.8.8 or later.
 See <<headers>> for more information.
 
+[[x29-template-changes]]
+==== `KafkaTemplate` Changes
+
+In 3.0, the futures returned by this class will be `CompletableFuture` s instead of `ListenableFuture` s.
+See <<kafka-template>> for assistance in transitioning when using this release.
+
 [[x29-rkt-changes]]
 ==== `ReplyingKafkaTemplate` Changes
 
 The template now provides a method to wait for assignment on the reply container, to avoid a race when sending a request before the reply container is initialized.
 Also available in version 2.8.8 or later.
 See <<replying-template>>.
+
+In 3.0, the futures returned by this class will be `CompletableFuture` s instead of `ListenableFuture` s.
+See <<replying-template>> and <<exchanging-messages>> for assistance in transitioning when using this release.
 
 === What's New in 2.8 Since 2.7
 

--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -170,25 +170,25 @@ The following listing shows the relevant methods from `KafkaTemplate`:
 ====
 [source, java]
 ----
-ListenableFuture<SendResult<K, V>> sendDefault(V data);
+CompletableFuture<SendResult<K, V>> sendDefault(V data);
 
-ListenableFuture<SendResult<K, V>> sendDefault(K key, V data);
+CompletableFuture<SendResult<K, V>> sendDefault(K key, V data);
 
-ListenableFuture<SendResult<K, V>> sendDefault(Integer partition, K key, V data);
+CompletableFuture<SendResult<K, V>> sendDefault(Integer partition, K key, V data);
 
-ListenableFuture<SendResult<K, V>> sendDefault(Integer partition, Long timestamp, K key, V data);
+CompletableFuture<SendResult<K, V>> sendDefault(Integer partition, Long timestamp, K key, V data);
 
-ListenableFuture<SendResult<K, V>> send(String topic, V data);
+CompletableFuture<SendResult<K, V>> send(String topic, V data);
 
-ListenableFuture<SendResult<K, V>> send(String topic, K key, V data);
+CompletableFuture<SendResult<K, V>> send(String topic, K key, V data);
 
-ListenableFuture<SendResult<K, V>> send(String topic, Integer partition, K key, V data);
+CompletableFuture<SendResult<K, V>> send(String topic, Integer partition, K key, V data);
 
-ListenableFuture<SendResult<K, V>> send(String topic, Integer partition, Long timestamp, K key, V data);
+CompletableFuture<SendResult<K, V>> send(String topic, Integer partition, Long timestamp, K key, V data);
 
-ListenableFuture<SendResult<K, V>> send(ProducerRecord<K, V> record);
+CompletableFuture<SendResult<K, V>> send(ProducerRecord<K, V> record);
 
-ListenableFuture<SendResult<K, V>> send(Message<?> message);
+CompletableFuture<SendResult<K, V>> send(Message<?> message);
 
 Map<MetricName, ? extends Metric> metrics();
 
@@ -210,22 +210,8 @@ interface ProducerCallback<K, V, T> {
 
 See the https://docs.spring.io/spring-kafka/api/org/springframework/kafka/core/KafkaTemplate.html[Javadoc] for more detail.
 
-IMPORTANT: In version 3.0, the methods that returned `ListenableFuture` have been changed to return `CompletableFuture`.
-To facilitate the migration, the 2.9 version added a method `.usingCompletableFuture()` which provided the same methods with `CompletableFuture` return types.
-
-====
-[source, java]
-----
-KafkaOperations2<String, String> template = new KafkaTemplate<>().usingCompletableFuture();
-CompletableFuture<SendResult<String, String>> future = template.send(topic1, 0, 0, "buz")
-        .whenComplete((sr, thrown) -> {
-            ...
-         });
-)
-----
-====
-
-`KafkaOperations2` and `.usingCompletableFuture()` have now been deprecated, and should be removed, since the method simply returns `this`.
+IMPORTANT: In version 3.0, the methods that previously returned `ListenableFuture` have been changed to return `CompletableFuture`.
+To facilitate the migration, the 2.9 version added a method `.usingCompletableFuture()` which provided the same methods with `CompletableFuture` return types; this method is no longer available.
 
 The `sendDefault` API requires that a default topic has been provided to the template.
 
@@ -319,26 +305,16 @@ By default, the template is configured with a `LoggingProducerListener`, which l
 
 For convenience, default method implementations are provided in case you want to implement only one of the methods.
 
-Notice that the send methods return a `ListenableFuture<SendResult>`.
+Notice that the send methods return a `CompletableFuture<SendResult>`.
 You can register a callback with the listener to receive the result of the send asynchronously.
 The following example shows how to do so:
 
 ====
 [source, java]
 ----
-ListenableFuture<SendResult<Integer, String>> future = template.send("myTopic", "something");
-future.addCallback(new ListenableFutureCallback<SendResult<Integer, String>>() {
-
-    @Override
-    public void onSuccess(SendResult<Integer, String> result) {
-        ...
-    }
-
-    @Override
-    public void onFailure(Throwable ex) {
-        ...
-    }
-
+CompletableFuture<SendResult<Integer, String>> future = template.send("myTopic", "something");
+future.whenComplete((result, ex) -> {
+    ...
 });
 ----
 ====
@@ -346,48 +322,10 @@ future.addCallback(new ListenableFutureCallback<SendResult<Integer, String>>() {
 `SendResult` has two properties, a `ProducerRecord` and `RecordMetadata`.
 See the Kafka API documentation for information about those objects.
 
-The `Throwable` in `onFailure` can be cast to a `KafkaProducerException`; its `failedProducerRecord` property contains the failed record.
-
-Starting with version 2.5, you can use a `KafkaSendCallback` instead of a `ListenableFutureCallback`, making it easier to extract the failed `ProducerRecord`, avoiding the need to cast the `Throwable`:
-
-====
-[source, java]
-----
-ListenableFuture<SendResult<Integer, String>> future = template.send("topic", 1, "thing");
-future.addCallback(new KafkaSendCallback<Integer, String>() {
-
-    @Override
-    public void onSuccess(SendResult<Integer, String> result) {
-        ...
-    }
-
-    @Override
-    public void onFailure(KafkaProducerException ex) {
-        ProducerRecord<Integer, String> failed = ex.getFailedProducerRecord();
-        ...
-    }
-
-});
-----
-====
-
-You can also use a pair of lambdas:
-
-====
-[source, java]
-----
-ListenableFuture<SendResult<Integer, String>> future = template.send("topic", 1, "thing");
-future.addCallback(result -> {
-        ...
-    }, (KafkaFailureCallback<Integer, String>) ex -> {
-            ProducerRecord<Integer, String> failed = ex.getFailedProducerRecord();
-            ...
-    });
-----
-====
+The `Throwable` can be cast to a `KafkaProducerException`; its `failedProducerRecord` property contains the failed record.
 
 If you wish to block the sending thread to await the result, you can invoke the future's `get()` method; using the method with a timeout is recommended.
-You may wish to invoke `flush()` before waiting or, for convenience, the template has a constructor with an `autoFlush` parameter that causes the template to `flush()` on each send.
+If you have set a `linger.ms`, you may wish to invoke `flush()` before waiting or, for convenience, the template has a constructor with an `autoFlush` parameter that causes the template to `flush()` on each send.
 Flushing is only needed if you have set the `linger.ms` producer property and want to immediately send a partial batch.
 
 ====== Examples
@@ -401,19 +339,14 @@ This section shows examples of sending messages to Kafka:
 public void sendToKafka(final MyOutputData data) {
     final ProducerRecord<String, String> record = createRecord(data);
 
-    ListenableFuture<SendResult<Integer, String>> future = template.send(record);
-    future.addCallback(new KafkaSendCallback<Integer, String>() {
-
-        @Override
-        public void onSuccess(SendResult<Integer, String> result) {
+    CompletableFuture<SendResult<Integer, String>> future = template.send(record);
+    future.whenComplete((result, ex) -> {
+        if (ex == null) {
             handleSuccess(data);
         }
-
-        @Override
-        public void onFailure(KafkaProducerException ex) {
+        else {
             handleFailure(data, record, ex);
         }
-
     });
 }
 ----
@@ -566,13 +499,11 @@ RequestReplyFuture<K, V, R> sendAndReceive(ProducerRecord<K, V> record,
 
 (Also see <<exchanging-messages>>).
 
-The result is a `ListenableFuture` that is asynchronously populated with the result (or an exception, for a timeout).
+The result is a `CompletableFuture` that is asynchronously populated with the result (or an exception, for a timeout).
 The result also has a `sendFuture` property, which is the result of calling `KafkaTemplate.send()`.
 You can use this future to determine the result of the send operation.
 
 IMPORTANT: In version 3.0, the futures returned by these methods (and their `sendFuture` properties) have been changed to  `CompletableFuture` s instead of `ListenableFuture` s.
-To assit in the transition, using this version 2.9, you could convert these types to a `CompleteableFuture` by calling `asCompletable()` on the returned `Future`.
-This method is no longer available and the future itself is a `CompletableFuture`.
 
 If the first method is used, or the `replyTimeout` argument is `null`, the template's `defaultReplyTimeout` property is used (5 seconds by default).
 
@@ -813,8 +744,6 @@ RequestReplyMessageFuture<K, V> sendAndReceive(Message<?> message);
 These will use the template's default `replyTimeout`, there are also overloaded versions that can take a timeout in the method call.
 
 IMPORTANT: In version 3.0, the futures returned by these methods (and their `sendFuture` properties) have been changed to  `CompletableFuture` s instead of `ListenableFuture` s.
-To assit in the transition, using this version 2.9, you could convert these types to a `CompleteableFuture` by calling `asCompletable()` on the returned `Future`.
-This method is no longer available and the future itself is a `CompletableFuture`.
 
 Use the first method if the consumer's `Deserializer` or the template's `MessageConverter` can convert the payload without any additional information, either via configuration or type metadata in the reply message.
 
@@ -2261,6 +2190,7 @@ public ConcurrentKafkaListenerContainerFactory<Integer, String> kafkaListenerCon
 ====
 
 When you use `@SendTo`, you must configure the `ConcurrentKafkaListenerContainerFactory` with a `KafkaTemplate` in its `replyTemplate` property to perform the send.
+Spring Boot will automatically wire in its auto configured template (or any if a single instance is present).
 
 NOTE: Unless you use <<replying-template,request/reply semantics>> only the simple `send(topic, value)` method is used, so you may wish to create a subclass to generate the partition or key.
 The following example shows how to do so:
@@ -2273,7 +2203,7 @@ public KafkaTemplate<String, String> myReplyingTemplate() {
     return new KafkaTemplate<Integer, String>(producerFactory()) {
 
         @Override
-        public ListenableFuture<SendResult<String, String>> send(String topic, String data) {
+        public CompletableFuture<SendResult<String, String>> send(String topic, String data) {
             return super.send(topic, partitionForData(data), keyForData(data), data);
         }
 

--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -210,6 +210,23 @@ interface ProducerCallback<K, V, T> {
 
 See the https://docs.spring.io/spring-kafka/api/org/springframework/kafka/core/KafkaTemplate.html[Javadoc] for more detail.
 
+IMPORTANT: In version 3.0, the methods that returned `ListenableFuture` have been changed to return `CompletableFuture`.
+To facilitate the migration, the 2.9 version added a method `.usingCompletableFuture()` which provided the same methods with `CompletableFuture` return types.
+
+====
+[source, java]
+----
+KafkaOperations2<String, String> template = new KafkaTemplate<>().usingCompletableFuture();
+CompletableFuture<SendResult<String, String>> future = template.send(topic1, 0, 0, "buz")
+        .whenComplete((sr, thrown) -> {
+            ...
+         });
+)
+----
+====
+
+`KafkaOperations2` and `.usingCompletableFuture()` have now been deprecated, and should be removed, since the method simply returns `this`.
+
 The `sendDefault` API requires that a default topic has been provided to the template.
 
 The API takes in a `timestamp` as a parameter and stores this timestamp in the record.
@@ -553,6 +570,10 @@ The result is a `ListenableFuture` that is asynchronously populated with the res
 The result also has a `sendFuture` property, which is the result of calling `KafkaTemplate.send()`.
 You can use this future to determine the result of the send operation.
 
+IMPORTANT: In version 3.0, the futures returned by these methods (and their `sendFuture` properties) have been changed to  `CompletableFuture` s instead of `ListenableFuture` s.
+To assit in the transition, using this version 2.9, you could convert these types to a `CompleteableFuture` by calling `asCompletable()` on the returned `Future`.
+This method is no longer available and the future itself is a `CompletableFuture`.
+
 If the first method is used, or the `replyTimeout` argument is `null`, the template's `defaultReplyTimeout` property is used (5 seconds by default).
 
 Starting with version 2.8.8, the template has a new method `waitForAssignment`.
@@ -790,6 +811,10 @@ RequestReplyMessageFuture<K, V> sendAndReceive(Message<?> message);
 ====
 
 These will use the template's default `replyTimeout`, there are also overloaded versions that can take a timeout in the method call.
+
+IMPORTANT: In version 3.0, the futures returned by these methods (and their `sendFuture` properties) have been changed to  `CompletableFuture` s instead of `ListenableFuture` s.
+To assit in the transition, using this version 2.9, you could convert these types to a `CompleteableFuture` by calling `asCompletable()` on the returned `Future`.
+This method is no longer available and the future itself is a `CompletableFuture`.
 
 Use the first method if the consumer's `Deserializer` or the template's `MessageConverter` can convert the payload without any additional information, either via configuration or type metadata in the reply message.
 

--- a/spring-kafka-docs/src/main/asciidoc/whats-new.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/whats-new.adoc
@@ -34,3 +34,15 @@ See <<retry-config>> for more information.
 
 Events related to consumer authentication and authorization failures are now published by the container.
 See <<events>> for more information.
+
+[[x30-template-changes]]
+==== `KafkaTemplate` Changes
+
+The futures returned by this class are now `CompletableFuture` s instead of `ListenableFuture` s.
+See <<kafka-template>>.
+
+[[x30-rkt-changes]]
+==== `ReplyingKafkaTemplate` Changes
+
+The futures returned by this class are now `CompletableFuture` s instead of `ListenableFuture` s.
+See <<replying-template>> and <<exchanging-messages>>.

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaOperations.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaOperations.java
@@ -57,8 +57,7 @@ import org.springframework.util.concurrent.ListenableFuture;
  * @author Gary Russell
  * @author Biju Kunjummen
  */
-@SuppressWarnings("deprecation")
-public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
+public interface KafkaOperations<K, V> {
 
 	/**
 	 * Default timeout for {@link #receive(String, int, long)}.
@@ -70,7 +69,6 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * @param data The data.
 	 * @return a Future for the {@link SendResult}.
 	 */
-	@Override
 	CompletableFuture<SendResult<K, V>> sendDefault(V data);
 
 	/**
@@ -79,7 +77,6 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * @param data The data.
 	 * @return a Future for the {@link SendResult}.
 	 */
-	@Override
 	CompletableFuture<SendResult<K, V>> sendDefault(K key, V data);
 
 	/**
@@ -89,7 +86,6 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * @param data the data.
 	 * @return a Future for the {@link SendResult}.
 	 */
-	@Override
 	CompletableFuture<SendResult<K, V>> sendDefault(Integer partition, K key, V data);
 
 	/**
@@ -101,7 +97,6 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * @return a Future for the {@link SendResult}.
 	 * @since 1.3
 	 */
-	@Override
 	CompletableFuture<SendResult<K, V>> sendDefault(Integer partition, Long timestamp, K key, V data);
 
 	/**
@@ -110,7 +105,6 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * @param data The data.
 	 * @return a Future for the {@link SendResult}.
 	 */
-	@Override
 	CompletableFuture<SendResult<K, V>> send(String topic, V data);
 
 	/**
@@ -120,7 +114,6 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * @param data The data.
 	 * @return a Future for the {@link SendResult}.
 	 */
-	@Override
 	CompletableFuture<SendResult<K, V>> send(String topic, K key, V data);
 
 	/**
@@ -131,7 +124,6 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * @param data the data.
 	 * @return a Future for the {@link SendResult}.
 	 */
-	@Override
 	CompletableFuture<SendResult<K, V>> send(String topic, Integer partition, K key, V data);
 
 	/**
@@ -144,7 +136,6 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * @return a Future for the {@link SendResult}.
 	 * @since 1.3
 	 */
-	@Override
 	CompletableFuture<SendResult<K, V>> send(String topic, Integer partition, Long timestamp, K key, V data);
 
 	/**
@@ -153,7 +144,6 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * @return a Future for the {@link SendResult}.
 	 * @since 1.3
 	 */
-	@Override
 	CompletableFuture<SendResult<K, V>> send(ProducerRecord<K, V> record);
 
 	/**
@@ -165,7 +155,6 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * @see org.springframework.kafka.support.KafkaHeaders#PARTITION
 	 * @see org.springframework.kafka.support.KafkaHeaders#KEY
 	 */
-	@Override
 	CompletableFuture<SendResult<K, V>> send(Message<?> message);
 
 	/**
@@ -174,7 +163,6 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * @return the partition info.
 	 * @since 1.1
 	 */
-	@Override
 	List<PartitionInfo> partitionsFor(String topic);
 
 	/**
@@ -182,7 +170,6 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * @return the metrics.
 	 * @since 1.1
 	 */
-	@Override
 	Map<MetricName, ? extends Metric> metrics();
 
 	/**
@@ -192,7 +179,6 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * @return the result.
 	 * @since 1.1
 	 */
-	@Override
 	@Nullable
 	<T> T execute(ProducerCallback<K, V, T> callback);
 
@@ -205,14 +191,12 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * @return the result.
 	 * @since 1.1
 	 */
-	@Override
 	@Nullable
 	<T> T executeInTransaction(OperationsCallback<K, V, T> callback);
 
 	/**
 	 * Flush the producer.
 	 */
-	@Override
 	void flush();
 
 	/**
@@ -227,7 +211,6 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * @since 2.5
 	 * @see Producer#sendOffsetsToTransaction(Map, ConsumerGroupMetadata)
 	 */
-	@Override
 	default void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets,
 			ConsumerGroupMetadata groupMetadata) {
 
@@ -240,7 +223,6 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * @return true or false.
 	 * @since 2.3
 	 */
-	@Override
 	boolean isTransactional();
 
 	/**
@@ -248,7 +230,6 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * @return true to allow.
 	 * @since 2.4.3
 	 */
-	@Override
 	default boolean isAllowNonTransactional() {
 		return false;
 	}
@@ -259,7 +240,6 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * @return true if a transaction is running.
 	 * @since 2.5
 	 */
-	@Override
 	default boolean inTransaction() {
 		return false;
 	}
@@ -269,7 +249,6 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * @return the factory.
 	 * @since 2.5
 	 */
-	@Override
 	default ProducerFactory<K, V> getProducerFactory() {
 		throw new UnsupportedOperationException("This implementation does not support this operation");
 	}
@@ -283,7 +262,6 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * @since 2.8
 	 * @see #DEFAULT_POLL_TIMEOUT
 	 */
-	@Override
 	@Nullable
 	default ConsumerRecord<K, V> receive(String topic, int partition, long offset) {
 		return receive(topic, partition, offset, DEFAULT_POLL_TIMEOUT);
@@ -298,7 +276,6 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * @return the record or null.
 	 * @since 2.8
 	 */
-	@Override
 	@Nullable
 	ConsumerRecord<K, V> receive(String topic, int partition, long offset, Duration pollTimeout);
 
@@ -310,7 +287,6 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * @since 2.8
 	 * @see #DEFAULT_POLL_TIMEOUT
 	 */
-	@Override
 	default ConsumerRecords<K, V> receive(Collection<TopicPartitionOffset> requested) {
 		return receive(requested, DEFAULT_POLL_TIMEOUT);
 	}
@@ -322,21 +298,7 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * @return the record or null.
 	 * @since 2.8
 	 */
-	@Override
 	ConsumerRecords<K, V> receive(Collection<TopicPartitionOffset> requested, Duration pollTimeout);
-
-	/**
-	 * Return an implementation that returns {@link CompletableFuture} instead of
-	 * {@link CompletableFuture}. The methods returning {@link ListenableFuture} will be
-	 * removed in 3.0
-	 * @return the implementation.
-	 * @since 2.9.
-	 * @deprecated no longer needed; {@link KafkaOperations} now returns {@link CompletableFuture}.
-	 */
-	@Deprecated
-	default KafkaOperations2<K, V> usingCompletableFuture() {
-		return this;
-	}
 
 	/**
 	 * A callback for executing arbitrary operations on the {@link Producer}.

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaOperations.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaOperations.java
@@ -37,7 +37,6 @@ import org.springframework.kafka.support.SendResult;
 import org.springframework.kafka.support.TopicPartitionOffset;
 import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
-import org.springframework.util.concurrent.ListenableFuture;
 
 /**
  * The basic Kafka operations contract returning {@link CompletableFuture}s.

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaOperations2.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaOperations2.java
@@ -33,11 +33,12 @@ import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 
+import org.springframework.kafka.core.KafkaOperations.OperationsCallback;
+import org.springframework.kafka.core.KafkaOperations.ProducerCallback;
 import org.springframework.kafka.support.SendResult;
 import org.springframework.kafka.support.TopicPartitionOffset;
 import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
-import org.springframework.util.concurrent.ListenableFuture;
 
 /**
  * The basic Kafka operations contract returning {@link CompletableFuture}s.
@@ -45,20 +46,12 @@ import org.springframework.util.concurrent.ListenableFuture;
  * @param <K> the key type.
  * @param <V> the value type.
  *
- * If the Kafka topic is set with {@link org.apache.kafka.common.record.TimestampType#CREATE_TIME CreateTime}
- * all send operations will use the user provided time if provided, else
- * {@link org.apache.kafka.clients.producer.KafkaProducer} will generate one
- *
- * If the topic is set with {@link org.apache.kafka.common.record.TimestampType#LOG_APPEND_TIME LogAppendTime}
- * then the user provided timestamp will be ignored and instead will be the
- * Kafka broker local time when the message is appended
- *
- * @author Marius Bogoevici
  * @author Gary Russell
- * @author Biju Kunjummen
+ * @since 2.9
+ * @deprecated no longer needed; use {@code KafkaOperations}.
  */
-@SuppressWarnings("deprecation")
-public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
+@Deprecated
+public interface KafkaOperations2<K, V> {
 
 	/**
 	 * Default timeout for {@link #receive(String, int, long)}.
@@ -70,7 +63,6 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * @param data The data.
 	 * @return a Future for the {@link SendResult}.
 	 */
-	@Override
 	CompletableFuture<SendResult<K, V>> sendDefault(V data);
 
 	/**
@@ -79,7 +71,6 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * @param data The data.
 	 * @return a Future for the {@link SendResult}.
 	 */
-	@Override
 	CompletableFuture<SendResult<K, V>> sendDefault(K key, V data);
 
 	/**
@@ -89,7 +80,6 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * @param data the data.
 	 * @return a Future for the {@link SendResult}.
 	 */
-	@Override
 	CompletableFuture<SendResult<K, V>> sendDefault(Integer partition, K key, V data);
 
 	/**
@@ -99,9 +89,7 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * @param key the key.
 	 * @param data the data.
 	 * @return a Future for the {@link SendResult}.
-	 * @since 1.3
 	 */
-	@Override
 	CompletableFuture<SendResult<K, V>> sendDefault(Integer partition, Long timestamp, K key, V data);
 
 	/**
@@ -110,7 +98,6 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * @param data The data.
 	 * @return a Future for the {@link SendResult}.
 	 */
-	@Override
 	CompletableFuture<SendResult<K, V>> send(String topic, V data);
 
 	/**
@@ -120,7 +107,6 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * @param data The data.
 	 * @return a Future for the {@link SendResult}.
 	 */
-	@Override
 	CompletableFuture<SendResult<K, V>> send(String topic, K key, V data);
 
 	/**
@@ -131,7 +117,6 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * @param data the data.
 	 * @return a Future for the {@link SendResult}.
 	 */
-	@Override
 	CompletableFuture<SendResult<K, V>> send(String topic, Integer partition, K key, V data);
 
 	/**
@@ -142,18 +127,14 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * @param key the key.
 	 * @param data the data.
 	 * @return a Future for the {@link SendResult}.
-	 * @since 1.3
 	 */
-	@Override
 	CompletableFuture<SendResult<K, V>> send(String topic, Integer partition, Long timestamp, K key, V data);
 
 	/**
 	 * Send the provided {@link ProducerRecord}.
 	 * @param record the record.
 	 * @return a Future for the {@link SendResult}.
-	 * @since 1.3
 	 */
-	@Override
 	CompletableFuture<SendResult<K, V>> send(ProducerRecord<K, V> record);
 
 	/**
@@ -165,24 +146,19 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * @see org.springframework.kafka.support.KafkaHeaders#PARTITION
 	 * @see org.springframework.kafka.support.KafkaHeaders#KEY
 	 */
-	@Override
 	CompletableFuture<SendResult<K, V>> send(Message<?> message);
 
 	/**
 	 * See {@link Producer#partitionsFor(String)}.
 	 * @param topic the topic.
 	 * @return the partition info.
-	 * @since 1.1
 	 */
-	@Override
 	List<PartitionInfo> partitionsFor(String topic);
 
 	/**
 	 * See {@link Producer#metrics()}.
 	 * @return the metrics.
-	 * @since 1.1
 	 */
-	@Override
 	Map<MetricName, ? extends Metric> metrics();
 
 	/**
@@ -190,9 +166,7 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * @param callback the callback.
 	 * @param <T> the result type.
 	 * @return the result.
-	 * @since 1.1
 	 */
-	@Override
 	@Nullable
 	<T> T execute(ProducerCallback<K, V, T> callback);
 
@@ -203,16 +177,13 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * @param callback the callback.
 	 * @param <T> the result type.
 	 * @return the result.
-	 * @since 1.1
 	 */
-	@Override
 	@Nullable
 	<T> T executeInTransaction(OperationsCallback<K, V, T> callback);
 
 	/**
 	 * Flush the producer.
 	 */
-	@Override
 	void flush();
 
 	/**
@@ -224,10 +195,8 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * Use with 2.5 brokers or later.
 	 * @param offsets The offsets.
 	 * @param groupMetadata the consumer group metadata.
-	 * @since 2.5
 	 * @see Producer#sendOffsetsToTransaction(Map, ConsumerGroupMetadata)
 	 */
-	@Override
 	default void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets,
 			ConsumerGroupMetadata groupMetadata) {
 
@@ -238,17 +207,13 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * Return true if the implementation supports transactions (has a transaction-capable
 	 * producer factory).
 	 * @return true or false.
-	 * @since 2.3
 	 */
-	@Override
 	boolean isTransactional();
 
 	/**
 	 * Return true if this template, when transactional, allows non-transactional operations.
 	 * @return true to allow.
-	 * @since 2.4.3
 	 */
-	@Override
 	default boolean isAllowNonTransactional() {
 		return false;
 	}
@@ -257,9 +222,7 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * Return true if the template is currently running in a transaction on the calling
 	 * thread.
 	 * @return true if a transaction is running.
-	 * @since 2.5
 	 */
-	@Override
 	default boolean inTransaction() {
 		return false;
 	}
@@ -267,9 +230,7 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	/**
 	 * Return the producer factory used by this template.
 	 * @return the factory.
-	 * @since 2.5
 	 */
-	@Override
 	default ProducerFactory<K, V> getProducerFactory() {
 		throw new UnsupportedOperationException("This implementation does not support this operation");
 	}
@@ -280,10 +241,8 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * @param partition the partition.
 	 * @param offset the offset.
 	 * @return the record or null.
-	 * @since 2.8
 	 * @see #DEFAULT_POLL_TIMEOUT
 	 */
-	@Override
 	@Nullable
 	default ConsumerRecord<K, V> receive(String topic, int partition, long offset) {
 		return receive(topic, partition, offset, DEFAULT_POLL_TIMEOUT);
@@ -296,9 +255,7 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * @param offset the offset.
 	 * @param pollTimeout the timeout.
 	 * @return the record or null.
-	 * @since 2.8
 	 */
-	@Override
 	@Nullable
 	ConsumerRecord<K, V> receive(String topic, int partition, long offset, Duration pollTimeout);
 
@@ -307,10 +264,8 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * absolute, positive offsets are supported.
 	 * @param requested a collection of record requests (topic/partition/offset).
 	 * @return the records
-	 * @since 2.8
 	 * @see #DEFAULT_POLL_TIMEOUT
 	 */
-	@Override
 	default ConsumerRecords<K, V> receive(Collection<TopicPartitionOffset> requested) {
 		return receive(requested, DEFAULT_POLL_TIMEOUT);
 	}
@@ -320,48 +275,7 @@ public interface KafkaOperations<K, V> extends KafkaOperations2<K, V> {
 	 * @param requested a collection of record requests (topic/partition/offset).
 	 * @param pollTimeout the timeout.
 	 * @return the record or null.
-	 * @since 2.8
 	 */
-	@Override
 	ConsumerRecords<K, V> receive(Collection<TopicPartitionOffset> requested, Duration pollTimeout);
-
-	/**
-	 * Return an implementation that returns {@link CompletableFuture} instead of
-	 * {@link CompletableFuture}. The methods returning {@link ListenableFuture} will be
-	 * removed in 3.0
-	 * @return the implementation.
-	 * @since 2.9.
-	 * @deprecated no longer needed; {@link KafkaOperations} now returns {@link CompletableFuture}.
-	 */
-	@Deprecated
-	default KafkaOperations2<K, V> usingCompletableFuture() {
-		return this;
-	}
-
-	/**
-	 * A callback for executing arbitrary operations on the {@link Producer}.
-	 * @param <K> the key type.
-	 * @param <V> the value type.
-	 * @param <T> the return type.
-	 * @since 1.3
-	 */
-	interface ProducerCallback<K, V, T> {
-
-		T doInKafka(Producer<K, V> producer);
-
-	}
-
-	/**
-	 * A callback for executing arbitrary operations on the {@link KafkaOperations}.
-	 * @param <K> the key type.
-	 * @param <V> the value type.
-	 * @param <T> the return type.
-	 * @since 1.3
-	 */
-	interface OperationsCallback<K, V, T> {
-
-		T doInOperations(KafkaOperations<K, V> operations);
-
-	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/requestreply/AggregatingReplyingKafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/requestreply/AggregatingReplyingKafkaTemplate.java
@@ -170,7 +170,7 @@ public class AggregatingReplyingKafkaTemplate<K, V, R>
 					.map(RecordHolder::getRecord)
 					.collect(Collectors.toList());
 			if (this.releaseStrategy.test(list, true)) {
-				future.set(new ConsumerRecord<>(PARTIAL_RESULTS_AFTER_TIMEOUT_TOPIC, 0, 0L, null, list));
+				future.complete(new ConsumerRecord<>(PARTIAL_RESULTS_AFTER_TIMEOUT_TOPIC, 0, 0L, null, list));
 				return true;
 			}
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/requestreply/RequestReplyFuture.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/requestreply/RequestReplyFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,14 +16,14 @@
 
 package org.springframework.kafka.requestreply;
 
+import java.util.concurrent.CompletableFuture;
+
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
 import org.springframework.kafka.support.SendResult;
-import org.springframework.util.concurrent.ListenableFuture;
-import org.springframework.util.concurrent.SettableListenableFuture;
 
 /**
- * A listenable future for requests/replies.
+ * A {@link CompletableFuture} for requests/replies.
  *
  * @param <K> the key type.
  * @param <V> the outbound data type.
@@ -33,15 +33,21 @@ import org.springframework.util.concurrent.SettableListenableFuture;
  * @since 2.1.3
  *
  */
-public class RequestReplyFuture<K, V, R> extends SettableListenableFuture<ConsumerRecord<K, R>> {
+public class RequestReplyFuture<K, V, R> extends CompletableFuture<ConsumerRecord<K, R>> {
 
-	private volatile ListenableFuture<SendResult<K, V>> sendFuture;
+	private volatile CompletableFuture<SendResult<K, V>> sendFuture;
 
-	protected void setSendFuture(ListenableFuture<SendResult<K, V>> sendFuture) {
+	private CompletableFuture<SendResult<K, V>> completableSendFuture;
+
+	protected void setSendFuture(CompletableFuture<SendResult<K, V>> sendFuture) {
 		this.sendFuture = sendFuture;
 	}
 
-	public ListenableFuture<SendResult<K, V>> getSendFuture() {
+	/**
+	 * Return the send future.
+	 * @return the send future.
+	 */
+	public CompletableFuture<SendResult<K, V>> getSendFuture() {
 		return this.sendFuture;
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/requestreply/RequestReplyMessageFuture.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/requestreply/RequestReplyMessageFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2021-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,10 @@
 
 package org.springframework.kafka.requestreply;
 
+import java.util.concurrent.CompletableFuture;
+
 import org.springframework.kafka.support.SendResult;
 import org.springframework.messaging.Message;
-import org.springframework.util.concurrent.ListenableFuture;
-import org.springframework.util.concurrent.SettableListenableFuture;
 
 /**
  * A listenable future for {@link Message} replies.
@@ -31,11 +31,11 @@ import org.springframework.util.concurrent.SettableListenableFuture;
  * @since 2.7
  *
  */
-public class RequestReplyMessageFuture<K, V> extends SettableListenableFuture<Message<?>> {
+public class RequestReplyMessageFuture<K, V> extends CompletableFuture<Message<?>> {
 
-	private final ListenableFuture<SendResult<K, V>> sendFuture;
+	private final CompletableFuture<SendResult<K, V>> sendFuture; // NOSONAR
 
-	RequestReplyMessageFuture(ListenableFuture<SendResult<K, V>> sendFuture) {
+	RequestReplyMessageFuture(CompletableFuture<SendResult<K, V>> sendFuture) {
 		this.sendFuture = sendFuture;
 	}
 
@@ -43,7 +43,7 @@ public class RequestReplyMessageFuture<K, V> extends SettableListenableFuture<Me
 	 * Return the send future.
 	 * @return the send future.
 	 */
-	public ListenableFuture<SendResult<K, V>> getSendFuture() {
+	public CompletableFuture<SendResult<K, V>> getSendFuture() {
 		return this.sendFuture;
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/requestreply/RequestReplyTypedMessageFuture.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/requestreply/RequestReplyTypedMessageFuture.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2021-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,13 +16,13 @@
 
 package org.springframework.kafka.requestreply;
 
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import org.springframework.kafka.support.SendResult;
 import org.springframework.messaging.Message;
-import org.springframework.util.concurrent.ListenableFuture;
 
 /**
  * A listenable future for {@link Message} replies with a specific payload type.
@@ -37,7 +37,7 @@ import org.springframework.util.concurrent.ListenableFuture;
  */
 public class RequestReplyTypedMessageFuture<K, V, P> extends RequestReplyMessageFuture<K, V> {
 
-	RequestReplyTypedMessageFuture(ListenableFuture<SendResult<K, V>> sendFuture) {
+	RequestReplyTypedMessageFuture(CompletableFuture<SendResult<K, V>> sendFuture) {
 		super(sendFuture);
 	}
 
@@ -54,6 +54,5 @@ public class RequestReplyTypedMessageFuture<K, V, P> extends RequestReplyMessage
 
 		return (Message<P>) super.get(timeout, unit);
 	}
-
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/SendResult.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/SendResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 
 /**
- * Result for a ListenableFuture after a send.
+ * Result for a {@link java.util.concurrent.CompletableFuture} after a send.
  *
  * @param <K> the key type.
  * @param <V> the value type.

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -39,6 +39,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
@@ -155,7 +156,6 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.MimeType;
-import org.springframework.util.concurrent.ListenableFuture;
 import org.springframework.validation.Errors;
 import org.springframework.validation.Validator;
 
@@ -1442,7 +1442,7 @@ public class EnableKafkaIntegrationTests {
 			return new KafkaTemplate<Integer, String>(producerFactory(), true) {
 
 				@Override
-				public ListenableFuture<SendResult<Integer, String>> send(String topic, String data) {
+				public CompletableFuture<SendResult<Integer, String>> send(String topic, String data) {
 					return super.send(topic, 0, null, data);
 				}
 
@@ -1455,7 +1455,7 @@ public class EnableKafkaIntegrationTests {
 			return new KafkaTemplate<Integer, Object>(jsonProducerFactory(), true) {
 
 				@Override
-				public ListenableFuture<SendResult<Integer, Object>> send(String topic, Object data) {
+				public CompletableFuture<SendResult<Integer, Object>> send(String topic, Object data) {
 					return super.send(topic, 0, null, data);
 				}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -58,7 +59,6 @@ import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.kafka.transaction.KafkaTransactionManager;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
-import org.springframework.util.concurrent.ListenableFuture;
 
 /**
  * @author Gary Russell
@@ -337,7 +337,7 @@ public class DefaultKafkaConsumerFactoryTests {
 		KafkaTemplate<Integer, String> template = new KafkaTemplate<>(pf);
 		DefaultKafkaProducerFactory<Integer, String> pfTx = new DefaultKafkaProducerFactory<>(producerProps);
 		pfTx.setTransactionIdPrefix("fooTx.");
-		KafkaTemplate<Integer, String> templateTx = new KafkaTemplate<>(pfTx);
+		KafkaOperations<Integer, String> templateTx = new KafkaTemplate<>(pfTx);
 		Map<String, Object> consumerProps = KafkaTestUtils.consumerProps("txCache1Group", "false", this.embeddedKafka);
 		DefaultKafkaConsumerFactory<Integer, String> cf = new DefaultKafkaConsumerFactory<>(consumerProps);
 		AtomicReference<Consumer<Integer, String>> wrapped = new AtomicReference<>();
@@ -362,7 +362,7 @@ public class DefaultKafkaConsumerFactoryTests {
 				containerProps);
 		container.start();
 		try {
-			ListenableFuture<SendResult<Integer, String>> future = template.send("txCache1", "foo");
+			CompletableFuture<SendResult<Integer, String>> future = template.send("txCache1", "foo");
 			future.get(10, TimeUnit.SECONDS);
 			pf.getCache();
 			assertThat(KafkaTestUtils.getPropertyValue(pf, "cache", Map.class)).hasSize(0);

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/DeadLetterPublishingRecovererTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/DeadLetterPublishingRecovererTests.java
@@ -44,6 +44,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -71,8 +72,6 @@ import org.springframework.kafka.support.SendResult;
 import org.springframework.kafka.support.serializer.DeserializationException;
 import org.springframework.kafka.support.serializer.SerializationUtils;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
-import org.springframework.util.concurrent.ListenableFuture;
-import org.springframework.util.concurrent.SettableListenableFuture;
 
 /**
  * @author Gary Russell
@@ -80,6 +79,7 @@ import org.springframework.util.concurrent.SettableListenableFuture;
  * @since 2.4.3
  *
  */
+@SuppressWarnings("deprecation")
 public class DeadLetterPublishingRecovererTests {
 
 	@SuppressWarnings({ "unchecked", "rawtypes" })
@@ -89,8 +89,8 @@ public class DeadLetterPublishingRecovererTests {
 		given(template.isTransactional()).willReturn(true);
 		given(template.inTransaction()).willReturn(false);
 		given(template.isAllowNonTransactional()).willReturn(true);
-		SettableListenableFuture future = new SettableListenableFuture();
-		future.set(new Object());
+		CompletableFuture future = new CompletableFuture();
+		future.complete(new Object());
 		given(template.send(any(ProducerRecord.class))).willReturn(future);
 		DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(template);
 		ConsumerRecord<String, String> record = new ConsumerRecord<>("foo", 0, 0L, "bar", "baz");
@@ -116,8 +116,8 @@ public class DeadLetterPublishingRecovererTests {
 		KafkaOperations<?, ?> template = mock(KafkaOperations.class);
 		given(template.isTransactional()).willReturn(true);
 		given(template.inTransaction()).willReturn(true);
-		SettableListenableFuture future = new SettableListenableFuture();
-		future.set(new Object());
+		CompletableFuture future = new CompletableFuture();
+		future.complete(new Object());
 		given(template.send(any(ProducerRecord.class))).willReturn(future);
 		DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(template);
 		ConsumerRecord<String, String> record = new ConsumerRecord<>("foo", 0, 0L, "bar", "baz");
@@ -131,8 +131,8 @@ public class DeadLetterPublishingRecovererTests {
 	void testNonTx() {
 		KafkaOperations<?, ?> template = mock(KafkaOperations.class);
 		given(template.isTransactional()).willReturn(false);
-		SettableListenableFuture future = new SettableListenableFuture();
-		future.set(new Object());
+		CompletableFuture future = new CompletableFuture();
+		future.complete(new Object());
 		given(template.send(any(ProducerRecord.class))).willReturn(future);
 		DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(template);
 		ConsumerRecord<String, String> record = new ConsumerRecord<>("foo", 0, 0L, "bar", "baz");
@@ -153,8 +153,8 @@ public class DeadLetterPublishingRecovererTests {
 			((OperationsCallback) inv.getArgument(0)).doInOperations(template);
 			return null;
 		}).given(template).executeInTransaction(any());
-		SettableListenableFuture future = new SettableListenableFuture();
-		future.set(new Object());
+		CompletableFuture future = new CompletableFuture();
+		future.complete(new Object());
 		given(template.send(any(ProducerRecord.class))).willReturn(future);
 		DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(template);
 		ConsumerRecord<String, String> record = new ConsumerRecord<>("foo", 0, 0L, "bar", "baz");
@@ -174,8 +174,8 @@ public class DeadLetterPublishingRecovererTests {
 		Headers custom = new RecordHeaders();
 		custom.add(new RecordHeader("foo", "bar".getBytes()));
 		recoverer.setHeadersFunction((rec, ex) -> custom);
-		SettableListenableFuture future = new SettableListenableFuture();
-		future.set(new Object());
+		CompletableFuture future = new CompletableFuture();
+		future.complete(new Object());
 		willReturn(future).given(template).send(any(ProducerRecord.class));
 		ConsumerRecord<String, String> record = new ConsumerRecord<>("foo", 0, 0L, 0L, TimestampType.CREATE_TIME,
 				0, 0, "bar", "baz", headers, Optional.empty());
@@ -200,8 +200,8 @@ public class DeadLetterPublishingRecovererTests {
 		DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(template);
 		Headers headers = new RecordHeaders();
 		headers.add(new RecordHeader(SerializationUtils.KEY_DESERIALIZER_EXCEPTION_HEADER, header(true)));
-		SettableListenableFuture future = new SettableListenableFuture();
-		future.set(new Object());
+		CompletableFuture future = new CompletableFuture();
+		future.complete(new Object());
 		willReturn(future).given(template).send(any(ProducerRecord.class));
 		ConsumerRecord<String, String> record = new ConsumerRecord<>("foo", 0, 0L, 0L, TimestampType.CREATE_TIME,
 				0, 0, "bar", "baz", headers, Optional.empty());
@@ -221,8 +221,8 @@ public class DeadLetterPublishingRecovererTests {
 		DeserializationException deserEx = createDeserEx(true);
 		headers.add(
 				new RecordHeader(SerializationUtils.KEY_DESERIALIZER_EXCEPTION_HEADER, header(true, deserEx)));
-		SettableListenableFuture future = new SettableListenableFuture();
-		future.set(new Object());
+		CompletableFuture future = new CompletableFuture();
+		future.complete(new Object());
 		willReturn(future).given(template).send(any(ProducerRecord.class));
 		ConsumerRecord<String, String> record = new ConsumerRecord<>("foo", 0, 0L, 0L, TimestampType.CREATE_TIME,
 				0, 0, "bar", "baz", headers, Optional.empty());
@@ -244,8 +244,8 @@ public class DeadLetterPublishingRecovererTests {
 		Headers headers = new RecordHeaders();
 		headers.add(new RecordHeader(SerializationUtils.VALUE_DESERIALIZER_EXCEPTION_HEADER, header(false)));
 		headers.add(new RecordHeader(SerializationUtils.KEY_DESERIALIZER_EXCEPTION_HEADER, header(true)));
-		SettableListenableFuture future = new SettableListenableFuture();
-		future.set(new Object());
+		CompletableFuture future = new CompletableFuture();
+		future.complete(new Object());
 		willReturn(future).given(template).send(any(ProducerRecord.class));
 		ConsumerRecord<String, String> record = new ConsumerRecord<>("foo", 0, 0L, 0L, TimestampType.CREATE_TIME,
 				0, 0, "bar", "baz", headers, Optional.empty());
@@ -263,8 +263,8 @@ public class DeadLetterPublishingRecovererTests {
 	@Test
 	void tombstoneWithMultiTemplates() {
 		KafkaOperations<?, ?> template1 = mock(KafkaOperations.class);
-		SettableListenableFuture future = new SettableListenableFuture();
-		future.set(new Object());
+		CompletableFuture future = new CompletableFuture();
+		future.complete(new Object());
 		given(template1.send(any(ProducerRecord.class))).willReturn(future);
 		KafkaOperations<?, ?> template2 = mock(KafkaOperations.class);
 		Map<Class<?>, KafkaOperations<?, ?>> templates = new LinkedHashMap<>();
@@ -281,8 +281,8 @@ public class DeadLetterPublishingRecovererTests {
 	void tombstoneWithMultiTemplatesExplicit() {
 		KafkaOperations<?, ?> template1 = mock(KafkaOperations.class);
 		KafkaOperations<?, ?> template2 = mock(KafkaOperations.class);
-		SettableListenableFuture future = new SettableListenableFuture();
-		future.set(new Object());
+		CompletableFuture future = new CompletableFuture();
+		future.complete(new Object());
 		given(template2.send(any(ProducerRecord.class))).willReturn(future);
 		Map<Class<?>, KafkaOperations<?, ?>> templates = new LinkedHashMap<>();
 		templates.put(String.class, template1);
@@ -318,7 +318,7 @@ public class DeadLetterPublishingRecovererTests {
 	@Test
 	void allOriginalHeaders() {
 		KafkaOperations<?, ?> template = mock(KafkaOperations.class);
-		ListenableFuture future = mock(ListenableFuture.class);
+		CompletableFuture future = mock(CompletableFuture.class);
 		given(template.send(any(ProducerRecord.class))).willReturn(future);
 		ConsumerRecord<String, String> record = new ConsumerRecord<>("foo", 0, 0L, "bar", null);
 		DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(template);
@@ -338,7 +338,7 @@ public class DeadLetterPublishingRecovererTests {
 	@Test
 	void dontAppendOriginalHeaders() {
 		KafkaOperations<?, ?> template = mock(KafkaOperations.class);
-		ListenableFuture future = mock(ListenableFuture.class);
+		CompletableFuture future = mock(CompletableFuture.class);
 		given(template.send(any(ProducerRecord.class))).willReturn(future);
 		ConsumerRecord<String, String> record = new ConsumerRecord<>("foo", 0, 0L, 1234L,
 				TimestampType.CREATE_TIME, 123, 123, "bar", null, new RecordHeaders(), Optional.empty());
@@ -389,7 +389,7 @@ public class DeadLetterPublishingRecovererTests {
 	@Test
 	void appendOriginalHeaders() {
 		KafkaOperations<?, ?> template = mock(KafkaOperations.class);
-		ListenableFuture future = mock(ListenableFuture.class);
+		CompletableFuture future = mock(CompletableFuture.class);
 		given(template.send(any(ProducerRecord.class))).willReturn(future);
 		ConsumerRecord<String, String> record = new ConsumerRecord<>("foo", 0, 0L, 1234L,
 				TimestampType.CREATE_TIME, 123, 123, "bar", null, new RecordHeaders(), Optional.empty());
@@ -450,7 +450,7 @@ public class DeadLetterPublishingRecovererTests {
 		props.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 10L);
 		given(pf.getConfigurationProperties()).willReturn(props);
 		given(template.getProducerFactory()).willReturn(pf);
-		ListenableFuture<?> future = mock(ListenableFuture.class);
+		CompletableFuture<?> future = mock(CompletableFuture.class);
 		ArgumentCaptor<Long> timeoutCaptor = ArgumentCaptor.forClass(Long.class);
 		given(template.send(any(ProducerRecord.class))).willReturn(future);
 		given(future.get(timeoutCaptor.capture(), eq(TimeUnit.MILLISECONDS))).willThrow(new TimeoutException());
@@ -473,11 +473,11 @@ public class DeadLetterPublishingRecovererTests {
 		Map<String, Object> props = new HashMap<>();
 		given(pf.getConfigurationProperties()).willReturn(props);
 		given(template.getProducerFactory()).willReturn(pf);
-		SettableListenableFuture<SendResult> future = spy(new SettableListenableFuture<>());
+		CompletableFuture<SendResult> future = spy(new CompletableFuture<>());
 		ArgumentCaptor<Long> timeoutCaptor = ArgumentCaptor.forClass(Long.class);
 		given(template.send(any(ProducerRecord.class))).willReturn(future);
 		willAnswer(inv -> {
-			future.set(new SendResult(null, null));
+			future.complete(new SendResult(null, null));
 			return null;
 		}).given(future).get(timeoutCaptor.capture(), eq(TimeUnit.MILLISECONDS));
 		ConsumerRecord<String, String> record = new ConsumerRecord<>("foo", 0, 0L, "bar", null);
@@ -498,11 +498,11 @@ public class DeadLetterPublishingRecovererTests {
 		props.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, 30_000L);
 		given(pf.getConfigurationProperties()).willReturn(props);
 		given(template.getProducerFactory()).willReturn(pf);
-		SettableListenableFuture<SendResult> future = spy(new SettableListenableFuture<>());
+		CompletableFuture<SendResult> future = spy(new CompletableFuture<>());
 		ArgumentCaptor<Long> timeoutCaptor = ArgumentCaptor.forClass(Long.class);
 		given(template.send(any(ProducerRecord.class))).willReturn(future);
 		willAnswer(inv -> {
-			future.set(new SendResult(null, null));
+			future.complete(new SendResult(null, null));
 			return null;
 		}).given(future).get(timeoutCaptor.capture(), eq(TimeUnit.MILLISECONDS));
 		ConsumerRecord<String, String> record = new ConsumerRecord<>("foo", 0, 0L, "bar", null);
@@ -518,7 +518,7 @@ public class DeadLetterPublishingRecovererTests {
 	@Test
 	void notFailIfSendResultIsError() throws Exception {
 		KafkaOperations<?, ?> template = mock(KafkaOperations.class);
-		ListenableFuture<?> future = mock(ListenableFuture.class);
+		CompletableFuture<?> future = mock(CompletableFuture.class);
 		given(template.send(any(ProducerRecord.class))).willReturn(future);
 		given(future.get(anyLong(), eq(TimeUnit.MILLISECONDS))).willThrow(new TimeoutException());
 		ConsumerRecord<String, String> record = new ConsumerRecord<>("foo", 0, 0L, "bar", null);
@@ -531,7 +531,7 @@ public class DeadLetterPublishingRecovererTests {
 	@Test
 	void throwIfNoDestinationReturned() {
 		KafkaOperations<?, ?> template = mock(KafkaOperations.class);
-		ListenableFuture<?> future = mock(ListenableFuture.class);
+		CompletableFuture<?> future = mock(CompletableFuture.class);
 		given(template.send(any(ProducerRecord.class))).willReturn(future);
 		ConsumerRecord<String, String> record = new ConsumerRecord<>("foo", 0, 0L, "bar", null);
 		DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(template, (cr, e) -> null);
@@ -544,7 +544,7 @@ public class DeadLetterPublishingRecovererTests {
 	@Test
 	void notThrowIfNoDestinationReturnedByDefault() {
 		KafkaOperations<?, ?> template = mock(KafkaOperations.class);
-		ListenableFuture<?> future = mock(ListenableFuture.class);
+		CompletableFuture<?> future = mock(CompletableFuture.class);
 		given(template.send(any(ProducerRecord.class))).willReturn(future);
 		ConsumerRecord<String, String> record = new ConsumerRecord<>("foo", 0, 0L, "bar", null);
 		DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(template, (cr, e) -> null);
@@ -555,7 +555,7 @@ public class DeadLetterPublishingRecovererTests {
 	@Test
 	void noCircularRoutingIfFatal() {
 		KafkaOperations<?, ?> template = mock(KafkaOperations.class);
-		ListenableFuture<Object> future = mock(ListenableFuture.class);
+		CompletableFuture<Object> future = mock(CompletableFuture.class);
 		given(template.send(any(ProducerRecord.class))).willReturn(future);
 		ConsumerRecord<String, String> record = new ConsumerRecord<>("foo", 0, 0L, "bar", null);
 		DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(template,
@@ -575,7 +575,7 @@ public class DeadLetterPublishingRecovererTests {
 	@Test
 	void doNotSkipCircularFatalIfSet() {
 		KafkaOperations<?, ?> template = mock(KafkaOperations.class);
-		ListenableFuture<Object> future = mock(ListenableFuture.class);
+		CompletableFuture<Object> future = mock(CompletableFuture.class);
 		given(template.send(any(ProducerRecord.class))).willReturn(future);
 		ConsumerRecord<String, String> record = new ConsumerRecord<>("foo", 0, 0L, "bar", null);
 		DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(template,
@@ -596,7 +596,7 @@ public class DeadLetterPublishingRecovererTests {
 	@Test
 	void headerBitsTurnedOffOneByOne() {
 		KafkaOperations<?, ?> template = mock(KafkaOperations.class);
-		ListenableFuture future = mock(ListenableFuture.class);
+		CompletableFuture future = mock(CompletableFuture.class);
 		given(template.send(any(ProducerRecord.class))).willReturn(future);
 		ConsumerRecord<String, String> record = new ConsumerRecord<>("foo", 0, 0L, "bar", null);
 		DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(template);
@@ -793,7 +793,7 @@ public class DeadLetterPublishingRecovererTests {
 	@Test
 	void headerCreator() {
 		KafkaOperations<?, ?> template = mock(KafkaOperations.class);
-		ListenableFuture future = mock(ListenableFuture.class);
+		CompletableFuture future = mock(CompletableFuture.class);
 		given(template.send(any(ProducerRecord.class))).willReturn(future);
 		ConsumerRecord<String, String> record = new ConsumerRecord<>("foo", 0, 0L, "bar", null);
 		DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(template);
@@ -819,7 +819,7 @@ public class DeadLetterPublishingRecovererTests {
 	@Test
 	void addHeaderFunctionsProcessedInOrder() {
 		KafkaOperations<?, ?> template = mock(KafkaOperations.class);
-		ListenableFuture future = mock(ListenableFuture.class);
+		CompletableFuture future = mock(CompletableFuture.class);
 		given(template.send(any(ProducerRecord.class))).willReturn(future);
 		ConsumerRecord<String, String> record = new ConsumerRecord<>("foo", 0, 0L, "bar", null);
 		DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(template);
@@ -856,7 +856,7 @@ public class DeadLetterPublishingRecovererTests {
 	@Test
 	void immutableHeaders() {
 		KafkaOperations<?, ?> template = mock(KafkaOperations.class);
-		ListenableFuture future = mock(ListenableFuture.class);
+		CompletableFuture future = mock(CompletableFuture.class);
 		given(template.send(any(ProducerRecord.class))).willReturn(future);
 		ConsumerRecord<String, String> record = new ConsumerRecord<>("foo", 0, 0L, "bar", null);
 		DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(template);

--- a/spring-kafka/src/test/java/org/springframework/kafka/requestreply/ReplyingKafkaTemplateTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/requestreply/ReplyingKafkaTemplateTests.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -219,9 +220,10 @@ public class ReplyingKafkaTemplateTests {
 		try {
 			template.setMessageConverter(new StringJsonMessageConverter());
 			template.setDefaultReplyTimeout(Duration.ofSeconds(30));
-			RequestReplyMessageFuture<Integer, String> fut = template.sendAndReceive(MessageBuilder.withPayload("foo")
-					.setHeader(KafkaHeaders.TOPIC, A_REQUEST)
-					.build());
+			RequestReplyMessageFuture<Integer, String> fut = template
+					.sendAndReceive(MessageBuilder.withPayload("foo")
+							.setHeader(KafkaHeaders.TOPIC, A_REQUEST)
+							.build());
 			fut.getSendFuture().get(10, TimeUnit.SECONDS); // send ok
 			Message<?> reply = fut.get(30, TimeUnit.SECONDS);
 			assertThat(reply.getPayload()).isEqualTo("FOO");
@@ -711,7 +713,7 @@ public class ReplyingKafkaTemplateTests {
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
-	void requestTimeoutWithMessage() {
+	void requestTimeoutWithMessage() throws Exception {
 		ProducerFactory pf = mock(ProducerFactory.class);
 		Producer producer = mock(Producer.class);
 		willAnswer(invocation -> {
@@ -727,7 +729,7 @@ public class ReplyingKafkaTemplateTests {
 				.setHeader(KafkaHeaders.TOPIC, "foo")
 				.build();
 		long t1 = System.currentTimeMillis();
-		RequestReplyTypedMessageFuture<String, String, Foo> future = template.sendAndReceive(msg, Duration.ofMillis(10),
+		CompletableFuture future = template.sendAndReceive(msg, Duration.ofMillis(10),
 				new ParameterizedTypeReference<Foo>() {
 				});
 		try {

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DeadLetterPublishingRecovererFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DeadLetterPublishingRecovererFactoryTests.java
@@ -37,6 +37,7 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -62,14 +63,13 @@ import org.springframework.kafka.listener.KafkaBackoffException;
 import org.springframework.kafka.listener.TimestampedException;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.test.condition.LogLevels;
-import org.springframework.util.concurrent.ListenableFuture;
 
 /**
  * @author Tomaz Fernandes
  * @since 2.7
  */
 @ExtendWith(MockitoExtension.class)
-@SuppressWarnings({"unchecked", "rawtypes"})
+@SuppressWarnings({"unchecked", "rawtypes", "deprecation"})
 class DeadLetterPublishingRecovererFactoryTests {
 
 	private final Clock clock = TestClockUtils.CLOCK;
@@ -94,7 +94,7 @@ class DeadLetterPublishingRecovererFactoryTests {
 	private KafkaOperations<?, ?> kafkaOperations;
 
 	@Mock
-	private ListenableFuture<?> listenableFuture;
+	private CompletableFuture<?> completableFuture;
 
 	@Captor
 	private ArgumentCaptor<ProducerRecord> producerRecordCaptor;
@@ -119,7 +119,7 @@ class DeadLetterPublishingRecovererFactoryTests {
 		given(destinationTopicResolver.getDestinationTopicByName(testRetryTopic)).willReturn(destinationTopic);
 		given(destinationTopic.getDestinationDelay()).willReturn(1000L);
 		willReturn(this.kafkaOperations).given(destinationTopic).getKafkaOperations();
-		given(kafkaOperations.send(any(ProducerRecord.class))).willReturn(listenableFuture);
+		given(kafkaOperations.send(any(ProducerRecord.class))).willReturn(completableFuture);
 		this.consumerRecord.headers().add(RetryTopicHeaders.DEFAULT_HEADER_ORIGINAL_TIMESTAMP, originalTimestampBytes);
 
 		DeadLetterPublishingRecovererFactory factory = new DeadLetterPublishingRecovererFactory(this.destinationTopicResolver);
@@ -160,7 +160,7 @@ class DeadLetterPublishingRecovererFactoryTests {
 		given(destinationTopic.getDestinationName()).willReturn(testRetryTopic);
 		given(destinationTopicResolver.getDestinationTopicByName(testRetryTopic)).willReturn(destinationTopic);
 		willReturn(kafkaOperations).given(destinationTopic).getKafkaOperations();
-		given(kafkaOperations.send(any(ProducerRecord.class))).willReturn(listenableFuture);
+		given(kafkaOperations.send(any(ProducerRecord.class))).willReturn(completableFuture);
 
 		DeadLetterPublishingRecovererFactory factory = new DeadLetterPublishingRecovererFactory(this.destinationTopicResolver);
 
@@ -193,7 +193,7 @@ class DeadLetterPublishingRecovererFactoryTests {
 		given(destinationTopic.getDestinationName()).willReturn(testRetryTopic);
 		given(destinationTopicResolver.getDestinationTopicByName(testRetryTopic)).willReturn(destinationTopic);
 		willReturn(kafkaOperations).given(destinationTopic).getKafkaOperations();
-		given(kafkaOperations.send(any(ProducerRecord.class))).willReturn(listenableFuture);
+		given(kafkaOperations.send(any(ProducerRecord.class))).willReturn(completableFuture);
 
 		DeadLetterPublishingRecovererFactory factory = new DeadLetterPublishingRecovererFactory(this.destinationTopicResolver);
 
@@ -224,7 +224,7 @@ class DeadLetterPublishingRecovererFactoryTests {
 		given(destinationTopic.getDestinationName()).willReturn(testRetryTopic);
 		given(destinationTopicResolver.getDestinationTopicByName(testRetryTopic)).willReturn(destinationTopic);
 		willReturn(this.kafkaOperations).given(destinationTopic).getKafkaOperations();
-		given(kafkaOperations.send(any(ProducerRecord.class))).willReturn(listenableFuture);
+		given(kafkaOperations.send(any(ProducerRecord.class))).willReturn(completableFuture);
 
 		DeadLetterPublishingRecovererFactory factory = new DeadLetterPublishingRecovererFactory(
 				this.destinationTopicResolver);
@@ -259,7 +259,7 @@ class DeadLetterPublishingRecovererFactoryTests {
 		given(destinationTopic.getDestinationName()).willReturn(testRetryTopic);
 		given(destinationTopicResolver.getDestinationTopicByName(testRetryTopic)).willReturn(destinationTopic);
 		willReturn(this.kafkaOperations).given(destinationTopic).getKafkaOperations();
-		given(kafkaOperations.send(any(ProducerRecord.class))).willReturn(listenableFuture);
+		given(kafkaOperations.send(any(ProducerRecord.class))).willReturn(completableFuture);
 
 		DeadLetterPublishingRecovererFactory factory = new DeadLetterPublishingRecovererFactory(this.destinationTopicResolver);
 


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2357

Spring Framework is planning to deprecate `ListenableFuture` in 6.0.

Add methods to the `KafkaOperations` (`KafkaTemplate`) that return
`CompletableFuture` instead; the `ListenableFuture` methods have now
been removed in 3.0.
