### PR TITLE
Fix NPE in Global Embedded Kafka

### DIFF
--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/junit/GlobalEmbeddedKafkaTestExecutionListener.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/junit/GlobalEmbeddedKafkaTestExecutionListener.java
@@ -98,7 +98,7 @@ public class GlobalEmbeddedKafkaTestExecutionListener implements TestExecutionLi
 			Integer partitions = configurationParameters.get(PARTITIONS_PROPERTY_NAME, Integer::parseInt).orElse(2);
 			Map<String, String> brokerProperties =
 					configurationParameters.get(BROKER_PROPERTIES_LOCATION_PROPERTY_NAME, this::brokerProperties)
-							.orElse(null);
+							.orElse(Map.of());
 			String brokerListProperty = configurationParameters.get(EmbeddedKafkaBroker.BROKER_LIST_PROPERTY)
 					.orElse(null);
 			int[] ports =

--- a/spring-kafka-test/src/test/java/org/springframework/kafka/test/junit/GlobalEmbeddedKafkaTestExecutionListenerTests.java
+++ b/spring-kafka-test/src/test/java/org/springframework/kafka/test/junit/GlobalEmbeddedKafkaTestExecutionListenerTests.java
@@ -38,6 +38,7 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
@@ -63,11 +64,39 @@ public class GlobalEmbeddedKafkaTestExecutionListenerTests {
 	@AfterAll
 	static void tearDown() {
 		System.clearProperty(GlobalEmbeddedKafkaTestExecutionListener.LISTENER_ENABLED_PROPERTY_NAME);
+	}
+
+	@AfterEach
+	void cleanUp() {
 		System.clearProperty(GlobalEmbeddedKafkaTestExecutionListener.BROKER_PROPERTIES_LOCATION_PROPERTY_NAME);
 	}
 
 	@Test
-	void testGlobalEmbeddedKafkaTestExecutionListener() throws IOException {
+	void testGlobalEmbeddedKafkaTestExecutionListener() {
+		var discoveryRequest =
+				LauncherDiscoveryRequestBuilder.request()
+						.selectors(DiscoverySelectors.selectClass(TestClass1.class),
+								DiscoverySelectors.selectClass(TestClass2.class))
+						.build();
+
+		var summaryGeneratingListener = new SummaryGeneratingListener();
+		LauncherFactory.create().execute(discoveryRequest, summaryGeneratingListener);
+
+		var summary = summaryGeneratingListener.getSummary();
+
+		try {
+			assertThat(summary.getTestsStartedCount()).isEqualTo(2);
+			assertThat(summary.getTestsSucceededCount()).isEqualTo(2);
+			assertThat(summary.getTestsFailedCount()).isEqualTo(0);
+		}
+		catch (Exception ex) {
+			summary.printFailuresTo(new PrintWriter(System.out));
+			throw ex;
+		}
+	}
+
+	@Test
+	void testGlobalEmbeddedKafkaWithBrokerProperties() throws IOException {
 		var brokerProperties = new Properties();
 		brokerProperties.setProperty("auto.create.topics.enable", "false");
 
@@ -134,7 +163,7 @@ public class GlobalEmbeddedKafkaTestExecutionListenerTests {
 					System.getProperty("spring.kafka.bootstrap-servers"));
 			producerConfigs.put(ProducerConfig.RETRIES_CONFIG, 1);
 			producerConfigs.put(ProducerConfig.RETRY_BACKOFF_MS_CONFIG, 1);
-			producerConfigs.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, 10);
+			producerConfigs.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, 1000);
 
 			StringSerializer serializer = new StringSerializer();
 			try (var kafkaProducer = new KafkaProducer<>(producerConfigs, serializer, serializer)) {


### PR DESCRIPTION
The `EmbeddedKafkaBroker.brokerProperties(brokerProperties)` does not accept a `null`.

* Fix `brokerProperties` map extraction for a `.orElse(Map.of())` instead of `null`
* Modify `GlobalEmbeddedKafkaTestExecutionListenerTests` to ensure that `brokerProperties`
are covered both ways - present and missed

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
