### PR TITLE
GH-2357: Remove Remaining Uses of ListenableFuture

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ ext {
 	springBootVersion = '2.6.7' // docs module
 	springDataVersion = '2022.0.0-M5'
 	springRetryVersion = '1.3.3'
-	springVersion = '6.0.0-M5'
+	springVersion = '6.0.0-SNAPSHOT'
 	zookeeperVersion = '3.6.3'
 
 	idPrefix = 'kafka'

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
@@ -33,7 +33,7 @@ import org.apache.kafka.common.TopicPartition;
 
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.core.task.AsyncListenableTaskExecutor;
+import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.support.TopicPartitionOffset;
@@ -62,7 +62,7 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 
 	private final List<KafkaMessageListenerContainer<K, V>> containers = new ArrayList<>();
 
-	private final List<AsyncListenableTaskExecutor> executors = new ArrayList<>();
+	private final List<AsyncTaskExecutor> executors = new ArrayList<>();
 
 	private int concurrency = 1;
 
@@ -237,7 +237,7 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 			stopAbnormally(() -> {
 			});
 		});
-		AsyncListenableTaskExecutor exec = container.getContainerProperties().getConsumerTaskExecutor();
+		AsyncTaskExecutor exec = container.getContainerProperties().getListenerTaskExecutor();
 		if (exec == null) {
 			if ((this.executors.size() > index)) {
 				exec = this.executors.get(index);
@@ -246,7 +246,7 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 				exec = new SimpleAsyncTaskExecutor(beanName + "-C-");
 				this.executors.add(exec);
 			}
-			container.getContainerProperties().setConsumerTaskExecutor(exec);
+			container.getContainerProperties().setListenerTaskExecutor(exec);
 		}
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
@@ -30,7 +30,7 @@ import org.aopalliance.aop.Advice;
 import org.springframework.aop.framework.Advised;
 import org.springframework.aop.framework.ProxyFactory;
 import org.springframework.aop.support.AopUtils;
-import org.springframework.core.task.AsyncListenableTaskExecutor;
+import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.kafka.support.TopicPartitionOffset;
 import org.springframework.lang.Nullable;
 import org.springframework.scheduling.TaskScheduler;
@@ -231,7 +231,7 @@ public class ContainerProperties extends ConsumerProperties {
 	/**
 	 * The executor for threads that poll the consumer.
 	 */
-	private AsyncListenableTaskExecutor consumerTaskExecutor;
+	private AsyncTaskExecutor listenerTaskExecutor;
 
 	/**
 	 * The timeout for shutting down the container. This is the maximum amount of
@@ -380,10 +380,11 @@ public class ContainerProperties extends ConsumerProperties {
 
 	/**
 	 * Set the executor for threads that poll the consumer.
-	 * @param consumerTaskExecutor the executor
+	 * @param listenerTaskExecutor the executor
+	 * @since 2.8.9
 	 */
-	public void setConsumerTaskExecutor(@Nullable AsyncListenableTaskExecutor consumerTaskExecutor) {
-		this.consumerTaskExecutor = consumerTaskExecutor;
+	public void setListenerTaskExecutor(@Nullable AsyncTaskExecutor listenerTaskExecutor) {
+		this.listenerTaskExecutor = listenerTaskExecutor;
 	}
 
 	/**
@@ -466,8 +467,8 @@ public class ContainerProperties extends ConsumerProperties {
 	 * @return the executor.
 	 */
 	@Nullable
-	public AsyncListenableTaskExecutor getConsumerTaskExecutor() {
-		return this.consumerTaskExecutor;
+	public AsyncTaskExecutor getListenerTaskExecutor() {
+		return this.listenerTaskExecutor;
 	}
 
 	public long getShutdownTimeout() {
@@ -919,8 +920,8 @@ public class ContainerProperties extends ConsumerProperties {
 				+ "\n ackCount=" + this.ackCount
 				+ "\n ackTime=" + this.ackTime
 				+ "\n messageListener=" + this.messageListener
-				+ (this.consumerTaskExecutor != null
-						? "\n consumerTaskExecutor=" + this.consumerTaskExecutor
+				+ (this.listenerTaskExecutor != null
+						? "\n listenerTaskExecutor=" + this.listenerTaskExecutor
 						: "")
 				+ "\n shutdownTimeout=" + this.shutdownTimeout
 				+ "\n idleEventInterval="

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaProducerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaProducerFactoryTests.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -58,7 +59,6 @@ import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.kafka.transaction.KafkaTransactionManager;
 import org.springframework.transaction.CannotCreateTransactionException;
 import org.springframework.transaction.support.TransactionTemplate;
-import org.springframework.util.concurrent.SettableListenableFuture;
 
 /**
  * @author Gary Russell
@@ -71,7 +71,7 @@ public class DefaultKafkaProducerFactoryTests {
 	@Test
 	void testProducerClosedAfterBadTransition() throws Exception {
 		final Producer producer = mock(Producer.class);
-		given(producer.send(any(), any())).willReturn(new SettableListenableFuture<>());
+		given(producer.send(any(), any())).willReturn(new CompletableFuture());
 		DefaultKafkaProducerFactory pf = new DefaultKafkaProducerFactory(new HashMap<>()) {
 
 			@Override

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTests.java
@@ -96,7 +96,6 @@ import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
-import org.springframework.util.concurrent.SettableListenableFuture;
 
 /**
  * @author Gary Russell
@@ -422,7 +421,7 @@ public class KafkaTemplateTests {
 		willAnswer(inv -> {
 			Callback callback = inv.getArgument(1);
 			callback.onCompletion(null, new RuntimeException("test"));
-			return new SettableListenableFuture<RecordMetadata>();
+			return new CompletableFuture<RecordMetadata>();
 		}).given(producer).send(any(), any());
 		ProducerFactory<Integer, String> pf = mock(ProducerFactory.class);
 		given(pf.createProducer()).willReturn(producer);
@@ -449,7 +448,7 @@ public class KafkaTemplateTests {
 		willAnswer(inv -> {
 			Callback callback = inv.getArgument(1);
 			callback.onCompletion(null, new RuntimeException("test"));
-			return new SettableListenableFuture<RecordMetadata>();
+			return new CompletableFuture<RecordMetadata>();
 		}).given(producer).send(any(), any());
 		ProducerFactory<Integer, String> pf = mock(ProducerFactory.class);
 		given(pf.createProducer()).willReturn(producer);

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTransactionTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTransactionTests.java
@@ -39,6 +39,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -79,7 +80,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.AbstractPlatformTransactionManager;
 import org.springframework.transaction.support.DefaultTransactionStatus;
 import org.springframework.transaction.support.TransactionTemplate;
-import org.springframework.util.concurrent.SettableListenableFuture;
 
 /**
  * @author Gary Russell
@@ -316,10 +316,10 @@ public class KafkaTemplateTransactionTests {
 	public void testDeadLetterPublisherWhileTransactionActive() {
 		@SuppressWarnings("unchecked")
 		Producer<Object, Object> producer1 = mock(Producer.class);
-		given(producer1.send(any(), any())).willReturn(new SettableListenableFuture<>());
+		given(producer1.send(any(), any())).willReturn(new CompletableFuture<>());
 		@SuppressWarnings("unchecked")
 		Producer<Object, Object> producer2 = mock(Producer.class);
-		given(producer2.send(any(), any())).willReturn(new SettableListenableFuture<>());
+		given(producer2.send(any(), any())).willReturn(new CompletableFuture<>());
 		producer1.initTransactions();
 
 		@SuppressWarnings("unchecked")
@@ -503,10 +503,10 @@ public class KafkaTemplateTransactionTests {
 	public void testExecuteInTransactionNewInnerTx() {
 		@SuppressWarnings("unchecked")
 		Producer<Object, Object> producer1 = mock(Producer.class);
-		given(producer1.send(any(), any())).willReturn(new SettableListenableFuture<>());
+		given(producer1.send(any(), any())).willReturn(new CompletableFuture<>());
 		@SuppressWarnings("unchecked")
 		Producer<Object, Object> producer2 = mock(Producer.class);
-		given(producer2.send(any(), any())).willReturn(new SettableListenableFuture<>());
+		given(producer2.send(any(), any())).willReturn(new CompletableFuture<>());
 		producer1.initTransactions();
 		AtomicBoolean first = new AtomicBoolean(true);
 
@@ -596,7 +596,7 @@ public class KafkaTemplateTransactionTests {
 		@Bean
 		public Producer producer1() {
 			Producer mock = mock(Producer.class);
-			given(mock.send(any(), any())).willReturn(new SettableListenableFuture<>());
+			given(mock.send(any(), any())).willReturn(new CompletableFuture<>());
 			return mock;
 		}
 
@@ -604,7 +604,7 @@ public class KafkaTemplateTransactionTests {
 		@Bean
 		public Producer producer2() {
 			Producer mock = mock(Producer.class);
-			given(mock.send(any(), any())).willReturn(new SettableListenableFuture<>());
+			given(mock.send(any(), any())).willReturn(new CompletableFuture<>());
 			return mock;
 		}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/RoutingKafkaTemplateTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/RoutingKafkaTemplateTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,13 +25,13 @@ import static org.mockito.Mockito.verify;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.regex.Pattern;
 
 import org.apache.kafka.clients.producer.Producer;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.kafka.test.utils.KafkaTestUtils;
-import org.springframework.util.concurrent.SettableListenableFuture;
 
 /**
  * @author Gary Russell
@@ -44,9 +44,9 @@ public class RoutingKafkaTemplateTests {
 	@Test
 	public void routing() {
 		Producer<Object, Object> p1 = mock(Producer.class);
-		given(p1.send(any(), any())).willReturn(new SettableListenableFuture<>());
+		given(p1.send(any(), any())).willReturn(new CompletableFuture<>());
 		Producer<Object, Object> p2 = mock(Producer.class);
-		given(p2.send(any(), any())).willReturn(new SettableListenableFuture<>());
+		given(p2.send(any(), any())).willReturn(new CompletableFuture<>());
 		ProducerFactory<Object, Object> pf1 = mock(ProducerFactory.class);
 		ProducerFactory<Object, Object> pf2 = mock(ProducerFactory.class);
 		given(pf1.createProducer()).willReturn(p1);

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerMockTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerMockTests.java
@@ -101,7 +101,7 @@ public class ConcurrentMessageListenerContainerMockTests {
 		ThreadPoolTaskExecutor exec = new ThreadPoolTaskExecutor();
 		exec.setCorePoolSize(1);
 		exec.afterPropertiesSet();
-		containerProperties.setConsumerTaskExecutor(exec);
+		containerProperties.setListenerTaskExecutor(exec);
 		containerProperties.setConsumerStartTimeout(Duration.ofMillis(50));
 		ConcurrentMessageListenerContainer container = new ConcurrentMessageListenerContainer<>(consumerFactory,
 				containerProperties);

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
@@ -227,7 +227,7 @@ public class KafkaMessageListenerContainerTests {
 		ThreadPoolTaskScheduler scheduler = new ThreadPoolTaskScheduler();
 		scheduler.setPoolSize(10);
 		scheduler.initialize();
-		containerProps.setConsumerTaskExecutor(scheduler);
+		containerProps.setListenerTaskExecutor(scheduler);
 		KafkaMessageListenerContainer<Integer, String> container =
 				new KafkaMessageListenerContainer<>(cf, containerProps);
 		container.setBeanName("delegate");

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/TransactionalContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/TransactionalContainerTests.java
@@ -44,6 +44,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -101,7 +102,6 @@ import org.springframework.transaction.support.AbstractPlatformTransactionManage
 import org.springframework.transaction.support.DefaultTransactionDefinition;
 import org.springframework.transaction.support.DefaultTransactionStatus;
 import org.springframework.util.backoff.FixedBackOff;
-import org.springframework.util.concurrent.SettableListenableFuture;
 
 /**
  * @author Gary Russell
@@ -210,7 +210,7 @@ public class TransactionalContainerTests {
 				return null;
 			}).given(producer).sendOffsetsToTransaction(any(), any(ConsumerGroupMetadata.class));
 		}
-		given(producer.send(any(), any())).willReturn(new SettableListenableFuture<>());
+		given(producer.send(any(), any())).willReturn(new CompletableFuture<>());
 		final CountDownLatch closeLatch = new CountDownLatch(2);
 		willAnswer(i -> {
 			closeLatch.countDown();
@@ -455,7 +455,7 @@ public class TransactionalContainerTests {
 		ConsumerFactory cf = mock(ConsumerFactory.class);
 		willReturn(consumer).given(cf).createConsumer("group", "", null, KafkaTestUtils.defaultPropertyOverrides());
 		Producer producer = mock(Producer.class);
-		given(producer.send(any(), any())).willReturn(new SettableListenableFuture<>());
+		given(producer.send(any(), any())).willReturn(new CompletableFuture<>());
 
 		final CountDownLatch closeLatch = new CountDownLatch(1);
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/requestreply/ReplyingKafkaTemplateTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/requestreply/ReplyingKafkaTemplateTests.java
@@ -97,7 +97,6 @@ import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
-import org.springframework.util.concurrent.SettableListenableFuture;
 
 /**
  * @author Gary Russell
@@ -554,7 +553,7 @@ public class ReplyingKafkaTemplateTests {
 		willAnswer(invocation -> {
 			ProducerRecord rec = invocation.getArgument(0);
 			correlation.set(rec.headers().lastHeader(KafkaHeaders.CORRELATION_ID).value());
-			return new SettableListenableFuture<>();
+			return new CompletableFuture<>();
 		}).given(producer).send(any(), any());
 		AggregatingReplyingKafkaTemplate template = new AggregatingReplyingKafkaTemplate(pf, container,
 				(list, timeout) -> true);
@@ -693,8 +692,8 @@ public class ReplyingKafkaTemplateTests {
 		Producer producer = mock(Producer.class);
 		willAnswer(invocation -> {
 			Callback callback = invocation.getArgument(1);
-			SettableListenableFuture<Object> future = new SettableListenableFuture<>();
-			future.set("done");
+			CompletableFuture<Object> future = new CompletableFuture<>();
+			future.complete("done");
 			callback.onCompletion(new RecordMetadata(new TopicPartition("foo", 0), 0L, 0, 0L, 0, 0), null);
 			return future;
 		}).given(producer).send(any(), any());
@@ -717,7 +716,7 @@ public class ReplyingKafkaTemplateTests {
 		ProducerFactory pf = mock(ProducerFactory.class);
 		Producer producer = mock(Producer.class);
 		willAnswer(invocation -> {
-			return new SettableListenableFuture<>();
+			return new CompletableFuture<>();
 		}).given(producer).send(any(), any());
 		given(pf.createProducer()).willReturn(producer);
 		GenericMessageListenerContainer container = mock(GenericMessageListenerContainer.class);

--- a/spring-kafka/src/test/java/org/springframework/kafka/streams/KafkaStreamsTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/streams/KafkaStreamsTests.java
@@ -23,6 +23,7 @@ import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -72,7 +73,6 @@ import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
-import org.springframework.util.concurrent.SettableListenableFuture;
 
 /**
  * @author Artem Bilan
@@ -105,7 +105,7 @@ public class KafkaStreamsTests {
 	private KafkaTemplate<Integer, String> kafkaTemplate;
 
 	@Autowired
-	private SettableListenableFuture<ConsumerRecord<?, String>> resultFuture;
+	private CompletableFuture<ConsumerRecord<?, String>> resultFuture;
 
 	@Autowired
 	private StreamsBuilderFactoryBean streamsBuilderFactoryBean;
@@ -264,13 +264,13 @@ public class KafkaStreamsTests {
 		}
 
 		@Bean
-		public SettableListenableFuture<ConsumerRecord<?, String>> resultFuture() {
-			return new SettableListenableFuture<>();
+		public CompletableFuture<ConsumerRecord<?, String>> resultFuture() {
+			return new CompletableFuture<>();
 		}
 
 		@KafkaListener(topics = "${streaming.topic.two}")
 		public void listener(ConsumerRecord<?, String> payload) {
-			resultFuture().set(payload);
+			resultFuture().complete(payload);
 		}
 
 	}

--- a/spring-kafka/src/test/java/org/springframework/kafka/streams/RecoveringDeserializationExceptionHandlerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/streams/RecoveringDeserializationExceptionHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2020 the original author or authors.
+ * Copyright 2019-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -65,7 +66,6 @@ import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
-import org.springframework.util.concurrent.SettableListenableFuture;
 
 /**
  * @author Gary Russell
@@ -81,7 +81,7 @@ public class RecoveringDeserializationExceptionHandlerTests {
 	private KafkaTemplate<byte[], byte[]> kafkaTemplate;
 
 	@Autowired
-	private SettableListenableFuture<ConsumerRecord<byte[], byte[]>> resultFuture;
+	private CompletableFuture<ConsumerRecord<byte[], byte[]>> resultFuture;
 
 	@Test
 	void viaStringProperty() {
@@ -237,13 +237,13 @@ public class RecoveringDeserializationExceptionHandlerTests {
 		}
 
 		@Bean
-		public SettableListenableFuture<ConsumerRecord<byte[], byte[]>> resultFuture() {
-			return new SettableListenableFuture<>();
+		public CompletableFuture<ConsumerRecord<byte[], byte[]>> resultFuture() {
+			return new CompletableFuture<>();
 		}
 
 		@KafkaListener(topics = "recovererDLQ")
 		public void listener(ConsumerRecord<byte[], byte[]> payload) {
-			resultFuture().set(payload);
+			resultFuture().complete(payload);
 		}
 
 	}


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2357

**main only; will issue separate PR to deprecate setters in 2.9**
