### PR TITLE
Remove sharing of the retrying field in FallbackBatchErrorHandler

### DIFF
--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/FallbackBatchErrorHandlerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/FallbackBatchErrorHandlerTests.java
@@ -16,17 +16,17 @@
 
 package org.springframework.kafka.listener;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willAnswer;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.springframework.kafka.KafkaException;
+import org.springframework.util.ReflectionUtils;
+import org.springframework.util.backoff.FixedBackOff;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -34,15 +34,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.common.TopicPartition;
-import org.junit.jupiter.api.Test;
-import org.mockito.InOrder;
-
-import org.springframework.kafka.KafkaException;
-import org.springframework.util.backoff.FixedBackOff;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 /**
  * @author Gary Russell
@@ -202,4 +205,35 @@ public class FallbackBatchErrorHandlerTests {
 		verifyNoMoreInteractions(consumer);
 	}
 
+	@Test
+	void resetRetryingFlagOnExceptionFromRetryBatch() {
+		FallbackBatchErrorHandler eh = new FallbackBatchErrorHandler(new FixedBackOff(0L, 1L), (consumerRecord, e) -> { });
+
+		Consumer<?, ?> consumer = mock(Consumer.class);
+		// KafkaException could be thrown from SeekToCurrentBatchErrorHandler, but it is hard to mock
+		KafkaException exception = new KafkaException("Failed consumer.resume()");
+		doThrow(exception).when(consumer).resume(any());
+
+		MessageListenerContainer container = mock(MessageListenerContainer.class);
+		given(container.isRunning()).willReturn(true);
+
+		Map<TopicPartition, List<ConsumerRecord<Object, Object>>> map = new HashMap<>();
+		map.put(new TopicPartition("foo", 0),
+				Collections.singletonList(new ConsumerRecord<>("foo", 0, 0L, "foo", "bar")));
+		ConsumerRecords<?, ?> records = new ConsumerRecords<>(map);
+
+		assertThatThrownBy(() -> eh.handle(new RuntimeException(), records, consumer, container, () -> {}))
+				.isSameAs(exception);
+
+		assertThat(getRetryingFieldValue(eh))
+				.withFailMessage("retrying field was not reset to false")
+				.isFalse();
+	}
+
+	private boolean getRetryingFieldValue(FallbackBatchErrorHandler errorHandler) {
+		Field field = ReflectionUtils.findField(FallbackBatchErrorHandler.class, "retrying");
+		ReflectionUtils.makeAccessible(field);
+		ThreadLocal<Boolean> value = (ThreadLocal<Boolean>) ReflectionUtils.getField(field, errorHandler);
+		return value.get();
+	}
 }


### PR DESCRIPTION
This PR fixes 2 issues:
1. If an exception is thrown from ErrorHandlingUtils.retryBatch (for instance if SeekToCurrentBatchErrorHandler failed), then retrying field will never be reset back to false.
2. Error handlers are shared between different consumers when  concurrency > 1, when one of them is retrying and rebalancing happens, it may result in one of the consumer being paused and never recovering again.

I'm not sure if it is a good idea in general to add a state to a shared class, it probably should be attributed to a particular consumer rather than an error handler.

Fixes #2382 