### PR TITLE
Fix typo in changes-since-1.0.adoc

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/changes-since-1.0.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/changes-since-1.0.adoc
@@ -19,7 +19,7 @@ See <<backoff-handlers>> for more information.
 ==== Listener Container Changes
 
 `interceptBeforeTx` now works with all transaction managers (previously it was only applied when a `KafkaAwareTransactionManager` was used).
-See <<interceptBeforeTX>>.
+See <<interceptBeforeTx>>.
 
 A new container property `pauseImmediate` is provided which allows the container to pause the consumer after the current record is processed, instead of after all the records from the previous poll have been processed.
 See <<pauseImmediate>>.


### PR DESCRIPTION
same as #2384

(https://docs.spring.io/spring-kafka/docs/3.0.0-SNAPSHOT/reference/html/#x29-lc-changes)