### PR TITLE
GH-2184: Don't Log KafkaBackoffException

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/DefaultErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/DefaultErrorHandler.java
@@ -157,7 +157,12 @@ public class DefaultErrorHandler extends FailedBatchProcessor implements CommonE
 			return getFailureTracker().recovered(record, thrownException, container, consumer);
 		}
 		catch (Exception ex) {
-			logger.error(ex, "Failed to handle " + KafkaUtils.format(record) + " with " + thrownException);
+			if (SeekUtils.isBackoffException(thrownException)) {
+				this.logger.debug(ex, "Failed to handle " + KafkaUtils.format(record) + " with " + thrownException);
+			}
+			else {
+				this.logger.error(ex, "Failed to handle " + KafkaUtils.format(record) + " with " + thrownException);
+			}
 			return false;
 		}
 	}


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2184

`KafkaBackOffException`s are incorrectly logged at ERROR level during
retries when using the no-seek error handling mode.

They are not logged in the seek mode; see
https://github.com/spring-projects/spring-kafka/commit/448871ac6529a45f4d54f837d370696c76705191

**cherry-pick to 2.9.x**

