### PR TITLE
GH-2400: ReplyingKT Improve CorrelationId Logging

### DIFF
--- a/spring-kafka/src/test/java/org/springframework/kafka/requestreply/CorrelationKeyTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/requestreply/CorrelationKeyTests.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.requestreply;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author Gary Russell
+ * @since 2.8.10
+ *
+ */
+public class CorrelationKeyTests {
+
+	@Test
+	void asString() {
+		CorrelationKey key = new CorrelationKey(new byte[16]);
+		assertThat(key.toString()).isEqualTo("00000000-0000-0000-0000-000000000000");
+		key = new CorrelationKey(new byte[10]);
+		assertThat(key.toString()).isEqualTo("00000000000000000000");
+	}
+
+}


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2400

Use a hex string instead of a `BigInteger` in `toString`. Also, if the bytes are the length of a UUID, use the standard representation thereof.

**cherry-pick to 2.9.x**
