### PR TITLE
GH-2399: ReplyingKT Human Readable Correlation

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/requestreply/AggregatingReplyingKafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/requestreply/AggregatingReplyingKafkaTemplate.java
@@ -16,6 +16,7 @@
 
 package org.springframework.kafka.requestreply;
 
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -70,7 +71,7 @@ public class AggregatingReplyingKafkaTemplate<K, V, R>
 
 	private static final int DEFAULT_COMMIT_TIMEOUT = 30;
 
-	private final Map<CorrelationKey, Set<RecordHolder<K, R>>> pending = new HashMap<>();
+	private final Map<Object, Set<RecordHolder<K, R>>> pending = new HashMap<>();
 
 	private final Map<TopicPartition, Long> offsets = new HashMap<>();
 
@@ -132,7 +133,9 @@ public class AggregatingReplyingKafkaTemplate<K, V, R>
 						+ " in the '" + correlationHeaderName + "' header");
 			}
 			else {
-				CorrelationKey correlationId = new CorrelationKey(correlation.value());
+				Object correlationId = isBinaryCorrelation()
+						? new CorrelationKey(correlation.value())
+						: new String(correlation.value(), StandardCharsets.UTF_8);
 				synchronized (this) {
 					if (isPending(correlationId)) {
 						List<ConsumerRecord<K, R>> list = addToCollection(record, correlationId).stream()
@@ -142,8 +145,10 @@ public class AggregatingReplyingKafkaTemplate<K, V, R>
 							ConsumerRecord<K, Collection<ConsumerRecord<K, R>>> done =
 									new ConsumerRecord<>(AGGREGATED_RESULTS_TOPIC, 0, 0L, null, list);
 							done.headers()
-									.add(new RecordHeader(correlationHeaderName, correlationId
-											.getCorrelationId()));
+									.add(new RecordHeader(correlationHeaderName,
+											isBinaryCorrelation()
+													? ((CorrelationKey) correlationId).getCorrelationId()
+													: ((String) correlationId).getBytes(StandardCharsets.UTF_8)));
 							this.pending.remove(correlationId);
 							checkOffsetsAndCommitIfNecessary(list, consumer);
 							completed.add(done);
@@ -161,7 +166,7 @@ public class AggregatingReplyingKafkaTemplate<K, V, R>
 	}
 
 	@Override
-	protected synchronized boolean handleTimeout(CorrelationKey correlationId,
+	protected synchronized boolean handleTimeout(Object correlationId,
 			RequestReplyFuture<K, V, Collection<ConsumerRecord<K, R>>> future) {
 
 		Set<RecordHolder<K, R>> removed = this.pending.remove(correlationId);
@@ -191,7 +196,7 @@ public class AggregatingReplyingKafkaTemplate<K, V, R>
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
-	private Set<RecordHolder<K, R>> addToCollection(ConsumerRecord record, CorrelationKey correlationId) {
+	private Set<RecordHolder<K, R>> addToCollection(ConsumerRecord record, Object correlationId) {
 		Set<RecordHolder<K, R>> set = this.pending.computeIfAbsent(correlationId, id -> new LinkedHashSet<>());
 		set.add(new RecordHolder<>(record));
 		return set;

--- a/spring-kafka/src/test/java/org/springframework/kafka/requestreply/ReplyingKafkaTemplateTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/requestreply/ReplyingKafkaTemplateTests.java
@@ -493,7 +493,7 @@ public class ReplyingKafkaTemplateTests {
 	}
 
 	@Test
-	public void testAggregateNormaStringCorrelationl() throws Exception {
+	public void testAggregateNormalStringCorrelation() throws Exception {
 		AggregatingReplyingKafkaTemplate<Integer, String, String> template = aggregatingTemplate(
 				new TopicPartitionOffset(D_REPLY, 0), 2, new AtomicInteger());
 		try {

--- a/spring-kafka/src/test/java/org/springframework/kafka/requestreply/ReplyingKafkaTemplateTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/requestreply/ReplyingKafkaTemplateTests.java
@@ -399,6 +399,26 @@ public class ReplyingKafkaTemplateTests {
 	}
 
 	@Test
+	public void testGoodDefaultReplyHeadersStringCorrelation() throws Exception {
+		ReplyingKafkaTemplate<Integer, String, String> template = createTemplate(
+				new TopicPartitionOffset(A_REPLY, 3));
+		try {
+			template.setDefaultReplyTimeout(Duration.ofSeconds(30));
+			template.setBinaryCorrelation(false);
+			ProducerRecord<Integer, String> record = new ProducerRecord<>(A_REQUEST, "bar");
+			RequestReplyFuture<Integer, String, String> future = template.sendAndReceive(record);
+			future.getSendFuture().get(10, TimeUnit.SECONDS); // send ok
+			ConsumerRecord<Integer, String> consumerRecord = future.get(30, TimeUnit.SECONDS);
+			assertThat(consumerRecord.value()).isEqualTo("BAR");
+			assertThat(consumerRecord.partition()).isEqualTo(3);
+		}
+		finally {
+			template.stop();
+			template.destroy();
+		}
+	}
+
+	@Test
 	public void testGoodSamePartition() throws Exception {
 		ReplyingKafkaTemplate<Integer, String, String> template = createTemplate(A_REPLY);
 		try {
@@ -472,6 +492,35 @@ public class ReplyingKafkaTemplateTests {
 		}
 	}
 
+	@Test
+	public void testAggregateNormaStringCorrelationl() throws Exception {
+		AggregatingReplyingKafkaTemplate<Integer, String, String> template = aggregatingTemplate(
+				new TopicPartitionOffset(D_REPLY, 0), 2, new AtomicInteger());
+		try {
+			template.setCorrelationHeaderName("customCorrelation");
+			template.setBinaryCorrelation(false);
+			template.setDefaultReplyTimeout(Duration.ofSeconds(30));
+			ProducerRecord<Integer, String> record = new ProducerRecord<>(D_REQUEST, null, null, null, "foo");
+			RequestReplyFuture<Integer, String, Collection<ConsumerRecord<Integer, String>>> future =
+					template.sendAndReceive(record);
+			future.getSendFuture().get(10, TimeUnit.SECONDS); // send ok
+			ConsumerRecord<Integer, Collection<ConsumerRecord<Integer, String>>> consumerRecord =
+					future.get(30, TimeUnit.SECONDS);
+			assertThat(consumerRecord.value().size()).isEqualTo(2);
+			Iterator<ConsumerRecord<Integer, String>> iterator = consumerRecord.value().iterator();
+			String value1 = iterator.next().value();
+			assertThat(value1).isIn("fOO", "FOO");
+			String value2 = iterator.next().value();
+			assertThat(value2).isIn("fOO", "FOO");
+			assertThat(value2).isNotSameAs(value1);
+			assertThat(consumerRecord.topic()).isEqualTo(AggregatingReplyingKafkaTemplate.AGGREGATED_RESULTS_TOPIC);
+		}
+		finally {
+			template.stop();
+			template.destroy();
+		}
+	}
+
 	@SuppressWarnings("unchecked")
 	@Test
 	@Disabled("time sensitive")
@@ -480,6 +529,7 @@ public class ReplyingKafkaTemplateTests {
 				new TopicPartitionOffset(E_REPLY, 0), 3, new AtomicInteger());
 		try {
 			template.setDefaultReplyTimeout(Duration.ofSeconds(5));
+			template.setCorrelationHeaderName("customCorrelation");
 			ProducerRecord<Integer, String> record = new ProducerRecord<>(E_REQUEST, null, null, null, "foo");
 			RequestReplyFuture<Integer, String, Collection<ConsumerRecord<Integer, String>>> future =
 					template.sendAndReceive(record);
@@ -508,7 +558,6 @@ public class ReplyingKafkaTemplateTests {
 	}
 
 	@Test
-	@Disabled("time sensitive")
 	public void testAggregateTimeoutPartial() throws Exception {
 		AtomicInteger releaseCount = new AtomicInteger();
 		AggregatingReplyingKafkaTemplate<Integer, String, String> template = aggregatingTemplate(
@@ -516,6 +565,7 @@ public class ReplyingKafkaTemplateTests {
 		template.setReturnPartialOnTimeout(true);
 		try {
 			template.setDefaultReplyTimeout(Duration.ofSeconds(5));
+			template.setCorrelationHeaderName("customCorrelation");
 			ProducerRecord<Integer, String> record = new ProducerRecord<>(F_REQUEST, null, null, null, "foo");
 			RequestReplyFuture<Integer, String, Collection<ConsumerRecord<Integer, String>>> future =
 					template.sendAndReceive(record);
@@ -531,7 +581,40 @@ public class ReplyingKafkaTemplateTests {
 			assertThat(value2).isNotSameAs(value1);
 			assertThat(consumerRecord.topic())
 					.isEqualTo(AggregatingReplyingKafkaTemplate.PARTIAL_RESULTS_AFTER_TIMEOUT_TOPIC);
-			assertThat(releaseCount.get()).isEqualTo(2);
+			assertThat(releaseCount.get()).isEqualTo(3);
+		}
+		finally {
+			template.stop();
+			template.destroy();
+		}
+	}
+
+	@Test
+	public void testAggregateTimeoutPartialStringCorrelation() throws Exception {
+		AtomicInteger releaseCount = new AtomicInteger();
+		AggregatingReplyingKafkaTemplate<Integer, String, String> template = aggregatingTemplate(
+				new TopicPartitionOffset(F_REPLY, 0), 3, releaseCount);
+		template.setReturnPartialOnTimeout(true);
+		template.setBinaryCorrelation(false);
+		try {
+			template.setDefaultReplyTimeout(Duration.ofSeconds(5));
+			template.setCorrelationHeaderName("customCorrelation");
+			ProducerRecord<Integer, String> record = new ProducerRecord<>(F_REQUEST, null, null, null, "foo");
+			RequestReplyFuture<Integer, String, Collection<ConsumerRecord<Integer, String>>> future =
+					template.sendAndReceive(record);
+			future.getSendFuture().get(10, TimeUnit.SECONDS); // send ok
+			ConsumerRecord<Integer, Collection<ConsumerRecord<Integer, String>>> consumerRecord =
+					future.get(30, TimeUnit.SECONDS);
+			assertThat(consumerRecord.value().size()).isEqualTo(2);
+			Iterator<ConsumerRecord<Integer, String>> iterator = consumerRecord.value().iterator();
+			String value1 = iterator.next().value();
+			assertThat(value1).isIn("fOO", "FOO");
+			String value2 = iterator.next().value();
+			assertThat(value2).isIn("fOO", "FOO");
+			assertThat(value2).isNotSameAs(value1);
+			assertThat(consumerRecord.topic())
+					.isEqualTo(AggregatingReplyingKafkaTemplate.PARTIAL_RESULTS_AFTER_TIMEOUT_TOPIC);
+			assertThat(releaseCount.get()).isEqualTo(3);
 		}
 		finally {
 			template.stop();
@@ -654,7 +737,7 @@ public class ReplyingKafkaTemplateTests {
 				new AggregatingReplyingKafkaTemplate<>(this.config.pf(), container,
 						(list, timeout) -> {
 							releaseCount.incrementAndGet();
-							return list.size() == releaseSize;
+							return list.size() == releaseSize || timeout;
 						});
 		template.setSharedReplyTopic(true);
 		template.start();


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2399

By default, the correlationId header contains a binary representation of a UUID; add an option to use a String representation instead.
