### PR TITLE
GH-2395: RetryListener - Add Batch Methods

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -5279,6 +5279,7 @@ public DefaultErrorHandler errorHandler(ConsumerRecordRecoverer recoverer) {
 ====
 
 The error handler can be configured with one or more `RetryListener` s, receiving notifications of retry and recovery progress.
+Starting with version 2.8.10, methods for batch listeners were added.
 
 ====
 [source, java]
@@ -5293,6 +5294,15 @@ public interface RetryListener {
 
     default void recoveryFailed(ConsumerRecord<?, ?> record, Exception original, Exception failure) {
     }
+
+	default void failedDelivery(ConsumerRecords<?, ?> records, Exception ex, int deliveryAttempt) {
+	}
+
+	default void recovered(ConsumerRecords<?, ?> records, Exception ex) {
+	}
+
+	default void recoveryFailed(ConsumerRecords<?, ?> records, Exception original, Exception failure) {
+	}
 
 }
 ----

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordProcessor.java
@@ -16,6 +16,8 @@
 
 package org.springframework.kafka.listener;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
@@ -53,6 +55,8 @@ public abstract class FailedRecordProcessor extends ExceptionClassifier implemen
 	protected final LogAccessor logger = new LogAccessor(LogFactory.getLog(getClass())); // NOSONAR
 
 	private final FailedRecordTracker failureTracker;
+
+	private final List<RetryListener> retryListeners = new ArrayList<>();
 
 	private boolean commitRecovered;
 
@@ -130,7 +134,14 @@ public abstract class FailedRecordProcessor extends ExceptionClassifier implemen
 	 * @since 2.7
 	 */
 	public void setRetryListeners(RetryListener... listeners) {
+		Assert.noNullElements(listeners, "'listeners' cannot have null elements");
 		this.failureTracker.setRetryListeners(listeners);
+		this.retryListeners.clear();
+		this.retryListeners.addAll(Arrays.asList(listeners));
+	}
+
+	protected List<RetryListener> getRetryListeners() {
+		return this.retryListeners;
 	}
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/RetryListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/RetryListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2021-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.kafka.listener;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
 
 /**
  * A listener for retry activity.
@@ -51,6 +52,33 @@ public interface RetryListener {
 	 * @param failure the exception thrown by the recoverer.
 	 */
 	default void recoveryFailed(ConsumerRecord<?, ?> record, Exception original, Exception failure) {
+	}
+
+	/**
+	 * Called after a delivery failed for batch records.
+	 * @param records the records.
+	 * @param ex the exception.
+	 * @param deliveryAttempt the delivery attempt, if available.
+	 * @since 2.8.10
+	 */
+	default void failedDelivery(ConsumerRecords<?, ?> records, Exception ex, int deliveryAttempt) {
+	}
+
+	/**
+	 * Called after a failing record was successfully recovered.
+	 * @param records the record.
+	 * @param ex the exception.
+	 */
+	default void recovered(ConsumerRecords<?, ?> records, Exception ex) {
+	}
+
+	/**
+	 * Called after a recovery attempt failed.
+	 * @param records the record.
+	 * @param original the original exception causing the recovery attempt.
+	 * @param failure the exception thrown by the recoverer.
+	 */
+	default void recoveryFailed(ConsumerRecords<?, ?> records, Exception original, Exception failure) {
 	}
 
 }


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2395

Previously, `RetryListener` only supported record listeners; add methods for retrying batches.

**cherry-pick to 2.9.x, 2.8.x**
