### PR TITLE
GH-2348: Custom Correlation Consumer Side

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -726,6 +726,9 @@ These header names are used by the `@KafkaListener` infrastructure to route the 
 Starting with version 2.3, you can customize the header names - the template has 3 properties `correlationHeaderName`, `replyTopicHeaderName`, and `replyPartitionHeaderName`.
 This is useful if your server is not a Spring application (or does not use the `@KafkaListener`).
 
+NOTE: Conversely, if the requesting application is not a spring application and puts correlation information in a different header, starting with version 3.0, you can configure a custom `correlationHeaderName` on the listener container factory and that header will be echoed back.
+Previously, the listener had to echo custom correlation headers.
+
 [[exchanging-messages]]
 ====== Request/Reply with `Message<?>` s
 

--- a/spring-kafka-docs/src/main/asciidoc/whats-new.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/whats-new.adoc
@@ -52,3 +52,9 @@ See <<kafka-template>>.
 
 The futures returned by this class are now `CompletableFuture` s instead of `ListenableFuture` s.
 See <<replying-template>> and <<exchanging-messages>>.
+
+[[x30-listener]]
+==== `@KafkaListener` Changes
+
+You can now use a custom correlation header which will be echoed in any reply message.
+See the note at the end of <<replying-template>> for more information.

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
@@ -108,6 +108,8 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 
 	private ContainerCustomizer<K, V, C> containerCustomizer;
 
+	private String correlationHeaderName;
+
 	@Override
 	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
 		this.applicationContext = applicationContext;
@@ -321,6 +323,17 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 		this.containerCustomizer = containerCustomizer;
 	}
 
+	/**
+	 * Set a custom header name for the correlation id. Default
+	 * {@link org.springframework.kafka.support.KafkaHeaders#CORRELATION_ID}. This header
+	 * will be echoed back in any reply message.
+	 * @param correlationHeaderName the header name.
+	 * @since 3.0
+	 */
+	public void setCorrelationHeaderName(String correlationHeaderName) {
+		this.correlationHeaderName = correlationHeaderName;
+	}
+
 	@SuppressWarnings("deprecation")
 	@Override
 	public void afterPropertiesSet() {
@@ -363,7 +376,8 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 				.acceptIfNotNull(this.ackDiscarded, aklEndpoint::setAckDiscarded)
 				.acceptIfNotNull(this.replyTemplate, aklEndpoint::setReplyTemplate)
 				.acceptIfNotNull(this.replyHeadersConfigurer, aklEndpoint::setReplyHeadersConfigurer)
-				.acceptIfNotNull(this.batchToRecordAdapter, aklEndpoint::setBatchToRecordAdapter);
+				.acceptIfNotNull(this.batchToRecordAdapter, aklEndpoint::setBatchToRecordAdapter)
+				.acceptIfNotNull(this.correlationHeaderName, aklEndpoint::setCorrelationHeaderName);
 		if (aklEndpoint.getBatchListener() == null) {
 			JavaUtils.INSTANCE
 					.acceptIfNotNull(this.batchListener, aklEndpoint::setBatchListener);


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2348

The replying template supports a custom header for correlation for cases when the consumer side is not a Spring app and uses a different header.

Support a custom header name on the consumer side, for cases where the client side is not Spring and uses a different header.
