### PR TITLE
GH-2419: DLPR: Protect Against Non-Compliant PF

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
@@ -688,7 +688,13 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 	protected Duration determineSendTimeout(KafkaOperations<?, ?> template) {
 		ProducerFactory<? extends Object, ? extends Object> producerFactory = template.getProducerFactory();
 		if (producerFactory != null) { // NOSONAR - will only occur in mock tests
-			Map<String, Object> props = producerFactory.getConfigurationProperties();
+			Map<String, Object> props;
+			try {
+				props = producerFactory.getConfigurationProperties();
+			}
+			catch (UnsupportedOperationException ex) {
+				props = Collections.emptyMap();
+			}
 			if (props != null) { // NOSONAR - will only occur in mock tests
 				return KafkaUtils.determineSendTimeout(props, this.timeoutBuffer,
 						this.waitForSendResultTimeout.toMillis());


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2419

We try to obtain the configured request timeout using the producer factory's configuration properties. Some wrappers (e.g. open tracing) do not implement this method, so fallback to the default instead of throwing an USOE.

**cherry-pick to 2.9.x, 2.8.x**
