### PR TITLE
GH-2432: Fix Retryable Topic Provisioning

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
@@ -21,7 +21,6 @@ import java.util.Collection;
 import java.util.function.Consumer;
 
 import org.apache.commons.logging.LogFactory;
-import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
 import org.springframework.beans.BeansException;
@@ -37,6 +36,7 @@ import org.springframework.kafka.config.MethodKafkaListenerEndpoint;
 import org.springframework.kafka.config.MultiMethodKafkaListenerEndpoint;
 import org.springframework.kafka.support.EndpointHandlerMethod;
 import org.springframework.kafka.support.KafkaUtils;
+import org.springframework.kafka.support.TopicForRetryable;
 import org.springframework.lang.Nullable;
 
 
@@ -363,7 +363,7 @@ public class RetryTopicConfigurer implements BeanFactoryAware {
 				String beanName = topic + "-topicRegistrationBean";
 				if (!bf.containsBean(beanName)) {
 					bf.registerSingleton(beanName,
-							new NewTopic(topic, config.getNumPartitions(), config.getReplicationFactor()));
+							new TopicForRetryable(topic, config.getNumPartitions(), config.getReplicationFactor()));
 				}
 			}
 		);

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/TopicForRetryable.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/TopicForRetryable.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support;
+
+import org.apache.kafka.clients.admin.NewTopic;
+
+/**
+ * Marker to indicate this {@link NewTopic} is for retryable topics; admin will ignore these if
+ * a regular {@link NewTopic} exist.
+ *
+ * @author Gary Russell
+ * @since 2.8.10
+ *
+ */
+public class TopicForRetryable extends NewTopic {
+
+	/**
+	 * Create an instance with the provided properties.
+	 * @param topic the topic.
+	 * @param numPartitions the partitions.
+	 * @param replicationFactor the replication factor.
+	 */
+	public TopicForRetryable(String topic, int numPartitions, short replicationFactor) {
+		super(topic, numPartitions, replicationFactor);
+	}
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicIntegrationTests.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.kafka.clients.admin.AdminClientConfig;
@@ -156,11 +157,14 @@ public class RetryTopicIntegrationTests extends AbstractRetryTopicIntegrationTes
 		}, m -> m.getName().equals("newTopics"));
 		@SuppressWarnings("unchecked")
 		Collection<NewTopic> weededTopics = (Collection<NewTopic>) method.get().invoke(admin);
+		AtomicInteger weeded = new AtomicInteger();
 		weededTopics.forEach(topic -> {
 			if (topic.name().equals(THIRD_TOPIC) || topic.name().equals(FOURTH_TOPIC)) {
 				assertThat(topic).isExactlyInstanceOf(NewTopic.class);
+				weeded.incrementAndGet();
 			}
 		});
+		assertThat(weeded.get()).isEqualTo(2);
 	}
 
 	@Test


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2432

Don't provision an individual retry topic bean, if there is already a `NewTopic` bean with the same topic name.

**cherry-pick to 2.9.x, 2.8.x**
