### PR TITLE
Add meta-annotation support to RetryableTopic

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryableTopic.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryableTopic.java
@@ -41,7 +41,7 @@ import org.springframework.retry.annotation.Backoff;
  *
  * @see org.springframework.kafka.retrytopic.RetryTopicConfigurer
  */
-@Target({ ElementType.METHOD })
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface RetryableTopic {

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryableTopic.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryableTopic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,6 +37,7 @@ import org.springframework.retry.annotation.Backoff;
  *
  * @author Tomaz Fernandes
  * @author Gary Russell
+ * @author Fabio da Silva Jr.
  * @since 2.7
  *
  * @see org.springframework.kafka.retrytopic.RetryTopicConfigurer

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
@@ -138,11 +138,23 @@ import org.springframework.lang.Nullable;
  *
  * <p>The other, non-exclusive way to configure the endpoints is through the convenient
  * {@link org.springframework.kafka.annotation.RetryableTopic} annotation, that can be placed on any
- * {@link org.springframework.kafka.annotation.KafkaListener} annotated methods, such as:
+ * {@link org.springframework.kafka.annotation.KafkaListener} annotated methods, directly, such as:
  *
  * <pre>
  *     <code>@RetryableTopic(attempts = 3,
  *     		backoff = @Backoff(delay = 700, maxDelay = 12000, multiplier = 3))</code>
+ *     <code>@KafkaListener(topics = "my-annotated-topic")
+ *     public void processMessage(MyPojo message) {
+ *        		// ... message processing
+ *     }</code>
+ *</pre>
+ * <p> Or through meta-annotations, such as:
+ * <pre>
+ *     <code>@RetryableTopic(attempts = 3,
+ *     		backoff = @Backoff(delay = 700, maxDelay = 12000, multiplier = 3))</code>
+ *     <code>public @interface WithExponentialBackoffRetry { }</code>
+ *
+ *     <code>@WithExponentialBackoffRetry</code>
  *     <code>@KafkaListener(topics = "my-annotated-topic")
  *     public void processMessage(MyPojo message) {
  *        		// ... message processing

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
@@ -204,6 +204,7 @@ import org.springframework.lang.Nullable;
  * If no DLT handler is provided, the default {@link LoggingDltListenerHandlerMethod} is used.
  *
  * @author Tomaz Fernandes
+ * @author Fabio da Silva Jr.
  * @since 2.7
  *
  * @see RetryTopicConfigurationBuilder

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationProviderTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationProviderTests.java
@@ -45,6 +45,7 @@ import org.springframework.kafka.core.KafkaOperations;
 /**
  * @author Tomaz Fernandes
  * @author Gary Russell
+ * @author Fabio da Silva Jr.
  * @since 2.7
  */
 @ExtendWith(MockitoExtension.class)

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationProviderTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationProviderTests.java
@@ -25,6 +25,10 @@ import static org.mockito.BDDMockito.willReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.lang.reflect.Method;
 import java.util.Collections;
 
@@ -60,6 +64,8 @@ class RetryTopicConfigurationProviderTests {
 	private final Method annotatedMethod = getAnnotatedMethod("annotatedMethod");
 
 	private final Method nonAnnotatedMethod = getAnnotatedMethod("nonAnnotatedMethod");
+
+	private final Method metaAnnotatedMethod = getAnnotatedMethod("metaAnnotatedMethod");
 
 	private Method getAnnotatedMethod(String methodName) {
 		try {
@@ -136,6 +142,19 @@ class RetryTopicConfigurationProviderTests {
 
 	}
 
+	@Test
+	void shouldProvideFromMetaAnnotation() {
+
+		// setup
+		willReturn(kafkaOperations).given(beanFactory).getBean("retryTopicDefaultKafkaTemplate", KafkaOperations.class);
+
+		// given
+		RetryTopicConfigurationProvider provider = new RetryTopicConfigurationProvider(beanFactory);
+		RetryTopicConfiguration configuration = provider.findRetryConfigurationFor(topics, metaAnnotatedMethod, bean);
+
+		// then
+		then(this.beanFactory).should(times(0)).getBeansOfType(RetryTopicConfiguration.class);
+	}
 
 	@Test
 	void shouldNotConfigureIfBeanFactoryNull() {
@@ -155,6 +174,17 @@ class RetryTopicConfigurationProviderTests {
 	}
 
 	public void nonAnnotatedMethod() {
+		// NoOps
+	}
+
+	@Target({ElementType.METHOD})
+	@Retention(RetentionPolicy.RUNTIME)
+	@RetryableTopic
+	static @interface MetaAnnotatedRetryableTopic {
+	}
+
+	@MetaAnnotatedRetryableTopic
+	public void metaAnnotatedMethod() {
 		// NoOps
 	}
 }


### PR DESCRIPTION
This PR resolves #2435 

With this change we will be able to create new annotations, meta-annotated with `RetryableTopic`. This makes it possible to share the same configurations from a `RetryableTopic` annotation across multiple `KafkaListener` annotated methods, making configuration details transparent, reducing boilerplate.
