### PR TITLE
GH-2443: Distinct Concurrency for Retry Containers

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/retrytopic.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/retrytopic.adoc
@@ -52,6 +52,9 @@ NOTE: It is not necessary to also add `@EnableKafka`, if you add this annotation
 Also, starting with that version, for more advanced configuration of the feature's components and global features, the `RetryTopicConfigurationSupport` class should be extended in a `@Configuration` class, and the appropriate methods overridden.
 For more details refer to <<retry-topic-global-settings>>.
 
+By default, the containers for the retry topics will have the same concurrency as the main container.
+Starting with version 3.0, you can set a different `concurrency` for the retry containers (either on the annotation, or in `RetryConfigurationBuilder`).
+
 IMPORTANT: Only one of the above techniques can be used, and only one `@Configuration` class can extend `RetryTopicConfigurationSupport`.
 
 ===== Using the `@RetryableTopic` annotation
@@ -114,6 +117,7 @@ public RetryTopicConfiguration myRetryTopic(KafkaTemplate<String, MyPojo> templa
             .newInstance()
             .fixedBackoff(3000)
             .maxAttempts(5)
+            .concurrency(1)
             .includeTopics("my-topic", "my-other-topic")
             .create(template);
 }

--- a/spring-kafka-docs/src/main/asciidoc/whats-new.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/whats-new.adoc
@@ -33,6 +33,9 @@ See <<same-broker-multiple-tests>> for more information.
 ==== Retryable Topics Changes
 
 The bootstrapping of <<retry-topic>> infrastructure beans has changed in this release to avoid some timing problems that occurred in some application regarding application initialization.
+
+You can now set a different `concurrency` for the retry containers; by default, the concurrency is the same as the main container.
+
 See <<retry-config>> for more information.
 
 [[x30-lc-changes]]

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryableTopic.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryableTopic.java
@@ -194,4 +194,12 @@ public @interface RetryableTopic {
 	 */
 	String autoStartDltHandler() default "";
 
+	/**
+	 * Concurrency for the retry and DLT containers; if not specified, the main container
+	 * concurrency is used.
+	 * @return the concurrency.
+	 * @since 3.0
+	 */
+	String concurrency() default "";
+
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryableTopicAnnotationProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryableTopicAnnotationProcessor.java
@@ -129,6 +129,7 @@ public class RetryableTopicAnnotationProcessor {
 		}
 		return RetryTopicConfigurationBuilder.newInstance()
 				.maxAttempts(resolveExpressionAsInteger(annotation.attempts(), "attempts", true))
+				.concurrency(resolveExpressionAsInteger(annotation.concurrency(), "concurrency", false))
 				.customBackoff(createBackoffFromAnnotation(annotation.backoff(), this.beanFactory))
 				.retryTopicSuffix(resolveExpressionAsString(annotation.retryTopicSuffix(), "retryTopicSuffix"))
 				.dltSuffix(resolveExpressionAsString(annotation.dltTopicSuffix(), "dltTopicSuffix"))

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfiguration.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.springframework.kafka.support.AllowDenyCollectionManager;
 import org.springframework.kafka.support.EndpointHandlerMethod;
+import org.springframework.lang.Nullable;
 
 /**
  * Contains the provided configuration for the retryable topics.
@@ -45,18 +46,23 @@ public class RetryTopicConfiguration {
 
 	private final ListenerContainerFactoryConfigurer.Configuration factoryConfigurerConfig;
 
+	@Nullable
+	private final Integer concurrency;
+
 	RetryTopicConfiguration(List<DestinationTopic.Properties> destinationTopicProperties,
 							EndpointHandlerMethod dltHandlerMethod,
 							TopicCreation kafkaTopicAutoCreationConfig,
 							AllowDenyCollectionManager<String> topicAllowListManager,
 							ListenerContainerFactoryResolver.Configuration factoryResolverConfig,
-							ListenerContainerFactoryConfigurer.Configuration factoryConfigurerConfig) {
+							ListenerContainerFactoryConfigurer.Configuration factoryConfigurerConfig,
+							@Nullable Integer concurrency) {
 		this.destinationTopicProperties = destinationTopicProperties;
 		this.dltHandlerMethod = dltHandlerMethod;
 		this.kafkaTopicAutoCreationConfig = kafkaTopicAutoCreationConfig;
 		this.topicAllowListManager = topicAllowListManager;
 		this.factoryResolverConfig = factoryResolverConfig;
 		this.factoryConfigurerConfig = factoryConfigurerConfig;
+		this.concurrency = concurrency;
 	}
 
 	public boolean hasConfigurationForTopics(String[] topics) {
@@ -81,6 +87,11 @@ public class RetryTopicConfiguration {
 
 	public List<DestinationTopic.Properties> getDestinationTopicProperties() {
 		return this.destinationTopicProperties;
+	}
+
+	@Nullable
+	public Integer getConcurrency() {
+		return this.concurrency;
 	}
 
 	static class TopicCreation {

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationBuilder.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationBuilder.java
@@ -80,6 +80,8 @@ public class RetryTopicConfigurationBuilder {
 
 	private Boolean autoStartDltHandler;
 
+	private Integer concurrency;
+
 	/* ---------------- DLT Behavior -------------- */
 	/**
 	 * Configure a DLT handler method.
@@ -90,6 +92,11 @@ public class RetryTopicConfigurationBuilder {
 	 */
 	public RetryTopicConfigurationBuilder dltHandlerMethod(String beanName, String methodName) {
 		this.dltHandlerMethod = RetryTopicConfigurer.createHandlerMethodWith(beanName, methodName);
+		return this;
+	}
+
+	public RetryTopicConfigurationBuilder concurrency(Integer concurrency) {
+		this.concurrency = concurrency;
 		return this;
 	}
 
@@ -360,7 +367,7 @@ public class RetryTopicConfigurationBuilder {
 								.createProperties();
 		return new RetryTopicConfiguration(destinationTopicProperties,
 				this.dltHandlerMethod, this.topicCreationConfiguration, allowListManager,
-				factoryResolverConfig, factoryConfigurerConfig);
+				factoryResolverConfig, factoryConfigurerConfig, this.concurrency);
 	}
 
 	private BinaryExceptionClassifier buildClassifier() {

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationBuilder.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationBuilder.java
@@ -242,7 +242,7 @@ public class RetryTopicConfigurationBuilder {
 	/* ---------------- Configure BackOff -------------- */
 
 	/**
-	 * Configure the maximum delivery attempts.
+	 * Configure the maximum delivery attempts (including the first).
 	 * @param maxAttempts the attempts.
 	 * @return the builder.
 	 */
@@ -255,8 +255,8 @@ public class RetryTopicConfigurationBuilder {
 	}
 
 	/**
-	 * Configure a global timeout, after which a record will go straight to the DLT the
-	 * next time a listener throws an exception.
+	 * Configure a global timeout, in milliseconds, after which a record will go straight
+	 * to the DLT the next time a listener throws an exception. Default no timeout.
 	 * @param timeout the timeout.
 	 * @return the builder.
 	 */

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationBuilder.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationBuilder.java
@@ -95,33 +95,52 @@ public class RetryTopicConfigurationBuilder {
 		return this;
 	}
 
+	/**
+	 * Configure the concurrency for the retry and DLT containers.
+	 * @param concurrency the concurrency.
+	 * @return the builder.
+	 * @since 3.0
+	 */
 	public RetryTopicConfigurationBuilder concurrency(Integer concurrency) {
 		this.concurrency = concurrency;
 		return this;
 	}
 
-	public RetryTopicConfigurationBuilder dltHandlerMethod(
-			EndpointHandlerMethod endpointHandlerMethod) {
-
+	/**
+	 * Configure a DLT handler method.
+	 * @param endpointHandlerMethod the handler method.
+	 * @return the builder.
+	 */
+	public RetryTopicConfigurationBuilder dltHandlerMethod(EndpointHandlerMethod endpointHandlerMethod) {
 		this.dltHandlerMethod = endpointHandlerMethod;
 		return this;
 	}
 
+	/**
+	 * Configure the {@link DltStrategy} to {@link DltStrategy#FAIL_ON_ERROR}.
+	 * @return the builder.
+	 */
 	public RetryTopicConfigurationBuilder doNotRetryOnDltFailure() {
-		this.dltStrategy =
-				DltStrategy.FAIL_ON_ERROR;
+		this.dltStrategy = DltStrategy.FAIL_ON_ERROR;
 		return this;
 	}
 
-	public RetryTopicConfigurationBuilder dltProcessingFailureStrategy(
-			DltStrategy dltStrategy) {
+	/**
+	 * Configure the {@link DltStrategy}.
+	 * @param dltStrategy the strategy.
+	 * @return the builder.
+	 */
+	public RetryTopicConfigurationBuilder dltProcessingFailureStrategy(DltStrategy dltStrategy) {
 		this.dltStrategy = dltStrategy;
 		return this;
 	}
 
+	/**
+	 * Configure the {@link DltStrategy} to {@link DltStrategy#NO_DLT}.
+	 * @return the builder.
+	 */
 	public RetryTopicConfigurationBuilder doNotConfigureDlt() {
-		this.dltStrategy =
-				DltStrategy.NO_DLT;
+		this.dltStrategy = DltStrategy.NO_DLT;
 		return this;
 	}
 
@@ -138,21 +157,41 @@ public class RetryTopicConfigurationBuilder {
 	}
 
 	/* ---------------- Configure Topic GateKeeper -------------- */
+	/**
+	 * Configure the topic names for which to use the target configuration.
+	 * @param topicNames the names.
+	 * @return the builder.
+	 */
 	public RetryTopicConfigurationBuilder includeTopics(List<String> topicNames) {
 		this.includeTopicNames.addAll(topicNames);
 		return this;
 	}
 
+	/**
+	 * Configure the topic names for which the target configuration will NOT be used.
+	 * @param topicNames the names.
+	 * @return the builder.
+	 */
 	public RetryTopicConfigurationBuilder excludeTopics(List<String> topicNames) {
 		this.excludeTopicNames.addAll(topicNames);
 		return this;
 	}
 
+	/**
+	 * Configure a topic name for which to use the target configuration.
+	 * @param topicName the name.
+	 * @return the builder.
+	 */
 	public RetryTopicConfigurationBuilder includeTopic(String topicName) {
 		this.includeTopicNames.add(topicName);
 		return this;
 	}
 
+	/**
+	 * Configure a topic name for which the target configuration will NOT be used.
+	 * @param topicName the name.
+	 * @return the builder.
+	 */
 	public RetryTopicConfigurationBuilder excludeTopic(String topicName) {
 		this.excludeTopicNames.add(topicName);
 		return this;
@@ -160,21 +199,41 @@ public class RetryTopicConfigurationBuilder {
 
 	/* ---------------- Configure Topic Suffixes -------------- */
 
+	/**
+	 * Configure the suffix to add to the retry topics.
+	 * @param suffix the suffix.
+	 * @return the builder.
+	 */
 	public RetryTopicConfigurationBuilder retryTopicSuffix(String suffix) {
 		this.retryTopicSuffix = suffix;
 		return this;
 	}
 
+	/**
+	 * Configure the suffix to add to the DLT topic.
+	 * @param suffix the suffix.
+	 * @return the builder.
+	 */
 	public RetryTopicConfigurationBuilder dltSuffix(String suffix) {
 		this.dltSuffix = suffix;
 		return this;
 	}
 
+	/**
+	 * Configure the retry topic names to be suffixed with ordinal index values.
+	 * @return the builder.
+	 * @see TopicSuffixingStrategy#SUFFIX_WITH_INDEX_VALUE
+	 */
 	public RetryTopicConfigurationBuilder suffixTopicsWithIndexValues() {
 		this.topicSuffixingStrategy = TopicSuffixingStrategy.SUFFIX_WITH_INDEX_VALUE;
 		return this;
 	}
 
+	/**
+	 * Configure the retry topic name {@link TopicSuffixingStrategy}.
+	 * @param topicSuffixingStrategy the strategy.
+	 * @return the builder.
+	 */
 	public RetryTopicConfigurationBuilder setTopicSuffixingStrategy(TopicSuffixingStrategy topicSuffixingStrategy) {
 		this.topicSuffixingStrategy = topicSuffixingStrategy;
 		return this;
@@ -182,6 +241,11 @@ public class RetryTopicConfigurationBuilder {
 
 	/* ---------------- Configure BackOff -------------- */
 
+	/**
+	 * Configure the maximum delivery attempts.
+	 * @param maxAttempts the attempts.
+	 * @return the builder.
+	 */
 	public RetryTopicConfigurationBuilder maxAttempts(int maxAttempts) {
 		Assert.isTrue(maxAttempts > 0, "Number of attempts should be positive");
 		Assert.isTrue(this.maxAttempts == RetryTopicConstants.NOT_SET,
@@ -190,15 +254,37 @@ public class RetryTopicConfigurationBuilder {
 		return this;
 	}
 
+	/**
+	 * Configure a global timeout, after which a record will go straight to the DLT the
+	 * next time a listener throws an exception.
+	 * @param timeout the timeout.
+	 * @return the builder.
+	 */
 	public RetryTopicConfigurationBuilder timeoutAfter(long timeout) {
 		this.timeout = timeout;
 		return this;
 	}
 
+	/**
+	 * Configure an {@link ExponentialBackOffPolicy}.
+	 * @param initialInterval the initial delay interval.
+	 * @param multiplier the multiplier.
+	 * @param maxInterval the maximum delay interval.
+	 * @return the builder.
+	 */
 	public RetryTopicConfigurationBuilder exponentialBackoff(long initialInterval, double multiplier, long maxInterval) {
 		return exponentialBackoff(initialInterval, multiplier, maxInterval, false);
 	}
 
+	/**
+	 * Configure an {@link ExponentialBackOffPolicy} or
+	 * {@link ExponentialRandomBackOffPolicy} depending on the random parameter.
+	 * @param initialInterval the initial delay interval.
+	 * @param multiplier the multiplier.
+	 * @param maxInterval the maximum delay interval.
+	 * @param withRandom true for an {@link ExponentialRandomBackOffPolicy}.
+	 * @return the builder.
+	 */
 	public RetryTopicConfigurationBuilder exponentialBackoff(long initialInterval, double multiplier, long maxInterval,
 			boolean withRandom) {
 
@@ -215,6 +301,11 @@ public class RetryTopicConfigurationBuilder {
 		return this;
 	}
 
+	/**
+	 * Configure a {@link FixedBackOffPolicy}.
+	 * @param interval the interval.
+	 * @return the builder.
+	 */
 	public RetryTopicConfigurationBuilder fixedBackOff(long interval) {
 		Assert.isNull(this.backOffPolicy, ALREADY_SELECTED);
 		Assert.isTrue(interval >= 1, "Interval should be >= 1");
@@ -224,6 +315,12 @@ public class RetryTopicConfigurationBuilder {
 		return this;
 	}
 
+	/**
+	 * Configure a {@link UniformRandomBackOffPolicy}.
+	 * @param minInterval the minimum interval.
+	 * @param maxInterval the maximum interval.
+	 * @return the builder.
+	 */
 	public RetryTopicConfigurationBuilder uniformRandomBackoff(long minInterval, long maxInterval) {
 		Assert.isNull(this.backOffPolicy, ALREADY_SELECTED);
 		Assert.isTrue(minInterval >= 1, "Min interval should be >= 1");
@@ -236,12 +333,21 @@ public class RetryTopicConfigurationBuilder {
 		return this;
 	}
 
+	/**
+	 * Configure a {@link NoBackOffPolicy}.
+	 * @return the builder.
+	 */
 	public RetryTopicConfigurationBuilder noBackoff() {
 		Assert.isNull(this.backOffPolicy, ALREADY_SELECTED);
 		this.backOffPolicy = new NoBackOffPolicy();
 		return this;
 	}
 
+	/**
+	 * Configure a custom {@link SleepingBackOffPolicy}.
+	 * @param backOffPolicy the policy.
+	 * @return the builder.
+	 */
 	public RetryTopicConfigurationBuilder customBackoff(SleepingBackOffPolicy<?> backOffPolicy) {
 		Assert.isNull(this.backOffPolicy, ALREADY_SELECTED);
 		Assert.notNull(backOffPolicy, "You should provide non null custom policy");
@@ -249,36 +355,73 @@ public class RetryTopicConfigurationBuilder {
 		return this;
 	}
 
+
+	/**
+	 * Configure a {@link FixedBackOffPolicy}.
+	 * @param interval the interval.
+	 * @return the builder.
+	 */
 	public RetryTopicConfigurationBuilder fixedBackOff(int interval) {
+		Assert.isNull(this.backOffPolicy, ALREADY_SELECTED);
 		FixedBackOffPolicy policy = new FixedBackOffPolicy();
 		policy.setBackOffPeriod(interval);
 		this.backOffPolicy = policy;
 		return this;
 	}
 
+	/**
+	 * Configure the use of a single retry topic with fixed delays.
+	 * @return the builder.
+	 * @see FixedDelayStrategy#SINGLE_TOPIC
+	 */
 	public RetryTopicConfigurationBuilder useSingleTopicForFixedDelays() {
 		this.fixedDelayStrategy = FixedDelayStrategy.SINGLE_TOPIC;
 		return this;
 	}
 
-	public RetryTopicConfigurationBuilder useSingleTopicForFixedDelays(FixedDelayStrategy useSameTopicForFixedDelays) {
-		this.fixedDelayStrategy = useSameTopicForFixedDelays;
+	/**
+	 * Configure the {@link FixedDelayStrategy}; default is
+	 * {@link FixedDelayStrategy#MULTIPLE_TOPICS}.
+	 * @param delayStrategy the delay strategy.
+	 * @return the builder.
+	 */
+	public RetryTopicConfigurationBuilder useSingleTopicForFixedDelays(FixedDelayStrategy delayStrategy) {
+		this.fixedDelayStrategy = delayStrategy;
 		return this;
 	}
 
 	/* ---------------- Configure Topics Auto Creation -------------- */
 
+	/**
+	 * Configure the topic creation behavior to NOT auto create topics.
+	 * @return the builder.
+	 */
 	public RetryTopicConfigurationBuilder doNotAutoCreateRetryTopics() {
 		this.topicCreationConfiguration = new RetryTopicConfiguration.TopicCreation(false);
 		return this;
 	}
 
+	/**
+	 * Configure the topic creation behavior to auto create topics with the provided
+	 * properties.
+	 * @param numPartitions the number of partitions.
+	 * @param replicationFactor the replication factor.
+	 * @return the builder.
+	 */
 	public RetryTopicConfigurationBuilder autoCreateTopicsWith(int numPartitions, short replicationFactor) {
 		this.topicCreationConfiguration = new RetryTopicConfiguration.TopicCreation(true, numPartitions,
 				replicationFactor);
 		return this;
 	}
 
+	/**
+	 * Configure the topic creation behavior to optionall create topics with the provided
+	 * properties.
+	 * @param shouldCreate true to auto create.
+	 * @param numPartitions the number of partitions.
+	 * @param replicationFactor the replication factor.
+	 * @return the builder.
+	 */
 	public RetryTopicConfigurationBuilder autoCreateTopics(boolean shouldCreate, int numPartitions,
 			short replicationFactor) {
 
@@ -289,16 +432,31 @@ public class RetryTopicConfigurationBuilder {
 
 	/* ---------------- Configure Exception Classifier -------------- */
 
+	/**
+	 * Configure the behavior to retry on the provided {@link Throwable}.
+	 * @param throwable the throwable.
+	 * @return the builder.
+	 */
 	public RetryTopicConfigurationBuilder retryOn(Class<? extends Throwable> throwable) {
 		classifierBuilder().retryOn(throwable);
 		return this;
 	}
 
+	/**
+	 * Configure the behavior to NOT retry on the provided {@link Throwable}.
+	 * @param throwable the throwable.
+	 * @return the builder.
+	 */
 	public RetryTopicConfigurationBuilder notRetryOn(Class<? extends Throwable> throwable) {
 		classifierBuilder().notRetryOn(throwable);
 		return this;
 	}
 
+	/**
+	 * Configure the behavior to retry on the provided {@link Throwable}s.
+	 * @param throwables the throwables.
+	 * @return the builder.
+	 */
 	public RetryTopicConfigurationBuilder retryOn(List<Class<? extends Throwable>> throwables) {
 		throwables
 				.stream()
@@ -306,6 +464,11 @@ public class RetryTopicConfigurationBuilder {
 		return this;
 	}
 
+	/**
+	 * Configure the behavior to NOT retry on the provided {@link Throwable}s.
+	 * @param throwables the throwables.
+	 * @return the builder.
+	 */
 	public RetryTopicConfigurationBuilder notRetryOn(List<Class<? extends Throwable>> throwables) {
 		throwables
 				.stream()
@@ -313,11 +476,20 @@ public class RetryTopicConfigurationBuilder {
 		return this;
 	}
 
+	/**
+	 * Configure the classifier to traverse the cause chain.
+	 * @return the builder.
+	 */
 	public RetryTopicConfigurationBuilder traversingCauses() {
 		classifierBuilder().traversingCauses();
 		return this;
 	}
 
+	/**
+	 * Configure the classifier to traverse, or not, the cause chain.
+	 * @param traversing true to traverse.
+	 * @return the builder.
+	 */
 	public RetryTopicConfigurationBuilder traversingCauses(boolean traversing) {
 		if (traversing) {
 			classifierBuilder().traversingCauses();
@@ -333,16 +505,31 @@ public class RetryTopicConfigurationBuilder {
 	}
 
 	/* ---------------- Configure KafkaListenerContainerFactory -------------- */
+	/**
+	 * Configure the container factory to use.
+	 * @param factory the factory.
+	 * @return the builder.
+	 */
 	public RetryTopicConfigurationBuilder listenerFactory(ConcurrentKafkaListenerContainerFactory<?, ?> factory) {
 		this.listenerContainerFactory = factory;
 		return this;
 	}
 
+	/**
+	 * Configure the container factory to use via its bean name.
+	 * @param factoryBeanName the factory bean name.
+	 * @return the builder.
+	 */
 	public RetryTopicConfigurationBuilder listenerFactory(String factoryBeanName) {
 		this.listenerContainerFactoryName = factoryBeanName;
 		return this;
 	}
 
+	/**
+	 * Create the {@link RetryTopicConfiguration} with the provided template.
+	 * @param sendToTopicKafkaTemplate the template.
+	 * @return the configuration.
+	 */
 	// The templates are configured per ListenerContainerFactory. Only the first configured ones will be used.
 	public RetryTopicConfiguration create(KafkaOperations<?, ?> sendToTopicKafkaTemplate) {
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
@@ -339,6 +339,10 @@ public class RetryTopicConfigurer implements BeanFactoryAware {
 				: new MethodKafkaListenerEndpoint<>();
 
 		endpointProcessor.accept(endpoint);
+		Integer concurrency = configuration.getConcurrency();
+		if (!destinationTopicProperties.isMainEndpoint() && concurrency != null) {
+			endpoint.setConcurrency(concurrency);
+		}
 
 		EndpointHandlerMethod endpointBeanMethod =
 				getEndpointHandlerMethod(mainEndpoint, configuration, destinationTopicProperties);


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2443

Optionally configure a different concurrency for retry containers.
