### PR TITLE
GH-2459: FallbackBatchErrorHandler Retryable Ex

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ExceptionClassifier.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ExceptionClassifier.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.springframework.classify.BinaryExceptionClassifier;
 import org.springframework.kafka.support.converter.ConversionException;
@@ -149,6 +150,16 @@ public abstract class ExceptionClassifier extends KafkaExceptionLogLevelAware {
 	@SuppressWarnings("varargs")
 	public final void addNotRetryableExceptions(Class<? extends Exception>... exceptionTypes) {
 		add(false, exceptionTypes);
+		notRetryable(Arrays.stream(exceptionTypes));
+	}
+
+	/**
+	 * Subclasses can override this to receive notification of configuration of not
+	 * retryable exceptions.
+	 * @param notRetryable the not retryable exceptions.
+	 * @since 2.9.3
+	 */
+	protected void notRetryable(Stream<Class<? extends Exception>> notRetryable) {
 	}
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedBatchProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedBatchProcessor.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
+import java.util.stream.Stream;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -99,6 +100,31 @@ public abstract class FailedBatchProcessor extends FailedRecordProcessor {
 		if (this.fallbackBatchHandler instanceof KafkaExceptionLogLevelAware handler) {
 			handler.setLogLevel(logLevel);
 		}
+	}
+
+	@Override
+	protected void notRetryable(Stream<Class<? extends Exception>> notRetryable) {
+		if (this.fallbackBatchHandler instanceof ExceptionClassifier handler) {
+			notRetryable.forEach(ex -> handler.addNotRetryableExceptions(ex));
+		}
+	}
+
+	@Override
+	public void setClassifications(Map<Class<? extends Throwable>, Boolean> classifications, boolean defaultValue) {
+		super.setClassifications(classifications, defaultValue);
+		if (this.fallbackBatchHandler instanceof ExceptionClassifier handler) {
+			handler.setClassifications(classifications, defaultValue);
+		}
+	}
+
+	@Override
+	@Nullable
+	public Boolean removeClassification(Class<? extends Exception> exceptionType) {
+		Boolean removed = super.removeClassification(exceptionType);
+		if (this.fallbackBatchHandler instanceof ExceptionClassifier handler) {
+			handler.removeClassification(exceptionType);
+		}
+		return removed;
 	}
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordProcessor.java
@@ -45,13 +45,7 @@ public abstract class FailedRecordProcessor extends ExceptionClassifier implemen
 
 	private final BiFunction<ConsumerRecord<?, ?>, Exception, BackOff> noRetriesForClassified =
 			(rec, ex) -> {
-				Exception theEx = ex;
-				if (theEx instanceof TimestampedException && theEx.getCause() instanceof Exception cause) {
-					theEx = cause;
-				}
-				if (theEx instanceof ListenerExecutionFailedException && theEx.getCause() instanceof Exception cause) {
-					theEx = cause;
-				}
+				Exception theEx = ErrorHandlingUtils.unwrapIfNeeded(ex);
 				if (!getClassifier().classify(theEx)) {
 					return NO_RETRIES_OR_DELAY_BACKOFF;
 				}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FallbackBatchErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FallbackBatchErrorHandler.java
@@ -48,7 +48,7 @@ import org.springframework.util.backoff.FixedBackOff;
  * @since 2.3.7
  *
  */
-class FallbackBatchErrorHandler extends KafkaExceptionLogLevelAware implements CommonErrorHandler {
+class FallbackBatchErrorHandler extends ExceptionClassifier implements CommonErrorHandler {
 
 	private final LogAccessor logger = new LogAccessor(LogFactory.getLog(getClass()));
 
@@ -124,7 +124,7 @@ class FallbackBatchErrorHandler extends KafkaExceptionLogLevelAware implements C
 		this.retrying.set(true);
 		try {
 			ErrorHandlingUtils.retryBatch(thrownException, records, consumer, container, invokeListener, this.backOff,
-					this.seeker, this.recoverer, this.logger, getLogLevel(), this.retryListeners);
+					this.seeker, this.recoverer, this.logger, getLogLevel(), this.retryListeners, getClassifier());
 		}
 		finally {
 			this.retrying.set(false);


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2459

The `FallbackBatchErrorHandler` was not an `ExceptionClassifier`. The default error handler should propagate exception classifications.

**3.0.x - I will back port**
