### PR TITLE
GH-2459: FallbackBatchErrorHandler Retryable Ex

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ErrorHandlerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ErrorHandlerAdapter.java
@@ -19,6 +19,8 @@ package org.springframework.kafka.listener;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -26,6 +28,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.common.TopicPartition;
 
 import org.springframework.kafka.support.TopicPartitionOffset;
+import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
 /**
@@ -35,7 +38,7 @@ import org.springframework.util.Assert;
  * @since 2.7.4
  *
  */
-class ErrorHandlerAdapter implements CommonErrorHandler {
+class ErrorHandlerAdapter extends ExceptionClassifier implements CommonErrorHandler {
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	private static final ConsumerRecords EMPTY_BATCH = new ConsumerRecords(Collections.emptyMap());
@@ -169,6 +172,31 @@ class ErrorHandlerAdapter implements CommonErrorHandler {
 			((FallbackBatchErrorHandler) this.batchErrorHandler).onPartitionsAssigned(consumer, partitions,
 					publishPause);
 		}
+	}
+
+	@Override
+	protected void notRetryable(Stream<Class<? extends Exception>> notRetryable) {
+		if (this.batchErrorHandler instanceof ExceptionClassifier) {
+			notRetryable.forEach(ex -> ((ExceptionClassifier) this.batchErrorHandler).addNotRetryableExceptions(ex));
+		}
+	}
+
+	@Override
+	public void setClassifications(Map<Class<? extends Throwable>, Boolean> classifications, boolean defaultValue) {
+		super.setClassifications(classifications, defaultValue);
+		if (this.batchErrorHandler instanceof ExceptionClassifier) {
+			((ExceptionClassifier) this.batchErrorHandler).setClassifications(classifications, defaultValue);
+		}
+	}
+
+	@Override
+	@Nullable
+	public Boolean removeClassification(Class<? extends Exception> exceptionType) {
+		Boolean removed = super.removeClassification(exceptionType);
+		if (this.batchErrorHandler instanceof ExceptionClassifier) {
+			((ExceptionClassifier) this.batchErrorHandler).removeClassification(exceptionType);
+		}
+		return removed;
 	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ExceptionClassifier.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ExceptionClassifier.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.springframework.classify.BinaryExceptionClassifier;
 import org.springframework.kafka.support.converter.ConversionException;
@@ -130,6 +131,16 @@ public abstract class ExceptionClassifier extends KafkaExceptionLogLevelAware {
 	@SuppressWarnings("varargs")
 	public final void addNotRetryableExceptions(Class<? extends Exception>... exceptionTypes) {
 		add(false, exceptionTypes);
+		notRetryable(Arrays.stream(exceptionTypes));
+	}
+
+	/**
+	 * Subclasses can override this to receive notification of configuration of not
+	 * retryable exceptions.
+	 * @param notRetryable the not retryable exceptions.
+	 * @since 2.9.3
+	 */
+	protected void notRetryable(Stream<Class<? extends Exception>> notRetryable) {
 	}
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FallbackBatchErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FallbackBatchErrorHandler.java
@@ -41,7 +41,7 @@ import org.springframework.util.backoff.FixedBackOff;
  * @since 2.3.7
  *
  */
-class FallbackBatchErrorHandler extends KafkaExceptionLogLevelAware
+class FallbackBatchErrorHandler extends ExceptionClassifier
 		implements ListenerInvokingBatchErrorHandler {
 
 	private final LogAccessor logger = new LogAccessor(LogFactory.getLog(getClass()));
@@ -105,7 +105,7 @@ class FallbackBatchErrorHandler extends KafkaExceptionLogLevelAware
 		this.retrying.set(true);
 		try {
 			ErrorHandlingUtils.retryBatch(thrownException, records, consumer, container, invokeListener, this.backOff,
-					this.seeker, this.recoverer, this.logger, getLogLevel());
+					this.seeker, this.recoverer, this.logger, getLogLevel(), null, getClassifier());
 		}
 		finally {
 			this.retrying.set(false);


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2459

The `FallbackBatchErrorHandler` was not an `ExceptionClassifier`. The default error handler should propagate exception classifications.

**2.9.x - I will back port**

Essentially the same as main, but removed Java 17 `instanceof` pattern matching, adapted the error handler adapter, deprecated old `ErrorHandlingUtils` method.