### PR TITLE
Add merged annotations support to RetryableTopic

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryTopicConfigurationProvider.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryTopicConfigurationProvider.java
@@ -27,7 +27,10 @@ import org.springframework.beans.factory.config.BeanExpressionContext;
 import org.springframework.beans.factory.config.BeanExpressionResolver;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.expression.StandardBeanExpressionResolver;
-import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.core.annotation.MergedAnnotation;
+import org.springframework.core.annotation.MergedAnnotations;
+import org.springframework.core.annotation.MergedAnnotations.SearchStrategy;
+import org.springframework.core.annotation.RepeatableContainers;
 import org.springframework.core.log.LogAccessor;
 import org.springframework.kafka.retrytopic.RetryTopicConfiguration;
 
@@ -88,7 +91,11 @@ public class RetryTopicConfigurationProvider {
 		this.expressionContext = expressionContext;
 	}
 	public RetryTopicConfiguration findRetryConfigurationFor(String[] topics, Method method, Object bean) {
-		RetryableTopic annotation = AnnotationUtils.findAnnotation(method, RetryableTopic.class);
+		RetryableTopic annotation = MergedAnnotations.from(method, SearchStrategy.TYPE_HIERARCHY,
+					RepeatableContainers.none())
+				.get(RetryableTopic.class)
+				.synthesize(MergedAnnotation::isPresent)
+				.orElse(null);
 		return annotation != null
 				? new RetryableTopicAnnotationProcessor(this.beanFactory, this.resolver, this.expressionContext)
 						.processAnnotation(topics, method, annotation, bean)

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
@@ -150,11 +150,13 @@ import org.springframework.lang.Nullable;
  *</pre>
  * <p> Or through meta-annotations, such as:
  * <pre>
- *     <code>@RetryableTopic(attempts = 3,
- *     		backoff = @Backoff(delay = 700, maxDelay = 12000, multiplier = 3))</code>
- *     <code>public @interface WithExponentialBackoffRetry { }</code>
+ *     <code>@RetryableTopic(backoff = @Backoff(delay = 700, maxDelay = 12000, multiplier = 3))</code>
+ *     <code>public @interface WithExponentialBackoffRetry {</code>
+ *     <code>   	{@literal @}AliasFor(attribute = "attempts", annotation = RetryableTopic.class)
+ *        	String retries();
+ *     }</code>
  *
- *     <code>@WithExponentialBackoffRetry</code>
+ *     <code>@WithExponentialBackoffRetry(retries = "3")</code>
  *     <code>@KafkaListener(topics = "my-annotated-topic")
  *     public void processMessage(MyPojo message) {
  *        		// ... message processing

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ErrorHandlingCoverageTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ErrorHandlingCoverageTests.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *      https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationProviderTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationProviderTests.java
@@ -38,6 +38,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.core.annotation.AliasFor;
 import org.springframework.kafka.annotation.RetryTopicConfigurationProvider;
 import org.springframework.kafka.annotation.RetryableTopic;
 import org.springframework.kafka.core.KafkaOperations;
@@ -155,6 +156,8 @@ class RetryTopicConfigurationProviderTests {
 
 		// then
 		then(this.beanFactory).should(times(0)).getBeansOfType(RetryTopicConfiguration.class);
+		assertThat(configuration.getConcurrency()).isEqualTo(3);
+
 	}
 
 	@Test
@@ -182,6 +185,8 @@ class RetryTopicConfigurationProviderTests {
 	@Retention(RetentionPolicy.RUNTIME)
 	@RetryableTopic
 	static @interface MetaAnnotatedRetryableTopic {
+		@AliasFor(attribute = "concurrency", annotation = RetryableTopic.class)
+		String parallelism() default "3";
 	}
 
 	@MetaAnnotatedRetryableTopic


### PR DESCRIPTION
This PR resolves #2441 

Added support to merged-annotations on `@RetryableTopic` annotation. With this, we can create new annotations meta-annotated with @RetryableTopic having aliases values that will be passed to @RetryableTopic through merged annotations.