### PR TITLE
Fix Get ObservationRegistry

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
@@ -422,7 +422,8 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 	@Override
 	public void afterSingletonsInstantiated() {
 		if (this.observationEnabled && this.applicationContext != null) {
-			this.observationRegistry = this.applicationContext.getBeanProvider(ObservationRegistry.class).getIfUnique();
+			this.observationRegistry = this.applicationContext.getBeanProvider(ObservationRegistry.class)
+					.getIfUnique(() -> this.observationRegistry);
 			this.kafkaAdmin = this.applicationContext.getBeanProvider(KafkaAdmin.class).getIfUnique();
 			if (this.kafkaAdmin != null) {
 				this.clusterId = this.kafkaAdmin.clusterId();
@@ -433,6 +434,7 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 		}
 	}
 
+	@Nullable
 	private String clusterId() {
 		if (this.kafkaAdmin != null && this.clusterId == null) {
 			this.clusterId = this.kafkaAdmin.clusterId();

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -371,7 +371,10 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		if (applicationContext != null && containerProperties.isObservationEnabled()) {
 			ObjectProvider<ObservationRegistry> registry =
 					applicationContext.getBeanProvider(ObservationRegistry.class);
-			observationRegistry = registry.getIfUnique();
+			ObservationRegistry reg = registry.getIfUnique();
+			if (reg != null) {
+				observationRegistry = reg;
+			}
 		}
 		this.listenerConsumer = new ListenerConsumer(listener, listenerType, observationRegistry);
 		setRunning(true);


### PR DESCRIPTION
`ObservationRegistry` cannot be null; current code uses `ObjectProvider.getIfUnique()`, which can return null.

In those cases, use the default NOOP registry.