### PR TITLE
GH-2478: Improve `RetryTopicComponentFactory` Conf

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/whats-new.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/whats-new.adoc
@@ -49,6 +49,9 @@ You can now configure multiple `@RetryableTopic` listeners on the same topic in 
 Previously, this was not possible.
 See <<multi-retry>> for more information.
 
+There are breaking API changes in `RetryTopicConfigurationSupport`; specifically, if you override the bean definition methods for `destinationTopicResolver`, `kafkaConsumerBackoffManager` and/or `retryTopicConfigurer`;
+these methods now require an `ObjectProvider<RetryTopicComponentFactory>` parameter.
+
 [[x30-lc-changes]]
 ==== Listener Container Changes
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicSameContainerFactoryIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicSameContainerFactoryIntegrationTests.java
@@ -18,6 +18,8 @@ package org.springframework.kafka.retrytopic;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -82,7 +84,7 @@ public class RetryTopicSameContainerFactoryIntegrationTests {
 	private CountDownLatchContainer latchContainer;
 
 	@Test
-	void shouldRetryFirstAndSecondTopics() {
+	void shouldRetryFirstAndSecondTopics(@Autowired RetryTopicComponentFactory componentFactory) {
 		logger.debug("Sending message to topic " + FIRST_TOPIC);
 		sendKafkaTemplate.send(FIRST_TOPIC, "Testing topic 1");
 		logger.debug("Sending message to topic " + SECOND_TOPIC);
@@ -91,6 +93,7 @@ public class RetryTopicSameContainerFactoryIntegrationTests {
 		assertThat(awaitLatch(latchContainer.countDownLatchDltOne)).isTrue();
 		assertThat(awaitLatch(latchContainer.countDownLatch2)).isTrue();
 		assertThat(awaitLatch(latchContainer.customizerLatch)).isTrue();
+		verify(componentFactory).destinationTopicResolver();
 	}
 
 	private boolean awaitLatch(CountDownLatch latch) {
@@ -238,6 +241,11 @@ public class RetryTopicSameContainerFactoryIntegrationTests {
 		@Bean
 		TaskScheduler sched() {
 			return new ThreadPoolTaskScheduler();
+		}
+
+		@Bean
+		RetryTopicComponentFactory componentFactory() {
+			return spy(new RetryTopicComponentFactory());
 		}
 
 	}


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2478

Allow users to define a `RetryTopicComponentFactory` bean for use in infrastructure bean definitions.

Previously, although `createComponentFactory()` can be overridden, it is called early in the class lifecycle and can't have any dependencies on Spring beans.

Now, if the application context contains a unique bean of this type, it is used instead.

**Cannot back port due to breaking API changes; work around for 2.9.x is to override one or more of `destinationTopicResolver`, `kafkaConsumerBackoffManager` and/or `retryTopicConfigurer` bean definition methods.**
