### PR TITLE
GH-2481: Global Embedded Broker and JUnit Platform

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/testing.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/testing.adoc
@@ -221,6 +221,7 @@ This could be a problem if, say, you run your tests in a Gradle daemon.
 You should not use this technique in such a situation, or you should use something to call `destroy()` on the `EmbeddedKafkaBroker` when your tests are complete.
 
 Starting with version 3.0, the framework exposes a `GlobalEmbeddedKafkaTestExecutionListener` for the JUnit Platform; it is disabled by default.
+This requires JUnit Platform 1.8 or greater.
 The purpose of this listener is to start one global `EmbeddedKafkaBroker` for the whole test plan and stop it at the end of the plan.
 To enable this listener, and therefore have a single global embedded Kafka cluster for all the tests in the project, the `spring.kafka.global.embedded.enabled` property must be set to `true` via system properties or JUnit Platform configuration.
 In addition, these properties can be provided:

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/junit/GlobalEmbeddedKafkaTestExecutionListener.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/junit/GlobalEmbeddedKafkaTestExecutionListener.java
@@ -84,10 +84,27 @@ public class GlobalEmbeddedKafkaTestExecutionListener implements TestExecutionLi
 	public static final String BROKER_PROPERTIES_LOCATION_PROPERTY_NAME =
 			"spring.kafka.embedded.broker.properties.location";
 
+	private static final boolean JUNIT_PLATFORM_COMPATIBLE;
+
+	static {
+		boolean compat = false;
+		try {
+			TestPlan.class.getDeclaredMethod("getConfigurationParameters");
+			compat = true;
+		}
+		catch (NoSuchMethodException | SecurityException e) {
+			LOGGER.debug("JUnit Platform version must be >= 1.8 to use a global embedded kafka server");
+		}
+		JUNIT_PLATFORM_COMPATIBLE = compat;
+	}
+
 	private EmbeddedKafkaBroker embeddedKafkaBroker;
 
 	@Override
 	public void testPlanExecutionStarted(TestPlan testPlan) {
+		if (!JUNIT_PLATFORM_COMPATIBLE) {
+			return;
+		}
 		ConfigurationParameters configurationParameters = testPlan.getConfigurationParameters();
 		boolean enabled = configurationParameters.getBoolean(LISTENER_ENABLED_PROPERTY_NAME).orElse(false);
 		if (enabled) {

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/junit/GlobalEmbeddedKafkaTestExecutionListener.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/junit/GlobalEmbeddedKafkaTestExecutionListener.java
@@ -43,6 +43,7 @@ import org.springframework.util.StringUtils;
  * to enable it.
  *
  * @author Artem Bilan
+ * @author Gary Russell
  *
  * @since 3.0
  */


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2481

The Maven Surefire plugin uses an older version of JUnit platform which is incompatible with the Global embedded broker.

Check that the platform version is compatible before attempting to determine if a global embedded broker should be created.

Tested with a Spring Boot application.