### PR TITLE
GH-2490: Add JUnit Platform Test Dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -408,7 +408,7 @@ project ('spring-kafka-test') {
 		api "org.apache.kafka:kafka_$scalaVersion:$kafkaVersion"
 		api "org.apache.kafka:kafka_$scalaVersion:$kafkaVersion:test"
 		api 'org.junit.jupiter:junit-jupiter-api'
-		providedApi 'org.junit.platform:junit-platform-launcher'
+		api 'org.junit.platform:junit-platform-launcher'
 		optionalApi "org.hamcrest:hamcrest-core:$hamcrestVersion"
 		optionalApi "org.mockito:mockito-core:$mockitoVersion"
 		optionalApi ("junit:junit:$junit4Version") {

--- a/spring-kafka-docs/src/main/asciidoc/testing.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/testing.adoc
@@ -240,6 +240,9 @@ For example, a `spring.embedded.kafka.brokers.property=spring.kafka.bootstrap-se
 NOTE: It is recommended to not combine a global embedded Kafka and per-test class in a single test suite.
 Both of them share the same system properties, so it is very likely going to lead to unexpected behavior.
 
+NOTE: `spring-kafka-test` has transitive dependencies on `junit-jupiter-api` and `junit-platform-launcher` (the latter to support the global embedded broker).
+If you wish to use the embedded broker and are NOT using JUnit, you may wish to exclude these dependencies.
+
 [[embedded-kafka-annotation]]
 ==== @EmbeddedKafka Annotation
 We generally recommend that you use the rule as a `@ClassRule` to avoid starting and stopping the broker between tests (and use a different topic for each test).


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2490

The new global embedded kafka broker depends on the JUnit platform launcher. With gradle, the launcher must be on the test runtime class path. Add the launcher as a transitive dependency.

Tested with gradle and maven Boot apps.
