### PR TITLE
Fix Consumer Thread Naming Documentation

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -1800,13 +1800,13 @@ Use the `KafkaUtils` mechanism in that case.
 
 ===== Container Thread Naming
 
-Listener containers currently use two task executors, one to invoke the consumer and another that is used to invoke the listener when the kafka consumer property `enable.auto.commit` is `false`.
-You can provide custom executors by setting the `consumerExecutor` and `listenerExecutor` properties of the container's `ContainerProperties`.
+A `TaskExecutor` is used to invoke the consumer and the listener.
+You can provide a custom executor by setting the `consumerExecutor` property of the container's `ContainerProperties`.
 When using pooled executors, be sure that enough threads are available to handle the concurrency across all the containers in which they are used.
-When using the `ConcurrentMessageListenerContainer`, a thread from each is used for each consumer (`concurrency`).
+When using the `ConcurrentMessageListenerContainer`, a thread from the executor is used for each consumer (`concurrency`).
 
-If you do not provide a consumer executor, a `SimpleAsyncTaskExecutor` is used.
-This executor creates threads with names similar to `<beanName>-C-1` (consumer thread).
+If you do not provide a consumer executor, a `SimpleAsyncTaskExecutor` is used for each container.
+This executor creates threads with names similar to `<beanName>-C-<n>`.
 For the `ConcurrentMessageListenerContainer`, the `<beanName>` part of the thread name becomes `<beanName>-m`, where `m` represents the consumer instance.
 `n` increments each time the container is started.
 So, with a bean name of `container`, threads in this container will be named `container-0-C-1`, `container-1-C-1` etc., after the container is started the first time; `container-0-C-2`, `container-1-C-2` etc., after a stop and subsequent start.


### PR DESCRIPTION
The second task executor was removed in 1.3.x, but the documentation was not updated.

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
