### PR TITLE
Remove outdated information for transactional.id

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -3444,11 +3444,7 @@ Spring for Apache Kafka adds support in the following ways:
 Transactions are enabled by providing the `DefaultKafkaProducerFactory` with a `transactionIdPrefix`.
 In that case, instead of managing a single shared `Producer`, the factory maintains a cache of transactional producers.
 When the user calls `close()` on a producer, it is returned to the cache for reuse instead of actually being closed.
-The `transactional.id` property of each producer is `transactionIdPrefix` + `n`, where `n` starts with `0` and is incremented for each new producer, unless the transaction is started by a listener container with a record-based listener.
-In that case, the `transactional.id` is `<transactionIdPrefix>.<group.id>.<topic>.<partition>`.
-This is to properly support fencing zombies, https://www.confluent.io/blog/transactions-apache-kafka/[as described here].
-This new behavior was added in versions 1.3.7, 2.0.6, 2.1.10, and 2.2.0.
-If you wish to revert to the previous behavior, you can set the `producerPerConsumerPartition` property on the `DefaultKafkaProducerFactory` to `false`.
+The `transactional.id` property of each producer is `transactionIdPrefix` + `n`, where `n` starts with `0` and is incremented for each new producer.
 
 Also see <<exactly-once>>.
 

--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -3445,6 +3445,8 @@ Transactions are enabled by providing the `DefaultKafkaProducerFactory` with a `
 In that case, instead of managing a single shared `Producer`, the factory maintains a cache of transactional producers.
 When the user calls `close()` on a producer, it is returned to the cache for reuse instead of actually being closed.
 The `transactional.id` property of each producer is `transactionIdPrefix` + `n`, where `n` starts with `0` and is incremented for each new producer.
+In previous versions of Spring Kafka, the `transactional.id` was generated differently for transaction started by a listener container with a record-based listener to support fencing zombies, which is not necessary anymore with `EOSMode.V2` being the only option starting with 3.0.0.
+For applications running with multiple instances, the `transactionIdPrefix` should be unique per instance.
 
 Also see <<exactly-once>>.
 

--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -3445,8 +3445,8 @@ Transactions are enabled by providing the `DefaultKafkaProducerFactory` with a `
 In that case, instead of managing a single shared `Producer`, the factory maintains a cache of transactional producers.
 When the user calls `close()` on a producer, it is returned to the cache for reuse instead of actually being closed.
 The `transactional.id` property of each producer is `transactionIdPrefix` + `n`, where `n` starts with `0` and is incremented for each new producer.
-In previous versions of Spring Kafka, the `transactional.id` was generated differently for transaction started by a listener container with a record-based listener to support fencing zombies, which is not necessary anymore with `EOSMode.V2` being the only option starting with 3.0.0.
-For applications running with multiple instances, the `transactionIdPrefix` should be unique per instance.
+In previous versions of Spring for Apache Kafka, the `transactional.id` was generated differently for transactions started by a listener container with a record-based listener, to support fencing zombies, which is not necessary any more, with `EOSMode.V2` being the only option starting with 3.0.
+For applications running with multiple instances, the `transactionIdPrefix` must be unique per instance.
 
 Also see <<exactly-once>>.
 


### PR DESCRIPTION
Compare https://github.com/spring-projects/spring-kafka/issues/2515

With only EOSMode v2 supported, the alternative way of `transactional.id` creation is not used anymore and not needed anymore. This PR removes the outdated (and confusing) extra documentation in the overview section for transactions.