### PR TITLE
GH-2528: DLPR - Support Header Replacement

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/retrytopic.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/retrytopic.adoc
@@ -621,6 +621,9 @@ protected void configureCustomizers(CustomizersConfigurer customizersConfigurer)
 
 Starting with version 2.8.4, if you wish to add custom headers (in addition to the retry information headers added by the factory, you can add a `headersFunction` to the factory - `factory.setHeadersFunction((rec, ex) -> { ... })`
 
+By default, any headers added will be cumulative - Kafka headers can contain multiple values.
+Starting with version 2.9.5, if the `Headers` returned by the function contains a header of type `DeadLetterPublishingRecoverer.SingleRecordHeader`, then any existing values for that header will be removed and only the new single value will remain.
+
 [[retry-topic-combine-blocking]]
 ==== Combining Blocking and Non-Blocking Retries
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
@@ -230,7 +230,6 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 	 * {@link SingleRecordHeader}, then that header will replace any existing header of
 	 * that name, rather than being appended as a new value.
 	 * @param headersFunction the headers function.
-	 * @param headersFunction the headers function.
 	 * @since 2.5.4
 	 * @see #addHeadersFunction(BiFunction)
 	 */

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 the original author or authors.
+ * Copyright 2018-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,9 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeader;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 
 import org.springframework.core.log.LogAccessor;
@@ -224,7 +226,10 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 
 	/**
 	 * Set a function which will be called to obtain additional headers to add to the
-	 * published record.
+	 * published record. If a {@link Header} returned is an instance of
+	 * {@link SingleRecordHeader}, then that header will replace any existing header of
+	 * that name, rather than being appended as a new value.
+	 * @param headersFunction the headers function.
 	 * @param headersFunction the headers function.
 	 * @since 2.5.4
 	 * @see #addHeadersFunction(BiFunction)
@@ -411,7 +416,10 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 	/**
 	 * Add a function which will be called to obtain additional headers to add to the
 	 * published record. Functions are called in the order that they are added, and after
-	 * any function passed into {@link #setHeadersFunction(BiFunction)}.
+	 * any function passed into {@link #setHeadersFunction(BiFunction)}. If a
+	 * {@link Header} returned is an instance of {@link SingleRecordHeader}, then that
+	 * header will replace any existing header of that name, rather than being appended as
+	 * a new value.
 	 * @param headersFunction the headers function.
 	 * @since 2.8.4
 	 * @see #setHeadersFunction(BiFunction)
@@ -707,7 +715,12 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 		maybeAddOriginalHeaders(kafkaHeaders, record, exception);
 		Headers headers = this.headersFunction.apply(record, exception);
 		if (headers != null) {
-			headers.forEach(kafkaHeaders::add);
+			headers.forEach(header -> {
+				if (header instanceof SingleRecordHeader) {
+					kafkaHeaders.remove(header.key());
+				}
+				kafkaHeaders.add(header);
+			});
 		}
 	}
 
@@ -1371,6 +1384,36 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 		 * @param headerNames the heaader names to use.
 		 */
 		void create(Headers kafkaHeaders, Exception exception, boolean isKey, HeaderNames headerNames);
+
+	}
+
+	/**
+	 * A {@link Header} that indicates that this header should replace any existing headers
+	 * with this name, rather than being appended to the headers, which is the normal behavior.
+	 *
+	 * @since 2.9.5
+	 * @see DeadLetterPublishingRecoverer#setHeadersFunction(BiFunction)
+	 * @see DeadLetterPublishingRecoverer#addHeadersFunction(BiFunction)
+	 */
+	public static class SingleRecordHeader extends RecordHeader {
+
+		/**
+		 * Construct an instance.
+		 * @param key the key.
+		 * @param value the value.
+		 */
+		public SingleRecordHeader(String key, byte[] value) {
+			super(key, value);
+		}
+
+		/**
+		 * Construct an instance.
+		 * @param keyBuffer the key buffer.
+		 * @param valueBuffer the value buffer.
+		 */
+		public SingleRecordHeader(ByteBuffer keyBuffer, ByteBuffer valueBuffer) {
+			super(keyBuffer, valueBuffer);
+		}
 
 	}
 


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2528

When adding headers in a DLPR headers function, header values accumulate because Kafka headers support multiple values.

Provide a mechanism to allow adding a header to replace any existing header with that name.

**cherry-pick to 2.9.x**
