### PR TITLE
GH-2538: KafkaTemplate - Fix Eager Init Cluster Id

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaAdmin.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaAdmin.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 the original author or authors.
+ * Copyright 2017-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -130,6 +130,15 @@ public class KafkaAdmin extends KafkaResourceFactory
 	 */
 	public void setOperationTimeout(int operationTimeout) {
 		this.operationTimeout = operationTimeout;
+	}
+
+	/**
+	 * Return the operation timeout in seconds.
+	 * @return the timeout.
+	 * @since 3.0.2
+	 */
+	public int getOperationTimeout() {
+		return this.operationTimeout;
 	}
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 the original author or authors.
+ * Copyright 2015-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -434,9 +434,10 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 				if (!producerServers.equals(adminServers)) {
 					Map<String, Object> props = new HashMap<>(this.kafkaAdmin.getConfigurationProperties());
 					props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, producerServers);
+					int opTo = this.kafkaAdmin.getOperationTimeout();
 					this.kafkaAdmin = new KafkaAdmin(props);
+					this.kafkaAdmin.setOperationTimeout(opTo);
 				}
-				this.clusterId = this.kafkaAdmin.clusterId();
 			}
 		}
 		else if (this.micrometerEnabled) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -945,7 +945,9 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 						Map<String, Object> props = new HashMap<>(admin.getConfigurationProperties());
 						if (!props.get(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG).equals(this.bootstrapServers)) {
 							props.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, this.bootstrapServers);
+							int opTo = admin.getOperationTimeout();
 							admin = new KafkaAdmin(props);
+							admin.setOperationTimeout(opTo);
 						}
 					}
 					return admin;


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2538

The `KafkaTemplate` already has code to lazily fetch the cluster id when first needed. Remove the eager fetch in `afterSingletonsInstantiated`.

Also, when creating a new `KafkaAdmin` propagate the `operationTimeout` from the source admin (in both the template and listener container).
