### PR TITLE
Fix retry logic causing consumer leaving the group

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ErrorHandlingUtils.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ErrorHandlingUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 the original author or authors.
+ * Copyright 2021-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ import org.springframework.util.backoff.BackOffExecution;
 /**
  * Utilities for error handling.
  *
- * @author Gary Russell
+ * @author Gary Russell, Andrii Pelesh
  * @since 2.8
  *
  */
@@ -96,6 +96,7 @@ public final class ErrorHandlingUtils {
 				if (!container.isRunning()) {
 					throw new KafkaException("Container stopped during retries");
 				}
+				consumer.poll(Duration.ZERO);
 				try {
 					invokeListener.run();
 					return;

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ErrorHandlingUtils.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ErrorHandlingUtils.java
@@ -36,7 +36,8 @@ import org.springframework.util.backoff.BackOffExecution;
 /**
  * Utilities for error handling.
  *
- * @author Gary Russell, Andrii Pelesh
+ * @author Gary Russell
+ * @author Andrii Pelesh
  * @since 2.8
  *
  */

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/FallbackBatchErrorHandlerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/FallbackBatchErrorHandlerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 the original author or authors.
+ * Copyright 2020-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,38 +17,24 @@
 package org.springframework.kafka.listener;
 
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.willAnswer;
-import static org.mockito.BDDMockito.willThrow;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-
-import java.lang.reflect.Field;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.common.TopicPartition;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
-
 import org.springframework.kafka.KafkaException;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.util.backoff.FixedBackOff;
+
+import java.lang.reflect.Field;
+import java.util.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.*;
 
 /**
  * @author Gary Russell
@@ -82,7 +68,7 @@ public class FallbackBatchErrorHandlerTests {
 		assertThat(this.invoked).isEqualTo(3);
 		assertThat(recovered).hasSize(2);
 		verify(consumer).pause(any());
-		verify(consumer, times(3)).poll(any());
+		verify(consumer, times(2 * this.invoked)).poll(any());
 		verify(consumer).resume(any());
 		verify(consumer, times(2)).assignment();
 		verifyNoMoreInteractions(consumer);
@@ -108,7 +94,7 @@ public class FallbackBatchErrorHandlerTests {
 		assertThat(this.invoked).isEqualTo(1);
 		assertThat(recovered).hasSize(0);
 		verify(consumer).pause(any());
-		verify(consumer).poll(any());
+		verify(consumer, times(2)).poll(any());
 		verify(consumer).resume(any());
 		verify(consumer, times(2)).assignment();
 		verifyNoMoreInteractions(consumer);
@@ -139,7 +125,7 @@ public class FallbackBatchErrorHandlerTests {
 		assertThat(this.invoked).isEqualTo(3);
 		assertThat(recovered).hasSize(1);
 		verify(consumer).pause(any());
-		verify(consumer, times(3)).poll(any());
+		verify(consumer, times(2 * this.invoked)).poll(any());
 		verify(consumer).resume(any());
 		verify(consumer, times(2)).assignment();
 		verify(consumer).seek(new TopicPartition("foo", 0), 0L);
@@ -174,7 +160,7 @@ public class FallbackBatchErrorHandlerTests {
 	}
 
 	@Test
-	void rePauseOnRebalance() {
+	void rePauseOnRebalance() throws InterruptedException {
 		this.invoked = 0;
 		List<ConsumerRecord<?, ?>> recovered = new ArrayList<>();
 		FallbackBatchErrorHandler eh = new FallbackBatchErrorHandler(new FixedBackOff(0L, 1L), (cr, ex) ->  {
@@ -208,9 +194,11 @@ public class FallbackBatchErrorHandlerTests {
 		inOrder.verify(container).publishConsumerPausedEvent(map.keySet(), "For batch retry");
 		inOrder.verify(consumer).poll(any());
 		inOrder.verify(consumer).pause(any());
+		inOrder.verify(consumer).poll(any());
+		inOrder.verify(consumer).pause(any());
 		inOrder.verify(consumer).resume(any());
 		inOrder.verify(container).publishConsumerResumedEvent(map.keySet());
-		verify(consumer, times(3)).assignment();
+		verify(consumer, times(4)).assignment();
 		verifyNoMoreInteractions(consumer);
 		assertThat(pubPauseCalled.get()).isTrue();
 	}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/FallbackBatchErrorHandlerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/FallbackBatchErrorHandlerTests.java
@@ -174,7 +174,7 @@ public class FallbackBatchErrorHandlerTests {
 	}
 
 	@Test
-	void rePauseOnRebalance() throws InterruptedException {
+	void rePauseOnRebalance() {
 		this.invoked = 0;
 		List<ConsumerRecord<?, ?>> recovered = new ArrayList<>();
 		FallbackBatchErrorHandler eh = new FallbackBatchErrorHandler(new FixedBackOff(0L, 1L), (cr, ex) ->  {

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/FallbackBatchErrorHandlerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/FallbackBatchErrorHandlerTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.kafka.listener;
 
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -48,7 +49,6 @@ import org.mockito.InOrder;
 import org.springframework.kafka.KafkaException;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.util.backoff.FixedBackOff;
-
 
 /**
  * @author Gary Russell

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/FallbackBatchErrorHandlerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/FallbackBatchErrorHandlerTests.java
@@ -16,6 +16,27 @@
 
 package org.springframework.kafka.listener;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willAnswer;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -23,18 +44,11 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.common.TopicPartition;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
+
 import org.springframework.kafka.KafkaException;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.util.backoff.FixedBackOff;
 
-import java.lang.reflect.Field;
-import java.util.*;
-import java.util.concurrent.atomic.AtomicBoolean;
-
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.BDDMockito.*;
 
 /**
  * @author Gary Russell


### PR DESCRIPTION
**Short problem description**: consumer leaves the group when combined processing+backoff time is higher than `max.poll.interval.ms`.
**Root cause**: The retry logic in `ErrorHandlingUtils` does not call `poll()` (on the paused consumer) before re-trying the listener runnable, it calls `poll()` only before backing off. So if backoffInterval + duration of the following retried execution is longer than `max.poll.interval` - consumer leaves the group.
**Solution**: Amend `ErrorHandlingUtils` to have an extra call to `consumer.poll` right before retrying the listener runnable.

#2542 
