### PR TITLE
GH-2565 Fix Resume Partition When Unassigned

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2022 the original author or authors.
+ * Copyright 2015-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -374,7 +374,7 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 		synchronized (this.lifecycleMonitor) {
 			this.containers
 					.stream()
-					.filter(container -> containsPartition(topicPartition, container))
+					.filter(container -> container.isPartitionPauseRequested(topicPartition))
 					.forEach(container -> container.resumePartition(topicPartition));
 		}
 	}


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2565

Previously, when a partition was resumed while not currently assigned, it would be paused indefinitely when reassigned.

This was caused by the `ConcurrentMessageListenerContainer` only resuming partitions in child containers if that partition is currently assigned to the container, leaving the pause request in place.

Use the `isPartitionPauseRequested()` method on the child container instead when deciding whether to resume the partition.

**cherry-pick to 2.9.x**

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
