### PR TITLE
GH-2566: Both Converters in Container Factory

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -1509,6 +1509,9 @@ public KafkaListenerContainerFactory<?> batchFactory() {
 NOTE: Starting with version 2.8, you can override the factory's `batchListener` propery using the `batch` property on the `@KafkaListener` annotation.
 This, together with the changes to <<error-handlers>> allows the same factory to be used for both record and batch listeners.
 
+NOTE: Starting with version 2.9.6, the container factory has separate setters for the `recordMessageConverter` and `batchMessageConverter` properties.
+Previously, there was only one property `messageConverter` which applied to both record and batch listeners.
+
 The following example shows how to receive a list of payloads:
 
 ====
@@ -4395,7 +4398,7 @@ public KafkaListenerContainerFactory<?> kafkaJsonListenerContainerFactory() {
     ConcurrentKafkaListenerContainerFactory<Integer, String> factory =
         new ConcurrentKafkaListenerContainerFactory<>();
     factory.setConsumerFactory(consumerFactory());
-    factory.setMessageConverter(new JsonMessageConverter());
+    factory.setRecordMessageConverter(new JsonMessageConverter());
     return factory;
 }
 ...
@@ -4677,7 +4680,7 @@ public KafkaListenerContainerFactory<?> kafkaListenerContainerFactory() {
             new ConcurrentKafkaListenerContainerFactory<>();
     factory.setConsumerFactory(consumerFactory());
     factory.setBatchListener(true);
-    factory.setMessageConverter(new BatchMessagingMessageConverter(converter()));
+    factory.setBatchMessageConverter(new BatchMessagingMessageConverter(converter()));
     return factory;
 }
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 the original author or authors.
+ * Copyright 2014-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -282,6 +282,7 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 	 * @return the batch listener flag.
 	 * @since 2.8
 	 */
+	@Override
 	@Nullable
 	public Boolean getBatchListener() {
 		return this.batchListener;

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2022 the original author or authors.
+ * Copyright 2002-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -162,6 +162,17 @@ public interface KafkaListenerEndpoint {
 	 */
 	@Nullable
 	default String getMainListenerId() {
+		return null;
+	}
+
+	/**
+	 * Return the current batch listener flag for this endpoint, or null if not explicitly
+	 * set.
+	 * @return the batch listener flag.
+	 * @since 2.9.6
+	 */
+	@Nullable
+	default Boolean getBatchListener() {
 		return null;
 	}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/BatchListenerConversionTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/BatchListenerConversionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 the original author or authors.
+ * Copyright 2017-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -173,7 +173,7 @@ public class BatchListenerConversionTests {
 					new ConcurrentKafkaListenerContainerFactory<>();
 			factory.setConsumerFactory(consumerFactory(embeddedKafka));
 			factory.setBatchListener(true);
-			factory.setMessageConverter(new BatchMessagingMessageConverter(converter()));
+			factory.setBatchMessageConverter(new BatchMessagingMessageConverter(converter()));
 			factory.setReplyTemplate(template(embeddedKafka));
 			DefaultErrorHandler eh = new DefaultErrorHandler(new DeadLetterPublishingRecoverer(template));
 			factory.setCommonErrorHandler(eh);

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1091,7 +1091,7 @@ public class EnableKafkaIntegrationTests {
 				}
 			});
 			factory.getContainerProperties().setMicrometerTags(Collections.singletonMap("extraTag", "foo"));
-			factory.setMessageConverter(new RecordMessageConverter() {
+			factory.setRecordMessageConverter(new RecordMessageConverter() {
 
 				@Override
 				public Message<?> toMessage(ConsumerRecord<?, ?> record, Acknowledgment acknowledgment,
@@ -1137,7 +1137,7 @@ public class EnableKafkaIntegrationTests {
 			DefaultJackson2JavaTypeMapper typeMapper = new DefaultJackson2JavaTypeMapper();
 			typeMapper.addTrustedPackages("*");
 			converter.setTypeMapper(typeMapper);
-			factory.setMessageConverter(converter);
+			factory.setRecordMessageConverter(converter);
 			return factory;
 		}
 
@@ -1154,7 +1154,7 @@ public class EnableKafkaIntegrationTests {
 			typeMapper.addTrustedPackages("*");
 			typeMapper.setTypePrecedence(TypePrecedence.TYPE_ID);
 			converter.setTypeMapper(typeMapper);
-			factory.setMessageConverter(converter);
+			factory.setRecordMessageConverter(converter);
 			return factory;
 		}
 
@@ -1167,7 +1167,7 @@ public class EnableKafkaIntegrationTests {
 			DefaultJackson2JavaTypeMapper typeMapper = new DefaultJackson2JavaTypeMapper();
 			typeMapper.addTrustedPackages("*");
 			converter.setTypeMapper(typeMapper);
-			factory.setMessageConverter(new ProjectingMessageConverter(converter));
+			factory.setRecordMessageConverter(new ProjectingMessageConverter(converter));
 			factory.setChangeConsumerThreadName(true);
 			factory.setThreadNameSupplier(container -> "foo." + container.getListenerId());
 			return factory;

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/adapter/BatchAdapterConversionErrorsTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/adapter/BatchAdapterConversionErrorsTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2021-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -165,7 +165,7 @@ public class BatchAdapterConversionErrorsTests {
 		public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
 			ConcurrentKafkaListenerContainerFactory factory = new ConcurrentKafkaListenerContainerFactory();
 			factory.setConsumerFactory(consumerFactory());
-			factory.setMessageConverter(new BatchMessagingMessageConverter(new JsonMessageConverter()));
+			factory.setBatchMessageConverter(new BatchMessagingMessageConverter(new JsonMessageConverter()));
 			factory.setBatchListener(true);
 			return factory;
 		}

--- a/spring-kafka/src/test/java/org/springframework/kafka/requestreply/ReplyingKafkaTemplateTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/requestreply/ReplyingKafkaTemplateTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 the original author or authors.
+ * Copyright 2018-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -900,7 +900,7 @@ public class ReplyingKafkaTemplateTests {
 			factory.setReplyTemplate(template());
 			MessagingMessageConverter messageConverter = new MessagingMessageConverter();
 			messageConverter.setHeaderMapper(new SimpleKafkaHeaderMapper());
-			factory.setMessageConverter(messageConverter);
+			factory.setRecordMessageConverter(messageConverter);
 			factory.setReplyHeadersConfigurer(new ReplyHeadersConfigurer() {
 
 				@Override


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2566

Now that both batch and record listners can be created by a single factory, it should be possible to configure both a `RecordMessageConverter` and `BatchMessageConverter`.

Previously, only a single `MessageConverter` could be configured.

**cherry-pick to 2.9.x**

