### PR TITLE
GH-2576: Fix No Seeks After Error Handling

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -2643,7 +2643,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 
 		private boolean checkImmediatePause(Iterator<ConsumerRecord<K, V>> iterator) {
 			if (isPaused() && this.pauseImmediate) {
-				Map<TopicPartition, List<ConsumerRecord<K, V>>> remaining = new HashMap<>();
+				Map<TopicPartition, List<ConsumerRecord<K, V>>> remaining = new LinkedHashMap<>();
 				while (iterator.hasNext()) {
 					ConsumerRecord<K, V> next = iterator.next();
 					remaining.computeIfAbsent(new TopicPartition(next.topic(), next.partition()),
@@ -3498,6 +3498,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			@Override
 			public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
 				this.revoked.addAll(partitions);
+				removeRevokationsFromPending(partitions);
 				if (this.consumerAwareListener != null) {
 					this.consumerAwareListener.onPartitionsRevokedBeforeCommit(ListenerConsumer.this.consumer,
 							partitions);
@@ -3537,6 +3538,23 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 				}
 			}
 
+			private void removeRevokationsFromPending(Collection<TopicPartition> partitions) {
+				ConsumerRecords<K, V> remaining = ListenerConsumer.this.remainingRecords;
+				if (remaining != null && !partitions.isEmpty()) {
+					Set<TopicPartition> remainingParts = new LinkedHashSet<>(remaining.partitions());
+					remainingParts.removeAll(partitions);
+					if (!remainingParts.isEmpty()) {
+						Map<TopicPartition, List<ConsumerRecord<K, V>>> trimmed = new LinkedHashMap<>();
+						remainingParts.forEach(part -> trimmed.computeIfAbsent(part, tp -> remaining.records(tp)));
+						ListenerConsumer.this.remainingRecords = new ConsumerRecords<>(trimmed);
+					}
+					else {
+						ListenerConsumer.this.remainingRecords = null;
+					}
+					ListenerConsumer.this.logger.debug(() -> "Removed " + partitions + " from remaining records");
+				}
+			}
+
 			@Override
 			public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
 				repauseIfNeeded(partitions);
@@ -3568,7 +3586,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			}
 
 			private void repauseIfNeeded(Collection<TopicPartition> partitions) {
-				if (isPaused()) {
+				if (isPaused() || ListenerConsumer.this.remainingRecords != null && !partitions.isEmpty()) {
 					ListenerConsumer.this.consumer.pause(partitions);
 					ListenerConsumer.this.consumerPaused = true;
 					ListenerConsumer.this.logger.warn("Paused consumer resumed by Kafka due to rebalance; "

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -3498,7 +3498,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			@Override
 			public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
 				this.revoked.addAll(partitions);
-				removeRevokationsFromPending(partitions);
+				removeRevocationsFromPending(partitions);
 				if (this.consumerAwareListener != null) {
 					this.consumerAwareListener.onPartitionsRevokedBeforeCommit(ListenerConsumer.this.consumer,
 							partitions);
@@ -3538,7 +3538,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 				}
 			}
 
-			private void removeRevokationsFromPending(Collection<TopicPartition> partitions) {
+			private void removeRevocationsFromPending(Collection<TopicPartition> partitions) {
 				ConsumerRecords<K, V> remaining = ListenerConsumer.this.remainingRecords;
 				if (remaining != null && !partitions.isEmpty()) {
 					Set<TopicPartition> remainingParts = new LinkedHashSet<>(remaining.partitions());


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2576

When the error handler `seeksAfterError` is false, we keep the unprocessed records in memory (`retainedRecords`), pause the consumer, and attempt redelivery.

If a rebalance occurs during this state, the behavior depends on whether a legacy or cooperative partition assignor is used.

With a legacy assignor, all partitions are unassigned and usually a subset is reassigned. This causes their positions to be reset to the last committed offset. In this case, all retained records must be cleared, otherwise an emergency stop occurs because records are polled when we don't expect them.

With a cooperative assignor, only a subset of the partitions are revoked. Records for these partitions must be pruned from the `retainedRecords` and not redelivered to the listener.

- add code to the rebalance listener to prune the revoked paritions from the retained records
- re-pause any assigned partitions if retained records are present

Add tests for both types of assignor.

Also tested with the reporter's reproducer.

**cherry-pick to 2.9.x**
