### PR TITLE
GH-2583 ProducerFactory.createProducer argument @Nullable

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/ProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/ProducerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,7 @@ public interface ProducerFactory<K, V> {
 	 * @return the producer.
 	 * @since 2.3
 	 */
-	default Producer<K, V> createProducer(@SuppressWarnings("unused") String txIdPrefix) {
+	default Producer<K, V> createProducer(@Nullable @SuppressWarnings("unused") String txIdPrefix) {
 		throw new UnsupportedOperationException("This factory does not support this method");
 	}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTransactionTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTransactionTests.java
@@ -72,6 +72,7 @@ import org.springframework.kafka.test.condition.EmbeddedKafkaCondition;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.kafka.transaction.KafkaTransactionManager;
+import org.springframework.lang.Nullable;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionException;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
@@ -387,7 +388,7 @@ public class KafkaTemplateTransactionTests {
 
 			@SuppressWarnings({ "rawtypes", "unchecked" })
 			@Override
-			public Producer<String, String> createProducer(String txIdPrefixArg) {
+			public Producer<String, String> createProducer(@Nullable String txIdPrefixArg) {
 				CloseSafeProducer<String, String> closeSafeProducer = new CloseSafeProducer<>(producer,
 						(prod, timeout) -> {
 							prod.closeDelegate(timeout, Collections.emptyList());
@@ -423,7 +424,7 @@ public class KafkaTemplateTransactionTests {
 
 			@SuppressWarnings("unchecked")
 			@Override
-			public Producer<String, String> createProducer(String txIdPrefixArg) {
+			public Producer<String, String> createProducer(@Nullable String txIdPrefixArg) {
 				BlockingQueue<CloseSafeProducer<String, String>> cache = new LinkedBlockingDeque<>(1);
 				try {
 					cache.put(new CloseSafeProducer<>(mock(Producer.class), this::removeProducer,

--- a/spring-kafka/src/test/kotlin/org/springframework/kafka/core/KotlinProducerFactoryTests.kt
+++ b/spring-kafka/src/test/kotlin/org/springframework/kafka/core/KotlinProducerFactoryTests.kt
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test
 
 /**
  * @author Antonio Tomac
- * @since 3.1
+ * @since 2.9.6
  * @see [ProducerFactory.createProducer]
  */
 class KotlinProducerFactoryTests {

--- a/spring-kafka/src/test/kotlin/org/springframework/kafka/core/KotlinProducerFactoryTests.kt
+++ b/spring-kafka/src/test/kotlin/org/springframework/kafka/core/KotlinProducerFactoryTests.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2016-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.core
+
+import org.apache.kafka.clients.producer.MockProducer
+import org.apache.kafka.clients.producer.Producer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * @author Antonio Tomac
+ * @since 3.1
+ * @see [ProducerFactory.createProducer]
+ */
+class KotlinProducerFactoryTests {
+
+	class KotlinProducerFactory : ProducerFactory<Any, Any> {
+		override fun createProducer(): Producer<Any, Any> = MockProducer()
+
+		/**
+		 * This override checks correct nullability of [txIdPrefix] in [ProducerFactory.createProducer]
+		 * Reason, kotlin compiler warning:
+		 *
+		 * Override 'fun createProducer(txIdPrefix: String?): Producer<Any, Any>' has incorrect nullability
+		 * in its signature comparing with overridden 'fun createProducer(txIdPrefix: String): Producer<Any!, Any!>'
+		 * This warning will become an error soon. See [KT-36770](https://youtrack.jetbrains.com/issue/KT-36770) for details
+		 */
+		override fun createProducer(txIdPrefix: String?): Producer<Any, Any> = MockProducer()
+	}
+
+	private val producerFactory: ProducerFactory<Any, Any> = KotlinProducerFactory()
+
+	@Test
+	fun `test instantiation with null txIdPrefix`() {
+		val producer = producerFactory.createProducer(null)
+		assertThat(producer).isInstanceOf(MockProducer::class.java)
+	}
+
+	@Test
+	fun `test instantiation with non-null txIdPrefix`() {
+		val producer = producerFactory.createProducer("foo")
+		assertThat(producer).isInstanceOf(MockProducer::class.java)
+	}
+}


### PR DESCRIPTION
Resolves: #2583

ProducerFactory.createProducer argument txIdPrefix is non-nullable which causes kotlin compiler to emit warning if implementations declare txIdPrefix as nullable txIdPrefix: String?

This PR changes signature of ProducerFactory.createProducer so that `txIdPrefix` is `@Nullable` and also adds unit test to verify compilation, and to verify that future versions of Kotlin won't cause compile errors.

Current users of kotlin who implemented ProducerFactory.createProducer(txIdPrefix) with `txIdPrefix: String` (non-nullable) will start seeing kotlin compiler warning that their signature is not matching base signature.
