### PR TITLE
GH-2596: Fix No Seek Error Handling

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonLoggingErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonLoggingErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 the original author or authors.
+ * Copyright 2021-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,12 +47,13 @@ public class CommonLoggingErrorHandler implements CommonErrorHandler {
 		this.ackAfterHandle = ackAfterHandle;
 	}
 
+
 	@Override
-	@Deprecated(since = "2.9", forRemoval = true) // in 3.1
-	public void handleRecord(Exception thrownException, ConsumerRecord<?, ?> record, Consumer<?, ?> consumer,
+	public boolean handleOne(Exception thrownException, ConsumerRecord<?, ?> record, Consumer<?, ?> consumer,
 			MessageListenerContainer container) {
 
 		LOGGER.error(thrownException, () -> "Error occured while processing: " + KafkaUtils.format(record));
+		return true;
 	}
 
 	@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -175,6 +175,10 @@ public class ContainerProperties extends ConsumerProperties {
 
 	private static final double DEFAULT_IDLE_BEFORE_DATA_MULTIPLIER = 5.0;
 
+	private static final long ONE_HUNDRED = 100L;
+
+	private static final Duration DEFAULT_PAUSED_POLL_TIMEOUT = Duration.ofMillis(ONE_HUNDRED);
+
 	private final Map<String, String> micrometerTags = new HashMap<>();
 
 	private final List<Advice> adviceChain = new ArrayList<>();
@@ -188,7 +192,7 @@ public class ContainerProperties extends ConsumerProperties {
 	 * when they all have been processed by the listener</li>
 	 * <li>TIME: Commit pending offsets after {@link #setAckTime(long) ackTime} number of
 	 * milliseconds; (should be greater than
-	 * {@code #setPollTimeout(long) pollTimeout}.</li>
+	 * {@code ConsumerProperties#setPollTimeout(long) pollTimeout}.</li>
 	 * <li>COUNT: Commit pending offsets after at least {@link #setAckCount(int) ackCount}
 	 * number of records have been processed</li>
 	 * <li>COUNT_TIME: Commit pending offsets after {@link #setAckTime(long) ackTime}
@@ -287,6 +291,8 @@ public class ContainerProperties extends ConsumerProperties {
 
 	private KafkaListenerObservationConvention observationConvention;
 
+	private Duration pollTimeoutWhilePaused = DEFAULT_PAUSED_POLL_TIMEOUT;
+
 	/**
 	 * Create properties for a container that will subscribe to the specified topics.
 	 * @param topics the topics.
@@ -336,7 +342,7 @@ public class ContainerProperties extends ConsumerProperties {
 	 * when they all have been processed by the listener</li>
 	 * <li>TIME: Commit pending offsets after {@link #setAckTime(long) ackTime} number of
 	 * milliseconds; (should be greater than
-	 * {@code #setPollTimeout(long) pollTimeout}.</li>
+	 * {@code ConsumerProperties#setPollTimeout(long) pollTimeout}.</li>
 	 * <li>COUNT: Commit pending offsets after at least {@link #setAckCount(int) ackCount}
 	 * number of records have been processed</li>
 	 * <li>COUNT_TIME: Commit pending offsets after {@link #setAckTime(long) ackTime}
@@ -568,11 +574,10 @@ public class ContainerProperties extends ConsumerProperties {
 	}
 
 	/**
-	 * If the time since the last poll / {@link #getPollTimeout() poll timeout}
-	 * exceeds this value, a NonResponsiveConsumerEvent is published.
-	 * This value should be more than 1.0 to avoid a race condition that can cause
-	 * spurious events to be published.
-	 * Default {@value #DEFAULT_NO_POLL_THRESHOLD}.
+	 * If the time since the last poll / {@link ConsumerProperties#getPollTimeout() poll
+	 * timeout} exceeds this value, a NonResponsiveConsumerEvent is published. This value
+	 * should be more than 1.0 to avoid a race condition that can cause spurious events to
+	 * be published. Default {@value #DEFAULT_NO_POLL_THRESHOLD}.
 	 * @param noPollThreshold the threshold
 	 * @since 1.3.1
 	 */
@@ -945,6 +950,28 @@ public class ContainerProperties extends ConsumerProperties {
 		this.observationConvention = observationConvention;
 	}
 
+	/**
+	 * The poll timeout to use while paused; usually a lower number than
+	 * {@link ConsumerProperties#setPollTimeout(long) pollTimeout}.
+	 * @return the pollTimeoutWhilePaused
+	 * @since 2.9.7
+	 */
+	public Duration getPollTimeoutWhilePaused() {
+		return this.pollTimeoutWhilePaused;
+	}
+
+	/**
+	 * Set the poll timeout to use while paused; usually a lower number than
+	 * {@link ConsumerProperties#setPollTimeout(long) pollTimeout}. Should be greater than
+	 * zero to avoid a tight CPU loop while the consumer is paused. Default is 100ms.
+	 * @param pollTimeoutWhilePaused the pollTimeoutWhilePaused to set
+	 * @since 2.9.7
+	 */
+	public void setPollTimeoutWhilePaused(Duration pollTimeoutWhilePaused) {
+		Assert.notNull(pollTimeoutWhilePaused, "'pollTimeoutWhilePaused' cannot be null");
+		this.pollTimeoutWhilePaused = pollTimeoutWhilePaused;
+	}
+
 	@Override
 	public String toString() {
 		return "ContainerProperties ["
@@ -967,6 +994,7 @@ public class ContainerProperties extends ConsumerProperties {
 				+ "\n monitorInterval=" + this.monitorInterval
 				+ (this.scheduler != null ? "\n scheduler=" + this.scheduler : "")
 				+ "\n noPollThreshold=" + this.noPollThreshold
+				+ "\n pollTimeoutWhilePaused=" + this.pollTimeoutWhilePaused
 				+ "\n subBatchPerPartition=" + this.subBatchPerPartition
 				+ "\n assignmentCommitOption=" + this.assignmentCommitOption
 				+ "\n deliveryAttemptHeader=" + this.deliveryAttemptHeader

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ContainerPauseImmediateTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ContainerPauseImmediateTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,7 +89,7 @@ public class ContainerPauseImmediateTests {
 		inOrder.verify(this.consumer).assign(any(Collection.class));
 		inOrder.verify(this.consumer).poll(Duration.ofMillis(ContainerProperties.DEFAULT_POLL_TIMEOUT));
 		inOrder.verify(this.consumer).pause(any());
-		inOrder.verify(this.consumer).poll(Duration.ofMillis(ContainerProperties.DEFAULT_POLL_TIMEOUT));
+		inOrder.verify(this.consumer).poll(Duration.ZERO);
 		assertThat(this.config.count).isEqualTo(4);
 		assertThat(this.config.contents).contains("foo", "bar", "baz", "qux");
 		this.registry.getListenerContainer("id").resume();
@@ -178,7 +178,7 @@ public class ContainerPauseImmediateTests {
 						}
 						return new ConsumerRecords(Collections.emptyMap());
 				}
-			}).given(consumer).poll(Duration.ofMillis(ContainerProperties.DEFAULT_POLL_TIMEOUT));
+			}).given(consumer).poll(any());
 			List<TopicPartition> paused = new ArrayList<>();
 			willAnswer(i -> {
 				this.commitLatch.countDown();
@@ -209,6 +209,7 @@ public class ContainerPauseImmediateTests {
 			factory.setConsumerFactory(consumerFactory(registry));
 			factory.getContainerProperties().setAckMode(AckMode.RECORD);
 			factory.getContainerProperties().setPauseImmediate(true);
+			factory.getContainerProperties().setPollTimeoutWhilePaused(Duration.ZERO);
 			return factory;
 		}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/DefaultErrorHandlerNoSeeksBatchAckTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/DefaultErrorHandlerNoSeeksBatchAckTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,6 +101,7 @@ public class DefaultErrorHandlerNoSeeksBatchAckTests {
 		offsets.put(new TopicPartition("foo", 1), new OffsetAndMetadata(1L));
 		inOrder.verify(this.consumer).commitSync(offsets, Duration.ofSeconds(60));
 		inOrder.verify(this.consumer).pause(any());
+		inOrder.verify(this.consumer).poll(Duration.ZERO);
 		inOrder.verify(this.consumer).resume(any());
 		offsets = new LinkedHashMap<>();
 		offsets.put(new TopicPartition("foo", 1), new OffsetAndMetadata(2L));
@@ -190,7 +191,7 @@ public class DefaultErrorHandlerNoSeeksBatchAckTests {
 						}
 						return ConsumerRecords.empty();
 				}
-			}).given(consumer).poll(Duration.ofMillis(ContainerProperties.DEFAULT_POLL_TIMEOUT));
+			}).given(consumer).poll(any());
 			willAnswer(i -> {
 				this.commitLatch.countDown();
 				return null;
@@ -208,6 +209,7 @@ public class DefaultErrorHandlerNoSeeksBatchAckTests {
 			ConcurrentKafkaListenerContainerFactory factory = new ConcurrentKafkaListenerContainerFactory();
 			factory.setConsumerFactory(consumerFactory());
 			factory.getContainerProperties().setAckMode(AckMode.BATCH);
+			factory.getContainerProperties().setPollTimeoutWhilePaused(Duration.ZERO);
 			DefaultErrorHandler eh = new DefaultErrorHandler();
 			eh.setSeekAfterError(false);
 			factory.setCommonErrorHandler(eh);

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/DefaultErrorHandlerNoSeeksRecordAckNoResumeContainerPausedTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/DefaultErrorHandlerNoSeeksRecordAckNoResumeContainerPausedTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -104,7 +104,7 @@ public class DefaultErrorHandlerNoSeeksRecordAckNoResumeContainerPausedTests {
 				Collections.singletonMap(new TopicPartition("foo", 1), new OffsetAndMetadata(1L)),
 				Duration.ofSeconds(60));
 		inOrder.verify(this.consumer).pause(any());
-		inOrder.verify(this.consumer).poll(Duration.ofMillis(ContainerProperties.DEFAULT_POLL_TIMEOUT));
+		inOrder.verify(this.consumer).poll(Duration.ZERO);
 		verify(this.consumer, never()).resume(any());
 		assertThat(this.config.count).isEqualTo(4);
 		assertThat(this.config.contents).contains("foo", "bar", "baz", "qux");
@@ -186,7 +186,7 @@ public class DefaultErrorHandlerNoSeeksRecordAckNoResumeContainerPausedTests {
 						}
 						return new ConsumerRecords(Collections.emptyMap());
 				}
-			}).given(consumer).poll(Duration.ofMillis(ContainerProperties.DEFAULT_POLL_TIMEOUT));
+			}).given(consumer).poll(any());
 			List<TopicPartition> paused = new ArrayList<>();
 			willAnswer(i -> {
 				this.commitLatch.countDown();
@@ -217,6 +217,7 @@ public class DefaultErrorHandlerNoSeeksRecordAckNoResumeContainerPausedTests {
 			ConcurrentKafkaListenerContainerFactory factory = new ConcurrentKafkaListenerContainerFactory();
 			factory.setConsumerFactory(consumerFactory(registry));
 			factory.getContainerProperties().setAckMode(AckMode.RECORD);
+			factory.getContainerProperties().setPollTimeoutWhilePaused(Duration.ZERO);
 			DefaultErrorHandler eh = new DefaultErrorHandler();
 			eh.setSeekAfterError(false);
 			factory.setCommonErrorHandler(eh);

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/DefaultErrorHandlerNoSeeksRecordAckNoResumePartitionTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/DefaultErrorHandlerNoSeeksRecordAckNoResumePartitionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -106,7 +106,7 @@ public class DefaultErrorHandlerNoSeeksRecordAckNoResumePartitionTests {
 				Collections.singletonMap(new TopicPartition("foo", 1), new OffsetAndMetadata(1L)),
 				Duration.ofSeconds(60));
 		inOrder.verify(this.consumer).pause(any());
-		inOrder.verify(this.consumer).poll(Duration.ofMillis(ContainerProperties.DEFAULT_POLL_TIMEOUT));
+		inOrder.verify(this.consumer).poll(Duration.ZERO);
 		verify(this.consumer, never()).resume(any());
 		assertThat(this.config.count).isEqualTo(4);
 		assertThat(this.config.contents).contains("foo", "bar", "baz", "qux");
@@ -195,7 +195,7 @@ public class DefaultErrorHandlerNoSeeksRecordAckNoResumePartitionTests {
 						}
 						return new ConsumerRecords(Collections.emptyMap());
 				}
-			}).given(consumer).poll(Duration.ofMillis(ContainerProperties.DEFAULT_POLL_TIMEOUT));
+			}).given(consumer).poll(any());
 			List<TopicPartition> paused = new ArrayList<>();
 			willAnswer(i -> {
 				this.commitLatch.countDown();
@@ -227,6 +227,7 @@ public class DefaultErrorHandlerNoSeeksRecordAckNoResumePartitionTests {
 			factory.setConsumerFactory(consumerFactory(registry));
 			factory.getContainerProperties().setAckMode(AckMode.RECORD);
 			factory.getContainerProperties().setDeliveryAttemptHeader(true);
+			factory.getContainerProperties().setPollTimeoutWhilePaused(Duration.ZERO);
 			factory.setRecordInterceptor((record, consumer) -> {
 				Config.this.deliveryAttempt = record.headers().lastHeader(KafkaHeaders.DELIVERY_ATTEMPT);
 				return record;

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/DefaultErrorHandlerNoSeeksRecordAckTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/DefaultErrorHandlerNoSeeksRecordAckTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -112,7 +112,7 @@ public class DefaultErrorHandlerNoSeeksRecordAckTests {
 				Collections.singletonMap(new TopicPartition("foo", 1), new OffsetAndMetadata(1L)),
 				Duration.ofSeconds(60));
 		inOrder.verify(this.consumer).pause(any());
-		inOrder.verify(this.consumer).poll(Duration.ofMillis(ContainerProperties.DEFAULT_POLL_TIMEOUT));
+		inOrder.verify(this.consumer).poll(Duration.ZERO);
 		inOrder.verify(this.consumer).commitSync(
 				Collections.singletonMap(new TopicPartition("foo", 1), new OffsetAndMetadata(2L)),
 				Duration.ofSeconds(60));
@@ -243,9 +243,9 @@ public class DefaultErrorHandlerNoSeeksRecordAckTests {
 						catch (InterruptedException e) {
 							Thread.currentThread().interrupt();
 						}
-						return new ConsumerRecords(Collections.emptyMap());
+						return ConsumerRecords.empty();
 				}
-			}).given(consumer).poll(Duration.ofMillis(ContainerProperties.DEFAULT_POLL_TIMEOUT));
+			}).given(consumer).poll(any());
 			List<TopicPartition> paused = new ArrayList<>();
 			willAnswer(i -> {
 				this.commitLatch.countDown();
@@ -276,6 +276,7 @@ public class DefaultErrorHandlerNoSeeksRecordAckTests {
 			factory.setConsumerFactory(consumerFactory());
 			factory.getContainerProperties().setAckMode(AckMode.RECORD);
 			factory.getContainerProperties().setDeliveryAttemptHeader(true);
+			factory.getContainerProperties().setPollTimeoutWhilePaused(Duration.ZERO);
 			factory.setRecordInterceptor((record, consumer) -> {
 				Config.this.deliveryAttempt = record.headers().lastHeader(KafkaHeaders.DELIVERY_ATTEMPT);
 				return record;

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/LoggingErrorHandlerNoPauseAfterHandle.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/LoggingErrorHandlerNoPauseAfterHandle.java
@@ -18,40 +18,34 @@ package org.springframework.kafka.listener;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyMap;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willAnswer;
-import static org.mockito.BDDMockito.willReturn;
-import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
-import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.clients.consumer.OffsetAndMetadata;
-import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.record.TimestampType;
 import org.junit.jupiter.api.Test;
-import org.mockito.InOrder;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
@@ -61,7 +55,7 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
 import org.springframework.kafka.core.ConsumerFactory;
-import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.listener.ContainerProperties.AckMode;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
@@ -73,18 +67,11 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
  */
 @SpringJUnitConfig
 @DirtiesContext
-@SuppressWarnings("deprecation")
-public class DefaultErrorHandlerNoSeeksBatchListenerTests {
-
-	private static final String CONTAINER_ID = "container";
+public class LoggingErrorHandlerNoPauseAfterHandle {
 
 	@SuppressWarnings("rawtypes")
 	@Autowired
 	private Consumer consumer;
-
-	@SuppressWarnings("rawtypes")
-	@Autowired
-	private Producer producer;
 
 	@Autowired
 	private Config config;
@@ -92,61 +79,46 @@ public class DefaultErrorHandlerNoSeeksBatchListenerTests {
 	@Autowired
 	private KafkaListenerEndpointRegistry registry;
 
-	/*
-	 * Deliver 6 records from three partitions, fail on the second record second
-	 * partition.
-	 */
 	@SuppressWarnings("unchecked")
 	@Test
-	void retriesWithNoSeeksBatchListener() throws Exception {
+	public void noPause(@Autowired CommonLoggingErrorHandler eh) throws Exception {
 		assertThat(this.config.deliveryLatch.await(10, TimeUnit.SECONDS)).isTrue();
-		assertThat(this.config.pollLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(this.config.commitLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(this.config.pollLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		this.registry.stop();
 		assertThat(this.config.closeLatch.await(10, TimeUnit.SECONDS)).isTrue();
-		InOrder inOrder = inOrder(this.consumer, this.producer);
-		inOrder.verify(this.consumer).subscribe(any(Collection.class), any(ConsumerRebalanceListener.class));
-		inOrder.verify(this.consumer).poll(Duration.ofMillis(ContainerProperties.DEFAULT_POLL_TIMEOUT));
-		Map<TopicPartition, OffsetAndMetadata> offsets = new LinkedHashMap<>();
-		offsets.put(new TopicPartition("foo", 0), new OffsetAndMetadata(2L));
-		offsets.put(new TopicPartition("foo", 1), new OffsetAndMetadata(1L));
-		inOrder.verify(this.consumer).commitSync(offsets, Duration.ofSeconds(60));
-		inOrder.verify(this.consumer).pause(any());
-		inOrder.verify(this.consumer).poll(Duration.ZERO);
-		offsets = new LinkedHashMap<>();
-		offsets.put(new TopicPartition("foo", 1), new OffsetAndMetadata(2L));
-		offsets.put(new TopicPartition("foo", 2), new OffsetAndMetadata(2L));
-		inOrder.verify(this.consumer).commitSync(offsets, Duration.ofSeconds(60));
-		inOrder.verify(this.consumer).resume(any());
-		assertThat(this.config.ehException).isInstanceOf(ListenerExecutionFailedException.class);
-		assertThat(((ListenerExecutionFailedException) this.config.ehException).getGroupId()).isEqualTo(CONTAINER_ID);
-		assertThat(this.config.contents).contains("foo", "bar", "baz", "qux", "qux", "qux", "fiz", "buz");
+		assertThat(this.config.count).isEqualTo(6);
+		assertThat(this.config.contents).contains("foo", "bar", "baz", "qux", "fiz", "buz");
+		verify(this.consumer, never()).seek(any(), anyLong());
+		verify(this.consumer, never()).pause(any());
+		verify(this.consumer, never()).poll(Duration.ZERO);
+		verify(eh).handleOne(any(), any(), any(), any());
 	}
 
 	@Configuration
 	@EnableKafka
 	public static class Config {
 
-		final CountDownLatch pollLatch = new CountDownLatch(1);
+		final List<String> contents = new ArrayList<>();
 
-		final CountDownLatch deliveryLatch = new CountDownLatch(2);
+		final CountDownLatch pollLatch = new CountDownLatch(4);
+
+		final CountDownLatch deliveryLatch = new CountDownLatch(6);
 
 		final CountDownLatch closeLatch = new CountDownLatch(1);
 
-		final CountDownLatch commitLatch = new CountDownLatch(2);
+		final CountDownLatch commitLatch = new CountDownLatch(6);
 
-		final AtomicBoolean fail = new AtomicBoolean(true);
+		int count;
 
-		final List<String> contents = new ArrayList<>();
-
-		volatile Exception ehException;
-
-		@KafkaListener(id = CONTAINER_ID, topics = "foo")
-		public void foo(List<String> in) {
-			this.contents.addAll(in);
+		@KafkaListener(groupId = "grp",
+				topicPartitions = @org.springframework.kafka.annotation.TopicPartition(topic = "foo",
+						partitions = "#{'0,1,2'.split(',')}"))
+		public void foo(String in) {
+			this.contents.add(in);
 			this.deliveryLatch.countDown();
-			if (this.fail.getAndSet(false)) {
-				throw new BatchListenerFailedException("test", 3);
+			if (++this.count == 4) { // part 1, offset 1
+				throw new RuntimeException("foo");
 			}
 		}
 
@@ -155,7 +127,7 @@ public class DefaultErrorHandlerNoSeeksBatchListenerTests {
 		public ConsumerFactory consumerFactory() {
 			ConsumerFactory consumerFactory = mock(ConsumerFactory.class);
 			final Consumer consumer = consumer();
-			given(consumerFactory.createConsumer(CONTAINER_ID, "", "-0", KafkaTestUtils.defaultPropertyOverrides()))
+			given(consumerFactory.createConsumer("grp", "", "-0", KafkaTestUtils.defaultPropertyOverrides()))
 				.willReturn(consumer);
 			return consumerFactory;
 		}
@@ -167,11 +139,6 @@ public class DefaultErrorHandlerNoSeeksBatchListenerTests {
 			final TopicPartition topicPartition0 = new TopicPartition("foo", 0);
 			final TopicPartition topicPartition1 = new TopicPartition("foo", 1);
 			final TopicPartition topicPartition2 = new TopicPartition("foo", 2);
-			willAnswer(i -> {
-				((ConsumerRebalanceListener) i.getArgument(1)).onPartitionsAssigned(
-						Collections.singletonList(topicPartition1));
-				return null;
-			}).given(consumer).subscribe(any(Collection.class), any(ConsumerRebalanceListener.class));
 			Map<TopicPartition, List<ConsumerRecord>> records1 = new LinkedHashMap<>();
 			records1.put(topicPartition0, Arrays.asList(
 					new ConsumerRecord("foo", 0, 0L, 0L, TimestampType.NO_TIMESTAMP_TYPE, 0, 0, null, "foo",
@@ -201,9 +168,10 @@ public class DefaultErrorHandlerNoSeeksBatchListenerTests {
 						catch (InterruptedException e) {
 							Thread.currentThread().interrupt();
 						}
-						return new ConsumerRecords(Collections.emptyMap());
+						return ConsumerRecords.empty();
 				}
 			}).given(consumer).poll(any());
+			List<TopicPartition> paused = new ArrayList<>();
 			willAnswer(i -> {
 				this.commitLatch.countDown();
 				return null;
@@ -212,47 +180,35 @@ public class DefaultErrorHandlerNoSeeksBatchListenerTests {
 				this.closeLatch.countDown();
 				return null;
 			}).given(consumer).close();
-			willReturn(new ConsumerGroupMetadata(CONTAINER_ID)).given(consumer).groupMetadata();
+			willAnswer(i -> {
+				paused.addAll(i.getArgument(0));
+				return null;
+			}).given(consumer).pause(any());
+			willAnswer(i -> {
+				return new HashSet<>(paused);
+			}).given(consumer).paused();
+			willAnswer(i -> {
+				paused.removeAll(i.getArgument(0));
+				return null;
+			}).given(consumer).resume(any());
 			return consumer;
 		}
 
 		@SuppressWarnings({ "rawtypes", "unchecked" })
 		@Bean
-		public ConcurrentKafkaListenerContainerFactory kafkaListenerContainerFactory() {
+		ConcurrentKafkaListenerContainerFactory kafkaListenerContainerFactory(CommonLoggingErrorHandler eh) {
 			ConcurrentKafkaListenerContainerFactory factory = new ConcurrentKafkaListenerContainerFactory();
 			factory.setConsumerFactory(consumerFactory());
-			factory.setBatchListener(true);
-			factory.getContainerProperties().setPollTimeoutWhilePaused(Duration.ZERO);
-			DefaultErrorHandler eh = new DefaultErrorHandler() {
-
-				@Override
-				public <K, V> ConsumerRecords<K, V> handleBatchAndReturnRemaining(Exception thrownException,
-						ConsumerRecords<?, ?> data, Consumer<?, ?> consumer, MessageListenerContainer container,
-						Runnable invokeListener) {
-
-					Config.this.ehException = thrownException;
-					return super.handleBatchAndReturnRemaining(thrownException, data, consumer, container, invokeListener);
-				}
-
-			};
-			eh.setSeekAfterError(false);
+			factory.getContainerProperties().setAckMode(AckMode.RECORD);
+			factory.getContainerProperties().setDeliveryAttemptHeader(true);
 			factory.setCommonErrorHandler(eh);
 			return factory;
 		}
 
-		@SuppressWarnings("rawtypes")
 		@Bean
-		public ProducerFactory producerFactory() {
-			ProducerFactory pf = mock(ProducerFactory.class);
-			given(pf.createProducer(isNull())).willReturn(producer());
-			given(pf.transactionCapable()).willReturn(true);
-			return pf;
-		}
-
-		@SuppressWarnings("rawtypes")
-		@Bean
-		public Producer producer() {
-			return mock(Producer.class);
+		CommonLoggingErrorHandler eh() {
+			CommonLoggingErrorHandler eh = spy(new CommonLoggingErrorHandler());
+			return eh;
 		}
 
 	}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/LoggingErrorHandlerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/LoggingErrorHandlerTests.java
@@ -67,7 +67,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
  */
 @SpringJUnitConfig
 @DirtiesContext
-public class LoggingErrorHandlerNoPauseAfterHandle {
+public class LoggingErrorHandlerTests {
 
 	@SuppressWarnings("rawtypes")
 	@Autowired
@@ -81,7 +81,7 @@ public class LoggingErrorHandlerNoPauseAfterHandle {
 
 	@SuppressWarnings("unchecked")
 	@Test
-	public void noPause(@Autowired CommonLoggingErrorHandler eh) throws Exception {
+	public void noPauseAfterHandle(@Autowired CommonLoggingErrorHandler eh) throws Exception {
 		assertThat(this.config.deliveryLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(this.config.commitLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(this.config.pollLatch.await(10, TimeUnit.SECONDS)).isTrue();

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/LoggingErrorHandlerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/LoggingErrorHandlerTests.java
@@ -201,6 +201,7 @@ public class LoggingErrorHandlerTests {
 			factory.setConsumerFactory(consumerFactory());
 			factory.getContainerProperties().setAckMode(AckMode.RECORD);
 			factory.getContainerProperties().setDeliveryAttemptHeader(true);
+			factory.getContainerProperties().setPollTimeoutWhilePaused(Duration.ZERO);
 			factory.setCommonErrorHandler(eh);
 			return factory;
 		}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/PauseContainerManualAssignmentTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/PauseContainerManualAssignmentTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -111,7 +111,7 @@ public class PauseContainerManualAssignmentTests {
 		inOrder.verify(this.consumer).pause(pauses.capture());
 		assertThat(pauses.getValue().stream().collect(Collectors.toList())).contains(new TopicPartition("foo", 0),
 				new TopicPartition("foo", 1), new TopicPartition("foo", 2));
-		inOrder.verify(this.consumer).poll(Duration.ofMillis(ContainerProperties.DEFAULT_POLL_TIMEOUT));
+		inOrder.verify(this.consumer).poll(Duration.ZERO);
 		verify(this.consumer, never()).resume(any());
 		assertThat(this.config.count).isEqualTo(4);
 		assertThat(this.config.contents).contains("foo", "bar", "baz", "qux");
@@ -200,7 +200,7 @@ public class PauseContainerManualAssignmentTests {
 						}
 						return new ConsumerRecords(Collections.emptyMap());
 				}
-			}).given(consumer).poll(Duration.ofMillis(ContainerProperties.DEFAULT_POLL_TIMEOUT));
+			}).given(consumer).poll(any());
 			List<TopicPartition> paused = new ArrayList<>();
 			willAnswer(i -> {
 				this.commitLatch.countDown();
@@ -231,6 +231,7 @@ public class PauseContainerManualAssignmentTests {
 			ConcurrentKafkaListenerContainerFactory factory = new ConcurrentKafkaListenerContainerFactory();
 			factory.setConsumerFactory(consumerFactory(registry));
 			factory.getContainerProperties().setAckMode(AckMode.RECORD);
+			factory.getContainerProperties().setPollTimeoutWhilePaused(Duration.ZERO);
 			DefaultErrorHandler eh = new DefaultErrorHandler();
 			eh.setSeekAfterError(false);
 			factory.setCommonErrorHandler(eh);


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2596

- Do not pause and poll when an error handler "handles" an error
  - this was a bug in that the remaining records were incorrectly built after the error handler indicated that it had handled the error
- Reduce the poll timeout while the consumer is paused because we won't receive any records anyway

**cherry-pick to 2.9.x**
