### PR TITLE
GH-2612: Add Option To Restart Container After Auth

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -2556,7 +2556,15 @@ See `monitorInterval`.
 
 |[[pollTimeout]]<<pollTimeout,`pollTimeout`>>
 |5000
-|The timeout passed into `Consumer.poll()`.
+|The timeout passed into `Consumer.poll()` in milliseconds.
+
+|[[pollTimeoutWhilePaused]]<<pollTimeoutWhilePaused,`pollTimeoutWhilePaused`>>
+|100
+|The timeout passed into `Consumer.poll()` (in milliseconds) when the container is in a paused state.
+
+|[[restartAfterAuthExceptions]]<<restartAfterAuthExceptions,`restartAfterAuthExceptions`>>
+|false
+|True to restart the container if it is stopped due to authorization/authentication exceptions.
 
 |[[scheduler]]<<scheduler,`scheduler`>>
 |`ThreadPoolTaskScheduler`

--- a/spring-kafka-docs/src/main/asciidoc/whats-new.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/whats-new.adoc
@@ -67,6 +67,9 @@ See <<events>> for more information.
 You can now customize the thread names used by consumer threads.
 See <<container-thread-naming>> for more information.
 
+The container property `restartAfterAuthException` has been added.
+See <<container-props>> for more information.
+
 [[x30-template-changes]]
 ==== `KafkaTemplate` Changes
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
@@ -293,6 +293,8 @@ public class ContainerProperties extends ConsumerProperties {
 
 	private Duration pollTimeoutWhilePaused = DEFAULT_PAUSED_POLL_TIMEOUT;
 
+	private boolean restartAfterAuthExceptions;
+
 	/**
 	 * Create properties for a container that will subscribe to the specified topics.
 	 * @param topics the topics.
@@ -972,6 +974,25 @@ public class ContainerProperties extends ConsumerProperties {
 		this.pollTimeoutWhilePaused = pollTimeoutWhilePaused;
 	}
 
+	/**
+	 * Restart the container if stopped due to an auth exception.
+	 * @return the restartAfterAuthExceptions
+	 * @since 2.9.7
+	 */
+	public boolean isRestartAfterAuthExceptions() {
+		return this.restartAfterAuthExceptions;
+	}
+
+	/**
+	 * Set to true to automatically restart the container if an auth exception is
+	 * detected by the container (or all child containers).
+	 * @param restartAfterAuthExceptions true to restart.
+	 * @since 2.9.7
+	 */
+	public void setRestartAfterAuthExceptions(boolean restartAfterAuthExceptions) {
+		this.restartAfterAuthExceptions = restartAfterAuthExceptions;
+	}
+
 	@Override
 	public String toString() {
 		return "ContainerProperties ["
@@ -1009,6 +1030,7 @@ public class ContainerProperties extends ConsumerProperties {
 				+ (this.observationConvention != null
 						? "\n observationConvention=" + this.observationConvention
 						: "")
+				+ "\n restartAfterAuthExceptions=" + this.restartAfterAuthExceptions
 				+ "\n]";
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -431,6 +431,15 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		}
 	}
 
+	@Override
+	public void childStopped(MessageListenerContainer child, Reason reason) {
+		if (reason.equals(Reason.AUTH) && child.equals(this)
+				&& getContainerProperties().isRestartAfterAuthExceptions()) {
+			setStoppedNormally(true);
+			start();
+		}
+	}
+
 	private void publishIdlePartitionEvent(long idleTime, TopicPartition topicPartition, Consumer<K, V> consumer, boolean paused) {
 		ApplicationEventPublisher publisher = getApplicationEventPublisher();
 		if (publisher != null) {
@@ -540,6 +549,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			}
 			publisher.publishEvent(new ConsumerStoppedEvent(this, this.thisOrParentContainer,
 					reason));
+			this.thisOrParentContainer.childStopped(this, reason);
 		}
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/MessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/MessageListenerContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import org.apache.kafka.common.TopicPartition;
 
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.context.SmartLifecycle;
+import org.springframework.kafka.event.ConsumerStoppedEvent;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.lang.Nullable;
 
@@ -258,6 +259,16 @@ public interface MessageListenerContainer extends SmartLifecycle, DisposableBean
 	 */
 	default MessageListenerContainer getContainerFor(String topic, int partition) {
 		return this;
+	}
+
+	/**
+	 * Notify a parent container that a child container has stopped due to an
+	 * authentication or authorization problem.
+	 * @param child the container.
+	 * @param reason the reason.
+	 * @since 2.9.7
+	 */
+	default void childStoppedForAuth(MessageListenerContainer child, ConsumerStoppedEvent.Reason reason) {
 	}
 
 	@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/MessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/MessageListenerContainer.java
@@ -262,13 +262,12 @@ public interface MessageListenerContainer extends SmartLifecycle, DisposableBean
 	}
 
 	/**
-	 * Notify a parent container that a child container has stopped due to an
-	 * authentication or authorization problem.
+	 * Notify a parent container that a child container has stopped.
 	 * @param child the container.
 	 * @param reason the reason.
 	 * @since 2.9.7
 	 */
-	default void childStoppedForAuth(MessageListenerContainer child, ConsumerStoppedEvent.Reason reason) {
+	default void childStopped(MessageListenerContainer child, ConsumerStoppedEvent.Reason reason) {
 	}
 
 	@Override

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/CommonContainerStoppingErrorHandler2Tests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/CommonContainerStoppingErrorHandler2Tests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 the original author or authors.
+ * Copyright 2017-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -183,7 +183,7 @@ public class CommonContainerStoppingErrorHandler2Tests {
 						catch (InterruptedException e) {
 							Thread.currentThread().interrupt();
 						}
-						return new ConsumerRecords(Collections.emptyMap());
+						return ConsumerRecords.empty();
 				}
 			}).given(consumer).poll(Duration.ofMillis(ContainerProperties.DEFAULT_POLL_TIMEOUT));
 			willAnswer(i -> {


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2612

Add a container property to enable restarting the container after an emergency stop due to authentication/authorization exceptions, perhaps due to credentials expiring.

**cherry-pick to 2.9.x**
