### PR TITLE
Improve observation by providing more tracing tags

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -160,6 +160,7 @@ import io.micrometer.observation.ObservationRegistry;
  * @author Tomaz Fernandes
  * @author Francois Rosiere
  * @author Daniel Gentes
+ * @author Christian Mergenthaler
  */
 public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		extends AbstractMessageListenerContainer<K, V> implements ConsumerPauseResumeEventPublisher {
@@ -2790,7 +2791,8 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			Observation observation = KafkaListenerObservation.LISTENER_OBSERVATION.observation(
 					this.containerProperties.getObservationConvention(),
 					DefaultKafkaListenerObservationConvention.INSTANCE,
-					() -> new KafkaRecordReceiverContext(cRecord, getListenerId(), getClientId(), getGroupId(), this::clusterId),
+					() -> new KafkaRecordReceiverContext(cRecord, getListenerId(), getClientId(), getGroupId(),
+							this::clusterId),
 					this.observationRegistry);
 			return observation.observe(() -> {
 				try {

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -2790,7 +2790,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			Observation observation = KafkaListenerObservation.LISTENER_OBSERVATION.observation(
 					this.containerProperties.getObservationConvention(),
 					DefaultKafkaListenerObservationConvention.INSTANCE,
-					() -> new KafkaRecordReceiverContext(cRecord, getListenerId(), this::clusterId),
+					() -> new KafkaRecordReceiverContext(cRecord, getListenerId(), getClientId(), getGroupId(), this::clusterId),
 					this.observationRegistry);
 			return observation.observe(() -> {
 				try {

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/micrometer/KafkaListenerObservation.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/micrometer/KafkaListenerObservation.java
@@ -206,14 +206,22 @@ public enum KafkaListenerObservation implements ObservationDocumentation {
 					ListenerLowCardinalityTags.MESSAGING_OPERATION.withValue("receive"),
 					ListenerLowCardinalityTags.MESSAGING_SOURCE_NAME.withValue(context.getSource()),
 					ListenerLowCardinalityTags.MESSAGING_SOURCE_KIND.withValue("topic"),
-					ListenerLowCardinalityTags.MESSAGING_PARTITION.withValue(context.getPartition()),
-					ListenerLowCardinalityTags.MESSAGING_OFFSET.withValue(context.getOffset()),
 					ListenerLowCardinalityTags.MESSAGING_CONSUMER_GROUP.withValue(context.getGroupId())
 			);
 
 			if (StringUtils.hasText(context.getClientId())) {
 				keyValues = keyValues.and(ListenerLowCardinalityTags.MESSAGING_CLIENT_ID.withValue(context.getClientId()));
 			}
+
+			return keyValues;
+		}
+
+		@Override
+		public KeyValues getHighCardinalityKeyValues(KafkaRecordReceiverContext context) {
+			KeyValues keyValues = KeyValues.of(
+					ListenerLowCardinalityTags.MESSAGING_PARTITION.withValue(context.getPartition()),
+					ListenerLowCardinalityTags.MESSAGING_OFFSET.withValue(context.getOffset())
+			);
 
 			return keyValues;
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/micrometer/KafkaListenerObservation.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/micrometer/KafkaListenerObservation.java
@@ -16,12 +16,13 @@
 
 package org.springframework.kafka.support.micrometer;
 
+import org.springframework.util.StringUtils;
+
 import io.micrometer.common.KeyValues;
 import io.micrometer.common.docs.KeyName;
 import io.micrometer.observation.Observation.Context;
 import io.micrometer.observation.ObservationConvention;
 import io.micrometer.observation.docs.ObservationDocumentation;
-import org.springframework.util.StringUtils;
 
 /**
  * Spring for Apache Kafka Observation for listeners.
@@ -73,7 +74,7 @@ public enum KafkaListenerObservation implements ObservationDocumentation {
 		},
 
 		/**
-		 * Messaging system
+		 * Messaging system.
 		 */
 		MESSAGING_SYSTEM {
 
@@ -85,7 +86,7 @@ public enum KafkaListenerObservation implements ObservationDocumentation {
 		},
 
 		/**
-		 * Messaging operation
+		 * Messaging operation.
 		 */
 		MESSAGING_OPERATION {
 
@@ -97,7 +98,7 @@ public enum KafkaListenerObservation implements ObservationDocumentation {
 		},
 
 		/**
-		 * Messaging consumer id
+		 * Messaging consumer id.
 		 */
 		MESSAGING_CONSUMER_ID {
 
@@ -109,7 +110,7 @@ public enum KafkaListenerObservation implements ObservationDocumentation {
 		},
 
 		/**
-		 * Messaging source name
+		 * Messaging source name.
 		 */
 		MESSAGING_SOURCE_NAME {
 
@@ -121,7 +122,7 @@ public enum KafkaListenerObservation implements ObservationDocumentation {
 		},
 
 		/**
-		 * Messaging source kind
+		 * Messaging source kind.
 		 */
 		MESSAGING_SOURCE_KIND {
 
@@ -133,7 +134,7 @@ public enum KafkaListenerObservation implements ObservationDocumentation {
 		},
 
 		/**
-		 * Messaging consumer group
+		 * Messaging consumer group.
 		 */
 		MESSAGING_CONSUMER_GROUP {
 
@@ -145,7 +146,7 @@ public enum KafkaListenerObservation implements ObservationDocumentation {
 		},
 
 		/**
-		 * Messaging client id
+		 * Messaging client id.
 		 */
 		MESSAGING_CLIENT_ID {
 
@@ -157,7 +158,7 @@ public enum KafkaListenerObservation implements ObservationDocumentation {
 		},
 
 		/**
-		 * Messaging partition
+		 * Messaging partition.
 		 */
 		MESSAGING_PARTITION {
 
@@ -169,7 +170,7 @@ public enum KafkaListenerObservation implements ObservationDocumentation {
 		},
 
 		/**
-		 * Messaging message offset
+		 * Messaging message offset.
 		 */
 		MESSAGING_OFFSET {
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/micrometer/KafkaListenerObservation.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/micrometer/KafkaListenerObservation.java
@@ -163,7 +163,7 @@ public enum KafkaListenerObservation implements ObservationDocumentation {
 
 			@Override
 			public String asString() {
-				return "messaging.kafka.partition";
+				return "messaging.kafka.source.partition";
 			}
 
 		},

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/micrometer/KafkaListenerObservation.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/micrometer/KafkaListenerObservation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import io.micrometer.common.docs.KeyName;
 import io.micrometer.observation.Observation.Context;
 import io.micrometer.observation.ObservationConvention;
 import io.micrometer.observation.docs.ObservationDocumentation;
+import org.springframework.util.StringUtils;
 
 /**
  * Spring for Apache Kafka Observation for listeners.
@@ -69,6 +70,114 @@ public enum KafkaListenerObservation implements ObservationDocumentation {
 				return "spring.kafka.listener.id";
 			}
 
+		},
+
+		/**
+		 * Messaging system
+		 */
+		MESSAGING_SYSTEM {
+
+			@Override
+			public String asString() {
+				return "messaging.system";
+			}
+
+		},
+
+		/**
+		 * Messaging operation
+		 */
+		MESSAGING_OPERATION {
+
+			@Override
+			public String asString() {
+				return "messaging.operation";
+			}
+
+		},
+
+		/**
+		 * Messaging consumer id
+		 */
+		MESSAGING_CONSUMER_ID {
+
+			@Override
+			public String asString() {
+				return "messaging.consumer.id";
+			}
+
+		},
+
+		/**
+		 * Messaging source name
+		 */
+		MESSAGING_SOURCE_NAME {
+
+			@Override
+			public String asString() {
+				return "messaging.source.name";
+			}
+
+		},
+
+		/**
+		 * Messaging source kind
+		 */
+		MESSAGING_SOURCE_KIND {
+
+			@Override
+			public String asString() {
+				return "messaging.source.kind";
+			}
+
+		},
+
+		/**
+		 * Messaging consumer group
+		 */
+		MESSAGING_CONSUMER_GROUP {
+
+			@Override
+			public String asString() {
+				return "messaging.kafka.consumer.group";
+			}
+
+		},
+
+		/**
+		 * Messaging client id
+		 */
+		MESSAGING_CLIENT_ID {
+
+			@Override
+			public String asString() {
+				return "messaging.kafka.client_id";
+			}
+
+		},
+
+		/**
+		 * Messaging partition
+		 */
+		MESSAGING_PARTITION {
+
+			@Override
+			public String asString() {
+				return "messaging.kafka.partition";
+			}
+
+		},
+
+		/**
+		 * Messaging message offset
+		 */
+		MESSAGING_OFFSET {
+
+			@Override
+			public String asString() {
+				return "messaging.kafka.message.offset";
+			}
+
 		}
 
 	}
@@ -90,8 +199,23 @@ public enum KafkaListenerObservation implements ObservationDocumentation {
 
 		@Override
 		public KeyValues getLowCardinalityKeyValues(KafkaRecordReceiverContext context) {
-			return KeyValues.of(KafkaListenerObservation.ListenerLowCardinalityTags.LISTENER_ID.asString(),
-							context.getListenerId());
+			KeyValues keyValues = KeyValues.of(
+					ListenerLowCardinalityTags.LISTENER_ID.withValue(context.getListenerId()),
+					ListenerLowCardinalityTags.MESSAGING_CONSUMER_ID.withValue(getConsumerId(context)),
+					ListenerLowCardinalityTags.MESSAGING_SYSTEM.withValue("kafka"),
+					ListenerLowCardinalityTags.MESSAGING_OPERATION.withValue("receive"),
+					ListenerLowCardinalityTags.MESSAGING_SOURCE_NAME.withValue(context.getSource()),
+					ListenerLowCardinalityTags.MESSAGING_SOURCE_KIND.withValue("topic"),
+					ListenerLowCardinalityTags.MESSAGING_PARTITION.withValue(context.getPartition()),
+					ListenerLowCardinalityTags.MESSAGING_OFFSET.withValue(context.getOffset()),
+					ListenerLowCardinalityTags.MESSAGING_CONSUMER_GROUP.withValue(context.getGroupId())
+			);
+
+			if (StringUtils.hasText(context.getClientId())) {
+				keyValues = keyValues.and(ListenerLowCardinalityTags.MESSAGING_CLIENT_ID.withValue(context.getClientId()));
+			}
+
+			return keyValues;
 		}
 
 		@Override
@@ -102,6 +226,13 @@ public enum KafkaListenerObservation implements ObservationDocumentation {
 		@Override
 		public String getName() {
 			return "spring.kafka.listener";
+		}
+
+		private String getConsumerId(KafkaRecordReceiverContext context) {
+			if (StringUtils.hasText(context.getClientId())) {
+				return context.getGroupId() + " - " + context.getClientId();
+			}
+			return context.getGroupId();
 		}
 
 	}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/micrometer/KafkaRecordReceiverContext.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/micrometer/KafkaRecordReceiverContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,10 +34,12 @@ import io.micrometer.observation.transport.ReceiverContext;
 public class KafkaRecordReceiverContext extends ReceiverContext<ConsumerRecord<?, ?>> {
 
 	private final String listenerId;
+	private final String clientId;
+	private final String groupId;
 
 	private final ConsumerRecord<?, ?> record;
 
-	public KafkaRecordReceiverContext(ConsumerRecord<?, ?> record, String listenerId, Supplier<String> clusterId) {
+	public KafkaRecordReceiverContext(ConsumerRecord<?, ?> record, String listenerId, String clientId, String groupId, Supplier<String> clusterId) {
 		super((carrier, key) -> {
 			Header header = carrier.headers().lastHeader(key);
 			if (header == null) {
@@ -48,12 +50,21 @@ public class KafkaRecordReceiverContext extends ReceiverContext<ConsumerRecord<?
 		setCarrier(record);
 		this.record = record;
 		this.listenerId = listenerId;
+		this.clientId = clientId;
+		this.groupId = groupId;
 		String cluster = clusterId.get();
 		setRemoteServiceName("Apache Kafka" + (cluster != null ? ": " + cluster : ""));
 	}
 
 	public String getListenerId() {
 		return this.listenerId;
+	}
+	public String getGroupId() {
+		return this.groupId;
+	}
+
+	public String getClientId() {
+		return clientId;
 	}
 
 	/**
@@ -62,6 +73,22 @@ public class KafkaRecordReceiverContext extends ReceiverContext<ConsumerRecord<?
 	 */
 	public String getSource() {
 		return this.record.topic();
+	}
+
+	/**
+	 * Return the partition.
+	 * @return the partition.
+	 */
+	public String getPartition() {
+		return Integer.toString(this.record.partition());
+	}
+
+	/**
+	 * Return the offset.
+	 * @return the offset.
+	 */
+	public String getOffset() {
+		return Long.toString(this.record.offset());
 	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/micrometer/KafkaRecordReceiverContext.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/micrometer/KafkaRecordReceiverContext.java
@@ -28,6 +28,7 @@ import io.micrometer.observation.transport.ReceiverContext;
  * {@link ReceiverContext} for {@link ConsumerRecord}s.
  *
  * @author Gary Russell
+ * @author Christian Mergenthaler
  * @since 3.0
  *
  */
@@ -39,7 +40,8 @@ public class KafkaRecordReceiverContext extends ReceiverContext<ConsumerRecord<?
 
 	private final ConsumerRecord<?, ?> record;
 
-	public KafkaRecordReceiverContext(ConsumerRecord<?, ?> record, String listenerId, String clientId, String groupId, Supplier<String> clusterId) {
+	public KafkaRecordReceiverContext(ConsumerRecord<?, ?> record, String listenerId, String clientId, String groupId,
+			Supplier<String> clusterId) {
 		super((carrier, key) -> {
 			Header header = carrier.headers().lastHeader(key);
 			if (header == null) {
@@ -59,12 +61,13 @@ public class KafkaRecordReceiverContext extends ReceiverContext<ConsumerRecord<?
 	public String getListenerId() {
 		return this.listenerId;
 	}
+
 	public String getGroupId() {
 		return this.groupId;
 	}
 
 	public String getClientId() {
-		return clientId;
+		return this.clientId;
 	}
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/micrometer/KafkaRecordSenderContext.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/micrometer/KafkaRecordSenderContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,5 +56,4 @@ public class KafkaRecordSenderContext extends SenderContext<ProducerRecord<?, ?>
 	public String getDestination() {
 		return this.destination;
 	}
-
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/micrometer/KafkaRecordSenderContext.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/micrometer/KafkaRecordSenderContext.java
@@ -27,6 +27,7 @@ import io.micrometer.observation.transport.SenderContext;
  * {@link SenderContext} for {@link ProducerRecord}s.
  *
  * @author Gary Russell
+ * @author Christian Mergenthaler
  * @since 3.0
  *
  */

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/micrometer/KafkaTemplateObservation.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/micrometer/KafkaTemplateObservation.java
@@ -27,6 +27,7 @@ import io.micrometer.observation.docs.ObservationDocumentation;
  * {@link org.springframework.kafka.core.KafkaTemplate}.
  *
  * @author Gary Russell
+ * @author Christian Mergenthaler
  * @since 3.0
  *
  */
@@ -72,7 +73,7 @@ public enum KafkaTemplateObservation implements ObservationDocumentation {
 		},
 
 		/**
-		 * Messaging system
+		 * Messaging system.
 		 */
 		MESSAGING_SYSTEM {
 
@@ -84,7 +85,7 @@ public enum KafkaTemplateObservation implements ObservationDocumentation {
 		},
 
 		/**
-		 * Messaging operation
+		 * Messaging operation.
 		 */
 		MESSAGING_OPERATION {
 
@@ -96,7 +97,7 @@ public enum KafkaTemplateObservation implements ObservationDocumentation {
 		},
 
 		/**
-		 * Messaging destination name
+		 * Messaging destination name.
 		 */
 		MESSAGING_DESTINATION_NAME {
 
@@ -108,7 +109,7 @@ public enum KafkaTemplateObservation implements ObservationDocumentation {
 		},
 
 		/**
-		 * Messaging destination kind
+		 * Messaging destination kind.
 		 */
 		MESSAGING_DESTINATION_KIND {
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/micrometer/KafkaTemplateObservation.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/micrometer/KafkaTemplateObservation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,6 +69,54 @@ public enum KafkaTemplateObservation implements ObservationDocumentation {
 				return "spring.kafka.template.name";
 			}
 
+		},
+
+		/**
+		 * Messaging system
+		 */
+		MESSAGING_SYSTEM {
+
+			@Override
+			public String asString() {
+				return "messaging.system";
+			}
+
+		},
+
+		/**
+		 * Messaging operation
+		 */
+		MESSAGING_OPERATION {
+
+			@Override
+			public String asString() {
+				return "messaging.operation";
+			}
+
+		},
+
+		/**
+		 * Messaging destination name
+		 */
+		MESSAGING_DESTINATION_NAME {
+
+			@Override
+			public String asString() {
+				return "messaging.destination.name";
+			}
+
+		},
+
+		/**
+		 * Messaging destination kind
+		 */
+		MESSAGING_DESTINATION_KIND {
+
+			@Override
+			public String asString() {
+				return "messaging.destination.kind";
+			}
+
 		}
 
 	}
@@ -90,13 +138,17 @@ public enum KafkaTemplateObservation implements ObservationDocumentation {
 
 		@Override
 		public KeyValues getLowCardinalityKeyValues(KafkaRecordSenderContext context) {
-			return KeyValues.of(KafkaTemplateObservation.TemplateLowCardinalityTags.BEAN_NAME.asString(),
-							context.getBeanName());
+			return KeyValues.of(
+					TemplateLowCardinalityTags.BEAN_NAME.withValue(context.getBeanName()),
+					TemplateLowCardinalityTags.MESSAGING_SYSTEM.withValue("kafka"),
+					TemplateLowCardinalityTags.MESSAGING_OPERATION.withValue("publish"),
+					TemplateLowCardinalityTags.MESSAGING_DESTINATION_KIND.withValue("topic"),
+					TemplateLowCardinalityTags.MESSAGING_DESTINATION_NAME.withValue(context.getDestination()));
 		}
 
 		@Override
 		public String getContextualName(KafkaRecordSenderContext context) {
-			return context.getDestination() + " send";
+			return context.getDestination() + " publish";
 		}
 
 		@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/micrometer/KafkaTemplateObservation.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/micrometer/KafkaTemplateObservation.java
@@ -148,7 +148,7 @@ public enum KafkaTemplateObservation implements ObservationDocumentation {
 
 		@Override
 		public String getContextualName(KafkaRecordSenderContext context) {
-			return context.getDestination() + " publish";
+			return context.getDestination() + " send";
 		}
 
 		@Override

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/micrometer/ObservationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/micrometer/ObservationTests.java
@@ -79,6 +79,7 @@ import io.micrometer.tracing.test.simple.SimpleTracer;
 
 /**
  * @author Gary Russell
+ * @author Christian Mergenthaler
  * @since 3.0
  *
  */

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/micrometer/ObservationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/micrometer/ObservationTests.java
@@ -107,22 +107,44 @@ public class ObservationTests {
 		assertThat(span.getTags()).containsEntry("spring.kafka.template.name", "template");
 		assertThat(span.getName()).isEqualTo("observation.testT1 send");
 		assertThat(span.getRemoteServiceName()).startsWith("Apache Kafka: ");
-		await().until(() -> spans.peekFirst().getTags().size() == 3);
+		await().until(() -> spans.peekFirst().getTags().size() == 12);
 		span = spans.poll();
 		assertThat(span.getTags())
 				.containsAllEntriesOf(
-						Map.of("spring.kafka.listener.id", "obs1-0", "foo", "some foo value", "bar", "some bar value"));
+						Map.ofEntries(Map.entry("spring.kafka.listener.id", "obs1-0"),
+								Map.entry("foo", "some foo value"),
+								Map.entry("bar", "some bar value"),
+								Map.entry("messaging.consumer.id", "obs1 - consumer-obs1-2"),
+								Map.entry("messaging.kafka.client_id", "consumer-obs1-2"),
+								Map.entry("messaging.kafka.consumer.group", "obs1"),
+								Map.entry("messaging.kafka.message.offset", "0"),
+								Map.entry("messaging.kafka.partition", "0"),
+								Map.entry("messaging.operation", "receive"),
+								Map.entry("messaging.source.kind", "topic"),
+								Map.entry("messaging.source.name", "observation.testT1"),
+								Map.entry("messaging.system", "kafka")));
 		assertThat(span.getName()).isEqualTo("observation.testT1 receive");
 		assertThat(span.getRemoteServiceName()).startsWith("Apache Kafka: ");
 		await().until(() -> spans.peekFirst().getTags().size() == 1);
 		span = spans.poll();
 		assertThat(span.getTags()).containsEntry("spring.kafka.template.name", "template");
 		assertThat(span.getName()).isEqualTo("observation.testT2 send");
-		await().until(() -> spans.peekFirst().getTags().size() == 3);
+		await().until(() -> spans.peekFirst().getTags().size() == 12);
 		span = spans.poll();
 		assertThat(span.getTags())
 				.containsAllEntriesOf(
-						Map.of("spring.kafka.listener.id", "obs2-0", "foo", "some foo value", "bar", "some bar value"));
+						Map.ofEntries(Map.entry("spring.kafka.listener.id", "obs2-0"),
+								Map.entry("foo", "some foo value"),
+								Map.entry("bar", "some bar value"),
+								Map.entry("messaging.consumer.id", "obs2 - consumer-obs2-1"),
+								Map.entry("messaging.kafka.client_id", "consumer-obs2-1"),
+								Map.entry("messaging.kafka.consumer.group", "obs2"),
+								Map.entry("messaging.kafka.message.offset", "0"),
+								Map.entry("messaging.kafka.partition", "0"),
+								Map.entry("messaging.operation", "receive"),
+								Map.entry("messaging.source.kind", "topic"),
+								Map.entry("messaging.source.name", "observation.testT2"),
+								Map.entry("messaging.system", "kafka")));
 		assertThat(span.getName()).isEqualTo("observation.testT2 receive");
 		template.setObservationConvention(new DefaultKafkaTemplateObservationConvention() {
 
@@ -154,7 +176,7 @@ public class ObservationTests {
 		assertThat(span.getTags()).containsEntry("spring.kafka.template.name", "template");
 		assertThat(span.getTags()).containsEntry("foo", "bar");
 		assertThat(span.getName()).isEqualTo("observation.testT1 send");
-		await().until(() -> spans.peekFirst().getTags().size() == 4);
+		await().until(() -> spans.peekFirst().getTags().size() == 13);
 		span = spans.poll();
 		assertThat(span.getTags())
 				.containsAllEntriesOf(Map.of("spring.kafka.listener.id", "obs1-0", "foo", "some foo value", "bar",
@@ -165,11 +187,22 @@ public class ObservationTests {
 		assertThat(span.getTags()).containsEntry("spring.kafka.template.name", "template");
 		assertThat(span.getTags()).containsEntry("foo", "bar");
 		assertThat(span.getName()).isEqualTo("observation.testT2 send");
-		await().until(() -> spans.peekFirst().getTags().size() == 3);
+		await().until(() -> spans.peekFirst().getTags().size() == 12);
 		span = spans.poll();
 		assertThat(span.getTags())
 				.containsAllEntriesOf(
-						Map.of("spring.kafka.listener.id", "obs2-0", "foo", "some foo value", "bar", "some bar value"));
+						Map.ofEntries(Map.entry("spring.kafka.listener.id", "obs2-0"),
+								Map.entry("foo", "some foo value"),
+								Map.entry("bar", "some bar value"),
+								Map.entry("messaging.consumer.id", "obs2 - consumer-obs2-1"),
+								Map.entry("messaging.kafka.client_id", "consumer-obs2-1"),
+								Map.entry("messaging.kafka.consumer.group", "obs2"),
+								Map.entry("messaging.kafka.message.offset", "1"),
+								Map.entry("messaging.kafka.partition", "0"),
+								Map.entry("messaging.operation", "receive"),
+								Map.entry("messaging.source.kind", "topic"),
+								Map.entry("messaging.source.name", "observation.testT2"),
+								Map.entry("messaging.system", "kafka")));
 		assertThat(span.getTags()).doesNotContainEntry("baz", "qux");
 		assertThat(span.getName()).isEqualTo("observation.testT2 receive");
 		MeterRegistryAssert.assertThat(meterRegistry)
@@ -177,10 +210,40 @@ public class ObservationTests {
 						KeyValues.of("spring.kafka.template.name", "template"))
 				.hasTimerWithNameAndTags("spring.kafka.template",
 						KeyValues.of("spring.kafka.template.name", "template", "foo", "bar"))
-				.hasTimerWithNameAndTags("spring.kafka.listener", KeyValues.of("spring.kafka.listener.id", "obs1-0"))
 				.hasTimerWithNameAndTags("spring.kafka.listener",
-						KeyValues.of("spring.kafka.listener.id", "obs1-0", "baz", "qux"))
-				.hasTimerWithNameAndTags("spring.kafka.listener", KeyValues.of("spring.kafka.listener.id", "obs2-0"));
+						KeyValues.of("spring.kafka.listener.id", "obs1-0",
+								"messaging.consumer.id", "obs1 - consumer-obs1-2",
+								"messaging.kafka.client_id", "consumer-obs1-2",
+								"messaging.kafka.consumer.group", "obs1",
+								"messaging.kafka.message.offset", "0",
+								"messaging.kafka.partition", "0",
+								"messaging.operation", "receive",
+								"messaging.source.kind", "topic",
+								"messaging.source.name", "observation.testT1",
+								"messaging.system", "kafka"))
+				.hasTimerWithNameAndTags("spring.kafka.listener",
+						KeyValues.of("spring.kafka.listener.id", "obs1-0",
+								"baz", "qux",
+								"messaging.consumer.id", "obs1 - consumer-obs1-3",
+								"messaging.kafka.client_id", "consumer-obs1-3",
+								"messaging.kafka.consumer.group", "obs1",
+								"messaging.kafka.message.offset", "1",
+								"messaging.kafka.partition", "0",
+								"messaging.operation", "receive",
+								"messaging.source.kind", "topic",
+								"messaging.source.name", "observation.testT1",
+								"messaging.system", "kafka"))
+				.hasTimerWithNameAndTags("spring.kafka.listener",
+						KeyValues.of("spring.kafka.listener.id", "obs2-0",
+								"messaging.consumer.id", "obs2 - consumer-obs2-1",
+								"messaging.kafka.client_id", "consumer-obs2-1",
+								"messaging.kafka.consumer.group", "obs2",
+								"messaging.kafka.message.offset", "0",
+								"messaging.kafka.partition", "0",
+								"messaging.operation", "receive",
+								"messaging.source.kind", "topic",
+								"messaging.source.name", "observation.testT2",
+								"messaging.system", "kafka"));
 		assertThat(admin.getConfigurationProperties())
 				.containsEntry(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, broker.getBrokersAsString());
 		// producer factory broker different to admin
@@ -232,7 +295,7 @@ public class ObservationTests {
 		@Bean
 		ProducerFactory<Integer, String> producerFactory(EmbeddedKafkaBroker broker) {
 			Map<String, Object> producerProps = KafkaTestUtils.producerProps(broker);
-			producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,  broker.getBrokersAsString() + ","
+			producerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, broker.getBrokersAsString() + ","
 					+ broker.getBrokersAsString());
 			return new DefaultKafkaProducerFactory<>(producerProps);
 		}
@@ -240,7 +303,7 @@ public class ObservationTests {
 		@Bean
 		ConsumerFactory<Integer, String> consumerFactory(EmbeddedKafkaBroker broker) {
 			Map<String, Object> consumerProps = KafkaTestUtils.consumerProps("obs", "false", broker);
-			consumerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,  broker.getBrokersAsString() + ","
+			consumerProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, broker.getBrokersAsString() + ","
 					+ broker.getBrokersAsString() + "," + broker.getBrokersAsString());
 			return new DefaultKafkaConsumerFactory<>(consumerProps);
 		}
@@ -290,14 +353,14 @@ public class ObservationTests {
 		ObservationRegistry observationRegistry(Tracer tracer, Propagator propagator, MeterRegistry meterRegistry) {
 			TestObservationRegistry observationRegistry = TestObservationRegistry.create();
 			observationRegistry.observationConfig().observationHandler(
-					// Composite will pick the first matching handler
-					new ObservationHandler.FirstMatchingCompositeObservationHandler(
-							// This is responsible for creating a child span on the sender side
-							new PropagatingSenderTracingObservationHandler<>(tracer, propagator),
-							// This is responsible for creating a span on the receiver side
-							new PropagatingReceiverTracingObservationHandler<>(tracer, propagator),
-							// This is responsible for creating a default span
-							new DefaultTracingObservationHandler(tracer)))
+							// Composite will pick the first matching handler
+							new ObservationHandler.FirstMatchingCompositeObservationHandler(
+									// This is responsible for creating a child span on the sender side
+									new PropagatingSenderTracingObservationHandler<>(tracer, propagator),
+									// This is responsible for creating a span on the receiver side
+									new PropagatingReceiverTracingObservationHandler<>(tracer, propagator),
+									// This is responsible for creating a default span
+									new DefaultTracingObservationHandler(tracer)))
 					.observationHandler(new DefaultMeterObservationHandler(meterRegistry));
 			return observationRegistry;
 		}

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/micrometer/ObservationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/micrometer/ObservationTests.java
@@ -83,7 +83,7 @@ import io.micrometer.tracing.test.simple.SimpleTracer;
  *
  */
 @SpringJUnitConfig
-@EmbeddedKafka(topics = { "observation.testT1", "observation.testT2", "ObservationTests.testT3" })
+@EmbeddedKafka(topics = { "observation.testT1", "observation.testT2", "ObservationTests.testT3" }, partitions = 1)
 @DirtiesContext
 public class ObservationTests {
 
@@ -110,7 +110,7 @@ public class ObservationTests {
 						"messaging.system", "kafka",
 						"messaging.destination.kind", "topic",
 						"messaging.destination.name", "observation.testT1"));
-		assertThat(span.getName()).isEqualTo("observation.testT1 publish");
+		assertThat(span.getName()).isEqualTo("observation.testT1 send");
 		assertThat(span.getRemoteServiceName()).startsWith("Apache Kafka: ");
 		await().until(() -> spans.peekFirst().getTags().size() == 12);
 		span = spans.poll();
@@ -119,8 +119,8 @@ public class ObservationTests {
 						Map.ofEntries(Map.entry("spring.kafka.listener.id", "obs1-0"),
 								Map.entry("foo", "some foo value"),
 								Map.entry("bar", "some bar value"),
-								Map.entry("messaging.consumer.id", "obs1 - consumer-obs1-2"),
-								Map.entry("messaging.kafka.client_id", "consumer-obs1-2"),
+								Map.entry("messaging.consumer.id", "obs1 - consumer-obs1-3"),
+								Map.entry("messaging.kafka.client_id", "consumer-obs1-3"),
 								Map.entry("messaging.kafka.consumer.group", "obs1"),
 								Map.entry("messaging.kafka.message.offset", "0"),
 								Map.entry("messaging.kafka.source.partition", "0"),
@@ -138,7 +138,7 @@ public class ObservationTests {
 						"messaging.system", "kafka",
 						"messaging.destination.kind", "topic",
 						"messaging.destination.name", "observation.testT2"));
-		assertThat(span.getName()).isEqualTo("observation.testT2 publish");
+		assertThat(span.getName()).isEqualTo("observation.testT2 send");
 		await().until(() -> spans.peekFirst().getTags().size() == 12);
 		span = spans.poll();
 		assertThat(span.getTags())
@@ -146,8 +146,8 @@ public class ObservationTests {
 						Map.ofEntries(Map.entry("spring.kafka.listener.id", "obs2-0"),
 								Map.entry("foo", "some foo value"),
 								Map.entry("bar", "some bar value"),
-								Map.entry("messaging.consumer.id", "obs2 - consumer-obs2-1"),
-								Map.entry("messaging.kafka.client_id", "consumer-obs2-1"),
+								Map.entry("messaging.consumer.id", "obs2 - consumer-obs2-2"),
+								Map.entry("messaging.kafka.client_id", "consumer-obs2-2"),
 								Map.entry("messaging.kafka.consumer.group", "obs2"),
 								Map.entry("messaging.kafka.message.offset", "0"),
 								Map.entry("messaging.kafka.source.partition", "0"),
@@ -190,7 +190,7 @@ public class ObservationTests {
 						"messaging.system", "kafka",
 						"messaging.destination.kind", "topic",
 						"messaging.destination.name", "observation.testT1"));
-		assertThat(span.getName()).isEqualTo("observation.testT1 publish");
+		assertThat(span.getName()).isEqualTo("observation.testT1 send");
 		await().until(() -> spans.peekFirst().getTags().size() == 13);
 		span = spans.poll();
 		assertThat(span.getTags())
@@ -206,7 +206,7 @@ public class ObservationTests {
 						"messaging.system", "kafka",
 						"messaging.destination.kind", "topic",
 						"messaging.destination.name", "observation.testT2"));
-		assertThat(span.getName()).isEqualTo("observation.testT2 publish");
+		assertThat(span.getName()).isEqualTo("observation.testT2 send");
 		await().until(() -> spans.peekFirst().getTags().size() == 12);
 		span = spans.poll();
 		assertThat(span.getTags())
@@ -214,8 +214,8 @@ public class ObservationTests {
 						Map.ofEntries(Map.entry("spring.kafka.listener.id", "obs2-0"),
 								Map.entry("foo", "some foo value"),
 								Map.entry("bar", "some bar value"),
-								Map.entry("messaging.consumer.id", "obs2 - consumer-obs2-1"),
-								Map.entry("messaging.kafka.client_id", "consumer-obs2-1"),
+								Map.entry("messaging.consumer.id", "obs2 - consumer-obs2-2"),
+								Map.entry("messaging.kafka.client_id", "consumer-obs2-2"),
 								Map.entry("messaging.kafka.consumer.group", "obs2"),
 								Map.entry("messaging.kafka.message.offset", "1"),
 								Map.entry("messaging.kafka.source.partition", "0"),
@@ -240,11 +240,9 @@ public class ObservationTests {
 								"messaging.destination.name", "observation.testT2"))
 				.hasTimerWithNameAndTags("spring.kafka.listener",
 						KeyValues.of("spring.kafka.listener.id", "obs1-0",
-								"messaging.consumer.id", "obs1 - consumer-obs1-2",
-								"messaging.kafka.client_id", "consumer-obs1-2",
+								"messaging.consumer.id", "obs1 - consumer-obs1-3",
+								"messaging.kafka.client_id", "consumer-obs1-3",
 								"messaging.kafka.consumer.group", "obs1",
-								"messaging.kafka.message.offset", "0",
-								"messaging.kafka.source.partition", "0",
 								"messaging.operation", "receive",
 								"messaging.source.kind", "topic",
 								"messaging.source.name", "observation.testT1",
@@ -252,22 +250,18 @@ public class ObservationTests {
 				.hasTimerWithNameAndTags("spring.kafka.listener",
 						KeyValues.of("spring.kafka.listener.id", "obs1-0",
 								"baz", "qux",
-								"messaging.consumer.id", "obs1 - consumer-obs1-3",
-								"messaging.kafka.client_id", "consumer-obs1-3",
+								"messaging.consumer.id", "obs1 - consumer-obs1-4",
+								"messaging.kafka.client_id", "consumer-obs1-4",
 								"messaging.kafka.consumer.group", "obs1",
-								"messaging.kafka.message.offset", "1",
-								"messaging.kafka.source.partition", "0",
 								"messaging.operation", "receive",
 								"messaging.source.kind", "topic",
 								"messaging.source.name", "observation.testT1",
 								"messaging.system", "kafka"))
 				.hasTimerWithNameAndTags("spring.kafka.listener",
 						KeyValues.of("spring.kafka.listener.id", "obs2-0",
-								"messaging.consumer.id", "obs2 - consumer-obs2-1",
-								"messaging.kafka.client_id", "consumer-obs2-1",
+								"messaging.consumer.id", "obs2 - consumer-obs2-2",
+								"messaging.kafka.client_id", "consumer-obs2-2",
 								"messaging.kafka.consumer.group", "obs2",
-								"messaging.kafka.message.offset", "0",
-								"messaging.kafka.source.partition", "0",
 								"messaging.operation", "receive",
 								"messaging.source.kind", "topic",
 								"messaging.source.name", "observation.testT2",


### PR DESCRIPTION
Opentelemetry defines standards for specifying and providing proper information for tracing spans (so called tags). 
This PR improves the observation by providing proper opentelemetry defined tags.

Fixes #2609 

As discussed in the issue, the remote service name is not explicitly set, because optentelemetry defines it as the `name of the broker or service the message will be sent to`, which would be a list of multiple brokers in the kafka service. For that reason, users are encouraged to override `KafkaTemplateObservationConvention` and `KafkaListenerObservationConvention` if they want it to have a unique name instead of the cluster-id.

_Note: Some informations are not available on the time the observation in the `KafkaTemplate` starts and would be null. Therefore I have not included in this PR, if you have suggestions on that feel free to share._