### PR TITLE
Making sure startup waits until consumer thread is completed

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -386,7 +386,8 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 				(result, ex) -> {
 					if (ex == null) {
 						this.startLatch.countDown();
-					} else {
+					}
+					else {
 						throw new RuntimeException(ex);
 					}
 				}


### PR DESCRIPTION
<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
Hi,

I ran into an issue when writing a test that uses the combination of the @EmbeddedKafka and the @MockBean annotation. It turned out to be a race condition. At first I opened an issue in the spring-boot issue tracker (https://github.com/spring-projects/spring-boot/issues/34595), but after an analysis by @wilkinsona he pointed out that the problem can be isolated to spring-kafka.

I had the problem using Spring Boot 2.7.9 with spring-kafka 2.8.11. That is why I first created this PR: https://github.com/spring-projects/spring-kafka/pull/2618
I didn't find any information, if PRs are only allowed on the main branch.