### PR TITLE
Update kafka to 3.4.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,7 +68,7 @@ ext {
 	jaywayJsonPathVersion = '2.7.0'
 	junit4Version = '4.13.2'
 	junitJupiterVersion = '5.9.1'
-	kafkaVersion = '3.3.2'
+	kafkaVersion = '3.4.0'
 	log4jVersion = '2.19.0'
 	micrometerDocsVersion = "1.0.1"
 	micrometerVersion = '1.10.4'


### PR DESCRIPTION
Currently is included the kafka version 3.3.2 with a medium vulnerability. For more details see https://cwe.mitre.org/data/definitions/502 and https://kafka.apache.org/cve-list. With the version 3.4.0 this is fixed.