### PR TITLE
GH-2642: Fix Race in KLABeanPostProcessor

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 the original author or authors.
+ * Copyright 2014-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -268,7 +268,7 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 	 * {@link #setEndpointRegistry endpoint registry} has to be explicitly configured.
 	 * @param beanFactory the {@link BeanFactory} to be used.
 	 */
-	public void setBeanFactory(BeanFactory beanFactory) {
+	public synchronized void setBeanFactory(BeanFactory beanFactory) {
 		this.beanFactory = beanFactory;
 		if (beanFactory instanceof ConfigurableListableBeanFactory clbf) {
 			this.resolver = clbf.getBeanExpressionResolver();
@@ -449,8 +449,8 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 		}
 	}
 
-	private void processMultiMethodListeners(Collection<KafkaListener> classLevelListeners, List<Method> multiMethods,
-			Object bean, String beanName) {
+	private synchronized void processMultiMethodListeners(Collection<KafkaListener> classLevelListeners,
+			List<Method> multiMethods, Object bean, String beanName) {
 
 		List<Method> checkedMethods = new ArrayList<>();
 		Method defaultMethod = null;
@@ -477,7 +477,9 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 		}
 	}
 
-	protected void processKafkaListener(KafkaListener kafkaListener, Method method, Object bean, String beanName) {
+	protected synchronized void processKafkaListener(KafkaListener kafkaListener, Method method, Object bean,
+			String beanName) {
+
 		Method methodToUse = checkProxy(method, bean);
 		MethodKafkaListenerEndpoint<K, V> endpoint = new MethodKafkaListenerEndpoint<>();
 		endpoint.setMethod(methodToUse);


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2642

Protect field `ListenerScope` from multi-threaded use (e.g. when creating prototype listeners).

**cherry-pick to 2.9.x**
