### PR TITLE
GH-2641: Fix Exception Change with RetryableTopic

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordTracker.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordTracker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 the original author or authors.
+ * Copyright 2018-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -200,8 +200,9 @@ class FailedRecordTracker implements RecoveryStrategy {
 			Map<TopicPartition, FailedRecord> map, TopicPartition topicPartition) {
 
 		Exception realException = exception;
-		if (realException  instanceof ListenerExecutionFailedException
-				&& realException.getCause() instanceof Exception) {
+		while ((realException  instanceof ListenerExecutionFailedException
+				|| realException instanceof TimestampedException)
+						&& realException.getCause() instanceof Exception) {
 
 			realException = (Exception) realException.getCause();
 		}


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2641

Need to traverse the cause tree to find the actual user exception.

Also tested with reporter's reproducer.

**cherry-pick to 2.9.x**
