### PR TITLE
Remove duplicate native hint registration.

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/aot/KafkaRuntimeHints.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/aot/KafkaRuntimeHints.java
@@ -121,10 +121,8 @@ public class KafkaRuntimeHints implements RuntimeHintsRegistrar {
 					KafkaResourceFactory.class,
 					KafkaTemplate.class,
 					ProducerFactory.class,
-					KafkaOperations.class,
 					ConsumerFactory.class,
 					LoggingProducerListener.class,
-					ImplicitLinkedHashCollection.Element.class,
 					KafkaListenerAnnotationBeanPostProcessor.class)
 				.forEach(type -> reflectionHints.registerType(type,
 						builder -> builder.withMembers(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,


### PR DESCRIPTION
Description:
While registering native hints for Spring Kafka project `KafkaOperations.class` and `ImplicitLinkedHashCollection.Element.class` is specified twice.