### PR TITLE
Remove duplicate from KafkaRuntimeHints

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/aot/KafkaRuntimeHints.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/aot/KafkaRuntimeHints.java
@@ -131,8 +131,7 @@ public class KafkaRuntimeHints implements RuntimeHintsRegistrar {
 
 		Stream.of(
 					KafkaBootstrapConfiguration.class,
-					CreatableTopic.class,
-					KafkaListenerEndpointRegistry.class)
+					CreatableTopic.class)
 				.forEach(type -> reflectionHints.registerType(type,
 						builder -> builder.withMembers(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS)));
 


### PR DESCRIPTION
Hey, sorry for one small PR again. I noticed one more duplicate.

`KafkaListenerEndpointRegistry.class` is specified above with categories that include more than one from where I removed it.
```
builder -> builder.withMembers(MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
								MemberCategory.INVOKE_DECLARED_METHODS,
								MemberCategory.INTROSPECT_PUBLIC_METHODS))
```