### PR TITLE
Expose user exception thrown during rebalance

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerAwareRebalanceListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerAwareRebalanceListener.java
@@ -52,7 +52,7 @@ public interface ConsumerAwareRebalanceListener extends ConsumerRebalanceListene
 			onPartitionsRevoked(partitions);
 		}
 		catch (Exception e) { // NOSONAR
-			LOGGER.debug(e, "User method threw exception");
+			LOGGER.error(e, "User method threw exception");
 		}
 	}
 
@@ -76,7 +76,7 @@ public interface ConsumerAwareRebalanceListener extends ConsumerRebalanceListene
 			onPartitionsLost(partitions);
 		}
 		catch (Exception e) { // NOSONAR
-			LOGGER.debug(e, "User method threw exception");
+			LOGGER.error(e, "User method threw exception");
 		}
 	}
 
@@ -91,7 +91,7 @@ public interface ConsumerAwareRebalanceListener extends ConsumerRebalanceListene
 			onPartitionsAssigned(partitions);
 		}
 		catch (Exception e) { // NOSONAR
-			LOGGER.debug(e, "User method threw exception");
+			LOGGER.error(e, "User method threw exception");
 		}
 	}
 


### PR DESCRIPTION
As a user, I do not want my exception be effectively ignored by framework by logging them on debug level

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
