### PR TITLE
GH-2671: Improve DLQ Exception Message Header

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ErrorHandlingUtils.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ErrorHandlingUtils.java
@@ -212,4 +212,22 @@ public final class ErrorHandlingUtils {
 		return theEx;
 	}
 
+	/**
+	 * Find the root cause, ignoring any {@link ListenerExecutionFailedException} and
+	 * {@link TimestampedException}.
+	 * @param exception the exception to examine.
+	 * @return the root cause.
+	 * @since 3.0.7
+	 */
+	public static Exception findRootCause(Exception exception) {
+		Exception realException = exception;
+		while ((realException  instanceof ListenerExecutionFailedException
+				|| realException instanceof TimestampedException)
+						&& realException.getCause() instanceof Exception cause) {
+
+			realException = cause;
+		}
+		return realException;
+	}
+
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordTracker.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordTracker.java
@@ -199,13 +199,7 @@ class FailedRecordTracker implements RecoveryStrategy {
 	private FailedRecord getFailedRecordInstance(ConsumerRecord<?, ?> record, Exception exception,
 			Map<TopicPartition, FailedRecord> map, TopicPartition topicPartition) {
 
-		Exception realException = exception;
-		while ((realException  instanceof ListenerExecutionFailedException
-				|| realException instanceof TimestampedException)
-						&& realException.getCause() instanceof Exception) {
-
-			realException = (Exception) realException.getCause();
-		}
+		Exception realException = ErrorHandlingUtils.findRootCause(exception);
 		FailedRecord failedRecord = map.get(topicPartition);
 		if (failedRecord == null || failedRecord.getOffset() != record.offset()
 				|| (this.resetStateOnExceptionChange

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/TransactionalContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/TransactionalContainerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 the original author or authors.
+ * Copyright 2017-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -751,8 +751,8 @@ public class TransactionalContainerTests {
 				.contains("ListenerExecutionFailedException");
 		assertThat(new String(headers.get(KafkaHeaders.DLT_EXCEPTION_CAUSE_FQCN, byte[].class)))
 				.isEqualTo("java.lang.RuntimeException");
-		assertThat(headers.get(KafkaHeaders.DLT_EXCEPTION_MESSAGE, byte[].class))
-				.contains("Listener failed".getBytes());
+		assertThat(new String(headers.get(KafkaHeaders.DLT_EXCEPTION_MESSAGE, byte[].class)))
+				.contains("Listener failed; fail for max failures");
 		assertThat(headers.get(KafkaHeaders.DLT_EXCEPTION_STACKTRACE)).isNotNull();
 		assertThat(headers.get(KafkaHeaders.DLT_EXCEPTION_STACKTRACE, byte[].class))
 				.contains("fail for max failures".getBytes());


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2671

With Spring Framework 6, `NestedRuntimeException.getMessage()` no longer includes the messages for nested exceptions via the cause chain.

See https://github.com/spring-projects/spring-framework/issues/25162

This means that the DLQ exception message header always contains the same `Failed listener` message.

Find the root cause exception and include its message in the header. Ignore any nested `TimestampedException` and `LEFE` between the top `LEFE` and the root cause; these will still appear in the stack trace.
