### PR TITLE
replace `.methodName()` with `methodName()` in documentation

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -89,7 +89,7 @@ include::{kotlin-examples}/topics/Config.kt[tag=topicBeans]
 ----
 ====
 
-Starting with version 2.6, you can omit `.partitions()` and/or `replicas()` and the broker defaults will be applied to those properties.
+Starting with version 2.6, you can omit `partitions()` and/or `replicas()` and the broker defaults will be applied to those properties.
 The broker version must be at least 2.4.0 to support this feature - see https://cwiki.apache.org/confluence/display/KAFKA/KIP-464%3A+Defaults+for+AdminClient%23createTopic[KIP-464].
 
 ====
@@ -211,7 +211,7 @@ interface ProducerCallback<K, V, T> {
 See the https://docs.spring.io/spring-kafka/api/org/springframework/kafka/core/KafkaTemplate.html[Javadoc] for more detail.
 
 IMPORTANT: In version 3.0, the methods that previously returned `ListenableFuture` have been changed to return `CompletableFuture`.
-To facilitate the migration, the 2.9 version added a method `.usingCompletableFuture()` which provided the same methods with `CompletableFuture` return types; this method is no longer available.
+To facilitate the migration, the 2.9 version added a method `usingCompletableFuture()` which provided the same methods with `CompletableFuture` return types; this method is no longer available.
 
 The `sendDefault` API requires that a default topic has been provided to the template.
 

--- a/spring-kafka-docs/src/main/asciidoc/retrytopic.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/retrytopic.adoc
@@ -970,7 +970,7 @@ NOTE: If no DLT handler is provided, the default RetryTopicConfigurer.LoggingDlt
 
 Starting with version 2.8, if you don't want to consume from the DLT in this application at all, including by the default handler (or you wish to defer consumption), you can control whether or not the DLT container starts, independent of the container factory's `autoStartup` property.
 
-When using the `@RetryableTopic` annotation, set the `autoStartDltHandler` property to `false`; when using the configuration builder, use `.autoStartDltHandler(false)` .
+When using the `@RetryableTopic` annotation, set the `autoStartDltHandler` property to `false`; when using the configuration builder, use `autoStartDltHandler(false)` .
 
 You can later start the DLT handler via the `KafkaListenerEndpointRegistry`.
 


### PR DESCRIPTION
There are two forms of method representation in the documentation.
- `methodName()`
- `.methodName()`

I think that `methodName()` is the commonly used form in this documentation.
How about replacing `.methodName()` to `methodName()` in this documentation.