### PR TITLE
docs: fix name of overriden method

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/retrytopic.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/retrytopic.adoc
@@ -477,7 +477,7 @@ See <<retry-topic-global-settings>> for more information.
 ----
 
 @Override
-protected void manageNonBlockingRetriesFatalExceptions(List<Class<? extends Throwable>> nonBlockingFatalExceptions) {
+protected void manageNonBlockingFatalExceptions(List<Class<? extends Throwable>> nonBlockingFatalExceptions) {
     nonBlockingFatalExceptions.add(MyNonBlockingException.class);
 }
 


### PR DESCRIPTION
Fixes a method name in retry-topics docs.
The method to override for managing fatal exceptions is called  `manageNonBlockingFatalExceptions` and not `manageNonBlockingRetriesFatalExceptions`. 