### PR TITLE
docs: fix Javadoc of CommonErrorHandler::remainingRecords

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonErrorHandler.java
@@ -38,10 +38,10 @@ import org.springframework.kafka.support.TopicPartitionOffset;
 public interface CommonErrorHandler extends DeliveryAttemptAware {
 
 	/**
-	 * Return false if this error handler should only receive the current failed record;
-	 * remaining records will be passed to the listener after the error handler returns.
-	 * When true (default), all remaining records including the failed record are passed
-	 * to the error handler.
+	 * Return false (default) if this error handler should only receive the current failed
+	 * record; remaining records will be passed to the listener after the error handler
+	 * returns. When true, all remaining records including the failed record are passed to
+	 * the error handler.
 	 * @return false to receive only the failed record.
 	 * @deprecated in favor of {@link #seeksAfterHandling()}.
 	 * @see #handleRecord(Exception, ConsumerRecord, Consumer, MessageListenerContainer)


### PR DESCRIPTION
The doc suggests that the default value of this method is false, even though it's actually true.  Update the doc to match the code.

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
