### PR TITLE
Default Empty Map for PF configurationProperties

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/ProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/ProducerFactory.java
@@ -123,7 +123,7 @@ public interface ProducerFactory<K, V> {
 	 * @since 2.5
 	 */
 	default Map<String, Object> getConfigurationProperties() {
-		throw new UnsupportedOperationException("This implementation doesn't support this method");
+		return Collections.emptyMap();
 	}
 
 	/**


### PR DESCRIPTION
The default behavior was to throw an `UnsupportedOperationException` which effectively makes the `MockProducerFactory` unusable without subclassing, e.g. in `spring-integration-kafka`, which calls that method to examine some properties.

Change the default behavior to return an empty map.
