### PR TITLE
GH-2699: Document Retry Limitation

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -1489,6 +1489,9 @@ This contains all the data from the `ConsumerRecord` except the key and value.
 ====== Batch Listeners
 
 Starting with version 1.1, you can configure `@KafkaListener` methods to receive the entire batch of consumer records received from the consumer poll.
+
+IMPORTANT: <<retry-topic>> are not supported with batch listeners.
+
 To configure the listener container factory to create batch listeners, you can set the `batchListener` property.
 The following example shows how to do so:
 

--- a/spring-kafka-docs/src/main/asciidoc/retrytopic.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/retrytopic.adoc
@@ -6,6 +6,8 @@ Version 2.9 changed the mechanism to bootstrap infrastructure beans; see <<retry
 Achieving non-blocking retry / dlt functionality with Kafka usually requires setting up extra topics and creating and configuring the corresponding listeners.
 Since 2.7 Spring for Apache Kafka offers support for that via the `@RetryableTopic` annotation and `RetryTopicConfiguration` class to simplify that bootstrapping.
 
+IMPORTANT: Non-blocking retries are not supported with <<batch-listeners>>.
+
 ==== How The Pattern Works
 
 If message processing fails, the message is forwarded to a retry topic with a back off timestamp.


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2699

`@RetryableTopic` is not supported with batch listeners.
