### PR TITLE
GH-2702: RetryableTopic with asyncAcks

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/retrytopic.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/retrytopic.adoc
@@ -22,6 +22,22 @@ IMPORTANT: You can set the `AckMode` mode you prefer, but `RECORD` is suggested.
 
 IMPORTANT: At this time this functionality doesn't support class level `@KafkaListener` annotations
 
+When using a manual `AckMode` with `asyncAcks` set to true, the `DefaultErrorHandler` must be configured with `seekAfterError` set to `false`.
+Starting with versions 2.9.10, 3.0.8, this will be set to true unconditionally for such configurations.
+With earlier versions, it was necessary to override the `RetryConfigurationSupport.configureCustomizers()` method to set the property to `true`.
+
+====
+[source, java]
+----
+@Override
+protected void configureCustomizers(CustomizersConfigurer customizersConfigurer) {
+    customizersConfigurer.customizeErrorHandler(eh -> eh.setSeekAfterError(false));
+}
+----
+====
+
+In addition, before those versions, using the default (logging) DLT handler was not compatible with any kind of manual `AckMode`, regardless of the `asyncAcks` property.
+
 ==== Back Off Delay Precision
 
 ===== Overview and Guarantees

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/KafkaBackoffAwareMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/KafkaBackoffAwareMessageListenerAdapter.java
@@ -50,8 +50,6 @@ public class KafkaBackoffAwareMessageListenerAdapter<K, V>
 		extends AbstractDelegatingMessageListenerAdapter<MessageListener<K, V>>
 		implements AcknowledgingConsumerAwareMessageListener<K, V> {
 
-	private static final Acknowledgment NO_OP_ACK = new NoOpAck();
-
 	private final String listenerId;
 
 	private final String backoffTimestampHeader;
@@ -96,12 +94,7 @@ public class KafkaBackoffAwareMessageListenerAdapter<K, V>
 				.ifPresent(nextExecutionTimestamp -> this.kafkaConsumerBackoffManager
 						.backOffIfNecessary(createContext(consumerRecord, nextExecutionTimestamp, consumer)));
 		try {
-			Acknowledgment ack = acknowledgment;
-			if (ack == null) {
-				// The default DLT handler now requires an Acknowledgment.
-				ack = NO_OP_ACK;
-			}
-			invokeDelegateOnMessage(consumerRecord, ack, consumer);
+			invokeDelegateOnMessage(consumerRecord, acknowledgment, consumer);
 		}
 		catch (Exception ex) {
 			throw new TimestampedException(ex, Instant.now(this.clock));
@@ -150,13 +143,4 @@ public class KafkaBackoffAwareMessageListenerAdapter<K, V>
 	public void onMessage(ConsumerRecord<K, V> data, Consumer<?, ?> consumer) {
 		onMessage(data, null, consumer);
 	}
-
-	static class NoOpAck implements Acknowledgment {
-
-		@Override
-		public void acknowledge() {
-		}
-
-	}
-
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
@@ -34,6 +34,7 @@ import org.springframework.kafka.config.KafkaListenerContainerFactory;
 import org.springframework.kafka.config.KafkaListenerEndpointRegistrar;
 import org.springframework.kafka.config.MethodKafkaListenerEndpoint;
 import org.springframework.kafka.config.MultiMethodKafkaListenerEndpoint;
+import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.kafka.support.EndpointHandlerMethod;
 import org.springframework.kafka.support.KafkaUtils;
 import org.springframework.kafka.support.TopicForRetryable;
@@ -468,7 +469,7 @@ public class RetryTopicConfigurer implements BeanFactoryAware {
 
 		public static final String DEFAULT_DLT_METHOD_NAME = "logMessage";
 
-		public void logMessage(Object message) {
+		public void logMessage(Object message, @Nullable Acknowledgment ack) {
 			if (message instanceof ConsumerRecord) {
 				LOGGER.info(() -> "Received message in dlt listener: "
 						+ KafkaUtils.format((ConsumerRecord<?, ?>) message));
@@ -476,7 +477,11 @@ public class RetryTopicConfigurer implements BeanFactoryAware {
 			else {
 				LOGGER.info(() -> "Received message in dlt listener.");
 			}
+			if (ack != null) {
+				ack.acknowledge();
+			}
 		}
+
 	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
@@ -38,6 +38,7 @@ import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.kafka.support.EndpointHandlerMethod;
 import org.springframework.kafka.support.KafkaUtils;
 import org.springframework.kafka.support.TopicForRetryable;
+import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
 
 
@@ -469,7 +470,7 @@ public class RetryTopicConfigurer implements BeanFactoryAware {
 
 		public static final String DEFAULT_DLT_METHOD_NAME = "logMessage";
 
-		public void logMessage(Object message, @Nullable Acknowledgment ack) {
+		public void logMessage(Object message, @NonNull Acknowledgment ack) {
 			if (message instanceof ConsumerRecord) {
 				LOGGER.info(() -> "Received message in dlt listener: "
 						+ KafkaUtils.format((ConsumerRecord<?, ?>) message));
@@ -477,9 +478,7 @@ public class RetryTopicConfigurer implements BeanFactoryAware {
 			else {
 				LOGGER.info(() -> "Received message in dlt listener.");
 			}
-			if (ack != null) {
-				ack.acknowledge();
-			}
+			ack.acknowledge();
 		}
 
 	}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/adapter/KafkaBackoffAwareMessageListenerAdapterTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/adapter/KafkaBackoffAwareMessageListenerAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.kafka.listener.adapter;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
@@ -147,7 +148,7 @@ class KafkaBackoffAwareMessageListenerAdapterTests {
 		then(kafkaConsumerBackoffManager).should(times(1))
 				.backOffIfNecessary(context);
 
-		then(delegate).should(times(1)).onMessage(data, null, null);
+		then(delegate).should(times(1)).onMessage(eq(data), any(), isNull());
 	}
 
 	@Test
@@ -159,7 +160,7 @@ class KafkaBackoffAwareMessageListenerAdapterTests {
 		given(kafkaConsumerBackoffManager.createContext(originalTimestamp, listenerId, topicPartition, null))
 				.willReturn(context);
 		RuntimeException thrownException = new RuntimeException();
-		willThrow(thrownException).given(delegate).onMessage(data, null, null);
+		willThrow(thrownException).given(delegate).onMessage(eq(data), any(), isNull());
 
 		KafkaBackoffAwareMessageListenerAdapter<Object, Object> backoffAwareMessageListenerAdapter =
 				new KafkaBackoffAwareMessageListenerAdapter<>(delegate, kafkaConsumerBackoffManager, listenerId, clock);
@@ -175,7 +176,7 @@ class KafkaBackoffAwareMessageListenerAdapterTests {
 		then(kafkaConsumerBackoffManager).should(times(1))
 				.backOffIfNecessary(context);
 
-		then(delegate).should(times(1)).onMessage(data, null, null);
+		then(delegate).should(times(1)).onMessage(eq(data), any(), isNull());
 	}
 
 	@Test
@@ -224,7 +225,7 @@ class KafkaBackoffAwareMessageListenerAdapterTests {
 		then(kafkaConsumerBackoffManager).should(times(1))
 				.backOffIfNecessary(context);
 
-		then(delegate).should(times(1)).onMessage(data, null, consumer);
+		then(delegate).should(times(1)).onMessage(eq(data), any(), eq(consumer));
 	}
 
 	@Test

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurerTests.java
@@ -24,6 +24,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.BDDMockito.willReturn;
 import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 
 import java.lang.reflect.Method;
@@ -51,6 +52,7 @@ import org.springframework.kafka.config.KafkaListenerContainerFactory;
 import org.springframework.kafka.config.KafkaListenerEndpointRegistrar;
 import org.springframework.kafka.config.MethodKafkaListenerEndpoint;
 import org.springframework.kafka.config.MultiMethodKafkaListenerEndpoint;
+import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.kafka.support.EndpointHandlerMethod;
 import org.springframework.kafka.test.condition.LogLevels;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -365,7 +367,7 @@ class RetryTopicConfigurerTests {
 	void shouldLogConsumerRecordMessage() {
 		RetryTopicConfigurer.LoggingDltListenerHandlerMethod method =
 				new RetryTopicConfigurer.LoggingDltListenerHandlerMethod();
-		method.logMessage(consumerRecordMessage, null);
+		method.logMessage(consumerRecordMessage, mock(Acknowledgment.class));
 		then(consumerRecordMessage).should().topic();
 	}
 
@@ -373,7 +375,7 @@ class RetryTopicConfigurerTests {
 	void shouldNotLogObjectMessage() {
 		RetryTopicConfigurer.LoggingDltListenerHandlerMethod method =
 				new RetryTopicConfigurer.LoggingDltListenerHandlerMethod();
-		method.logMessage(objectMessage, null);
+		method.logMessage(objectMessage, mock(Acknowledgment.class));
 		then(objectMessage).shouldHaveNoInteractions();
 	}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 the original author or authors.
+ * Copyright 2018-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -365,7 +365,7 @@ class RetryTopicConfigurerTests {
 	void shouldLogConsumerRecordMessage() {
 		RetryTopicConfigurer.LoggingDltListenerHandlerMethod method =
 				new RetryTopicConfigurer.LoggingDltListenerHandlerMethod();
-		method.logMessage(consumerRecordMessage);
+		method.logMessage(consumerRecordMessage, null);
 		then(consumerRecordMessage).should().topic();
 	}
 
@@ -373,7 +373,7 @@ class RetryTopicConfigurerTests {
 	void shouldNotLogObjectMessage() {
 		RetryTopicConfigurer.LoggingDltListenerHandlerMethod method =
 				new RetryTopicConfigurer.LoggingDltListenerHandlerMethod();
-		method.logMessage(objectMessage);
+		method.logMessage(objectMessage, null);
 		then(objectMessage).shouldHaveNoInteractions();
 	}
 


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2702

When using `asyncAcks` with manual ack modes, the `DefaultErrorHandler` must have `seekAfterError` set to `false`; this required user configuration.

The framework now unconditionally sets the property when it configures a container using a manual ack mode.

In addition, the default DLT handler was not compatible with any manual ack mode, regardless of the `asyncAcks` setting.

Add `Acknowledgment` to the `LoggingDltListenerHandlerMethod`.

Also tested with reporter's reproducer.

**cherry-pick to 2.9.x (will require instanceof polishing for Java 8)**
