### PR TITLE
GH-2711: Non-Blocking Retries and Custom Publisher

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/retrytopic.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/retrytopic.adoc
@@ -613,6 +613,29 @@ Starting with version 2.8.4, if you wish to add custom headers (in addition to t
 By default, any headers added will be cumulative - Kafka headers can contain multiple values.
 Starting with version 2.9.5, if the `Headers` returned by the function contains a header of type `DeadLetterPublishingRecoverer.SingleRecordHeader`, then any existing values for that header will be removed and only the new single value will remain.
 
+[[custom-dlpr]]
+===== Custom DeadLetterPublishingRecoverer
+
+As can be seen in <<retry-headers>> it is possible to customize the default `DeadLetterPublishingRecoverer` instances created by the framework.
+However, for some use cases, it is necessary to subclass the `DeadLetterPublishingRecoverer`, for example to override `createProducerRecord()` to modify the contents sent to the retry (or dead-letter) topics.
+Starting with version 3.0.9, you can override the `RetryConfigurationSupport.configureDeadLetterPublishingContainerFactory()` method to provide a `DeadLetterPublisherCreator` instance, for example:
+
+====
+[source, java]
+----
+@Override
+protected Consumer<DeadLetterPublishingRecovererFactory> 
+        configureDeadLetterPublishingContainerFactory() {
+    
+    return (factory) -> factory.setDeadLetterPublisherCreator(
+            (templateResolver, destinationResolver) ->
+                    new CustomDLPR(templateResolver, destinationResolver));
+}
+----
+====
+
+It is recommended that you use the provided resolvers when constructing the custom instance.
+
 [[retry-topic-combine-blocking]]
 ==== Combining Blocking and Non-Blocking Retries
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
@@ -863,7 +863,8 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 	 * in the sent record.
 	 * @return the header names.
 	 * @since 2.7
-	 * @deprecated since 3.0.9 - provide a supplier in the constructor instead
+	 * @deprecated since 3.0.9 - provide a supplier instead.
+	 * @see #setHeaderNamesSupplier(Supplier)
 	 */
 	@Nullable
 	@Deprecated(since = "3.0.9", forRemoval = true)
@@ -871,6 +872,12 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 		return null;
 	}
 
+	/**
+	 * Set a {@link Supplier} for {@link HeaderNames}.
+	 * @param supplier the supplier.
+	 * @since3.0.7
+	 *
+	 */
 	public void setHeaderNamesSupplier(Supplier<HeaderNames> supplier) {
 		Assert.notNull(supplier, "'HeaderNames supplier cannot be null");
 		this.headerNamesSupplier = supplier;

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
@@ -81,8 +81,6 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 
 	private static final long THIRTY = 30L;
 
-	private final HeaderNames headerNames = getHeaderNames();
-
 	private final boolean transactional;
 
 	private final BiFunction<ConsumerRecord<?, ?>, Exception, TopicPartition> destinationResolver;
@@ -90,6 +88,8 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 	private final Function<ProducerRecord<?, ?>, KafkaOperations<?, ?>> templateResolver;
 
 	private final EnumSet<HeaderNames.HeadersToAdd> whichHeaders = EnumSet.allOf(HeaderNames.HeadersToAdd.class);
+
+	private HeaderNames headerNames = getHeaderNames();
 
 	private boolean retainExceptionHeader;
 
@@ -114,6 +114,24 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 	private boolean skipSameTopicFatalExceptions = true;
 
 	private ExceptionHeadersCreator exceptionHeadersCreator = this::addExceptionInfoHeaders;
+
+	private Supplier<HeaderNames> headerNamesSupplier = () -> HeaderNames.Builder
+			.original()
+			.offsetHeader(KafkaHeaders.DLT_ORIGINAL_OFFSET)
+			.timestampHeader(KafkaHeaders.DLT_ORIGINAL_TIMESTAMP)
+			.timestampTypeHeader(KafkaHeaders.DLT_ORIGINAL_TIMESTAMP_TYPE)
+			.topicHeader(KafkaHeaders.DLT_ORIGINAL_TOPIC)
+			.partitionHeader(KafkaHeaders.DLT_ORIGINAL_PARTITION)
+			.consumerGroupHeader(KafkaHeaders.DLT_ORIGINAL_CONSUMER_GROUP)
+		.exception()
+			.keyExceptionFqcn(KafkaHeaders.DLT_KEY_EXCEPTION_FQCN)
+			.exceptionFqcn(KafkaHeaders.DLT_EXCEPTION_FQCN)
+			.exceptionCauseFqcn(KafkaHeaders.DLT_EXCEPTION_CAUSE_FQCN)
+			.keyExceptionMessage(KafkaHeaders.DLT_KEY_EXCEPTION_MESSAGE)
+			.exceptionMessage(KafkaHeaders.DLT_EXCEPTION_MESSAGE)
+			.keyExceptionStacktrace(KafkaHeaders.DLT_KEY_EXCEPTION_STACKTRACE)
+			.exceptionStacktrace(KafkaHeaders.DLT_EXCEPTION_STACKTRACE)
+		.build();
 
 	/**
 	 * Create an instance with the provided template and a default destination resolving
@@ -186,6 +204,23 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 			.map(t -> t.isTransactional())
 			.allMatch(t -> t.equals(tx)), "All templates must have the same setting for transactional");
 		this.destinationResolver = destinationResolver;
+	}
+
+	/**
+	* Create an instance with a template resolving function that receives the failed
+	* consumer record and the exception and returns a {@link KafkaOperations} and a
+	* flag on whether or not the publishing from this instance will be transactional
+	* or not. Also receives a destination resolving function that works similarly but
+	* returns a {@link TopicPartition} instead. If the partition in the {@link TopicPartition}
+	* is less than 0, no partition is set when publishing to the topic.
+	*
+	* @param templateResolver the function that resolver the {@link KafkaOperations} to use for publishing.
+	* @param destinationResolver the resolving function.
+	* @since 3.0.9
+	*/
+	public DeadLetterPublishingRecoverer(Function<ProducerRecord<?, ?>, KafkaOperations<?, ?>> templateResolver,
+										BiFunction<ConsumerRecord<?, ?>, Exception, TopicPartition> destinationResolver) {
+		this(templateResolver, false, destinationResolver);
 	}
 
 	/**
@@ -487,6 +522,9 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 	private void addAndEnhanceHeaders(ConsumerRecord<?, ?> record, Exception exception,
 			@Nullable DeserializationException vDeserEx, @Nullable DeserializationException kDeserEx, Headers headers) {
 
+		if (this.headerNames == null) {
+			this.headerNames = this.headerNamesSupplier.get();
+		}
 		if (kDeserEx != null) {
 			if (!this.retainExceptionHeader) {
 				headers.remove(SerializationUtils.KEY_DESERIALIZER_EXCEPTION_HEADER);
@@ -825,25 +863,17 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 	 * in the sent record.
 	 * @return the header names.
 	 * @since 2.7
+	 * @deprecated since 3.0.9 - provide a supplier in the constructor instead
 	 */
+	@Nullable
+	@Deprecated(since = "3.0.9", forRemoval = true)
 	protected HeaderNames getHeaderNames() {
-		return HeaderNames.Builder
-				.original()
-					.offsetHeader(KafkaHeaders.DLT_ORIGINAL_OFFSET)
-					.timestampHeader(KafkaHeaders.DLT_ORIGINAL_TIMESTAMP)
-					.timestampTypeHeader(KafkaHeaders.DLT_ORIGINAL_TIMESTAMP_TYPE)
-					.topicHeader(KafkaHeaders.DLT_ORIGINAL_TOPIC)
-					.partitionHeader(KafkaHeaders.DLT_ORIGINAL_PARTITION)
-					.consumerGroupHeader(KafkaHeaders.DLT_ORIGINAL_CONSUMER_GROUP)
-				.exception()
-					.keyExceptionFqcn(KafkaHeaders.DLT_KEY_EXCEPTION_FQCN)
-					.exceptionFqcn(KafkaHeaders.DLT_EXCEPTION_FQCN)
-					.exceptionCauseFqcn(KafkaHeaders.DLT_EXCEPTION_CAUSE_FQCN)
-					.keyExceptionMessage(KafkaHeaders.DLT_KEY_EXCEPTION_MESSAGE)
-					.exceptionMessage(KafkaHeaders.DLT_EXCEPTION_MESSAGE)
-					.keyExceptionStacktrace(KafkaHeaders.DLT_KEY_EXCEPTION_STACKTRACE)
-					.exceptionStacktrace(KafkaHeaders.DLT_EXCEPTION_STACKTRACE)
-				.build();
+		return null;
+	}
+
+	public void setHeaderNamesSupplier(Supplier<HeaderNames> supplier) {
+		Assert.notNull(supplier, "'HeaderNames supplier cannot be null");
+		this.headerNamesSupplier = supplier;
 	}
 
 	/**


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2711

Previously, it was not easy to provide custom DLPRs, for example to override `createProducerRecord`.
