### PR TITLE
GH-2716: Fix minor typo in Handling Exceptions docs section

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -5448,7 +5448,7 @@ For a batch listener, all the records in the batch are logged.
 If you wish to use a different error handling strategy for record and batch listeners, the `CommonMixedErrorHandler` is provided allowing the configuration of a specific error handler for each listener type.
 
 [[eh-summary]]
-===== Common Error Handler Summery
+===== Common Error Handler Summary
 
 * `DefaultErrorHandler`
 * `CommonContainerStoppingErrorHandler`


### PR DESCRIPTION
This PR fixes a minor typo in the docs: https://docs.spring.io/spring-kafka/docs/3.0.8/reference/html/#eh-summary.

![image](https://github.com/spring-projects/spring-kafka/assets/8041246/d9994f49-004f-4277-b20c-0d1ec0f3df1b)

Fixes #2716 

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
