### PR TITLE
GH-2723: Fix NPE in DelegatingInvocableHandler

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/DelegatingInvocableHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/DelegatingInvocableHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -182,8 +182,8 @@ public class DelegatingInvocableHandler {
 			if (handler == null) {
 				throw new KafkaException("No method found for " + payloadClass);
 			}
-			this.cachedHandlers.putIfAbsent(payloadClass, handler); //NOSONAR
 			setupReplyTo(handler);
+			this.cachedHandlers.putIfAbsent(payloadClass, handler); //NOSONAR
 		}
 		return handler;
 	}


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2723

Previously, it was possible for `handlerReturnsMessage` to return `null` when a `cachedHandlers` was present, causing an NPE when unboxing the `Boolean` value.

Ensure that the `handlerReturnsMessage` map is populated before adding the handler to `cachedHandlers`.

**cherry-pick to 2.9.x**
