### PR TITLE
Private Header Type for DeserializationExceptions

### DIFF
--- a/spring-kafka-docs/src/main/asciidoc/kafka.adoc
+++ b/spring-kafka-docs/src/main/asciidoc/kafka.adoc
@@ -4671,10 +4671,15 @@ void listen(List<Thing> in, @Header(KafkaHeaders.BATCH_CONVERTED_HEADERS) List<M
         Thing thing = in.get(i);
         if (thing == null
                 && headers.get(i).get(SerializationUtils.VALUE_DESERIALIZER_EXCEPTION_HEADER) != null) {
-            DeserializationException deserEx = ListenerUtils.byteArrayToDeserializationException(this.logger,
-                    (byte[]) headers.get(i).get(SerializationUtils.VALUE_DESERIALIZER_EXCEPTION_HEADER));
-            if (deserEx != null) {
-                logger.error(deserEx, "Record at index " + i + " could not be deserialized");
+            try {
+                DeserializationException deserEx = SerializationUtils.byteArrayToDeserializationException(this.logger,
+                        headers.get(i).get(SerializationUtils.VALUE_DESERIALIZER_EXCEPTION_HEADER));
+                if (deserEx != null) {
+                    logger.error(deserEx, "Record at index " + i + " could not be deserialized");
+                }
+            }
+            catch (Exception ex) {
+                logger.error(ex, "Record at index " + i + " could not be deserialized");
             }
             throw new BatchListenerFailedException("Deserialization", deserEx, i);
         }
@@ -4684,9 +4689,9 @@ void listen(List<Thing> in, @Header(KafkaHeaders.BATCH_CONVERTED_HEADERS) List<M
 ----
 ====
 
-`ListenerUtils.byteArrayToDeserializationException()` can be used to convert the header to a `DeserializationException`.
+`SerializationUtils.byteArrayToDeserializationException()` can be used to convert the header to a `DeserializationException`.
 
-When consuming `List<ConsumerRecord<?, ?>`, `ListenerUtils.getExceptionFromHeader()` is used instead:
+When consuming `List<ConsumerRecord<?, ?>`, `SerializationUtils.getExceptionFromHeader()` is used instead:
 
 ====
 [source, java]
@@ -4696,7 +4701,7 @@ void listen(List<ConsumerRecord<String, Thing>> in) {
     for (int i = 0; i < in.size(); i++) {
         ConsumerRecord<String, Thing> rec = in.get(i);
         if (rec.value() == null) {
-            DeserializationException deserEx = ListenerUtils.getExceptionFromHeader(rec,
+            DeserializationException deserEx = SerializationUtils.getExceptionFromHeader(rec,
                     SerializationUtils.VALUE_DESERIALIZER_EXCEPTION_HEADER, this.logger);
             if (deserEx != null) {
                 logger.error(deserEx, "Record at offset " + rec.offset() + " could not be deserialized");

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
@@ -506,9 +506,9 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 		if (consumer != null && this.verifyPartition) {
 			tp = checkPartition(tp, consumer);
 		}
-		DeserializationException vDeserEx = ListenerUtils.getExceptionFromHeader(record,
+		DeserializationException vDeserEx = SerializationUtils.getExceptionFromHeader(record,
 				SerializationUtils.VALUE_DESERIALIZER_EXCEPTION_HEADER, this.logger);
-		DeserializationException kDeserEx = ListenerUtils.getExceptionFromHeader(record,
+		DeserializationException kDeserEx = SerializationUtils.getExceptionFromHeader(record,
 				SerializationUtils.KEY_DESERIALIZER_EXCEPTION_HEADER, this.logger);
 		Headers headers = new RecordHeaders(record.headers().toArray());
 		addAndEnhanceHeaders(record, exception, vDeserEx, kDeserEx, headers);

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -2985,7 +2985,8 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		}
 
 		public void checkDeser(final ConsumerRecord<K, V> cRecord, String headerName) {
-			DeserializationException exception = ListenerUtils.getExceptionFromHeader(cRecord, headerName, this.logger);
+			DeserializationException exception = SerializationUtils.getExceptionFromHeader(cRecord, headerName,
+					this.logger);
 			if (exception != null) {
 				/*
 				 * Wrapping in a LEFE is not strictly correct, but required for backwards compatibility.

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ListenerUtils.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ListenerUtils.java
@@ -24,12 +24,10 @@ import java.util.function.Supplier;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
-import org.apache.kafka.common.header.Header;
-import org.apache.kafka.common.header.Headers;
-import org.apache.kafka.common.header.internals.RecordHeaders;
 
 import org.springframework.core.log.LogAccessor;
 import org.springframework.kafka.support.serializer.DeserializationException;
+import org.springframework.kafka.support.serializer.SerializationUtils;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.backoff.BackOff;
@@ -92,23 +90,15 @@ public final class ListenerUtils {
 	 * @param logger the logger for logging errors.
 	 * @return the exception or null.
 	 * @since 2.3
+	 * @deprecated in favor of
+	 * {@link SerializationUtils#getExceptionFromHeader(ConsumerRecord, String, LogAccessor)}.
 	 */
+	@Deprecated
 	@Nullable
 	public static DeserializationException getExceptionFromHeader(final ConsumerRecord<?, ?> record,
 			String headerName, LogAccessor logger) {
 
-		Header header = record.headers().lastHeader(headerName);
-		if (header != null) {
-			byte[] value = header.value();
-			DeserializationException exception = byteArrayToDeserializationException(logger, value);
-			if (exception != null) {
-				Headers headers = new RecordHeaders(record.headers().toArray());
-				headers.remove(headerName);
-				exception.setHeaders(headers);
-			}
-			return exception;
-		}
-		return null;
+		return SerializationUtils.getExceptionFromHeader(record, headerName, logger);
 	}
 
 	/**
@@ -118,7 +108,11 @@ public final class ListenerUtils {
 	 * @param value the bytes.
 	 * @return the exception or null if deserialization fails.
 	 * @since 2.8.1
+	 * @deprecated in favor of
+	 * {@link SerializationUtils#getExceptionFromHeader(ConsumerRecord, String, LogAccessor)} or
+	 * {@link SerializationUtils#byteArrayToDeserializationException(LogAccessor, org.apache.kafka.common.header.Header)}.
 	 */
+	@Deprecated
 	@Nullable
 	public static DeserializationException byteArrayToDeserializationException(LogAccessor logger, byte[] value) {
 		try {

--- a/spring-kafka/src/main/java/org/springframework/kafka/requestreply/ReplyingKafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/requestreply/ReplyingKafkaTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 the original author or authors.
+ * Copyright 2018-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,7 +48,6 @@ import org.springframework.kafka.listener.BatchMessageListener;
 import org.springframework.kafka.listener.ConsumerSeekAware;
 import org.springframework.kafka.listener.ContainerProperties;
 import org.springframework.kafka.listener.GenericMessageListenerContainer;
-import org.springframework.kafka.listener.ListenerUtils;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.support.KafkaUtils;
 import org.springframework.kafka.support.TopicPartitionOffset;
@@ -558,7 +557,7 @@ public class ReplyingKafkaTemplate<K, V, R> extends KafkaTemplate<K, V> implemen
 	 * Return a {@link DeserializationException} if either the key or value failed
 	 * deserialization; null otherwise. If you need to determine whether it was the key or
 	 * value, call
-	 * {@link ListenerUtils#getExceptionFromHeader(ConsumerRecord, String, LogAccessor)}
+	 * {@link SerializationUtils#getExceptionFromHeader(ConsumerRecord, String, LogAccessor)}
 	 * with {@link SerializationUtils#KEY_DESERIALIZER_EXCEPTION_HEADER} and
 	 * {@link SerializationUtils#VALUE_DESERIALIZER_EXCEPTION_HEADER} instead.
 	 * @param record the record.
@@ -568,14 +567,14 @@ public class ReplyingKafkaTemplate<K, V, R> extends KafkaTemplate<K, V> implemen
 	 */
 	@Nullable
 	public static DeserializationException checkDeserialization(ConsumerRecord<?, ?> record, LogAccessor logger) {
-		DeserializationException exception = ListenerUtils.getExceptionFromHeader(record,
+		DeserializationException exception = SerializationUtils.getExceptionFromHeader(record,
 				SerializationUtils.VALUE_DESERIALIZER_EXCEPTION_HEADER, logger);
 		if (exception != null) {
 			logger.error(exception, () -> "Reply value deserialization failed for " + record.topic() + "-"
 					+ record.partition() + "@" + record.offset());
 			return exception;
 		}
-		exception = ListenerUtils.getExceptionFromHeader(record,
+		exception = SerializationUtils.getExceptionFromHeader(record,
 				SerializationUtils.KEY_DESERIALIZER_EXCEPTION_HEADER, logger);
 		if (exception != null) {
 			logger.error(exception, () -> "Reply key deserialization failed for " + record.topic() + "-"

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DeserializationExceptionHeader.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DeserializationExceptionHeader.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support.serializer;
+
+import org.apache.kafka.common.header.internals.RecordHeader;
+
+/**
+ * A package-protected header used to contain serialized
+ * {@link DeserializationException}s. Only headers of this type will be examined for
+ * deserialization.
+ *
+ * @author Gary Russell
+ * @since 2.9.11
+ */
+class DeserializationExceptionHeader extends RecordHeader {
+
+	/**
+	 * Construct an instance with the provided properties.
+	 * @param key the key.
+	 * @param value the value;
+	 */
+	DeserializationExceptionHeader(String key, byte[] value) {
+		super(key, value);
+	}
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/DeadLetterPublishingRecovererTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/DeadLetterPublishingRecovererTests.java
@@ -73,6 +73,7 @@ import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.support.SendResult;
 import org.springframework.kafka.support.converter.ConversionException;
 import org.springframework.kafka.support.serializer.DeserializationException;
+import org.springframework.kafka.support.serializer.SerializationTestUtils;
 import org.springframework.kafka.support.serializer.SerializationUtils;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 
@@ -172,8 +173,10 @@ public class DeadLetterPublishingRecovererTests {
 		KafkaOperations<?, ?> template = mock(KafkaOperations.class);
 		DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(template);
 		Headers headers = new RecordHeaders();
-		headers.add(new RecordHeader(SerializationUtils.VALUE_DESERIALIZER_EXCEPTION_HEADER, header(false)));
-		headers.add(new RecordHeader(SerializationUtils.KEY_DESERIALIZER_EXCEPTION_HEADER, header(true)));
+		headers.add(SerializationTestUtils.deserializationHeader(SerializationUtils.VALUE_DESERIALIZER_EXCEPTION_HEADER,
+				header(false)));
+		headers.add(SerializationTestUtils.deserializationHeader(SerializationUtils.KEY_DESERIALIZER_EXCEPTION_HEADER,
+				header(true)));
 		Headers custom = new RecordHeaders();
 		custom.add(new RecordHeader("foo", "bar".getBytes()));
 		recoverer.setHeadersFunction((rec, ex) -> custom);
@@ -202,7 +205,8 @@ public class DeadLetterPublishingRecovererTests {
 		KafkaOperations<?, ?> template = mock(KafkaOperations.class);
 		DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(template);
 		Headers headers = new RecordHeaders();
-		headers.add(new RecordHeader(SerializationUtils.KEY_DESERIALIZER_EXCEPTION_HEADER, header(true)));
+		headers.add(SerializationTestUtils.deserializationHeader(SerializationUtils.KEY_DESERIALIZER_EXCEPTION_HEADER,
+				header(true)));
 		CompletableFuture future = new CompletableFuture();
 		future.complete(new Object());
 		willReturn(future).given(template).send(any(ProducerRecord.class));
@@ -222,8 +226,8 @@ public class DeadLetterPublishingRecovererTests {
 		DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(template);
 		Headers headers = new RecordHeaders();
 		DeserializationException deserEx = createDeserEx(true);
-		headers.add(
-				new RecordHeader(SerializationUtils.KEY_DESERIALIZER_EXCEPTION_HEADER, header(true, deserEx)));
+		headers.add(SerializationTestUtils.deserializationHeader(SerializationUtils.KEY_DESERIALIZER_EXCEPTION_HEADER,
+				header(true, deserEx)));
 		CompletableFuture future = new CompletableFuture();
 		future.complete(new Object());
 		willReturn(future).given(template).send(any(ProducerRecord.class));
@@ -245,8 +249,10 @@ public class DeadLetterPublishingRecovererTests {
 		DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(template);
 		recoverer.setRetainExceptionHeader(true);
 		Headers headers = new RecordHeaders();
-		headers.add(new RecordHeader(SerializationUtils.VALUE_DESERIALIZER_EXCEPTION_HEADER, header(false)));
-		headers.add(new RecordHeader(SerializationUtils.KEY_DESERIALIZER_EXCEPTION_HEADER, header(true)));
+		headers.add(SerializationTestUtils.deserializationHeader(SerializationUtils.VALUE_DESERIALIZER_EXCEPTION_HEADER,
+				header(false)));
+		headers.add(SerializationTestUtils.deserializationHeader(SerializationUtils.KEY_DESERIALIZER_EXCEPTION_HEADER,
+				header(true)));
 		CompletableFuture future = new CompletableFuture();
 		future.complete(new Object());
 		willReturn(future).given(template).send(any(ProducerRecord.class));

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ErrorHandlingDeserializerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ErrorHandlingDeserializerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 the original author or authors.
+ * Copyright 2018-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -129,8 +129,8 @@ public class ErrorHandlingDeserializerTests {
 		ErrorHandlingDeserializer<String> ehd = new ErrorHandlingDeserializer<>(new MyDes());
 		Headers headers = new RecordHeaders();
 		ehd.deserialize("foo", headers, new byte[1]);
-		DeserializationException dex = ListenerUtils.byteArrayToDeserializationException(null,
-				headers.lastHeader(SerializationUtils.VALUE_DESERIALIZER_EXCEPTION_HEADER).value());
+		DeserializationException dex = SerializationUtils.byteArrayToDeserializationException(null,
+				headers.lastHeader(SerializationUtils.VALUE_DESERIALIZER_EXCEPTION_HEADER));
 		assertThat(dex.getCause().getMessage())
 				.contains("Could not serialize")
 				.contains("original exception message");

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/adapter/BatchAdapterConversionErrorsTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/adapter/BatchAdapterConversionErrorsTests.java
@@ -37,7 +37,6 @@ import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.listener.BatchListenerFailedException;
 import org.springframework.kafka.listener.ListenerExecutionFailedException;
-import org.springframework.kafka.listener.ListenerUtils;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.support.converter.BatchMessagingMessageConverter;
 import org.springframework.kafka.support.converter.ConversionException;
@@ -74,7 +73,7 @@ public class BatchAdapterConversionErrorsTests {
 				.extracting("index")
 				.isEqualTo(1);
 		assertThat(listener.values).containsExactly(new Foo("baz"), null, new Foo("qux"));
-		DeserializationException vDeserEx = ListenerUtils.getExceptionFromHeader(junkRecord,
+		DeserializationException vDeserEx = SerializationUtils.getExceptionFromHeader(junkRecord,
 				SerializationUtils.VALUE_DESERIALIZER_EXCEPTION_HEADER, null);
 		assertThat(vDeserEx).isNotNull();
 		assertThat(vDeserEx.getData()).isEqualTo("JUNK".getBytes());

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/SerializationTestUtils.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/SerializationTestUtils.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support.serializer;
+
+import org.apache.kafka.common.header.Header;
+
+/**
+ * @author Gary Russell
+ * @since 2.9.11
+ *
+ */
+public final class SerializationTestUtils {
+
+	private SerializationTestUtils() {
+	}
+
+	public static Header deserializationHeader(String key, byte[] value) {
+		return new DeserializationExceptionHeader(key, value);
+	}
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/SerializationUtilsTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/SerializationUtilsTests.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support.serializer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willAnswer;
+import static org.mockito.BDDMockito.willReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.apache.commons.logging.LogFactory;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import org.springframework.core.log.LogAccessor;
+
+/**
+ * @author Gary Russell
+ * @since 2.9.11
+ *
+ */
+public class SerializationUtilsTests {
+
+	@Test
+	void foreignDeserEx() {
+		RecordHeaders headers = new RecordHeaders(
+				List.of(new RecordHeader(SerializationUtils.VALUE_DESERIALIZER_EXCEPTION_HEADER, "junk".getBytes())));
+		ConsumerRecord<String, String> rec = mock(ConsumerRecord.class);
+		willReturn(headers).given(rec).headers();
+		given(rec.topic()).willReturn("foo");
+		given(rec.partition()).willReturn(1);
+		given(rec.offset()).willReturn(0L);
+		LogAccessor logger = spy(new LogAccessor(LogFactory.getLog(getClass())));
+		ArgumentCaptor<Supplier<String>> captor = ArgumentCaptor.forClass(Supplier.class);
+		willAnswer(inv -> null).given(logger).warn(captor.capture());
+		assertThat(SerializationUtils.getExceptionFromHeader(rec,
+				SerializationUtils.VALUE_DESERIALIZER_EXCEPTION_HEADER, logger)).isNull();
+		assertThat(captor.getValue().get())
+				.isEqualTo("Foreign deserialization exception header in (foo-1@0) ignored; possible attack?");
+	}
+
+}


### PR DESCRIPTION
Use a package-private header for deserialization exceptions.

**cherry-pick to 2.9.x, 2.8.x**
