### PR TITLE
GH-2779: ParseStringDeserializer: Add Null Check

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ParseStringDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ParseStringDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -100,6 +100,9 @@ public class ParseStringDeserializer<T> implements Deserializer<T> {
 
 	@Override
 	public T deserialize(String topic, Headers headers, byte[] data) {
+		if (data == null) {
+			return null;
+		}
 		return this.parser.apply(new String(data, this.charset), headers);
 	}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/ToStringSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/ToStringSerializationTests.java
@@ -213,6 +213,13 @@ public class ToStringSerializationTests {
 	}
 
 	@Test
+	void nullValue() {
+		ParseStringDeserializer<Object> deserializer =
+				new ParseStringDeserializer<>(ToStringSerializationTests::parseWithHeaders);
+		assertThat(deserializer.deserialize("foo", new RecordHeaders(), null)).isNull();
+	}
+
+	@Test
 	@DisplayName("Test deserialization using headers via config")
 	public void testSerialization_usingHeadersViaConfig() {
 


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2779

Handle tombstone records.

**cherry-pick to 2.9.x**

