### PR TITLE
GH-2730: Avoid I/O in synchronized Blocks

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
@@ -30,6 +30,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiPredicate;
 import java.util.function.Supplier;
 
@@ -117,6 +118,8 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 		BeanNameAware, ApplicationListener<ContextStoppedEvent>, DisposableBean, SmartLifecycle {
 
 	private static final LogAccessor LOGGER = new LogAccessor(LogFactory.getLog(DefaultKafkaProducerFactory.class));
+
+	private final ReentrantLock globalLock = new ReentrantLock();
 
 	private final Map<String, Object> configs;
 
@@ -700,9 +703,13 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 	@Override
 	public void destroy() {
 		CloseSafeProducer<K, V> producerToClose;
-		synchronized (this) {
+		this.globalLock.lock();
+		try {
 			producerToClose = this.producer;
 			this.producer = null;
+		}
+		finally {
+			this.globalLock.unlock();
 		}
 		if (producerToClose != null) {
 			try {
@@ -782,7 +789,8 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 		if (this.producerPerThread) {
 			return getOrCreateThreadBoundProducer();
 		}
-		synchronized (this) {
+		this.globalLock.lock();
+		try {
 			if (this.producer != null && this.producer.closed) {
 				this.producer.closeDelegate(this.physicalCloseTimeout, this.listeners);
 				this.producer = null;
@@ -796,6 +804,9 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 				this.listeners.forEach(listener -> listener.producerAdded(this.producer.clientId, this.producer));
 			}
 			return this.producer;
+		}
+		finally {
+			this.globalLock.unlock();
 		}
 	}
 
@@ -881,7 +892,8 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 			return true;
 		}
 		else {
-			synchronized (this.cache) {
+			this.globalLock.lock();
+			try {
 				BlockingQueue<CloseSafeProducer<K, V>> txIdCache = getCache(producerToRemove.txIdPrefix);
 				if (producerToRemove.epoch != this.epoch.get()
 						|| (txIdCache != null && !txIdCache.contains(producerToRemove)
@@ -889,6 +901,9 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 					producerToRemove.closeDelegate(timeout, this.listeners);
 					return true;
 				}
+			}
+			finally {
+				this.globalLock.unlock();
 			}
 			return false;
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/requestreply/AggregatingReplyingKafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/requestreply/AggregatingReplyingKafkaTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 the original author or authors.
+ * Copyright 2019-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
 
@@ -70,6 +71,8 @@ public class AggregatingReplyingKafkaTemplate<K, V, R>
 	public static final String PARTIAL_RESULTS_AFTER_TIMEOUT_TOPIC = "partialResultsAfterTimeout";
 
 	private static final int DEFAULT_COMMIT_TIMEOUT = 30;
+
+	private final ReentrantLock aggregationLock = new ReentrantLock();
 
 	private final Map<Object, Set<RecordHolder<K, R>>> pending = new HashMap<>();
 
@@ -136,7 +139,8 @@ public class AggregatingReplyingKafkaTemplate<K, V, R>
 				Object correlationId = isBinaryCorrelation()
 						? new CorrelationKey(correlation.value())
 						: new String(correlation.value(), StandardCharsets.UTF_8);
-				synchronized (this) {
+				this.aggregationLock.lock();
+				try {
 					if (isPending(correlationId)) {
 						List<ConsumerRecord<K, R>> list = addToCollection(record, correlationId).stream()
 								.map(RecordHolder::getRecord)
@@ -158,6 +162,9 @@ public class AggregatingReplyingKafkaTemplate<K, V, R>
 						logLateArrival(record, correlationId);
 					}
 				}
+				finally {
+					this.aggregationLock.unlock();
+				}
 			}
 		});
 		if (completed.size() > 0) {
@@ -166,20 +173,26 @@ public class AggregatingReplyingKafkaTemplate<K, V, R>
 	}
 
 	@Override
-	protected synchronized boolean handleTimeout(Object correlationId,
+	protected boolean handleTimeout(Object correlationId,
 			RequestReplyFuture<K, V, Collection<ConsumerRecord<K, R>>> future) {
 
-		Set<RecordHolder<K, R>> removed = this.pending.remove(correlationId);
-		if (removed != null && this.returnPartialOnTimeout) {
-			List<ConsumerRecord<K, R>> list = removed.stream()
-					.map(RecordHolder::getRecord)
-					.collect(Collectors.toList());
-			if (this.releaseStrategy.test(list, true)) {
-				future.complete(new ConsumerRecord<>(PARTIAL_RESULTS_AFTER_TIMEOUT_TOPIC, 0, 0L, null, list));
-				return true;
+		this.aggregationLock.lock();
+		try {
+			Set<RecordHolder<K, R>> removed = this.pending.remove(correlationId);
+			if (removed != null && this.returnPartialOnTimeout) {
+				List<ConsumerRecord<K, R>> list = removed.stream()
+						.map(RecordHolder::getRecord)
+						.collect(Collectors.toList());
+				if (this.releaseStrategy.test(list, true)) {
+					future.complete(new ConsumerRecord<>(PARTIAL_RESULTS_AFTER_TIMEOUT_TOPIC, 0, 0L, null, list));
+					return true;
+				}
 			}
+			return false;
 		}
-		return false;
+		finally {
+			this.aggregationLock.unlock();
+		}
 	}
 
 	private void checkOffsetsAndCommitIfNecessary(List<ConsumerRecord<K, R>> list, Consumer<?, ?> consumer) {


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2730

Use `ReentrantLock`s when I/O is possible to avoid unnecessary virtual thread pinning. Synchronized blocks to protect update to shared fields are ok.
