### PR TITLE
Get rid of proxy in DefaultKafkaConsumerFactory

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.kafka.core;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
@@ -28,19 +29,13 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
-import org.aopalliance.aop.Advice;
-import org.aopalliance.intercept.MethodInterceptor;
-import org.aopalliance.intercept.MethodInvocation;
 import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
-import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.serialization.Deserializer;
 
-import org.springframework.aop.framework.ProxyFactory;
-import org.springframework.aop.support.NameMatchMethodPointcutAdvisor;
 import org.springframework.beans.factory.BeanNameAware;
 import org.springframework.core.log.LogAccessor;
 import org.springframework.lang.Nullable;
@@ -445,27 +440,10 @@ public class DefaultKafkaConsumerFactory<K, V> extends KafkaResourceFactory
 		}
 	}
 
-	@SuppressWarnings("resource")
 	protected Consumer<K, V> createKafkaConsumer(Map<String, Object> configProps) {
 		checkBootstrap(configProps);
 		Consumer<K, V> kafkaConsumer = createRawConsumer(configProps);
 
-		if (this.listeners.size() > 0) {
-			Map<MetricName, ? extends Metric> metrics = kafkaConsumer.metrics();
-			Iterator<MetricName> metricIterator = metrics.keySet().iterator();
-			String clientId;
-			if (metricIterator.hasNext()) {
-				clientId = metricIterator.next().tags().get("client-id");
-			}
-			else {
-				clientId = "unknown";
-			}
-			String id = this.beanName + "." + clientId;
-			kafkaConsumer = createProxy(kafkaConsumer, id);
-			for (Listener<K, V> listener : this.listeners) {
-				listener.consumerAdded(id, kafkaConsumer);
-			}
-		}
 		for (ConsumerPostProcessor<K, V> pp : this.postProcessors) {
 			kafkaConsumer = pp.apply(kafkaConsumer);
 		}
@@ -473,40 +451,57 @@ public class DefaultKafkaConsumerFactory<K, V> extends KafkaResourceFactory
 	}
 
 	/**
-	 * Create a Consumer.
+	 * Create a {@link Consumer}.
+	 * By default, this method returns an internal {@link ExtendedKafkaConsumer}
+	 * which is aware of provided into this {@link #listeners}, therefore it is recommended
+	 * to extend that class if {@link #listeners} are still involved for a custom {@link Consumer}.
 	 * @param configProps the configuration properties.
 	 * @return the consumer.
 	 * @since 2.5
 	 */
 	protected Consumer<K, V> createRawConsumer(Map<String, Object> configProps) {
-		return new KafkaConsumer<>(configProps, this.keyDeserializerSupplier.get(),
-				this.valueDeserializerSupplier.get());
-	}
-
-	@SuppressWarnings("unchecked")
-	private Consumer<K, V> createProxy(Consumer<K, V> kafkaConsumer, String id) {
-		ProxyFactory pf = new ProxyFactory(kafkaConsumer);
-		Advice advice = new MethodInterceptor() {
-
-			@Override
-			public Object invoke(MethodInvocation invocation) throws Throwable {
-				DefaultKafkaConsumerFactory.this.listeners.forEach(listener ->
-						listener.consumerRemoved(id, kafkaConsumer));
-				return invocation.proceed();
-			}
-
-		};
-		NameMatchMethodPointcutAdvisor advisor = new NameMatchMethodPointcutAdvisor(advice);
-		advisor.addMethodName("close");
-		pf.addAdvisor(advisor);
-		return (Consumer<K, V>) pf.getProxy();
+		return new ExtendedKafkaConsumer(configProps);
 	}
 
 	@Override
 	public boolean isAutoCommit() {
 		Object auto = this.configs.get(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG);
-		return auto instanceof Boolean ? (Boolean) auto
-				: auto instanceof String ? Boolean.valueOf((String) auto) : true;
+		return auto instanceof Boolean
+				? (Boolean) auto
+				: !(auto instanceof String) || Boolean.parseBoolean((String) auto);
+	}
+
+	protected class ExtendedKafkaConsumer extends KafkaConsumer<K, V> {
+
+		private String idForListeners;
+
+		protected ExtendedKafkaConsumer(Map<String, Object> configProps) {
+			super(configProps,
+					DefaultKafkaConsumerFactory.this.keyDeserializerSupplier.get(),
+					DefaultKafkaConsumerFactory.this.valueDeserializerSupplier.get());
+
+			if (!DefaultKafkaConsumerFactory.this.listeners.isEmpty()) {
+				Iterator<MetricName> metricIterator = metrics().keySet().iterator();
+				String clientId = "unknown";
+				if (metricIterator.hasNext()) {
+					clientId = metricIterator.next().tags().get("client-id");
+				}
+				this.idForListeners = DefaultKafkaConsumerFactory.this.beanName + "." + clientId;
+				for (Listener<K, V> listener : DefaultKafkaConsumerFactory.this.listeners) {
+					listener.consumerAdded(this.idForListeners, this);
+				}
+			}
+		}
+
+		@Override
+		public void close(Duration timeout) {
+			super.close(timeout);
+
+			for (Listener<K, V> listener : DefaultKafkaConsumerFactory.this.listeners) {
+				listener.consumerRemoved(this.idForListeners, this);
+			}
+		}
+
 	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
@@ -443,6 +443,11 @@ public class DefaultKafkaConsumerFactory<K, V> extends KafkaResourceFactory
 	protected Consumer<K, V> createKafkaConsumer(Map<String, Object> configProps) {
 		checkBootstrap(configProps);
 		Consumer<K, V> kafkaConsumer = createRawConsumer(configProps);
+		if (!this.listeners.isEmpty() && !(kafkaConsumer instanceof ExtendedKafkaConsumer)) {
+			LOGGER.warn("The 'ConsumerFactory.Listener' configuration is ignored " +
+					"because the consumer is not an instance of 'ExtendedKafkaConsumer'." +
+					"Consider to extend 'ExtendedKafkaConsumer' or implement your own 'ConsumerFactory'.");
+		}
 
 		for (ConsumerPostProcessor<K, V> pp : this.postProcessors) {
 			kafkaConsumer = pp.apply(kafkaConsumer);

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
@@ -446,7 +446,7 @@ public class DefaultKafkaConsumerFactory<K, V> extends KafkaResourceFactory
 		if (!this.listeners.isEmpty() && !(kafkaConsumer instanceof ExtendedKafkaConsumer)) {
 			LOGGER.warn("The 'ConsumerFactory.Listener' configuration is ignored " +
 					"because the consumer is not an instance of 'ExtendedKafkaConsumer'." +
-					"Consider to extend 'ExtendedKafkaConsumer' or implement your own 'ConsumerFactory'.");
+					"Consider extending 'ExtendedKafkaConsumer' or implement your own 'ConsumerFactory'.");
 		}
 
 		for (ConsumerPostProcessor<K, V> pp : this.postProcessors) {


### PR DESCRIPTION
The proxy in the `DefaultKafkaConsumerFactory` for `KafkaConsumer` is created only to intercept `close()` call to remove an instance from the `listeners`.
There is no need in such a proxy since simple `KafkaConsumer` class extension can handle that scenario.

The reason behind this change is to avoid a `Serializable` (`java.lang.reflect.Proxy`) header in the produced message for the `KafkaConsumer` where we still fail to serialize it because other properties of the proxy are not `Serializable`

* Introduce `DefaultKafkaConsumerFactory.ExtendedKafkaConsumer` to handle `listeners` interaction
* The `createRawConsumer()` might be considered as breaking change since now end-user must extend this `ExtendedKafkaConsumer` to be able to handle `listeners` same way as before
* Adjust `DefaultKafkaConsumerFactoryTests.listener()` test for the current code state

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
