### PR TITLE
Upgrade to Apache Kafka 3.6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,7 @@ ext {
 	jaywayJsonPathVersion = '2.8.0'
 	junit4Version = '4.13.2'
 	junitJupiterVersion = '5.10.0'
-	kafkaVersion = '3.5.1'
+	kafkaVersion = '3.6.0'
 	log4jVersion = '2.20.0'
 	micrometerDocsVersion = "1.0.2"
 	micrometerVersion = '1.12.0-M3'
@@ -406,8 +406,12 @@ project ('spring-kafka-test') {
 		api "org.apache.kafka:kafka-server-common:$kafkaVersion"
 		api "org.apache.kafka:kafka-server-common:$kafkaVersion:test"
 		api "org.apache.kafka:kafka-streams-test-utils:$kafkaVersion"
-		api "org.apache.kafka:kafka_$scalaVersion:$kafkaVersion"
-		api "org.apache.kafka:kafka_$scalaVersion:$kafkaVersion:test"
+		api ("org.apache.kafka:kafka_$scalaVersion:$kafkaVersion") {
+			exclude group: 'commons-logging'
+		}
+		api ("org.apache.kafka:kafka_$scalaVersion:$kafkaVersion:test") {
+			exclude group: 'commons-logging'
+		}
 		api 'org.junit.jupiter:junit-jupiter-api'
 		api 'org.junit.platform:junit-platform-launcher'
 		optionalApi "org.hamcrest:hamcrest-core:$hamcrestVersion"


### PR DESCRIPTION
- exclude transitive `commons-logging` dependency from `spring-kafka-test`.
