### PR TITLE
Fix Invalid exposeGroupId in Docs

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/receiving-messages/listener-group-id.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/receiving-messages/listener-group-id.adoc
@@ -9,8 +9,8 @@ Alternatively, you can access the group id in a method parameter.
 
 [source, java]
 ----
-@KafkaListener(id = "bar", topicPattern = "${topicTwo:annotated2}", exposeGroupId = "${always:true}")
-public void listener(@Payload String foo,
+@KafkaListener(id = "id", topicPattern = "someTopic")
+public void listener(@Payload String payload,
         @Header(KafkaHeaders.GROUP_ID) String groupId) {
 ...
 }


### PR DESCRIPTION
https://github.com/spring-projects/spring-kafka/pull/1030#discussion_r268874267

We removed the property from the annotation during PR review, but failed to correct the docs.
