### PR TITLE
GH-2826: Fix CommonDelegatingErrorHandler

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonDelegatingErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonDelegatingErrorHandler.java
@@ -70,7 +70,7 @@ public class CommonDelegatingErrorHandler implements CommonErrorHandler {
 		Assert.notNull(delegates, "'delegates' cannot be null");
 		this.delegates.clear();
 		this.delegates.putAll(delegates);
-		checkDelegatesAndUpdateClassifier();
+		checkDelegatesAndUpdateClassifier(this.delegates);
 	}
 
 	/**
@@ -111,12 +111,17 @@ public class CommonDelegatingErrorHandler implements CommonErrorHandler {
 	 * @param handler the handler.
 	 */
 	public void addDelegate(Class<? extends Throwable> throwable, CommonErrorHandler handler) {
-		this.delegates.put(throwable, handler);
-		checkDelegatesAndUpdateClassifier();
+		Map<Class<? extends Throwable>, CommonErrorHandler> delegatesToCheck = new LinkedHashMap<>(this.delegates);
+		delegatesToCheck.put(throwable, handler);
+		checkDelegatesAndUpdateClassifier(delegatesToCheck);
+		this.delegates.clear();
+		this.delegates.putAll(delegatesToCheck);
 	}
 
 	@SuppressWarnings("deprecation")
-	private void checkDelegatesAndUpdateClassifier() {
+	private void checkDelegatesAndUpdateClassifier(Map<Class<? extends Throwable>,
+			CommonErrorHandler> delegatesToCheck) {
+
 		boolean ackAfterHandle = this.defaultErrorHandler.isAckAfterHandle();
 		boolean seeksAfterHandling = this.defaultErrorHandler.seeksAfterHandling();
 		this.delegates.values().forEach(handler -> {
@@ -125,7 +130,7 @@ public class CommonDelegatingErrorHandler implements CommonErrorHandler {
 			Assert.isTrue(seeksAfterHandling == handler.seeksAfterHandling(),
 					"All delegates must return the same value when calling 'seeksAfterHandling()'");
 		});
-		updateClassifier(delegates);
+		updateClassifier(delegatesToCheck);
 	}
 
 	private void updateClassifier(Map<Class<? extends Throwable>, CommonErrorHandler> delegates) {

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/CommonDelegatingErrorHandlerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/CommonDelegatingErrorHandlerTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.kafka.listener;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -31,6 +32,7 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.kafka.KafkaException;
 import org.springframework.kafka.core.KafkaProducerException;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 /**
  * Tests for {@link CommonDelegatingErrorHandler}.
@@ -134,7 +136,7 @@ public class CommonDelegatingErrorHandlerTests {
 	}
 
 	@Test
-	@SuppressWarnings("ConstantConditions")
+	@SuppressWarnings({ "ConstantConditions", "unchecked" })
 	void testDelegateForClassifiableThrowableCauseIsAppliedWhenCauseTraversingIsEnabled() {
 		var defaultHandler = mock(CommonErrorHandler.class);
 
@@ -147,6 +149,10 @@ public class CommonDelegatingErrorHandlerTests {
 		delegatingErrorHandler.setErrorHandlers(Map.of(
 			KafkaException.class, directCauseErrorHandler
 		));
+		delegatingErrorHandler.addDelegate(IllegalStateException.class, mock(CommonErrorHandler.class));
+		assertThat(KafkaTestUtils.getPropertyValue(delegatingErrorHandler, "classifier.classified", Map.class).keySet())
+				.contains(IllegalStateException.class);
+
 
 		delegatingErrorHandler.handleRemaining(exc, Collections.emptyList(), mock(Consumer.class),
 			mock(MessageListenerContainer.class));


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2826

The `addDelegate` method did not update the classifier, so it failed to work when cause chain traversal is enabled.

**cherry-pick to 3.0.x, 2.9.x**
