### PR TITLE
GH-2838: JSON Deser. Remove Verbose Exc. Message

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2021 the original author or authors.
+ * Copyright 2015-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -584,9 +584,8 @@ public class JsonDeserializer<T> implements Deserializer<T> {
 		try {
 			return deserReader.readValue(data);
 		}
-		catch (IOException e) {
-			throw new SerializationException("Can't deserialize data [" + Arrays.toString(data) +
-					"] from topic [" + topic + "]", e);
+		catch (IOException ex) {
+			throw new SerializationException("Can't deserialize data  from topic [" + topic + "]", ex);
 		}
 	}
 


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2838

Previously, the exception message contained the entire JSON content.

**cherry pick to 3.0.x (#2839) and 2.9. (#2840)**

I will add What's New? content to each branch after the merge.
