### PR TITLE
Upgrade org.apache.kafka:kafka-clients to 3.6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ ext {
 	jaywayJsonPathVersion = '2.6.0'
 	junit4Version = '4.13.2'
 	junitJupiterVersion = '5.8.2'
-	kafkaVersion = '3.2.3'
+	kafkaVersion = '3.6.0'
 	log4jVersion = '2.17.2'
 	micrometerVersion = '1.9.14'
 	mockitoVersion = '4.5.1'


### PR DESCRIPTION
Upgrade org.apache.kafka:kafka-clients to 3.6.0 to fix [CVE-2023-43642](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-43642) for Spring-Boot 2.7.X.
