### PR TITLE
GH-2825: Provide a way to customize a single listener

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/container-factory.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/container-factory.adoc
@@ -38,8 +38,7 @@ public KafkaListenerContainerFactory<?> kafkaListenerContainerFactory() {
 }
 ----
 
-Starting with version 3.1.0, it's also possible to apply the same kind of customization on a single listener by specifying the bean name of a
-'ContainerPostProcessor' on the KafkaListener annotation.
+Starting with version 3.1, it's also possible to apply the same kind of customization on a single listener by specifying the bean name of a 'ContainerPostProcessor' on the KafkaListener annotation.
 
 [source, java]
 ----

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/container-factory.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/container-factory.adoc
@@ -38,3 +38,18 @@ public KafkaListenerContainerFactory<?> kafkaListenerContainerFactory() {
 }
 ----
 
+Starting with version 3.1.0, it's also possible to apply the same kind of customization on a single listener by specifying the bean name of a
+'ContainerPostProcessor' on the KafkaListener annotation.
+
+[source, java]
+----
+@Bean
+public ContainerPostProcessor<String, String, AbstractMessageListenerContainer<String, String>> customContainerPostProcessor() {
+    return container -> { /* customize the container */ };
+}
+
+...
+
+@KafkaListener(... containerPostProcessor="customContainerPostProcessor" ...)
+----
+

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -24,3 +24,9 @@ See <<ekb>> for more information.
 When a deserialization exception occurs, the `SerializationException` message no longer contains the data with the form `Can't deserialize data [[123, 34, 98, 97, 122, ...`; an array of numerical values for each data byte is not useful and can be verbose for large data.
 When used with an `ErrorHandlingDeserializer`, the `DeserializationException` sent to the error handler contains the `data` property which contains the raw data that could not be deserialized.
 When not used with an `ErrorHandlingDeserializer`, the `KafkaConsumer` will continually emit exceptions for the same record showing the topic/partition/offset and the cause thrown by Jackson.
+
+[[x31-cpp]]
+=== ContainerPostProcessor
+
+A post-processing can be applied on a listener container by specifying the bean name of a `ContainerPostProcessor` on the `@KafkaListener` annotation.
+See xref:kafka/container-factory.adoc[Container Factory] for more information.

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
@@ -327,9 +327,12 @@ public @interface KafkaListener {
 	String info() default "";
 
 	/**
-	 * Set the bean name of a {@link org.springframework.kafka.config.ContainerPostProcessor} to allow customizing the
-	 * container after its creation and configuration. This post processor is only applied on the current listener container
-	 * in contrast to the {@link org.springframework.kafka.config.ContainerCustomizer} which is applied on all listener containers.
+	 * Set the bean name of a {@link org.springframework.kafka.config.ContainerPostProcessor}
+	 * to allow customizing the container after its creation and configuration. This post
+	 * processor is only applied on the current listener container in contrast to the
+	 * {@link org.springframework.kafka.config.ContainerCustomizer} which is applied on all
+	 * listener containers.
+	 *
 	 * @return the bean name of the container post processor.
 	 * @since 3.1.0
 	 */

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -326,4 +326,12 @@ public @interface KafkaListener {
 	 */
 	String info() default "";
 
+	/**
+	 * Set the bean name of a {@link org.springframework.kafka.config.ContainerPostProcessor} to allow customizing the
+	 * container after its creation and configuration. This post processor is only applied on the current listener container
+	 * in contrast to the {@link org.springframework.kafka.config.ContainerCustomizer} which is applied on all listener containers.
+	 * @return the bean name of the container post processor.
+	 * @since 3.1.0
+	 */
+	String containerPostProcessor() default "";
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
@@ -331,10 +331,11 @@ public @interface KafkaListener {
 	 * to allow customizing the container after its creation and configuration. This post
 	 * processor is only applied on the current listener container in contrast to the
 	 * {@link org.springframework.kafka.config.ContainerCustomizer} which is applied on all
-	 * listener containers.
+	 * listener containers. This post processor is applied after the container customizer
+	 * (if present).
 	 *
 	 * @return the bean name of the container post processor.
-	 * @since 3.1.0
+	 * @since 3.1
 	 */
 	String containerPostProcessor() default "";
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
@@ -78,6 +78,7 @@ import org.springframework.core.log.LogAccessor;
 import org.springframework.format.Formatter;
 import org.springframework.format.FormatterRegistry;
 import org.springframework.format.support.DefaultFormattingConversionService;
+import org.springframework.kafka.config.ContainerPostProcessor;
 import org.springframework.kafka.config.KafkaListenerConfigUtils;
 import org.springframework.kafka.config.KafkaListenerContainerFactory;
 import org.springframework.kafka.config.KafkaListenerEndpointRegistrar;
@@ -663,6 +664,7 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 		resolveErrorHandler(endpoint, kafkaListener);
 		resolveContentTypeConverter(endpoint, kafkaListener);
 		resolveFilter(endpoint, kafkaListener);
+		resolveContainerPostProcessor(endpoint, kafkaListener);
 	}
 
 	private void resolveErrorHandler(MethodKafkaListenerEndpoint<?, ?> endpoint, KafkaListener kafkaListener) {
@@ -738,6 +740,13 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 			}
 		}
 		return factory;
+	}
+
+	private void resolveContainerPostProcessor(MethodKafkaListenerEndpoint<?, ?> endpoint, KafkaListener kafkaListener) {
+		final String containerPostProcessor = kafkaListener.containerPostProcessor();
+		if (StringUtils.hasText(containerPostProcessor)) {
+			endpoint.setContainerPostProcessor(this.beanFactory.getBean(containerPostProcessor, ContainerPostProcessor.class));
+		}
 	}
 
 	protected void assertBeanFactory() {

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
@@ -742,10 +742,12 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 		return factory;
 	}
 
-	private void resolveContainerPostProcessor(MethodKafkaListenerEndpoint<?, ?> endpoint, KafkaListener kafkaListener) {
+	private void resolveContainerPostProcessor(MethodKafkaListenerEndpoint<?, ?> endpoint,
+		KafkaListener kafkaListener) {
 		final String containerPostProcessor = kafkaListener.containerPostProcessor();
 		if (StringUtils.hasText(containerPostProcessor)) {
-			endpoint.setContainerPostProcessor(this.beanFactory.getBean(containerPostProcessor, ContainerPostProcessor.class));
+			endpoint.setContainerPostProcessor(this.beanFactory.getBean(containerPostProcessor,
+					ContainerPostProcessor.class));
 		}
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
@@ -744,6 +744,7 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 
 	private void resolveContainerPostProcessor(MethodKafkaListenerEndpoint<?, ?> endpoint,
 		KafkaListener kafkaListener) {
+
 		final String containerPostProcessor = kafkaListener.containerPostProcessor();
 		if (StringUtils.hasText(containerPostProcessor)) {
 			endpoint.setContainerPostProcessor(this.beanFactory.getBean(containerPostProcessor,

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
@@ -367,7 +367,7 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 			endpoint.setupListenerContainer(instance, this.recordMessageConverter);
 		}
 		initializeContainer(instance, endpoint);
-		customizeContainer(instance);
+		customizeContainer(instance, endpoint);
 		return instance;
 	}
 
@@ -439,58 +439,57 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 				.acceptIfNotNull(endpoint.getListenerInfo(), instance::setListenerInfo);
 	}
 
-	private void customizeContainer(C instance) {
-		if (this.containerCustomizer != null) {
-			this.containerCustomizer.configure(instance);
-		}
-	}
-
 	@Override
 	public C createContainer(TopicPartitionOffset... topicsAndPartitions) {
-		KafkaListenerEndpoint endpoint = new KafkaListenerEndpointAdapter() {
+		return createContainer(new KafkaListenerEndpointAdapter() {
 
 			@Override
 			public TopicPartitionOffset[] getTopicPartitionsToAssign() {
 				return Arrays.copyOf(topicsAndPartitions, topicsAndPartitions.length);
 			}
 
-		};
-		C container = createContainerInstance(endpoint);
-		initializeContainer(container, endpoint);
-		customizeContainer(container);
-		return container;
+		});
 	}
 
 	@Override
 	public C createContainer(String... topics) {
-		KafkaListenerEndpoint endpoint = new KafkaListenerEndpointAdapter() {
+		return createContainer(new KafkaListenerEndpointAdapter() {
 
 			@Override
 			public Collection<String> getTopics() {
 				return Arrays.asList(topics);
 			}
 
-		};
-		C container = createContainerInstance(endpoint);
-		initializeContainer(container, endpoint);
-		customizeContainer(container);
-		return container;
+		});
 	}
 
 	@Override
 	public C createContainer(Pattern topicPattern) {
-		KafkaListenerEndpoint endpoint = new KafkaListenerEndpointAdapter() {
+		return createContainer(new KafkaListenerEndpointAdapter() {
 
 			@Override
 			public Pattern getTopicPattern() {
 				return topicPattern;
 			}
 
-		};
-		C container = createContainerInstance(endpoint);
+		});
+	}
+
+	protected C createContainer(KafkaListenerEndpoint endpoint) {
+		final C container = createContainerInstance(endpoint);
 		initializeContainer(container, endpoint);
-		customizeContainer(container);
+		customizeContainer(container, endpoint);
 		return container;
 	}
 
+	@SuppressWarnings("unchecked")
+	protected void customizeContainer(C instance, KafkaListenerEndpoint endpoint) {
+		if (this.containerCustomizer != null) {
+			this.containerCustomizer.configure(instance);
+		}
+		final ContainerPostProcessor<K, V, C> containerPostProcessor = (ContainerPostProcessor<K, V, C>) endpoint.getContainerPostProcessor();
+		if (containerPostProcessor != null) {
+			containerPostProcessor.postProcess(instance);
+		}
+	}
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
@@ -487,7 +487,8 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 		if (this.containerCustomizer != null) {
 			this.containerCustomizer.configure(instance);
 		}
-		final ContainerPostProcessor<K, V, C> containerPostProcessor = (ContainerPostProcessor<K, V, C>) endpoint.getContainerPostProcessor();
+		final ContainerPostProcessor<K, V, C> containerPostProcessor = (ContainerPostProcessor<K, V, C>)
+				endpoint.getContainerPostProcessor();
 		if (containerPostProcessor != null) {
 			containerPostProcessor.postProcess(instance);
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
@@ -115,6 +115,8 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 
 	private String correlationHeaderName;
 
+	private ContainerPostProcessor<?, ?, ?> containerPostProcessor;
+
 	@Nullable
 	private String mainListenerId;
 
@@ -466,6 +468,22 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 	 */
 	public void setCorrelationHeaderName(String correlationHeaderName) {
 		this.correlationHeaderName = correlationHeaderName;
+	}
+
+	@Override
+	public ContainerPostProcessor<?, ?, ?> getContainerPostProcessor() {
+		return this.containerPostProcessor;
+	}
+
+	/**
+	 * Set the {@link ContainerPostProcessor} on the endpoint to allow customizing the
+	 * container after its creation and configuration.
+	 *
+	 * @param containerPostProcessor the post processor.
+	 * @since 3.1
+	 */
+	public void setContainerPostProcessor(ContainerPostProcessor<?, ?, ?> containerPostProcessor) {
+		this.containerPostProcessor = containerPostProcessor;
 	}
 
 	@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/ContainerPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/ContainerPostProcessor.java
@@ -20,10 +20,12 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.listener.AbstractMessageListenerContainer;
 
 /**
- * Called by the container factory after the container is created and configured. This post processor is applied
- * on the listener through the {@link KafkaListener#containerPostProcessor()} attribute.
+ * Called by the container factory after the container is created and configured. This
+ * post processor is applied on the listener through the
+ * {@link KafkaListener#containerPostProcessor()} attribute.
  * <p>
- * A {@link ContainerCustomizer} can be used when customization must be applied to all containers.
+ * A {@link ContainerCustomizer} can be used when customization must be applied to all
+ * containers.
  *
  * @param <K> the key type.
  * @param <V> the value type.
@@ -34,7 +36,6 @@ import org.springframework.kafka.listener.AbstractMessageListenerContainer;
  *
  * @see ContainerCustomizer
  * @see KafkaListener
- *
  */
 @FunctionalInterface
 public interface ContainerPostProcessor<K, V, C extends AbstractMessageListenerContainer<K, V>> {

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/ContainerPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/ContainerPostProcessor.java
@@ -25,14 +25,14 @@ import org.springframework.kafka.listener.AbstractMessageListenerContainer;
  * {@link KafkaListener#containerPostProcessor()} attribute.
  * <p>
  * A {@link ContainerCustomizer} can be used when customization must be applied to all
- * containers.
+ * containers. In that case, this will be applied after the customizer.
  *
  * @param <K> the key type.
  * @param <V> the value type.
  * @param <C> the container type.
  *
  * @author Francois Rosiere
- * @since 3.1.0
+ * @since 3.1
  *
  * @see ContainerCustomizer
  * @see KafkaListener

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/ContainerPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/ContainerPostProcessor.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.config;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.listener.AbstractMessageListenerContainer;
+
+/**
+ * Called by the container factory after the container is created and configured. This post processor is applied
+ * on the listener through the {@link KafkaListener#containerPostProcessor()} attribute.
+ * <p>
+ * A {@link ContainerCustomizer} can be used when customization must be applied to all containers.
+ *
+ * @param <K> the key type.
+ * @param <V> the value type.
+ * @param <C> the container type.
+ *
+ * @author Francois Rosiere
+ * @since 3.1.0
+ *
+ * @see ContainerCustomizer
+ * @see KafkaListener
+ *
+ */
+@FunctionalInterface
+public interface ContainerPostProcessor<K, V, C extends AbstractMessageListenerContainer<K, V>> {
+
+	/**
+	 * Post processes the container.
+	 *
+	 * @param container the container.
+	 */
+	void postProcess(C container);
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpoint.java
@@ -180,10 +180,11 @@ public interface KafkaListenerEndpoint {
 	 * Return the {@link ContainerPostProcessor} for this endpoint, or null if not
 	 * explicitly set.
 	 * @return the container post processor.
-	 * @since 3.1.0
+	 * @since 3.1
 	 */
 	@Nullable
 	default ContainerPostProcessor<?, ?, ?> getContainerPostProcessor() {
 		return null;
 	}
+
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpoint.java
@@ -176,4 +176,13 @@ public interface KafkaListenerEndpoint {
 		return null;
 	}
 
+	/**
+	 * Return the {@link ContainerPostProcessor} for this endpoint, or null if not explicitly set.
+	 * @return the container post processor.
+	 * @since 3.1.0
+	 */
+	@Nullable
+	default ContainerPostProcessor<?, ?, ?> getContainerPostProcessor() {
+		return null;
+	}
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpoint.java
@@ -177,7 +177,8 @@ public interface KafkaListenerEndpoint {
 	}
 
 	/**
-	 * Return the {@link ContainerPostProcessor} for this endpoint, or null if not explicitly set.
+	 * Return the {@link ContainerPostProcessor} for this endpoint, or null if not
+	 * explicitly set.
 	 * @return the container post processor.
 	 * @since 3.1.0
 	 */

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/MethodKafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/MethodKafkaListenerEndpoint.java
@@ -72,8 +72,6 @@ public class MethodKafkaListenerEndpoint<K, V> extends AbstractKafkaListenerEndp
 
 	private SmartMessageConverter messagingConverter;
 
-	private ContainerPostProcessor<?, ?, ?> containerPostProcessor;
-
 	/**
 	 * Set the object instance that should manage this endpoint.
 	 * @param bean the target bean instance.
@@ -128,22 +126,6 @@ public class MethodKafkaListenerEndpoint<K, V> extends AbstractKafkaListenerEndp
 	 */
 	public void setMessagingConverter(SmartMessageConverter messagingConverter) {
 		this.messagingConverter = messagingConverter;
-	}
-
-	@Override
-	public ContainerPostProcessor<?, ?, ?> getContainerPostProcessor() {
-		return this.containerPostProcessor;
-	}
-
-	/**
-	 * Set the {@link ContainerPostProcessor} on the endpoint to allow customizing the
-	 * container after its creation and configuration.
-	 *
-	 * @param containerPostProcessor the post processor.
-	 * @since 3.1.0
-	 */
-	public void setContainerPostProcessor(ContainerPostProcessor<?, ?, ?> containerPostProcessor) {
-		this.containerPostProcessor = containerPostProcessor;
 	}
 
 	@Nullable

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/MethodKafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/MethodKafkaListenerEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,6 +72,8 @@ public class MethodKafkaListenerEndpoint<K, V> extends AbstractKafkaListenerEndp
 
 	private SmartMessageConverter messagingConverter;
 
+	private ContainerPostProcessor<?, ?, ?> containerPostProcessor;
+
 	/**
 	 * Set the object instance that should manage this endpoint.
 	 * @param bean the target bean instance.
@@ -126,6 +128,22 @@ public class MethodKafkaListenerEndpoint<K, V> extends AbstractKafkaListenerEndp
 	 */
 	public void setMessagingConverter(SmartMessageConverter messagingConverter) {
 		this.messagingConverter = messagingConverter;
+	}
+
+	@Override
+	public ContainerPostProcessor<?, ?, ?> getContainerPostProcessor() {
+		return this.containerPostProcessor;
+	}
+
+	/**
+	 * Set the {@link ContainerPostProcessor} on the endpoint to allow customizing the
+	 * container after its creation and configuration.
+	 *
+	 * @param containerPostProcessor the post processor.
+	 * @since 3.1.0
+	 */
+	public void setContainerPostProcessor(ContainerPostProcessor<?, ?, ?> containerPostProcessor) {
+		this.containerPostProcessor = containerPostProcessor;
 	}
 
 	@Nullable

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ContainerCustomizationTest.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ContainerCustomizationTest.java
@@ -56,17 +56,22 @@ class ContainerCustomizationTest {
 	private static final String CONTAINER_CUSTOMIZER = "container-customizer";
 	private static final String POST_PROCESSOR = "post-processor";
 	private static final String POST_PROCESSOR_MULTI_METHOD = "post-processor-multi-method";
-	private static final String CONTAINER_CUSTOMIZER_AND_POST_PROCESSOR = "container-customizer-and-post-processor";
+	private static final String CONTAINER_CUSTOMIZER_AND_POST_PROCESSOR = "container-customizer" +
+			"-and-post-processor";
+
 	@Autowired
 	private ListenerContainerRegistry listenerContainerRegistry;
 
 	private static Stream<Arguments> listenerIdsWithRelatedInfo() {
 		return Stream.of(
 				Arguments.of(DEFAULT_LISTENER, null),
-				Arguments.of(CONTAINER_CUSTOMIZER, CONTAINER_CUSTOMIZER.getBytes(StandardCharsets.UTF_8)),
+				Arguments.of(CONTAINER_CUSTOMIZER,
+						CONTAINER_CUSTOMIZER.getBytes(StandardCharsets.UTF_8)),
 				Arguments.of(POST_PROCESSOR, POST_PROCESSOR.getBytes(StandardCharsets.UTF_8)),
-				Arguments.of(POST_PROCESSOR_MULTI_METHOD, POST_PROCESSOR.getBytes(StandardCharsets.UTF_8)),
-				Arguments.of(CONTAINER_CUSTOMIZER_AND_POST_PROCESSOR, POST_PROCESSOR.getBytes(StandardCharsets.UTF_8)));
+				Arguments.of(POST_PROCESSOR_MULTI_METHOD,
+						POST_PROCESSOR.getBytes(StandardCharsets.UTF_8)),
+				Arguments.of(CONTAINER_CUSTOMIZER_AND_POST_PROCESSOR,
+						POST_PROCESSOR.getBytes(StandardCharsets.UTF_8)));
 	}
 
 	@ParameterizedTest
@@ -77,7 +82,10 @@ class ContainerCustomizationTest {
 		assertThat(listenerContainer.getListenerInfo()).isEqualTo(listenerInfo);
 	}
 
-	@KafkaListener(id = POST_PROCESSOR_MULTI_METHOD, topics = TOPIC, containerPostProcessor = "infoContainerPostProcessor")
+	@KafkaListener(id = POST_PROCESSOR_MULTI_METHOD,
+			topics = TOPIC,
+			containerPostProcessor = "infoContainerPostProcessor"
+	)
 	static class MultiMethodListener {
 
 		@KafkaHandler
@@ -127,7 +135,8 @@ class ContainerCustomizationTest {
 		}
 
 		@Bean
-		public ContainerPostProcessor<String, String, AbstractMessageListenerContainer<String, String>> infoContainerPostProcessor() {
+		public ContainerPostProcessor<String, String, AbstractMessageListenerContainer<String,
+				String>> infoContainerPostProcessor() {
 			return container -> container.setListenerInfo(POST_PROCESSOR.getBytes(StandardCharsets.UTF_8));
 		}
 
@@ -146,7 +155,9 @@ class ContainerCustomizationTest {
 		@Bean
 		public ConcurrentKafkaListenerContainerFactory<String, String> containerFactoryWithCustomizer() {
 			final var containerFactory = createKafkaListenerContainerFactory();
-			containerFactory.setContainerCustomizer(container -> container.setListenerInfo(CONTAINER_CUSTOMIZER.getBytes(StandardCharsets.UTF_8)));
+			containerFactory.setContainerCustomizer(container ->
+					container.setListenerInfo(CONTAINER_CUSTOMIZER.getBytes(StandardCharsets.UTF_8))
+			);
 			return containerFactory;
 		}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ContainerCustomizationTest.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ContainerCustomizationTest.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright 2019-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.annotation.KafkaHandler;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.config.ContainerPostProcessor;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+/**
+ * Tests for container customizations.
+ *
+ * @author Francois Rosiere
+ * @since 3.1.0
+ */
+@SuppressWarnings("unused")
+@SpringJUnitConfig
+@DirtiesContext
+class ContainerCustomizationTest {
+
+	private static final String TOPIC = "foo";
+
+	private static final String DEFAULT_LISTENER = "default-listener";
+	private static final String CONTAINER_CUSTOMIZER = "container-customizer";
+	private static final String POST_PROCESSOR = "post-processor";
+	private static final String POST_PROCESSOR_MULTI_METHOD = "post-processor-multi-method";
+	private static final String CONTAINER_CUSTOMIZER_AND_POST_PROCESSOR = "container-customizer-and-post-processor";
+	@Autowired
+	private ListenerContainerRegistry listenerContainerRegistry;
+
+	private static Stream<Arguments> listenerIdsWithRelatedInfo() {
+		return Stream.of(
+				Arguments.of(DEFAULT_LISTENER, null),
+				Arguments.of(CONTAINER_CUSTOMIZER, CONTAINER_CUSTOMIZER.getBytes(StandardCharsets.UTF_8)),
+				Arguments.of(POST_PROCESSOR, POST_PROCESSOR.getBytes(StandardCharsets.UTF_8)),
+				Arguments.of(POST_PROCESSOR_MULTI_METHOD, POST_PROCESSOR.getBytes(StandardCharsets.UTF_8)),
+				Arguments.of(CONTAINER_CUSTOMIZER_AND_POST_PROCESSOR, POST_PROCESSOR.getBytes(StandardCharsets.UTF_8)));
+	}
+
+	@ParameterizedTest
+	@MethodSource("listenerIdsWithRelatedInfo")
+	void testCustomization(String listenerId, byte[] listenerInfo) {
+		final var listenerContainer = listenerContainerRegistry.getListenerContainer(listenerId);
+		assertThat(listenerContainer).isNotNull();
+		assertThat(listenerContainer.getListenerInfo()).isEqualTo(listenerInfo);
+	}
+
+	@KafkaListener(id = POST_PROCESSOR_MULTI_METHOD, topics = TOPIC, containerPostProcessor = "infoContainerPostProcessor")
+	static class MultiMethodListener {
+
+		@KafkaHandler
+		public void listen(String foo) {
+		}
+
+		@KafkaHandler
+		public void listen(Integer foo) {
+		}
+	}
+
+	@Configuration
+	@EnableKafka
+	static class Config {
+
+		@KafkaListener(
+				id = DEFAULT_LISTENER,
+				topics = TOPIC)
+		public void defaultListener(String foo) {
+		}
+
+		@KafkaListener(
+				id = CONTAINER_CUSTOMIZER,
+				topics = TOPIC,
+				containerFactory = "containerFactoryWithCustomizer")
+		public void containerCustomizer(String foo) {
+		}
+
+		@KafkaListener(
+				id = POST_PROCESSOR,
+				topics = TOPIC,
+				containerPostProcessor = "infoContainerPostProcessor")
+		public void postProcessor(String foo) {
+		}
+
+		@KafkaListener(
+				id = CONTAINER_CUSTOMIZER_AND_POST_PROCESSOR,
+				topics = TOPIC,
+				containerFactory = "containerFactoryWithCustomizer",
+				containerPostProcessor = "infoContainerPostProcessor")
+		public void containerCustomizerAndPostProcessor(String foo) {
+		}
+
+		@Bean
+		public MultiMethodListener multiMethodListener() {
+			return new MultiMethodListener();
+		}
+
+		@Bean
+		public ContainerPostProcessor<String, String, AbstractMessageListenerContainer<String, String>> infoContainerPostProcessor() {
+			return container -> container.setListenerInfo(POST_PROCESSOR.getBytes(StandardCharsets.UTF_8));
+		}
+
+		@Bean
+		@SuppressWarnings("unchecked")
+		public ConsumerFactory<String, String> consumerFactory() {
+			return mock(ConsumerFactory.class);
+		}
+
+		@Bean
+		@Primary
+		public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+			return createKafkaListenerContainerFactory();
+		}
+
+		@Bean
+		public ConcurrentKafkaListenerContainerFactory<String, String> containerFactoryWithCustomizer() {
+			final var containerFactory = createKafkaListenerContainerFactory();
+			containerFactory.setContainerCustomizer(container -> container.setListenerInfo(CONTAINER_CUSTOMIZER.getBytes(StandardCharsets.UTF_8)));
+			return containerFactory;
+		}
+
+		private ConcurrentKafkaListenerContainerFactory<String, String> createKafkaListenerContainerFactory() {
+			final var factory = new ConcurrentKafkaListenerContainerFactory<String, String>();
+			factory.setConsumerFactory(consumerFactory());
+			factory.setAutoStartup(false);
+			return factory;
+		}
+	}
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ContainerCustomizationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ContainerCustomizationTests.java
@@ -43,19 +43,23 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
  * Tests for container customizations.
  *
  * @author Francois Rosiere
- * @since 3.1.0
+ * @since 3.1
  */
 @SuppressWarnings("unused")
 @SpringJUnitConfig
 @DirtiesContext
-class ContainerCustomizationTest {
+class ContainerCustomizationTests {
 
 	private static final String TOPIC = "foo";
 
 	private static final String DEFAULT_LISTENER = "default-listener";
+
 	private static final String CONTAINER_CUSTOMIZER = "container-customizer";
+
 	private static final String POST_PROCESSOR = "post-processor";
+
 	private static final String POST_PROCESSOR_MULTI_METHOD = "post-processor-multi-method";
+
 	private static final String CONTAINER_CUSTOMIZER_AND_POST_PROCESSOR = "container-customizer" +
 			"-and-post-processor";
 


### PR DESCRIPTION
Sorry for the delay. Documentation has not been updated as I didn't know were to put this new feature. 

The ContainerPostProcessor support has been added. This one can be used in addition to the ContainerCustomizer. As the post processor is more specific, it will be applied after the customizer to allow fine grained customization per container.

Let me know if you have any remarks and I will update accordingly. Thanks.

Resolves https://github.com/spring-projects/spring-kafka/issues/2825
