### PR TITLE
bump recommended java version to 17 in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,9 @@ To check out the project and build from source, do the following:
     cd spring-kafka
     ./gradlew build
 
-The Java SE 7 or higher is recommended to build the project.
+Java 17 or later version is recommended to build the project.
 
-If you encounter out of memory errors during the build, increase available heap and permgen for Gradle:
-
-    GRADLE_OPTS='-XX:MaxPermSize=1024m -Xmx1024m'
+If you encounter out of memory errors during the build, tweak the `org.gradle.jvmargs` property in `gradle.properties`.
 
 To build and install jars into your local Maven cache:
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ To check out the project and build from source, do the following:
 
 Java 17 or later version is recommended to build the project.
 
-If you encounter out of memory errors during the build, tweak the `org.gradle.jvmargs` property in `gradle.properties`.
+If you encounter out of memory errors during the build, change the `org.gradle.jvmargs` property in `gradle.properties`.
 
 To build and install jars into your local Maven cache:
 


### PR DESCRIPTION
The Java version in README.md is still JAVA SE 7 or later, as specified in 2016. Seems we'd better bump it as per the version specified in build.gradle (Java 17).

Also perm size is deleted in Java 17, so the previous GRADLE_OPTS example doesn't apply. I changed the verbiage to point to the gradle.properties file.
