### PR TITLE
GH-2870: EmbeddedKafka: register BeanDefinition

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,7 @@ ext {
 	springBootVersion = '3.0.9' // docs module
 	springDataVersion = '2023.1.0-RC1'
 	springRetryVersion = '2.0.4'
-	springVersion = '6.1.0-RC1'
+	springVersion = '6.1.0-SNAPSHOT'
 	zookeeperVersion = '3.6.4'
 
 	idPrefix = 'kafka'

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaKraftBroker.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaKraftBroker.java
@@ -33,6 +33,7 @@ import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -91,6 +92,8 @@ public class EmbeddedKafkaKraftBroker implements EmbeddedKafkaBroker {
 	private final int partitionsPerTopic;
 
 	private final Properties brokerProperties = new Properties();
+
+	private final AtomicBoolean initialized = new AtomicBoolean();
 
 	private KafkaClusterTestKit cluster;
 
@@ -191,9 +194,11 @@ public class EmbeddedKafkaKraftBroker implements EmbeddedKafkaBroker {
 
 	@Override
 	public void afterPropertiesSet() {
-		overrideExitMethods();
-		addDefaultBrokerPropsIfAbsent(this.brokerProperties, this.count);
-		start();
+		if (this.initialized.compareAndSet(false, true)) {
+			overrideExitMethods();
+			addDefaultBrokerPropsIfAbsent(this.brokerProperties, this.count);
+			start();
+		}
 	}
 
 
@@ -232,7 +237,6 @@ public class EmbeddedKafkaKraftBroker implements EmbeddedKafkaBroker {
 			System.setProperty(this.brokerListProperty, getBrokersAsString());
 		}
 		System.setProperty(SPRING_EMBEDDED_KAFKA_BROKERS, getBrokersAsString());
-		System.setProperty(this.brokerListProperty, getBrokersAsString());
 	}
 
 	@Override

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafka.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafka.java
@@ -29,6 +29,7 @@ import org.springframework.core.annotation.AliasFor;
 import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.EmbeddedKafkaZKBroker;
 import org.springframework.kafka.test.condition.EmbeddedKafkaCondition;
+import org.springframework.test.context.aot.DisabledInAotMode;
 
 /**
  * Annotation that can be specified on a test class that runs Spring for Apache Kafka
@@ -72,6 +73,7 @@ import org.springframework.kafka.test.condition.EmbeddedKafkaCondition;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 @Inherited
+@DisabledInAotMode
 public @interface EmbeddedKafka {
 
 	/**

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizer.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizer.java
@@ -126,6 +126,9 @@ class EmbeddedKafkaContextCustomizer implements ContextCustomizer {
 			embeddedKafkaBroker.brokerListProperty(this.embeddedKafka.bootstrapServersProperty());
 		}
 
+		// Safe to start an embedded broker eagerly before context refresh
+		embeddedKafkaBroker.afterPropertiesSet();
+
 		((BeanDefinitionRegistry) beanFactory).registerBeanDefinition(EmbeddedKafkaBroker.BEAN_NAME,
 				new RootBeanDefinition(EmbeddedKafkaBroker.class, () -> embeddedKafkaBroker));
 	}

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizer.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizer.java
@@ -24,7 +24,9 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.DefaultSingletonBeanRegistry;
+import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.core.env.ConfigurableEnvironment;
 import org.springframework.core.io.Resource;
@@ -124,9 +126,8 @@ class EmbeddedKafkaContextCustomizer implements ContextCustomizer {
 			embeddedKafkaBroker.brokerListProperty(this.embeddedKafka.bootstrapServersProperty());
 		}
 
-		beanFactory.initializeBean(embeddedKafkaBroker, EmbeddedKafkaBroker.BEAN_NAME);
-		beanFactory.registerSingleton(EmbeddedKafkaBroker.BEAN_NAME, embeddedKafkaBroker);
-		((DefaultSingletonBeanRegistry) beanFactory).registerDisposableBean(EmbeddedKafkaBroker.BEAN_NAME, embeddedKafkaBroker);
+		((BeanDefinitionRegistry) beanFactory).registerBeanDefinition(EmbeddedKafkaBroker.BEAN_NAME,
+				new RootBeanDefinition(EmbeddedKafkaBroker.class, () -> embeddedKafkaBroker));
 	}
 
 	private int[] setupPorts() {


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-kafka/issues/2870

The `EmbeddedKafkaContextCustomizer` uses `beanFactory.initializeBean()` which is too early according to the `ApplicationContext` lifecycle since it is not refreshed yet for `ContextCustomizer`

* Rework the logic in the `EmbeddedKafkaContextCustomizer` to register a `BeanDefinition` for an `EmbeddedKafkaBroker` to include it into standard `ApplicationContext` lifecycle
* Also mark `@EmbeddedKafka` with a `@DisabledInAotMode` to disallow this kind of tests in native images

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
