### PR TITLE
Improved the immutable field TRUSTED_PACKAGES in the DefaultJackson2JavaTypeMapper class to a List.of method that returns an ImmutableList.

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/mapping/DefaultJackson2JavaTypeMapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/mapping/DefaultJackson2JavaTypeMapper.java
@@ -45,11 +45,7 @@ import com.fasterxml.jackson.databind.type.TypeFactory;
 public class DefaultJackson2JavaTypeMapper extends AbstractJavaTypeMapper
 		implements Jackson2JavaTypeMapper {
 
-	private static final List<String> TRUSTED_PACKAGES =
-			Arrays.asList(
-					"java.util",
-					"java.lang"
-			);
+	private static final List<String> TRUSTED_PACKAGES = List.of("java.util", "java.lang");
 
 	private final Set<String> trustedPackages = new LinkedHashSet<>(TRUSTED_PACKAGES);
 
@@ -78,7 +74,7 @@ public class DefaultJackson2JavaTypeMapper extends AbstractJavaTypeMapper
 	 */
 	@Override
 	public void addTrustedPackages(String... packagesToTrust) {
-		if (this.trustedPackages.size() == 0) {
+		if (this.trustedPackages.isEmpty()) {
 			return;
 		}
 		if (packagesToTrust != null) {


### PR DESCRIPTION
Improvements

1. The Arrays.asList method creates a List based on variable arguments, which can lead to heap pollution, and TRUST_PACKAGES is an immutable field, so it has been improved to utilize Immutable List.

2. Improved to call the empty method to clarify the intent, rather than directly comparing integers to see if the size of a Set is zero.