### PR TITLE
GH-2654: Incorrect retry topic suffix

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -38,3 +38,9 @@ See xref:kafka/container-factory.adoc[Container Factory] for more information.
 You can now add a `Validator` to this deserializer; if the delegate `Deserializer` successfully deserializes the object, but that object fails validation, an exception is thrown similar to a deserialization exception occurring.
 This allows the original raw data to be passed to the error handler.
 See xref:kafka/serdes.adoc#error-handling-deserializer[Using `ErrorHandlingDeserializer`] for more information.
+
+[[x31-retryable]]
+=== Retryable Topics
+Change suffix -retry-5000 to -retry when `@RetryableTopic(backoff = @Backoff(delay = 5000), attempts = "2", fixedDelayTopicStrategy = FixedDelayStrategy.SINGLE_TOPIC)`.
+If you want to keep suffix -retry-5000, use `@RetryableTopic(backoff = @Backoff(delay = 5000), attempts = "2")`.
+See xref:retrytopic/topic-naming.adoc[Topic Naming] for more information.

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -41,6 +41,6 @@ See xref:kafka/serdes.adoc#error-handling-deserializer[Using `ErrorHandlingDeser
 
 [[x31-retryable]]
 === Retryable Topics
-Change suffix -retry-5000 to -retry when `@RetryableTopic(backoff = @Backoff(delay = 5000), attempts = "2", fixedDelayTopicStrategy = FixedDelayStrategy.SINGLE_TOPIC)`.
-If you want to keep suffix -retry-5000, use `@RetryableTopic(backoff = @Backoff(delay = 5000), attempts = "2")`.
+Change suffix `-retry-5000` to `-retry` when `@RetryableTopic(backoff = @Backoff(delay = 5000), attempts = "2", fixedDelayTopicStrategy = FixedDelayStrategy.SINGLE_TOPIC)`.
+If you want to keep suffix `-retry-5000`, use `@RetryableTopic(backoff = @Backoff(delay = 5000), attempts = "2")`.
 See xref:retrytopic/topic-naming.adoc[Topic Naming] for more information.

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryTopicConfigurationProvider.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryTopicConfigurationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,7 +43,7 @@ import org.springframework.kafka.retrytopic.RetryTopicConfiguration;
  * annotation is available.
  *
  * If beans are found in the container there's a check to determine whether or not the
- * provided topics topics should be handled by any of such instances.
+ * provided topics should be handled by any of such instances.
  *
  * If the annotation is provided, a
  * {@link org.springframework.kafka.annotation.DltHandler} annotated method is looked up.

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryableTopic.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryableTopic.java
@@ -181,8 +181,6 @@ public @interface RetryableTopic {
 
 	/**
 	 * Topic reuse strategy for sequential attempts made with a same backoff interval.
-	 *
-	 * <p>Note: for fixed backoffs, when this is configured as
 	 * {@link SameIntervalTopicReuseStrategy#SINGLE_TOPIC}.
 	 * @return the strategy.
 	 * @since 3.0.4

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryableTopic.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryableTopic.java
@@ -183,8 +183,7 @@ public @interface RetryableTopic {
 	 * Topic reuse strategy for sequential attempts made with a same backoff interval.
 	 *
 	 * <p>Note: for fixed backoffs, when this is configured as
-	 * {@link SameIntervalTopicReuseStrategy#SINGLE_TOPIC}, it has precedence over
-	 * the configuration in {@link #fixedDelayTopicStrategy()}.
+	 * {@link SameIntervalTopicReuseStrategy#SINGLE_TOPIC}.
 	 * @return the strategy.
 	 * @since 3.0.4
 	 */

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DestinationTopicPropertiesFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DestinationTopicPropertiesFactory.java
@@ -128,7 +128,7 @@ public class DestinationTopicPropertiesFactory {
 	}
 
 	private boolean isSingleTopicFixedDelay() {
-		return isFixedDelay() && isSingleTopicSameIntervalTopicReuseStrategy();
+		return (this.backOffValues.size() == 1 || isFixedDelay()) && isSingleTopicSameIntervalTopicReuseStrategy();
 	}
 
 	private boolean isSingleTopicSameIntervalTopicReuseStrategy() {
@@ -220,8 +220,7 @@ public class DestinationTopicPropertiesFactory {
 	}
 
 	private boolean isDelayWithReusedTopic(Long backoffValue) {
-		return ((isSingleTopicFixedDelay()) ||
-				(hasDuplicates(backoffValue) && isSingleTopicSameIntervalTopicReuseStrategy()));
+		return hasDuplicates(backoffValue) && isSingleTopicSameIntervalTopicReuseStrategy();
 	}
 
 	private int getIndexInBackoffValues(int indexInBackoffValues, Long thisBackOffValue) {


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2654

* fix incorrect retry topic suffix when attempts is 2

* optimization method `isDelayWithReusedTopic`

* add retry topic integration tests when reuse retry topic

fix java doc in RetryTopic

* fix javadoc in `@RetryTopic`

* fix javadoc in `RetryTopicConfigurationProvider`
