### PR TITLE
Free exceptions from ConsumerAwareRebalanceListener

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerAwareRebalanceListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerAwareRebalanceListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 the original author or authors.
+ * Copyright 2017-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,12 +18,9 @@ package org.springframework.kafka.listener;
 
 import java.util.Collection;
 
-import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.common.TopicPartition;
-
-import org.springframework.core.log.LogAccessor;
 
 /**
  * A rebalance listener that provides access to the consumer object. Starting with version
@@ -36,10 +33,6 @@ import org.springframework.core.log.LogAccessor;
  */
 public interface ConsumerAwareRebalanceListener extends ConsumerRebalanceListener {
 
-	/**
-	 * {@link LogAccessor} for use in default methods.
-	 */
-	LogAccessor LOGGER = new LogAccessor(LogFactory.getLog(ConsumerAwareRebalanceListener.class));
 
 	/**
 	 * The same as {@link #onPartitionsRevoked(Collection)} with the additional consumer
@@ -48,12 +41,7 @@ public interface ConsumerAwareRebalanceListener extends ConsumerRebalanceListene
 	 * @param partitions the partitions.
 	 */
 	default void onPartitionsRevokedBeforeCommit(Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {
-		try {
-			onPartitionsRevoked(partitions);
-		}
-		catch (Exception e) { // NOSONAR
-			LOGGER.error(e, "User method threw exception");
-		}
+		onPartitionsRevoked(partitions);
 	}
 
 	/**
@@ -72,12 +60,7 @@ public interface ConsumerAwareRebalanceListener extends ConsumerRebalanceListene
 	 * @since 2.4
 	 */
 	default void onPartitionsLost(Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {
-		try {
-			onPartitionsLost(partitions);
-		}
-		catch (Exception e) { // NOSONAR
-			LOGGER.error(e, "User method threw exception");
-		}
+		onPartitionsLost(partitions);
 	}
 
 	/**
@@ -87,12 +70,7 @@ public interface ConsumerAwareRebalanceListener extends ConsumerRebalanceListene
 	 * @param partitions the partitions.
 	 */
 	default void onPartitionsAssigned(Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {
-		try {
-			onPartitionsAssigned(partitions);
-		}
-		catch (Exception e) { // NOSONAR
-			LOGGER.error(e, "User method threw exception");
-		}
+		onPartitionsAssigned(partitions);
 	}
 
 	@Override

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ConsumerAwareRebalanceListenerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ConsumerAwareRebalanceListenerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2021-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,20 +45,6 @@ public class ConsumerAwareRebalanceListenerTests {
 		assertThat(called.get()).isTrue();
 	}
 
-	@Test
-	void nonConsumerAwareTestAssignedThrows() {
-		AtomicBoolean called = new AtomicBoolean();
-		new ConsumerAwareRebalanceListener() {
-
-			@Override
-			public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
-				called.set(true);
-				throw new RuntimeException();
-			}
-
-		}.onPartitionsAssigned(null, null);
-		assertThat(called.get()).isTrue();
-	}
 
 	@Test
 	void nonConsumerAwareTestRevoked() {
@@ -74,20 +60,6 @@ public class ConsumerAwareRebalanceListenerTests {
 		assertThat(called.get()).isTrue();
 	}
 
-	@Test
-	void nonConsumerAwareTestRevokedThrows() {
-		AtomicBoolean called = new AtomicBoolean();
-		new ConsumerAwareRebalanceListener() {
-
-			@Override
-			public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
-				called.set(true);
-				throw new RuntimeException();
-			}
-
-		}.onPartitionsRevokedBeforeCommit(null, null);
-		assertThat(called.get()).isTrue();
-	}
 
 	@Test
 	void nonConsumerAwareTestLost() {
@@ -97,21 +69,6 @@ public class ConsumerAwareRebalanceListenerTests {
 			@Override
 			public void onPartitionsLost(Collection<TopicPartition> partitions) {
 				called.set(true);
-			}
-
-		}.onPartitionsLost(null, null);
-		assertThat(called.get()).isTrue();
-	}
-
-	@Test
-	void nonConsumerAwareTestLostThrows() {
-		AtomicBoolean called = new AtomicBoolean();
-		new ConsumerAwareRebalanceListener() {
-
-			@Override
-			public void onPartitionsLost(Collection<TopicPartition> partitions) {
-				called.set(true);
-				throw new RuntimeException();
 			}
 
 		}.onPartitionsLost(null, null);


### PR DESCRIPTION
org.apache.kafka.clients.consumer.internals.ConsumerCoordinator has logic to handle exception thrown by rebalance listener.

`firstException.compareAndSet(null, invokePartitionsAssigned(addedPartitions));`

If listener throws exception, it will be called again.

Moreover, particular exceptions, like `WakeupException` are contracted in Javadoc.

There is no need to hide from Kafka code problems, because Kafka have policy to manage problems.

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
