### PR TITLE
make EmbeddedKafkaBroker.BROKER_LIST_PROPERTY take precedence to default one

### DIFF
--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaKraftBroker.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaKraftBroker.java
@@ -76,12 +76,6 @@ public class EmbeddedKafkaKraftBroker implements EmbeddedKafkaBroker {
 
 	private static final LogAccessor LOGGER = new LogAccessor(LogFactory.getLog(EmbeddedKafkaKraftBroker.class));
 
-	/**
-	 * Set the value of this property to a property name that should be set to the list of
-	 * embedded broker addresses instead of {@value #SPRING_EMBEDDED_KAFKA_BROKERS}.
-	 */
-	public static final String BROKER_LIST_PROPERTY = "spring.embedded.kafka.brokers.property";
-
 	public static final int DEFAULT_ADMIN_TIMEOUT = 10;
 
 	private final int count;
@@ -225,14 +219,17 @@ public class EmbeddedKafkaKraftBroker implements EmbeddedKafkaBroker {
 		}
 
 		createKafkaTopics(this.topics);
-		if (this.brokerListProperty == null) {
-			this.brokerListProperty = System.getProperty(BROKER_LIST_PROPERTY);
-		}
+
+		String brokersAsString = getBrokersAsString();
 		if (this.brokerListProperty != null) {
-			System.setProperty(this.brokerListProperty, getBrokersAsString());
+			System.setProperty(this.brokerListProperty, brokersAsString);
 		}
-		System.setProperty(SPRING_EMBEDDED_KAFKA_BROKERS, getBrokersAsString());
-		System.setProperty(this.brokerListProperty, getBrokersAsString());
+		String globalBrokerListProperty = System.getProperties().containsKey(BROKER_LIST_PROPERTY)
+				? System.getProperties().getProperty(BROKER_LIST_PROPERTY)
+				: SPRING_EMBEDDED_KAFKA_BROKERS;
+		if (!globalBrokerListProperty.equals(this.brokerListProperty)) {
+			System.setProperty(globalBrokerListProperty, brokersAsString);
+		}
 	}
 
 	@Override

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaZKBroker.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaZKBroker.java
@@ -320,13 +320,17 @@ public class EmbeddedKafkaZKBroker implements EmbeddedKafkaBroker {
 			}
 		}
 		createKafkaTopics(this.topics);
-		if (this.brokerListProperty == null) {
-			this.brokerListProperty = System.getProperty(BROKER_LIST_PROPERTY);
-		}
+
+		String brokersAsString = getBrokersAsString();
 		if (this.brokerListProperty != null) {
-			System.setProperty(this.brokerListProperty, getBrokersAsString());
+			System.setProperty(this.brokerListProperty, brokersAsString);
 		}
-		System.setProperty(SPRING_EMBEDDED_KAFKA_BROKERS, getBrokersAsString());
+		String globalBrokerListProperty = System.getProperties().containsKey(BROKER_LIST_PROPERTY)
+				? System.getProperties().getProperty(BROKER_LIST_PROPERTY)
+				: SPRING_EMBEDDED_KAFKA_BROKERS;
+		if (!globalBrokerListProperty.equals(this.brokerListProperty)) {
+			System.setProperty(globalBrokerListProperty, brokersAsString);
+		}
 		System.setProperty(SPRING_EMBEDDED_ZOOKEEPER_CONNECT, getZookeeperConnectionString());
 	}
 


### PR DESCRIPTION
As per the javadoc:

> Instead of default spring.embedded.kafka.brokers system property, the address of the Kafka brokers can be exposed to any arbitrary and convenient property. For this purpose a spring.embedded.kafka.brokers.property (EmbeddedKafkaBroker.BROKER_LIST_PROPERTY) system property can be set before starting an embedded Kafka.

Literally it seems to imply when `spring.embedded.kafka.brokers.property ` is set, the default `spring.embedded.kafka.brokers` system property should not be set; but it seems regardless, the default is still set

Not 100% sure about my code changes and even my understanding is correct.