### PR TITLE
GH-2891: Always MANUAL with null group.id

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/tips.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/tips.adoc
@@ -44,6 +44,7 @@ public static class PartitionFinder {
 
 Using this in conjunction with `ConsumerConfig.AUTO_OFFSET_RESET_CONFIG=earliest` will load all records each time the application is started.
 You should also set the container's `AckMode` to `MANUAL` to prevent the container from committing offsets for a `null` consumer group.
+Starting with version 3.1, the container will automatically coerce the `AckMode` to `MANUAL` when manual topic assignment is used with no consumer `group.id`.
 However, starting with version 2.5.5, as shown above, you can apply an initial offset to all partitions; see xref:kafka/receiving-messages/listener-annotation.adoc#manual-assignment[Explicit Partition Assignment] for more information.
 
 [[ex-jdbc-sync]]

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -44,3 +44,9 @@ See xref:kafka/serdes.adoc#error-handling-deserializer[Using `ErrorHandlingDeser
 Change suffix `-retry-5000` to `-retry` when `@RetryableTopic(backoff = @Backoff(delay = 5000), attempts = "2", fixedDelayTopicStrategy = FixedDelayStrategy.SINGLE_TOPIC)`.
 If you want to keep suffix `-retry-5000`, use `@RetryableTopic(backoff = @Backoff(delay = 5000), attempts = "2")`.
 See xref:retrytopic/topic-naming.adoc[Topic Naming] for more information.
+
+[[x31-c]]
+=== Listener Container Changes
+
+When manually assigning partitions, with a `null` consumer `group.id`, the `AckMode` is now automatically coerced to `MANUAL`.
+See xref:tips.adoc#tip-assign-all-parts[Manually Assigning All Partitions] for more information.


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-kafka/issues/2891

When using manual partition assignment with `null` `group.id` always coerce `AckMode` to `MANUAL`.
