### PR TITLE
Improve Documentation: State on OOO-Commits page that AsyncAcks cannot be combined with nack()

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/receiving-messages/ooo-commits.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/receiving-messages/ooo-commits.adoc
@@ -9,3 +9,5 @@ The consumer will be paused (no new records delivered) until all the offsets for
 
 IMPORTANT: While this feature allows applications to process records asynchronously, it should be understood that it increases the possibility of duplicate deliveries after a failure.
 
+IMPORTANT: When `asyncAcks` is activated, it is not possible to use `nack()` (negative acknowledgments) when xref:kafka/receiving-messages/message-listener-container.adoc#committing-offsets[Committing Offsets].
+


### PR DESCRIPTION
This PR adds a note to the [documentation page](https://github.com/spring-projects/spring-kafka/blob/main/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/receiving-messages/ooo-commits.adoc) about `asyncAck` stating that it cannot be combined with `Acknowledgment.nack()`.

It was discussed in issue #2410, that `Acknowledgment.nack()` cannot be used when `asyncAck` set to `true`.
This was ensured with [: Disallow nack() with Out of Order Commits](https://github.com/garyrussell/spring-kafka/commit/18398517ee4bdcd05822319dabfad94b629bf9e8).
It was also documented at several places, e.g., with this commit: [: Disallow nack() with Out of Order Commits](https://github.com/spring-projects/spring-kafka/commit/950a2ea75cc4da9524ab275abe43d2a860380482).

However, it is not mentioned on the documentation page about out-of-order commits and `asyncAcks` that this cannot be combined with `nack()`. This note is important, because if a user plans to set `asyncAcks` to `true`, he should be made aware that `Acknowledgment.nack()` must not be used.

This note would have saved us some time. It would be great to see it added to the documentation.

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
