### PR TITLE
Improve Documentation about Acknowledgment.nack()

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/receiving-messages/message-listener-container.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/receiving-messages/message-listener-container.adoc
@@ -233,6 +233,8 @@ With a record listener, when `nack()` is called, any pending offsets are committ
 The consumer can be paused before redelivery, by setting the `sleep` argument.
 This is similar functionality to throwing an exception when the container is configured with a `DefaultErrorHandler`.
 
+IMPORTANT: `nack()` pauses the entire listener for the specified sleep duration including all assigned partitions.
+
 When using a batch listener, you can specify the index within the batch where the failure occurred.
 When `nack()` is called, offsets will be committed for records before the index and seeks are performed on the partitions for the failed and discarded records so that they will be redelivered on the next `poll()`.
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/Acknowledgment.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/Acknowledgment.java
@@ -41,7 +41,9 @@ public interface Acknowledgment {
 	/**
 	 * Negatively acknowledge the current record - discard remaining records from the poll
 	 * and re-seek all partitions so that this record will be redelivered after the sleep
-	 * duration. Must be called on the consumer thread.
+	 * duration. This will pause reading for the entire message listener for the specified
+	 * sleep duration and is not limited to a single partition.
+	 * Must be called on the consumer thread.
 	 * <p>
 	 * @param sleep the duration to sleep; the actual sleep time will be larger of this value
 	 * and the container's {@code maxPollInterval}, which defaults to 5 seconds.


### PR DESCRIPTION
From the current documentation, it was not clear to me what is the effect of calling `Acknowledgment.nack()` when a listener is assigned to multiple topics and/or partitions.

Looking at the implementation, I believe that calling `nack(Duration sleep)` will pause the entire listener for the specified sleep duration. Another option would have been that is only pauses reading from one partition or one topic, which other topics or partitions are still processed.

With this PR, I attempt to make this more clear on the documentation page and in the JavaDoc of `Acknowledgment.nack()`. 

Please feel free to discuss, improve and correct me in case I'm wrong. Thank you!

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
