### PR TITLE
fix some defects of setting default Message headers in MessagingMessageListenerAdapter

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
@@ -484,8 +484,9 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 				}
 				if (iterableOfMessages || this.splitIterables) {
 					((Iterable<V>) result).forEach(v -> {
-						if (v instanceof Message) {
-							this.replyTemplate.send((Message<?>) v);
+						if (v instanceof Message<?> mv) {
+							Message<?> aReply = checkHeaders(mv, topic, source);
+							this.replyTemplate.send(aReply);
 						}
 						else {
 							this.replyTemplate.send(topic, v);
@@ -506,9 +507,9 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 		MessageHeaders headers = reply.getHeaders();
 		boolean needsTopic = topic != null && headers.get(KafkaHeaders.TOPIC) == null;
 		boolean sourceIsMessage = source instanceof Message;
-		boolean needsCorrelation = sourceIsMessage && headers.get(this.correlationHeaderName) == null
+		boolean needsCorrelation = headers.get(this.correlationHeaderName) == null && sourceIsMessage
 				&& getCorrelation((Message<?>) source) != null;
-		boolean needsPartition = sourceIsMessage && headers.get(KafkaHeaders.PARTITION) == null
+		boolean needsPartition = headers.get(KafkaHeaders.PARTITION) == null && sourceIsMessage
 				&& getReplyPartition((Message<?>) source) != null;
 		if (needsTopic || needsCorrelation || needsPartition) {
 			MessageBuilder<?> builder = MessageBuilder.fromMessage(reply);

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
@@ -80,6 +80,7 @@ import org.springframework.util.StringUtils;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Venil Noronha
+ * @author Nathan Xu
  */
 public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerSeekAware {
 
@@ -514,11 +515,11 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 			if (needsTopic) {
 				builder.setHeader(KafkaHeaders.TOPIC, topic);
 			}
-			if (needsCorrelation && sourceIsMessage) {
+			if (needsCorrelation) {
 				builder.setHeader(this.correlationHeaderName,
 						((Message<?>) source).getHeaders().get(this.correlationHeaderName));
 			}
-			if (sourceIsMessage && reply.getHeaders().get(KafkaHeaders.REPLY_PARTITION) == null) {
+			if (needsPartition) {
 				setPartition(builder, (Message<?>) source);
 			}
 			reply = builder.build();


### PR DESCRIPTION
This PR aims to fix some minor defects in MessagingMessageListenerAdapter, including:

- improved the `checkHeaders()` method
- added the logic to apply `checkHeaders()` to Message element in Collection type return of method annotated with `@SendTo`
- added a unit testing case covering default header setting for `Iterable<Message<?>>` return type
