### PR TITLE
eliminate the usage of StringBuffer

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ErrorHandlingUtils.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ErrorHandlingUtils.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.BiConsumer;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -189,12 +191,9 @@ public final class ErrorHandlingUtils {
 	 * @return the String.
 	 */
 	public static String recordsToString(ConsumerRecords<?, ?> records) {
-		StringBuffer sb = new StringBuffer();
-		records.spliterator().forEachRemaining(rec -> sb
-				.append(KafkaUtils.format(rec))
-				.append(','));
-		sb.deleteCharAt(sb.length() - 1);
-		return sb.toString();
+		return StreamSupport.stream(records.spliterator(), false)
+				.map(KafkaUtils::format)
+				.collect(Collectors.joining(","));
 	}
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/LoggingProducerListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/LoggingProducerListener.java
@@ -69,7 +69,7 @@ public class LoggingProducerListener<K, V> implements ProducerListener<K, V> {
 	@Override
 	public void onError(ProducerRecord<K, V> record, @Nullable RecordMetadata recordMetadata, Exception exception) {
 		this.logger.error(exception, () -> {
-			StringBuffer logOutput = new StringBuffer();
+			StringBuilder logOutput = new StringBuilder();
 			logOutput.append("Exception thrown when sending a message");
 			if (this.includeContents) {
 				logOutput.append(" with key='")


### PR DESCRIPTION
There are two usages of `StringBuffer`. This PR aims to either replace it with more appropriate and efficient `StringBuilder` or simply eliminate its usage if better alternative exists.
