### PR TITLE
GH-2852: support fixed transaction id suffix

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/transactions.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/transactions.adoc
@@ -102,10 +102,39 @@ NOTE: If there is a `KafkaTransactionManager` (or synchronized) transaction in p
 Instead, a new "nested" transaction is used.
 
 [[transaction-id-prefix]]
-== `transactionIdPrefix`
+== `TransactionIdPrefix`
 
 With `EOSMode.V2` (aka `BETA`), the only supported mode, it is no longer necessary to use the same `transactional.id`, even for consumer-initiated transactions; in fact, it must be unique on each instance the same as for producer-initiated transactions.
 This property must have a different value on each application instance.
+
+[[transaction-id-suffix-fixed]]
+== `TransactionIdSuffix Fixed`
+
+Since 3.1, when setting `maxCache` greater than zero can reuse `transactional.id` within a specific range.
+When a transaction producer is requested and `transactional.id` all in use, throw a `NoProducerAvailableException`.
+User can use then use a RetryTemplate configured to retry that exception, with a suitably configured back off.
+
+[source, java]
+----
+public static class Config {
+
+    @Bean
+    public ProducerFactory<String, String> myProducerFactory() {
+        Map<String, Object> configs = producerConfigs();
+        configs.put(ProducerConfig.CLIENT_ID_CONFIG, "myClientId");
+        ...
+        DefaultKafkaProducerFactory<String, String> pf = new DefaultKafkaProducerFactory<>(configs);
+        ...
+        pf.setTransactionIdPrefix("my.txid.");
+        pf.setMaxCache(5);
+        return pf;
+    }
+
+}
+----
+When setting `maxCache` to 5, `transactional.id` is `my.txid.`++`{0-4}`+.
+
+IMPORTANT: When use `KafkaTransactionManager` in the `ConcurrentMessageListenerContainer`, `maxCache` must be greater than `concurrency`, also be careful nested transaction.
 
 [[tx-template-mixed]]
 == `KafkaTemplate` Transactional and non-Transactional Publishing

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/transactions.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/transactions.adoc
@@ -108,11 +108,11 @@ With `EOSMode.V2` (aka `BETA`), the only supported mode, it is no longer necessa
 This property must have a different value on each application instance.
 
 [[transaction-id-suffix-fixed]]
-== `TransactionIdSuffix Fixed`
+== `TransactionIdSuffix` Fixed
 
 Since 3.1, when setting `maxCache` greater than zero can reuse `transactional.id` within a specific range.
 When a transaction producer is requested and `transactional.id` all in use, throw a `NoProducerAvailableException`.
-User can use then use a RetryTemplate configured to retry that exception, with a suitably configured back off.
+We can then use a RetryTemplate configured to retry that exception, with a suitably configured back off.
 
 [source, java]
 ----
@@ -134,7 +134,10 @@ public static class Config {
 ----
 When setting `maxCache` to 5, `transactional.id` is `my.txid.`++`{0-4}`+.
 
-IMPORTANT: When use `KafkaTransactionManager` in the `ConcurrentMessageListenerContainer`, `maxCache` must be greater than `concurrency`, also be careful nested transaction.
+IMPORTANT: When use `KafkaTransactionManager` in the `ConcurrentMessageListenerContainer` and enable `maxCache`, `maxCache` must be greater than or equal to `concurrency`.
+If some `MessageListenerContainer` cannot get the transaction, will throw `NoProducerAvailableException`.
+When use nested transactions in `ConcurrentMessageListenerContainer`, `maxCache` needs to increase the number of nested transactions.
+
 
 [[tx-template-mixed]]
 == `KafkaTemplate` Transactional and non-Transactional Publishing

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -50,3 +50,9 @@ See xref:retrytopic/topic-naming.adoc[Topic Naming] for more information.
 
 When manually assigning partitions, with a `null` consumer `group.id`, the `AckMode` is now automatically coerced to `MANUAL`.
 See xref:tips.adoc#tip-assign-all-parts[Manually Assigning All Partitions] for more information.
+
+[[x31-dkpf]]
+=== DefaultKafkaProducerFactory
+
+When setting `maxCache` with `transactionIdPrefix`, can restrict `transaction.id` in range.
+See xref:kafka/transactions.adoc#transaction-id-suffix-fixed[Fixed TransactionIdSuffix] for more information.

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
@@ -424,6 +424,15 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 		return this.transactionIdPrefix;
 	}
 
+	public final boolean initTransactionIdSuffix(int transactionIdSuffix) {
+		Assert.isTrue(transactionIdSuffix >= 0, "'transactionIdSuffix' initial value must greater than or equal 0");
+		return this.transactionIdSuffix.compareAndSet(0, transactionIdSuffix);
+	}
+
+	public int getCurrTransactionIdSuffix() {
+		return this.transactionIdSuffix.get();
+	}
+
 	/**
 	 * Set to true to create a producer per thread instead of singleton that is shared by
 	 * all clients. Clients <b>must</b> call {@link #closeThreadBoundProducer()} to
@@ -498,7 +507,7 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 	 * @since 3.1
 	 */
 	public void setMaxCache(int maxCache) {
-		Assert.isTrue(maxCache >= 0, "max cache must greater than or equal 0");
+		Assert.isTrue(maxCache >= 0, "'maxCache' must greater than or equal 0");
 		this.maxCache = maxCache;
 	}
 
@@ -868,7 +877,7 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 						() -> "No suffix cache found for " + txIdPrefix + ", max cache" + this.maxCache);
 				suffix = suffixQueue.poll();
 				if (suffix == null) {
-					throw new NoProducerAvailableException("No transaction producer available for " + txIdPrefix);
+					throw new NoProducerAvailableException("No available transaction producer suffix for " + txIdPrefix);
 				}
 			}
 			else {

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/NoProducerAvailableException.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/NoProducerAvailableException.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.core;
+
+import org.springframework.lang.Nullable;
+
+/**
+ * An exception thrown by no transaction producer available exception, when set
+ * {@link DefaultKafkaProducerFactory} maxCache greater than 0.
+ *
+ * @author Wang Zhiyang
+ * @since 3.1.1
+ *
+ */
+public class NoProducerAvailableException extends RuntimeException {
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Constructs a new no producer available exception with the specified detail message and cause.
+	 * @param message the message.
+	 */
+	public NoProducerAvailableException(String message) {
+		this(message, null);
+	}
+
+	/**
+	 * Constructs a new no producer available exception with the specified detail message and cause.
+	 * @param message the message.
+	 * @param cause the cause.
+	 */
+	public NoProducerAvailableException(String message, @Nullable Throwable cause) {
+		super(message, cause);
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -926,7 +926,6 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			if (this.containerProperties.isLogContainerConfig()) {
 				this.logger.info(toString());
 			}
-			Map<String, Object> props = KafkaMessageListenerContainer.this.consumerFactory.getConfigurationProperties();
 			ApplicationContext applicationContext = getApplicationContext();
 			this.checkNullKeyForExceptions = this.containerProperties.isCheckDeserExWhenKeyNull()
 					|| ErrorHandlingUtils.checkDeserializer(KafkaMessageListenerContainer.this.consumerFactory,

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
@@ -376,6 +376,59 @@ public class DefaultKafkaConsumerFactoryTests {
 		}
 	}
 
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testNestedTxProducerIsFixed() throws Exception {
+		Map<String, Object> producerProps = KafkaTestUtils.producerProps(this.embeddedKafka);
+		DefaultKafkaProducerFactory<Integer, String> pf = new DefaultKafkaProducerFactory<>(producerProps);
+		KafkaTemplate<Integer, String> template = new KafkaTemplate<>(pf);
+		DefaultKafkaProducerFactory<Integer, String> pfTx = new DefaultKafkaProducerFactory<>(producerProps);
+		pfTx.setTransactionIdPrefix("fooTx.fixed.");
+		pfTx.setMaxCache(3);
+		KafkaOperations<Integer, String> templateTx = new KafkaTemplate<>(pfTx);
+		Map<String, Object> consumerProps = KafkaTestUtils.consumerProps("txCache1FixedGroup", "false", this.embeddedKafka);
+		DefaultKafkaConsumerFactory<Integer, String> cf = new DefaultKafkaConsumerFactory<>(consumerProps);
+		AtomicReference<Consumer<Integer, String>> wrapped = new AtomicReference<>();
+		cf.addPostProcessor(consumer -> {
+			ProxyFactory prox = new ProxyFactory();
+			prox.setTarget(consumer);
+			@SuppressWarnings("unchecked")
+			Consumer<Integer, String> proxy = (Consumer<Integer, String>) prox.getProxy();
+			wrapped.set(proxy);
+			return proxy;
+		});
+		ContainerProperties containerProps = new ContainerProperties("txCache1Fixed");
+		CountDownLatch latch = new CountDownLatch(1);
+		containerProps.setMessageListener((MessageListener<Integer, String>) r -> {
+			templateTx.executeInTransaction(t -> t.send("txCacheSendFromListener", "bar"));
+			templateTx.executeInTransaction(t -> t.send("txCacheSendFromListener", "baz"));
+			latch.countDown();
+		});
+		KafkaTransactionManager<Integer, String> tm = new KafkaTransactionManager<>(pfTx);
+		containerProps.setTransactionManager(tm);
+		KafkaMessageListenerContainer<Integer, String> container = new KafkaMessageListenerContainer<>(cf,
+				containerProps);
+		container.start();
+		try {
+			CompletableFuture<SendResult<Integer, String>> future = template.send("txCache1Fixed", "foo");
+			future.get(10, TimeUnit.SECONDS);
+			pf.getCache();
+			assertThat(KafkaTestUtils.getPropertyValue(pf, "cache", Map.class)).hasSize(0);
+			assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
+			assertThat(KafkaTestUtils.getPropertyValue(pfTx, "cache", Map.class)).hasSize(1);
+			assertThat(pfTx.getCache()).hasSize(1);
+			assertThat(KafkaTestUtils.getPropertyValue(pfTx, "suffixCache", Map.class)).hasSize(1);
+			//  1 tm tx producer and 1 templateTx tx producer
+			assertThat(pfTx.getSuffixCache()).hasSize(1);
+			assertThat(KafkaTestUtils.getPropertyValue(container, "listenerConsumer.consumer")).isSameAs(wrapped.get());
+		}
+		finally {
+			container.stop();
+			pf.destroy();
+			pfTx.destroy();
+		}
+	}
+
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
 	void listener() {

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTransactionTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTransactionTests.java
@@ -93,17 +93,18 @@ import org.springframework.transaction.support.TransactionTemplate;
  *
  */
 @EmbeddedKafka(topics = { KafkaTemplateTransactionTests.STRING_KEY_TOPIC,
-		KafkaTemplateTransactionTests.LOCAL_TX_IN_TOPIC }, brokerProperties = {
-				"transaction.state.log.replication.factor=1", "transaction.state.log.min.isr=1" })
+		KafkaTemplateTransactionTests.LOCAL_TX_IN_TOPIC, KafkaTemplateTransactionTests.LOCAL_FIXED_TX_IN_TOPIC },
+		brokerProperties = { "transaction.state.log.replication.factor=1", "transaction.state.log.min.isr=1" })
 public class KafkaTemplateTransactionTests {
 
 	public static final String STRING_KEY_TOPIC = "stringKeyTopic";
 
 	public static final String LOCAL_TX_IN_TOPIC = "localTxInTopic";
 
+	public static final String LOCAL_FIXED_TX_IN_TOPIC = "localFixedTxInTopic";
+
 	private final EmbeddedKafkaBroker embeddedKafka = EmbeddedKafkaCondition.getBroker();
 
-	@SuppressWarnings("deprecation")
 	@Test
 	public void testLocalTransaction() {
 		Map<String, Object> senderProps = KafkaTestUtils.producerProps(embeddedKafka);
@@ -118,7 +119,7 @@ public class KafkaTemplateTransactionTests {
 		DefaultKafkaConsumerFactory<String, String> cf = new DefaultKafkaConsumerFactory<>(consumerProps);
 		cf.setKeyDeserializer(new StringDeserializer());
 		Consumer<String, String> consumer = cf.createConsumer();
-		embeddedKafka.consumeFromAllEmbeddedTopics(consumer);
+		embeddedKafka.consumeFromEmbeddedTopics(consumer, STRING_KEY_TOPIC, LOCAL_TX_IN_TOPIC);
 		template.executeInTransaction(kt -> kt.send(LOCAL_TX_IN_TOPIC, "one"));
 		ConsumerRecord<String, String> singleRecord = KafkaTestUtils.getSingleRecord(consumer, LOCAL_TX_IN_TOPIC);
 		template.executeInTransaction(t -> {
@@ -157,6 +158,67 @@ public class KafkaTemplateTransactionTests {
 		assertThat(pf.getCache("tx.template.override.")).hasSize(1);
 		pf.destroy();
 		assertThat(pf.getCache()).hasSize(0);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testLocalTransactionIsFixed() {
+		Map<String, Object> senderProps = KafkaTestUtils.producerProps(embeddedKafka);
+		senderProps.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "my.transaction.fixed.");
+		senderProps.put(ProducerConfig.CLIENT_ID_CONFIG, "customClientIdFixed");
+		DefaultKafkaProducerFactory<String, String> pf = new DefaultKafkaProducerFactory<>(senderProps);
+		pf.setKeySerializer(new StringSerializer());
+		pf.setMaxCache(3);
+		KafkaTemplate<String, String> template = new KafkaTemplate<>(pf);
+		template.setDefaultTopic(STRING_KEY_TOPIC);
+		Map<String, Object> consumerProps = KafkaTestUtils.consumerProps("testLocalTxFixed", "false", embeddedKafka);
+		consumerProps.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
+		DefaultKafkaConsumerFactory<String, String> cf = new DefaultKafkaConsumerFactory<>(consumerProps);
+		cf.setKeyDeserializer(new StringDeserializer());
+		Consumer<String, String> consumer = cf.createConsumer();
+		embeddedKafka.consumeFromEmbeddedTopics(consumer, STRING_KEY_TOPIC, LOCAL_FIXED_TX_IN_TOPIC);
+		template.executeInTransaction(kt -> kt.send(LOCAL_FIXED_TX_IN_TOPIC, "one")); // suffix range {0-2}
+		ConsumerRecord<String, String> singleRecord = KafkaTestUtils.getSingleRecord(consumer, LOCAL_FIXED_TX_IN_TOPIC);
+		template.executeInTransaction(t -> {
+			pf.createProducer("testCustomClientIdIsUniqueFixed").close(); // suffix range {3-5}
+			t.sendDefault("foo", "bar");
+			t.sendDefault("baz", "qux");
+			t.sendOffsetsToTransaction(Collections.singletonMap(
+					new TopicPartition(LOCAL_FIXED_TX_IN_TOPIC, singleRecord.partition()),
+					new OffsetAndMetadata(singleRecord.offset() + 1L)), consumer.groupMetadata());
+			assertThat(KafkaTestUtils.getPropertyValue(
+					KafkaTestUtils.getPropertyValue(template, "producers", Map.class).get(Thread.currentThread()),
+					"delegate.transactionManager.transactionalId")).isEqualTo("my.transaction.fixed.0");
+			return null;
+		});
+		ConsumerRecords<String, String> records = KafkaTestUtils.getRecords(consumer);
+		Iterator<ConsumerRecord<String, String>> iterator = records.iterator();
+		ConsumerRecord<String, String> record = iterator.next();
+		assertThat(record).has(Assertions.<ConsumerRecord<String, String>>allOf(key("foo"), value("bar")));
+		if (!iterator.hasNext()) {
+			records = KafkaTestUtils.getRecords(consumer);
+			iterator = records.iterator();
+		}
+		record = iterator.next();
+		assertThat(record).has(Assertions.<ConsumerRecord<String, String>>allOf(key("baz"), value("qux")));
+		// 2 log slots, 1 for the record, 1 for the commit
+		assertThat(consumer.position(new TopicPartition(LOCAL_FIXED_TX_IN_TOPIC, singleRecord.partition()))).isEqualTo(2L);
+		consumer.close();
+		assertThat(pf.getCache()).hasSize(1);
+		template.setTransactionIdPrefix("tx.template.override.fixed."); // suffix range {6-8}
+		template.executeInTransaction(t -> {
+			assertThat(KafkaTestUtils.getPropertyValue(
+					KafkaTestUtils.getPropertyValue(template, "producers", Map.class).get(Thread.currentThread()),
+					"delegate.transactionManager.transactionalId")).isEqualTo("tx.template.override.fixed.6");
+			return null;
+		});
+		assertThat(pf.getCache("tx.template.override.fixed.")).hasSize(1);
+		assertThat(pf.getSuffixCache("tx.template.override.fixed.")).hasSize(2);
+		assertThat(pf.getCache("testCustomClientIdIsUniqueFixed")).hasSize(1);
+		assertThat(pf.getSuffixCache("testCustomClientIdIsUniqueFixed")).hasSize(2);
+		pf.destroy();
+		assertThat(pf.getCache()).hasSize(0);
+		assertThat(KafkaTestUtils.getPropertyValue(pf, "suffixCache", Map.class)).hasSize(0);
 	}
 
 	@Test

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/TransactionalContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/TransactionalContainerTests.java
@@ -496,12 +496,11 @@ public class TransactionalContainerTests {
 		verify(pf).createProducer(isNull());
 	}
 
-	@SuppressWarnings({ "unchecked", "deprecation" })
+	@SuppressWarnings({ "unchecked"})
 	@Test
 	public void testRollbackRecord() throws Exception {
 		logger.info("Start testRollbackRecord");
 		Map<String, Object> props = KafkaTestUtils.consumerProps("txTest1", "false", embeddedKafka);
-//		props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092"); test fallback to EOSMode.ALPHA
 		props.put(ConsumerConfig.GROUP_ID_CONFIG, "group");
 		props.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
 		DefaultKafkaConsumerFactory<Integer, String> cf = new DefaultKafkaConsumerFactory<>(props);
@@ -512,7 +511,6 @@ public class TransactionalContainerTests {
 		containerProps.setFixTxOffsets(true);
 
 		Map<String, Object> senderProps = KafkaTestUtils.producerProps(embeddedKafka);
-//		senderProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
 		DefaultKafkaProducerFactory<Integer, String> pf = new DefaultKafkaProducerFactory<>(senderProps);
 		pf.setTransactionIdPrefix("rr.");
 


### PR DESCRIPTION
Add properties `maxCache` at `DefaultKafkaProducerFactory`, setting `maxCache` greater than zero can reuse `transactional.id`.

If maxCache is 3, the suffix corresponding to the first prefix is 0-2, corresponding to the second prefix is 3-5.

Add new interface to initialize transactionIdSuffix.

Resolves #2852 