### PR TITLE
GH-2852: Provide a way to customize a transactionIdSuffix

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/transactions.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/transactions.adoc
@@ -126,8 +126,7 @@ public static class Config {
         ...
         DefaultKafkaProducerFactory<String, String> pf = new DefaultKafkaProducerFactory<>(configs);
         ...
-        DefaultTransactionIdSuffixStrategy ss = new DefaultTransactionIdSuffixStrategy();
-        ss.setMaxCache(5);
+        TransactionIdSuffixStrategy ss = new DefaultTransactionIdSuffixStrategy(5);
         pf.setTransactionIdSuffixStrategy(ss);
         return pf;
     }

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/transactions.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/transactions.adoc
@@ -102,10 +102,43 @@ NOTE: If there is a `KafkaTransactionManager` (or synchronized) transaction in p
 Instead, a new "nested" transaction is used.
 
 [[transaction-id-prefix]]
-== `transactionIdPrefix`
+== `TransactionIdPrefix`
 
 With `EOSMode.V2` (aka `BETA`), the only supported mode, it is no longer necessary to use the same `transactional.id`, even for consumer-initiated transactions; in fact, it must be unique on each instance the same as for producer-initiated transactions.
 This property must have a different value on each application instance.
+
+[[transaction-id-suffix-fixed]]
+== `TransactionIdSuffix Fixed`
+
+Since 3.2, a new `TransactionIdSuffixStrategy` interface was introduced to manage `transactional.id` suffix.
+The default implementation is `DefaultTransactionIdSuffixStrategy` when setting `maxCache` greater than zero can reuse `transactional.id` within a specific range, otherwise suffixes will be generated on the fly by incrementing a counter.
+When a transaction producer is requested and `transactional.id` all in use, throw a `NoProducerAvailableException`.
+User can then use a `RetryTemplate` configured to retry that exception, with a suitably configured back off.
+
+[source,java]
+----
+public static class Config {
+
+    @Bean
+    public ProducerFactory<String, String> myProducerFactory() {
+        Map<String, Object> configs = producerConfigs();
+        configs.put(ProducerConfig.CLIENT_ID_CONFIG, "myClientId");
+        ...
+        DefaultKafkaProducerFactory<String, String> pf = new DefaultKafkaProducerFactory<>(configs);
+        ...
+        DefaultTransactionIdSuffixStrategy ss = new DefaultTransactionIdSuffixStrategy();
+        ss.setMaxCache(5);
+        pf.setTransactionIdSuffixStrategy(ss);
+        return pf;
+    }
+
+}
+----
+When setting `maxCache` to 5, `transactional.id` is `my.txid.`++`{0-4}`+.
+
+IMPORTANT: When using `KafkaTransactionManager` with the `ConcurrentMessageListenerContainer` and enabling `maxCache`, it is necessary to set `maxCache` to a value greater than or equal to `concurrency`.
+If a `MessageListenerContainer` is unable to acquire a `transactional.id` suffix, it will throw a `NoProducerAvailableException`.
+When using nested transactions in the `ConcurrentMessageListenerContainer`, it is necessary to adjust the maxCache setting to handle the increased number of nested transactions.
 
 [[tx-template-mixed]]
 == `KafkaTemplate` Transactional and non-Transactional Publishing

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -10,5 +10,6 @@ For changes in earlier version, see xref:appendix/change-history.adoc[Change His
 [[x32-tiss]]
 === TransactionIdSuffixStrategy
 
-When setting `maxCache` with `transactionIdPrefix`, can restrict `transaction.id` in range.
+A new `TransactionIdSuffixStrategy` interface was introduced to manage `transactional.id` suffix.
+The default implementation is `DefaultTransactionIdSuffixStrategy` when setting `maxCache` greater than zero can reuse `transactional.id` within a specific range, otherwise suffixes will be generated on the fly by incrementing a counter.
 See xref:kafka/transactions.adoc#transaction-id-suffix-fixed[Fixed TransactionIdSuffix] for more information.

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -7,3 +7,8 @@
 This section covers the changes made from version 3.1 to version 3.2.
 For changes in earlier version, see xref:appendix/change-history.adoc[Change History].
 
+[[x32-tiss]]
+=== TransactionIdSuffixStrategy
+
+When setting `maxCache` with `transactionIdPrefix`, can restrict `transaction.id` in range.
+See xref:kafka/transactions.adoc#transaction-id-suffix-fixed[Fixed TransactionIdSuffix] for more information.

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 the original author or authors.
+ * Copyright 2016-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -135,7 +135,7 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 
 	private final AtomicBoolean running = new AtomicBoolean();
 
-	private TransactionIdSuffixStrategy transactionIdSuffixStrategy = new DefaultTransactionIdSuffixStrategy();
+	private TransactionIdSuffixStrategy transactionIdSuffixStrategy = new DefaultTransactionIdSuffixStrategy(0);
 
 	private Supplier<Serializer<K>> keySerializerSupplier;
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
@@ -121,8 +121,6 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 
 	private final Map<String, Object> configs;
 
-	private final AtomicInteger transactionIdSuffix = new AtomicInteger();
-
 	private final Map<String, BlockingQueue<CloseSafeProducer<K, V>>> cache = new ConcurrentHashMap<>();
 
 	private final Map<Thread, CloseSafeProducer<K, V>> threadBoundProducers = new ConcurrentHashMap<>();
@@ -136,6 +134,8 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 	private final List<ProducerPostProcessor<K, V>> postProcessors = new ArrayList<>();
 
 	private final AtomicBoolean running = new AtomicBoolean();
+
+	private TransactionIdSuffixStrategy transactionIdSuffixStrategy = new DefaultTransactionIdSuffixStrategy();
 
 	private Supplier<Serializer<K>> keySerializerSupplier;
 
@@ -351,6 +351,16 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 	}
 
 	/**
+	 * Set the transaction suffix strategy.
+	 * @param transactionIdSuffixStrategy the strategy.
+	 * @since 3.2
+	 */
+	public void setTransactionIdSuffixStrategy(TransactionIdSuffixStrategy transactionIdSuffixStrategy) {
+		Assert.notNull(transactionIdSuffixStrategy, "'transactionIdSuffixStrategy' cannot be null");
+		this.transactionIdSuffixStrategy = transactionIdSuffixStrategy;
+	}
+
+	/**
 	 * If true (default), programmatically provided serializers (via constructor or
 	 * setters) will be configured using the producer configuration. Set to false if the
 	 * serializers are already fully configured.
@@ -404,7 +414,7 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 
 	/**
 	 * Set a prefix for the {@link ProducerConfig#TRANSACTIONAL_ID_CONFIG} config. By
-	 * default a {@link ProducerConfig#TRANSACTIONAL_ID_CONFIG} value from configs is used
+	 * default, a {@link ProducerConfig#TRANSACTIONAL_ID_CONFIG} value from configs is used
 	 * as a prefix in the target producer configs.
 	 * @param transactionIdPrefix the prefix.
 	 * @since 1.3
@@ -536,9 +546,9 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 		producerProperties.putAll(overrideProperties);
 		producerProperties = ensureExistingTransactionIdPrefixInProperties(producerProperties);
 		DefaultKafkaProducerFactory<K, V> newFactory = new DefaultKafkaProducerFactory<>(producerProperties,
-						getKeySerializerSupplier(),
-						getValueSerializerSupplier(),
-						isConfigureSerializers());
+				getKeySerializerSupplier(),
+				getValueSerializerSupplier(),
+				isConfigureSerializers());
 		newFactory.setPhysicalCloseTimeout((int) getPhysicalCloseTimeout().getSeconds());
 		newFactory.setProducerPerThread(isProducerPerThread());
 		for (ProducerPostProcessor<K, V> templatePostProcessor : getPostProcessors()) {
@@ -690,7 +700,7 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 		}
 		if (producerToClose != null) {
 			try {
-				producerToClose.closeDelegate(this.physicalCloseTimeout, this.listeners);
+				producerToClose.closeDelegate(this.physicalCloseTimeout);
 			}
 			catch (Exception e) {
 				LOGGER.error(e, "Exception while closing producer");
@@ -700,7 +710,7 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 			CloseSafeProducer<K, V> next = queue.poll();
 			while (next != null) {
 				try {
-					next.closeDelegate(this.physicalCloseTimeout, this.listeners);
+					next.closeDelegate(this.physicalCloseTimeout);
 				}
 				catch (Exception e) {
 					LOGGER.error(e, "Exception while closing producer");
@@ -711,7 +721,7 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 		this.cache.clear();
 		this.threadBoundProducers.values().forEach(prod -> {
 			try {
-				prod.closeDelegate(this.physicalCloseTimeout, this.listeners);
+				prod.closeDelegate(this.physicalCloseTimeout);
 			}
 			catch (Exception e) {
 				LOGGER.error(e, "Exception while closing producer");
@@ -769,7 +779,7 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 		this.globalLock.lock();
 		try {
 			if (this.producer != null && this.producer.closed) {
-				this.producer.closeDelegate(this.physicalCloseTimeout, this.listeners);
+				this.producer.closeDelegate(this.physicalCloseTimeout);
 				this.producer = null;
 			}
 			if (this.producer != null && expire(this.producer)) {
@@ -820,6 +830,9 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 	 * @since 2.2.13
 	 */
 	protected final boolean removeProducer(CloseSafeProducer<K, V> producerToRemove, Duration timeout) {
+		if (producerToRemove.closed) {
+			this.listeners.forEach(listener -> listener.producerRemoved(producerToRemove.clientId, producerToRemove));
+		}
 		return producerToRemove.closed;
 	}
 
@@ -846,7 +859,8 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 			}
 		}
 		if (cachedProducer == null) {
-			return doCreateTxProducer(txIdPrefix, "" + this.transactionIdSuffix.getAndIncrement(), this::cacheReturner);
+			String suffix = this.transactionIdSuffixStrategy.acquireSuffix(txIdPrefix);
+			return doCreateTxProducer(txIdPrefix, suffix, this::cacheReturner);
 		}
 		else {
 			return cachedProducer;
@@ -856,24 +870,28 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 	private boolean expire(CloseSafeProducer<K, V> producer) {
 		boolean expired = this.maxAge > 0 && System.currentTimeMillis() - producer.created > this.maxAge;
 		if (expired) {
-			producer.closeDelegate(this.physicalCloseTimeout, this.listeners);
+			producer.closeDelegate(this.physicalCloseTimeout);
 		}
 		return expired;
 	}
 
 	boolean cacheReturner(CloseSafeProducer<K, V> producerToRemove, Duration timeout) {
 		if (producerToRemove.closed) {
-			producerToRemove.closeDelegate(timeout, this.listeners);
+			this.removeTransactionProducer(producerToRemove, timeout, this.listeners);
 			return true;
 		}
 		else {
 			this.globalLock.lock();
 			try {
+				if (producerToRemove.epoch != this.epoch.get()) {
+					this.removeTransactionProducer(producerToRemove, timeout, this.listeners);
+					return true;
+				}
 				BlockingQueue<CloseSafeProducer<K, V>> txIdCache = getCache(producerToRemove.txIdPrefix);
 				if (producerToRemove.epoch != this.epoch.get()
 						|| (txIdCache != null && !txIdCache.contains(producerToRemove)
 						&& !txIdCache.offer(producerToRemove))) {
-					producerToRemove.closeDelegate(timeout, this.listeners);
+					this.removeTransactionProducer(producerToRemove, timeout, this.listeners);
 					return true;
 				}
 			}
@@ -882,6 +900,12 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 			}
 			return false;
 		}
+	}
+
+	private void removeTransactionProducer(CloseSafeProducer<K, V> producer, Duration timeout,
+			List<Listener<K, V>> listeners) {
+		this.transactionIdSuffixStrategy.releaseSuffix(producer.txIdPrefix, producer.txIdSuffix);
+		listeners.forEach(listener -> listener.producerRemoved(producer.clientId, producer));
 	}
 
 	private CloseSafeProducer<K, V> doCreateTxProducer(String prefix, String suffix,
@@ -899,10 +923,13 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 				newEx.addSuppressed(ex2);
 				throw newEx; // NOSONAR - lost stack trace
 			}
+			finally {
+				this.transactionIdSuffixStrategy.releaseSuffix(prefix, suffix);
+			}
 			throw new KafkaException("initTransactions() failed", ex);
 		}
 		CloseSafeProducer<K, V> closeSafeProducer =
-				new CloseSafeProducer<>(newProducer, remover, prefix, this.physicalCloseTimeout, this.beanName,
+				new CloseSafeProducer<>(newProducer, remover, prefix, suffix, this.physicalCloseTimeout, this.beanName,
 						this.epoch.get());
 		this.listeners.forEach(listener -> listener.producerAdded(closeSafeProducer.clientId, closeSafeProducer));
 		return closeSafeProducer;
@@ -923,7 +950,7 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 	}
 
 	@Nullable
-	protected BlockingQueue<CloseSafeProducer<K, V>> getCache(String txIdPrefix) {
+	protected BlockingQueue<CloseSafeProducer<K, V>> getCache(@Nullable String txIdPrefix) {
 		if (txIdPrefix == null) {
 			return null;
 		}
@@ -941,7 +968,7 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 	public void closeThreadBoundProducer() {
 		CloseSafeProducer<K, V> tlProducer = this.threadBoundProducers.remove(Thread.currentThread());
 		if (tlProducer != null) {
-			tlProducer.closeDelegate(this.physicalCloseTimeout, this.listeners);
+			tlProducer.closeDelegate(this.physicalCloseTimeout);
 		}
 	}
 
@@ -991,6 +1018,8 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 
 		final String txIdPrefix; // NOSONAR
 
+		final String txIdSuffix;  // NOSONAR
+
 		final long created; // NOSONAR
 
 		private final Duration closeTimeout;
@@ -1010,14 +1039,21 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 			this(delegate, removeConsumerProducer, null, closeTimeout, factoryName, epoch);
 		}
 
+		CloseSafeProducer(Producer<K, V> delegate, BiPredicate<CloseSafeProducer<K, V>, Duration> removeProducer,
+				@Nullable String txIdPrefix, Duration closeTimeout, String factoryName, int epoch) {
+
+			this(delegate, removeProducer, txIdPrefix, null, closeTimeout, factoryName, epoch);
+		}
+
 		CloseSafeProducer(Producer<K, V> delegate,
 				BiPredicate<CloseSafeProducer<K, V>, Duration> removeProducer, @Nullable String txIdPrefix,
-				Duration closeTimeout, String factoryName, int epoch) {
+				@Nullable String txIdSuffix, Duration closeTimeout, String factoryName, int epoch) {
 
 			Assert.isTrue(!(delegate instanceof CloseSafeProducer), "Cannot double-wrap a producer");
 			this.delegate = delegate;
 			this.removeProducer = removeProducer;
 			this.txIdPrefix = txIdPrefix;
+			this.txIdSuffix = txIdSuffix;
 			this.closeTimeout = closeTimeout;
 			Map<MetricName, ? extends Metric> metrics = delegate.metrics();
 			Iterator<MetricName> metricIterator = metrics.keySet().iterator();
@@ -1057,7 +1093,6 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 					}
 					callback.onCompletion(metadata, exception);
 				}
-
 			});
 		}
 
@@ -1159,22 +1194,30 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 					this.removeProducer.test(this, this.producerFailed instanceof TimeoutException
 							? CLOSE_TIMEOUT_AFTER_TX_TIMEOUT
 							: timeout);
+					this.delegate.close(timeout == null ? this.closeTimeout : this.producerFailed instanceof TimeoutException
+							? CLOSE_TIMEOUT_AFTER_TX_TIMEOUT
+							: timeout);
 				}
 				else {
 					this.closed = this.removeProducer.test(this, timeout);
+					if (this.closed) {
+						this.delegate.close(timeout == null ? this.closeTimeout : timeout);
+					}
 				}
 			}
 		}
 
-		void closeDelegate(Duration timeout, List<Listener<K, V>> listeners) {
+		void closeDelegate(Duration timeout) {
 			try {
-				this.delegate.close(timeout == null ? this.closeTimeout : timeout);
+				if (!this.closed) {
+					this.delegate.close(timeout == null ? this.closeTimeout : timeout);
+					this.closed = true;
+					this.removeProducer.test(this, timeout == null ? this.closeTimeout : timeout);
+				}
 			}
 			catch (Exception ex) {
 				LOGGER.warn(ex, () -> "Failed to close " + this.delegate);
 			}
-			listeners.forEach(listener -> listener.producerRemoved(this.clientId, this));
-			this.closed = true;
 		}
 
 		@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultTransactionIdSuffixStrategy.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultTransactionIdSuffixStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 the original author or authors.
+ * Copyright 2016-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,9 +31,8 @@ import org.springframework.util.Assert;
  * Otherwise, the suffixes will be generated on the fly.
  *
  * <p>
- * Setting the {@link #setMaxCache(int)} enables caching to restrict the number of `transactional.id`.
  * The cache is per `transactional.id` prefix. The cache size is limited by the {@link #maxCache}.
- * Default is 0, which means no caching and restriction, so the `transactional.id` will be generated on the fly.
+ * A value of 0 means no caching and restriction, so the `transactional.id` will be generated on the fly.
  *
  * @author Ilya Starchenko
  *
@@ -45,7 +44,16 @@ public class DefaultTransactionIdSuffixStrategy implements TransactionIdSuffixSt
 
 	private final Map<String, BlockingQueue<String>> suffixCache = new ConcurrentHashMap<>();
 
-	private int maxCache;
+	private final int maxCache;
+
+	/**
+	 * Construct a transaction id suffix strategy with the provided size of the cache.
+	 * @param maxCache the maximum size of the cache.
+	 */
+	public DefaultTransactionIdSuffixStrategy(int maxCache) {
+		Assert.isTrue(maxCache >= 0, "'maxCache' must be greater than or equal to 0");
+		this.maxCache = maxCache;
+	}
 
 	/**
 	 * Acquire the suffix for the transactional producer from the cache or generate a new one
@@ -80,15 +88,6 @@ public class DefaultTransactionIdSuffixStrategy implements TransactionIdSuffixSt
 		if (queue != null && !queue.contains(suffix)) {
 			queue.add(suffix);
 		}
-	}
-
-	/**
-	 * Set the maximum size for transaction producer cache.
-	 * @param maxCache the maxCache to set
-	 */
-	public void setMaxCache(int maxCache) {
-		Assert.isTrue(maxCache >= 0, "'maxCache' must be greater than or equal to 0");
-		this.maxCache = maxCache;
 	}
 
 	@Nullable

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultTransactionIdSuffixStrategy.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultTransactionIdSuffixStrategy.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2016-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.core;
+
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+/**
+ * The {@link TransactionIdSuffixStrategy} implementation for managing transactional producer suffixes.
+ * If the {@link #maxCache} is greater than 0, the suffixes will be cached and reused.
+ * Otherwise, the suffixes will be generated on the fly.
+ *
+ * <p>
+ * Setting the {@link #setMaxCache(int)} enables caching to restrict the number of `transactional.id`.
+ * The cache is per `transactional.id` prefix. The cache size is limited by the {@link #maxCache}.
+ * Default is 0, which means no caching and restriction, so the `transactional.id` will be generated on the fly.
+ *
+ * @author Ilya Starchenko
+ *
+ * @since 3.2
+ */
+public class DefaultTransactionIdSuffixStrategy implements TransactionIdSuffixStrategy {
+
+	private final AtomicInteger transactionIdSuffix = new AtomicInteger();
+
+	private final Map<String, BlockingQueue<String>> suffixCache = new ConcurrentHashMap<>();
+
+	private int maxCache;
+
+	/**
+	 * Acquire the suffix for the transactional producer from the cache or generate a new one
+	 * if caching is disabled.
+	 * @param txIdPrefix the transaction id prefix.
+	 * @return the suffix.
+	 * @throws NoProducerAvailableException if caching is enabled and no suffixes are available.
+	 */
+	@Override
+	public String acquireSuffix(String txIdPrefix) {
+		Assert.notNull(txIdPrefix, "'txIdPrefix' must not be null");
+		BlockingQueue<String> cache = getSuffixCache(txIdPrefix);
+		if (cache == null) {
+			return String.valueOf(this.transactionIdSuffix.getAndIncrement());
+		}
+
+		String suffix = cache.poll();
+		if (suffix == null) {
+			throw new NoProducerAvailableException("No available transaction producer", txIdPrefix);
+		}
+		return suffix;
+	}
+
+	@Override
+	public void releaseSuffix(String txIdPrefix, String suffix) {
+		Assert.notNull(txIdPrefix, "'txIdPrefix' must not be null");
+		Assert.notNull(suffix, "'suffix' must not be null");
+		if (this.maxCache <= 0) {
+			return;
+		}
+		BlockingQueue<String> queue = getSuffixCache(txIdPrefix);
+		if (queue != null && !queue.contains(suffix)) {
+			queue.add(suffix);
+		}
+	}
+
+	/**
+	 * Set the maximum size for transaction producer cache.
+	 * @param maxCache the maxCache to set
+	 */
+	public void setMaxCache(int maxCache) {
+		Assert.isTrue(maxCache >= 0, "'maxCache' must be greater than or equal to 0");
+		this.maxCache = maxCache;
+	}
+
+	@Nullable
+	private BlockingQueue<String> getSuffixCache(String txIdPrefix) {
+		if (this.maxCache <= 0) {
+			return null;
+		}
+
+		return this.suffixCache.computeIfAbsent(txIdPrefix, txId -> {
+			BlockingQueue<String> queue = new LinkedBlockingQueue<>();
+			for (int suffix = 0; suffix < this.maxCache; suffix++) {
+				queue.add(String.valueOf(this.transactionIdSuffix.getAndIncrement()));
+			}
+			return queue;
+		});
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/NoProducerAvailableException.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/NoProducerAvailableException.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.core;
+
+import org.springframework.kafka.KafkaException;
+
+/**
+ * Exception when no producer is available.
+ *
+ * @author Wang Zhiyang
+ * @author Ilya Starchenko
+ *
+ * @since 3.2
+ */
+public class NoProducerAvailableException extends KafkaException {
+
+	private static final long serialVersionUID = 1L;
+	
+	private final String txIdPrefix;
+
+	/**
+	 * Constructs a new no producer available exception with the specified detail message.
+	 * @param message the message.
+	 * @param txIdPrefix the transaction id prefix.
+	 */
+	public NoProducerAvailableException(String message, String txIdPrefix) {
+		super(message);
+		this.txIdPrefix = txIdPrefix;
+	}
+
+	/**
+	 * Return the transaction id prefix that was used to create the producer and failed.
+	 * @return the transaction id prefix.
+	 */
+	public String getTxIdPrefix() {
+		return this.txIdPrefix;
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/NoProducerAvailableException.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/NoProducerAvailableException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2023 the original author or authors.
+ * Copyright 2023-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,7 +29,7 @@ import org.springframework.kafka.KafkaException;
 public class NoProducerAvailableException extends KafkaException {
 
 	private static final long serialVersionUID = 1L;
-	
+
 	private final String txIdPrefix;
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/TransactionIdSuffixStrategy.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/TransactionIdSuffixStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 the original author or authors.
+ * Copyright 2016-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/TransactionIdSuffixStrategy.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/TransactionIdSuffixStrategy.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2016-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.core;
+
+/**
+ * The strategy for managing transactional producer suffixes.
+ *
+ * @author Ilya Starchenko
+ *
+ * @since 3.2
+ */
+public interface TransactionIdSuffixStrategy {
+
+	/**
+	 * Acquire the suffix for the transactional producer.
+	 * @param txIdPrefix the transaction id prefix.
+	 * @return the suffix.
+	 */
+	String acquireSuffix(String txIdPrefix);
+
+	/**
+	 * Release the suffix for the transactional producer.
+	 * @param txIdPrefix the transaction id prefix.
+	 * @param suffix the suffix.
+	 */
+	void releaseSuffix(String txIdPrefix, String suffix);
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 the original author or authors.
+ * Copyright 2017-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -384,8 +384,7 @@ public class DefaultKafkaConsumerFactoryTests {
 		KafkaTemplate<Integer, String> template = new KafkaTemplate<>(pf);
 		DefaultKafkaProducerFactory<Integer, String> pfTx = new DefaultKafkaProducerFactory<>(producerProps);
 		pfTx.setTransactionIdPrefix("fooTx.fixed.");
-		DefaultTransactionIdSuffixStrategy suffixStrategy = new DefaultTransactionIdSuffixStrategy();
-		suffixStrategy.setMaxCache(3);
+		TransactionIdSuffixStrategy suffixStrategy = new DefaultTransactionIdSuffixStrategy(3);
 		pfTx.setTransactionIdSuffixStrategy(suffixStrategy);
 		KafkaOperations<Integer, String> templateTx = new KafkaTemplate<>(pfTx);
 		Map<String, Object> consumerProps = KafkaTestUtils.consumerProps("txCache1FixedGroup", "false", this.embeddedKafka);

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
@@ -376,6 +376,60 @@ public class DefaultKafkaConsumerFactoryTests {
 		}
 	}
 
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testNestedTxProducerIsFixed() throws Exception {
+		Map<String, Object> producerProps = KafkaTestUtils.producerProps(this.embeddedKafka);
+		DefaultKafkaProducerFactory<Integer, String> pf = new DefaultKafkaProducerFactory<>(producerProps);
+		KafkaTemplate<Integer, String> template = new KafkaTemplate<>(pf);
+		DefaultKafkaProducerFactory<Integer, String> pfTx = new DefaultKafkaProducerFactory<>(producerProps);
+		pfTx.setTransactionIdPrefix("fooTx.fixed.");
+		DefaultTransactionIdSuffixStrategy suffixStrategy = new DefaultTransactionIdSuffixStrategy();
+		suffixStrategy.setMaxCache(3);
+		pfTx.setTransactionIdSuffixStrategy(suffixStrategy);
+		KafkaOperations<Integer, String> templateTx = new KafkaTemplate<>(pfTx);
+		Map<String, Object> consumerProps = KafkaTestUtils.consumerProps("txCache1FixedGroup", "false", this.embeddedKafka);
+		DefaultKafkaConsumerFactory<Integer, String> cf = new DefaultKafkaConsumerFactory<>(consumerProps);
+		AtomicReference<Consumer<Integer, String>> wrapped = new AtomicReference<>();
+		cf.addPostProcessor(consumer -> {
+			ProxyFactory prox = new ProxyFactory();
+			prox.setTarget(consumer);
+			@SuppressWarnings("unchecked")
+			Consumer<Integer, String> proxy = (Consumer<Integer, String>) prox.getProxy();
+			wrapped.set(proxy);
+			return proxy;
+		});
+		ContainerProperties containerProps = new ContainerProperties("txCache1Fixed");
+		CountDownLatch latch = new CountDownLatch(1);
+		containerProps.setMessageListener((MessageListener<Integer, String>) r -> {
+			templateTx.executeInTransaction(t -> t.send("txCacheSendFromListener", "bar"));
+			templateTx.executeInTransaction(t -> t.send("txCacheSendFromListener", "baz"));
+			latch.countDown();
+		});
+		KafkaTransactionManager<Integer, String> tm = new KafkaTransactionManager<>(pfTx);
+		containerProps.setTransactionManager(tm);
+		KafkaMessageListenerContainer<Integer, String> container = new KafkaMessageListenerContainer<>(cf,
+				containerProps);
+		container.start();
+		try {
+			CompletableFuture<SendResult<Integer, String>> future = template.send("txCache1Fixed", "foo");
+			future.get(10, TimeUnit.SECONDS);
+			pf.getCache();
+			assertThat(KafkaTestUtils.getPropertyValue(pf, "cache", Map.class)).hasSize(0);
+			assertThat(latch.await(30, TimeUnit.SECONDS)).isTrue();
+			assertThat(KafkaTestUtils.getPropertyValue(pfTx, "cache", Map.class)).hasSize(1);
+			assertThat(pfTx.getCache()).hasSize(1);
+			assertThat(KafkaTestUtils.getPropertyValue(suffixStrategy, "suffixCache", Map.class)).hasSize(1);
+			//  1 tm tx producer and 1 templateTx tx producer
+			assertThat(KafkaTestUtils.getPropertyValue(container, "listenerConsumer.consumer")).isSameAs(wrapped.get());
+		}
+		finally {
+			container.stop();
+			pf.destroy();
+			pfTx.destroy();
+		}
+	}
+
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
 	void listener() {

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaProducerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaProducerFactoryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 the original author or authors.
+ * Copyright 2018-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -137,8 +137,7 @@ public class DefaultKafkaProducerFactoryTests {
 
 		};
 		pf.setTransactionIdPrefix("foo");
-		DefaultTransactionIdSuffixStrategy suffixStrategy = new DefaultTransactionIdSuffixStrategy();
-		suffixStrategy.setMaxCache(2);
+		TransactionIdSuffixStrategy suffixStrategy = new DefaultTransactionIdSuffixStrategy(2);
 		pf.setTransactionIdSuffixStrategy(suffixStrategy);
 
 		final AtomicInteger flag = new AtomicInteger();
@@ -310,8 +309,7 @@ public class DefaultKafkaProducerFactoryTests {
 		};
 		pf.setApplicationContext(ctx);
 		pf.setTransactionIdPrefix("foo");
-		DefaultTransactionIdSuffixStrategy suffixStrategy = new DefaultTransactionIdSuffixStrategy();
-		suffixStrategy.setMaxCache(3);
+		TransactionIdSuffixStrategy suffixStrategy = new DefaultTransactionIdSuffixStrategy(3);
 		pf.setTransactionIdSuffixStrategy(suffixStrategy);
 		Producer aProducer = pf.createProducer();
 		assertThat(aProducer).isNotNull();
@@ -391,8 +389,7 @@ public class DefaultKafkaProducerFactoryTests {
 		};
 		pf.setApplicationContext(ctx);
 		pf.setTransactionIdPrefix("foo");
-		DefaultTransactionIdSuffixStrategy suffixStrategy = new DefaultTransactionIdSuffixStrategy();
-		suffixStrategy.setMaxCache(3);
+		TransactionIdSuffixStrategy suffixStrategy = new DefaultTransactionIdSuffixStrategy(3);
 		pf.setTransactionIdSuffixStrategy(suffixStrategy);
 		Producer aProducer = pf.createProducer();
 		assertThat(aProducer).isNotNull();
@@ -556,8 +553,7 @@ public class DefaultKafkaProducerFactoryTests {
 
 		};
 		pf.setTransactionIdPrefix("foo");
-		DefaultTransactionIdSuffixStrategy suffixStrategy = new DefaultTransactionIdSuffixStrategy();
-		suffixStrategy.setMaxCache(2);
+		TransactionIdSuffixStrategy suffixStrategy = new DefaultTransactionIdSuffixStrategy(2);
 		pf.setTransactionIdSuffixStrategy(suffixStrategy);
 		Map<?, ?> suffixCache = KafkaTestUtils.getPropertyValue(suffixStrategy, "suffixCache", Map.class);
 		pf.createProducer();
@@ -695,8 +691,7 @@ public class DefaultKafkaProducerFactoryTests {
 		};
 		pf.setBootstrapServersSupplier(() -> "foo");
 		pf.setTransactionIdPrefix("tx.");
-		DefaultTransactionIdSuffixStrategy suffixStrategy = new DefaultTransactionIdSuffixStrategy();
-		suffixStrategy.setMaxCache(2);
+		TransactionIdSuffixStrategy suffixStrategy = new DefaultTransactionIdSuffixStrategy(2);
 		pf.setTransactionIdSuffixStrategy(suffixStrategy);
 		Producer aProducer = pf.createProducer();
 		assertThat(configPassedToKafkaConsumer.get(ProducerConfig.TRANSACTIONAL_ID_CONFIG)).isEqualTo("tx.0");

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaProducerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaProducerFactoryTests.java
@@ -70,7 +70,7 @@ public class DefaultKafkaProducerFactoryTests {
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
-	void testProducerClosedAfterBadTransition() throws Exception {
+	void testProducerClosedAfterBadTransition() {
 		final Producer producer = mock(Producer.class);
 		given(producer.send(any(), any())).willReturn(new CompletableFuture());
 		DefaultKafkaProducerFactory pf = new DefaultKafkaProducerFactory(new HashMap<>()) {
@@ -119,6 +119,120 @@ public class DefaultKafkaProducerFactoryTests {
 		inOrder.verify(producer).commitTransaction();
 		inOrder.verify(producer).beginTransaction();
 		inOrder.verify(producer).close(ProducerFactoryUtils.DEFAULT_CLOSE_TIMEOUT);
+		inOrder.verifyNoMoreInteractions();
+		pf.destroy();
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Test
+	void testMaxCacheProducerClosedAfterBadTransition() {
+		final Producer producer = mock(Producer.class);
+		given(producer.send(any(), any())).willReturn(new CompletableFuture());
+		DefaultKafkaProducerFactory pf = new DefaultKafkaProducerFactory(new HashMap<>()) {
+
+			@Override
+			protected Producer createRawProducer(Map configs) {
+				return producer;
+			}
+
+		};
+		pf.setTransactionIdPrefix("foo");
+		DefaultTransactionIdSuffixStrategy suffixStrategy = new DefaultTransactionIdSuffixStrategy();
+		suffixStrategy.setMaxCache(2);
+		pf.setTransactionIdSuffixStrategy(suffixStrategy);
+
+		final AtomicInteger flag = new AtomicInteger();
+		willAnswer(i -> {
+			if (flag.incrementAndGet() == 2) {
+				throw new KafkaException("Invalid begin transition ...");
+			}
+			return null;
+		}).given(producer).beginTransaction();
+
+		final AtomicInteger commitFlag = new AtomicInteger();
+		willAnswer(i -> {
+			if (commitFlag.incrementAndGet() == 2) {
+				throw new KafkaException("Invalid commit transition ...");
+			}
+			return null;
+		}).given(producer).commitTransaction();
+
+		final AtomicInteger abortFlag = new AtomicInteger();
+		willAnswer(i -> {
+			if (abortFlag.incrementAndGet() == 1) {
+				throw new KafkaException("Invalid abort transition ...");
+			}
+			return null;
+		}).given(producer).abortTransaction();
+
+		final AtomicInteger initFlag = new AtomicInteger();
+		willAnswer(i -> {
+			if (initFlag.incrementAndGet() == 4) {
+				throw new KafkaException("Invalid init transition ...");
+			}
+			return null;
+		}).given(producer).initTransactions();
+
+		final KafkaTemplate kafkaTemplate = new KafkaTemplate(pf);
+		KafkaTransactionManager tm = new KafkaTransactionManager(pf);
+		TransactionTemplate transactionTemplate = new TransactionTemplate(tm);
+		transactionTemplate.execute(s -> {
+			kafkaTemplate.send("foo", "bar");
+			return null;
+		});
+		Map<?, ?> cache = KafkaTestUtils.getPropertyValue(pf, "cache", Map.class);
+		assertThat(cache).hasSize(1);
+		Queue queue = (Queue) cache.get("foo");
+		assertThat(queue).hasSize(1);
+		Map<?, ?> suffixCache = KafkaTestUtils.getPropertyValue(suffixStrategy, "suffixCache", Map.class);
+		assertThat(suffixCache).hasSize(1);
+		Queue suffixQueue = (Queue) suffixCache.get("foo");
+		assertThat(suffixQueue).hasSize(1);
+
+		assertThatExceptionOfType(CannotCreateTransactionException.class)
+				.isThrownBy(() -> transactionTemplate.execute(s -> null));
+		assertThat(queue).hasSize(0);
+		assertThat(suffixQueue).hasSize(2);
+
+		assertThatExceptionOfType(KafkaException.class)
+				.isThrownBy(() -> transactionTemplate.execute(s -> null))
+				.withStackTraceContaining("Invalid commit transition");
+		assertThat(queue).hasSize(0);
+		assertThat(suffixQueue).hasSize(2);
+
+		assertThatExceptionOfType(KafkaException.class)
+				.isThrownBy(() -> {
+					transactionTemplate.execute(s -> {
+						throw new RuntimeException("rollback exception");
+					});
+				})
+				.withStackTraceContaining("Invalid abort transition");
+		assertThat(queue).hasSize(0);
+		assertThat(suffixQueue).hasSize(2);
+
+		assertThatExceptionOfType(CannotCreateTransactionException.class)
+				.isThrownBy(() -> transactionTemplate.execute(s -> null))
+				.withStackTraceContaining("Could not create Kafka transaction");
+		assertThat(queue).hasSize(0);
+		assertThat(suffixQueue).hasSize(2);
+
+		InOrder inOrder = inOrder(producer);
+		inOrder.verify(producer).initTransactions();
+		inOrder.verify(producer).beginTransaction();
+		inOrder.verify(producer).send(any(), any());
+		inOrder.verify(producer).commitTransaction();
+		inOrder.verify(producer).beginTransaction();
+		inOrder.verify(producer).close(ProducerFactoryUtils.DEFAULT_CLOSE_TIMEOUT);
+		inOrder.verify(producer).initTransactions();
+		inOrder.verify(producer).beginTransaction();
+		inOrder.verify(producer).commitTransaction();
+		inOrder.verify(producer).close(ProducerFactoryUtils.DEFAULT_CLOSE_TIMEOUT);
+		inOrder.verify(producer).initTransactions();
+		inOrder.verify(producer).beginTransaction();
+		inOrder.verify(producer).abortTransaction();
+		inOrder.verify(producer).close(ProducerFactoryUtils.DEFAULT_CLOSE_TIMEOUT);
+		inOrder.verify(producer).initTransactions();
+		inOrder.verify(producer).close(DefaultKafkaProducerFactory.DEFAULT_PHYSICAL_CLOSE_TIMEOUT);
 		inOrder.verifyNoMoreInteractions();
 		pf.destroy();
 	}
@@ -196,6 +310,9 @@ public class DefaultKafkaProducerFactoryTests {
 		};
 		pf.setApplicationContext(ctx);
 		pf.setTransactionIdPrefix("foo");
+		DefaultTransactionIdSuffixStrategy suffixStrategy = new DefaultTransactionIdSuffixStrategy();
+		suffixStrategy.setMaxCache(3);
+		pf.setTransactionIdSuffixStrategy(suffixStrategy);
 		Producer aProducer = pf.createProducer();
 		assertThat(aProducer).isNotNull();
 		aProducer.close();
@@ -207,12 +324,19 @@ public class DefaultKafkaProducerFactoryTests {
 		assertThat(cache.size()).isEqualTo(1);
 		Queue queue = (Queue) cache.get("foo");
 		assertThat(queue.size()).isEqualTo(1);
+		Map<?, ?> suffixCache = KafkaTestUtils.getPropertyValue(suffixStrategy, "suffixCache", Map.class);
+		assertThat(suffixCache.size()).isEqualTo(1);
+		Queue suffixQueue = (Queue) suffixCache.get("foo");
+		assertThat(suffixQueue.size()).isEqualTo(2);
 		pf.setMaxAge(Duration.ofMillis(10));
 		Thread.sleep(50);
 		aProducer = pf.createProducer();
 		assertThat(aProducer).isNotSameAs(bProducer);
 		pf.onApplicationEvent(new ContextStoppedEvent(ctx));
 		assertThat(queue.size()).isEqualTo(0);
+		assertThat(suffixCache.size()).isEqualTo(1);
+		Queue suffixQueue2 = (Queue) suffixCache.get("foo");
+		assertThat(suffixQueue2.size()).isEqualTo(2);
 		verify(producer).close(any(Duration.class));
 	}
 
@@ -267,6 +391,9 @@ public class DefaultKafkaProducerFactoryTests {
 		};
 		pf.setApplicationContext(ctx);
 		pf.setTransactionIdPrefix("foo");
+		DefaultTransactionIdSuffixStrategy suffixStrategy = new DefaultTransactionIdSuffixStrategy();
+		suffixStrategy.setMaxCache(3);
+		pf.setTransactionIdSuffixStrategy(suffixStrategy);
 		Producer aProducer = pf.createProducer();
 		assertThat(aProducer).isNotNull();
 		aProducer.close();
@@ -278,12 +405,19 @@ public class DefaultKafkaProducerFactoryTests {
 		assertThat(cache.size()).isEqualTo(1);
 		Queue queue = (Queue) cache.get("foo");
 		assertThat(queue.size()).isEqualTo(1);
+		Map<?, ?> suffixCache = KafkaTestUtils.getPropertyValue(suffixStrategy, "suffixCache", Map.class);
+		assertThat(suffixCache.size()).isEqualTo(1);
+		Queue suffixQueue = (Queue) suffixCache.get("foo");
+		assertThat(suffixQueue.size()).isEqualTo(2);
 		bProducer = pf.createProducer();
 		assertThat(bProducer).isSameAs(aProducer);
 		assertThat(queue.size()).isEqualTo(0);
 		pf.reset();
 		bProducer.close();
 		assertThat(queue.size()).isEqualTo(0);
+		assertThat(suffixCache.size()).isEqualTo(1);
+		Queue suffixQueue2 = (Queue) suffixCache.get("foo");
+		assertThat(suffixQueue2.size()).isEqualTo(3);
 		pf.destroy();
 	}
 
@@ -320,12 +454,12 @@ public class DefaultKafkaProducerFactoryTests {
 		pf.closeThreadBoundProducer();
 		assertThat(KafkaTestUtils.getPropertyValue(pf, "threadBoundProducers", Map.class).get(Thread.currentThread()))
 				.isNull();
-		verify(producer, times(3)).close(any(Duration.class));
+		verify(producer, times(2)).close(any(Duration.class));
 	}
 
 	@Test
 	@SuppressWarnings({ "rawtypes", "unchecked" })
-	void threadLocalLifecycle() throws InterruptedException {
+	void threadLocalLifecycle() {
 		final Producer producer = mock(Producer.class);
 		AtomicBoolean created = new AtomicBoolean();
 		DefaultKafkaProducerFactory pf = new DefaultKafkaProducerFactory(new HashMap<>()) {
@@ -407,6 +541,31 @@ public class DefaultKafkaProducerFactoryTests {
 		bProducer = pf.createProducer();
 		verify(producer1).close(any(Duration.class));
 		assertThat(bProducer).isNotSameAs(aProducer);
+	}
+
+	@Test
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	void testNoProducerException() {
+		final Producer producer = mock(Producer.class);
+		DefaultKafkaProducerFactory pf = new DefaultKafkaProducerFactory(new HashMap<>()) {
+
+			@Override
+			protected Producer createRawProducer(Map configs) {
+				return producer;
+			}
+
+		};
+		pf.setTransactionIdPrefix("foo");
+		DefaultTransactionIdSuffixStrategy suffixStrategy = new DefaultTransactionIdSuffixStrategy();
+		suffixStrategy.setMaxCache(2);
+		pf.setTransactionIdSuffixStrategy(suffixStrategy);
+		Map<?, ?> suffixCache = KafkaTestUtils.getPropertyValue(suffixStrategy, "suffixCache", Map.class);
+		pf.createProducer();
+		Queue queue = (Queue) suffixCache.get("foo");
+		assertThat(queue).hasSize(1);
+		pf.createProducer();
+		assertThat(queue).hasSize(0);
+		assertThatExceptionOfType(NoProducerAvailableException.class).isThrownBy(() -> pf.createProducer());
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
@@ -518,6 +677,38 @@ public class DefaultKafkaProducerFactoryTests {
 		assertThat(configPassedToKafkaConsumer.get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)).isEqualTo("bar");
 		pf.destroy();
 	}
+
+	@Test
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	void testTransactionId() throws InterruptedException {
+		final Producer producer = mock(Producer.class);
+		final Map<String, Object> configPassedToKafkaConsumer = new HashMap<>();
+		DefaultKafkaProducerFactory pf = new DefaultKafkaProducerFactory(new HashMap<>()) {
+
+			@Override
+			protected Producer createRawProducer(Map configs) {
+				configPassedToKafkaConsumer.clear();
+				configPassedToKafkaConsumer.putAll(configs);
+				return producer;
+			}
+
+		};
+		pf.setBootstrapServersSupplier(() -> "foo");
+		pf.setTransactionIdPrefix("tx.");
+		DefaultTransactionIdSuffixStrategy suffixStrategy = new DefaultTransactionIdSuffixStrategy();
+		suffixStrategy.setMaxCache(2);
+		pf.setTransactionIdSuffixStrategy(suffixStrategy);
+		Producer aProducer = pf.createProducer();
+		assertThat(configPassedToKafkaConsumer.get(ProducerConfig.TRANSACTIONAL_ID_CONFIG)).isEqualTo("tx.0");
+		Producer bProducer = pf.createProducer();
+		assertThat(configPassedToKafkaConsumer.get(ProducerConfig.TRANSACTIONAL_ID_CONFIG)).isEqualTo("tx.1");
+		bProducer.close(Duration.ofSeconds(20));
+		pf.setMaxAge(Duration.ofMillis(10));
+		Thread.sleep(50);
+		Producer cProducer = pf.createProducer();
+		assertThat(configPassedToKafkaConsumer.get(ProducerConfig.TRANSACTIONAL_ID_CONFIG)).isEqualTo("tx.1");
+	}
+
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultTransactionIdSuffixStrategyTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultTransactionIdSuffixStrategyTests.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2016-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+import java.util.Map;
+import java.util.Queue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+
+/**
+ * @author Ilya Starchenko
+ *
+ * @since 3.2
+ */
+class DefaultTransactionIdSuffixStrategyTests {
+
+	private DefaultTransactionIdSuffixStrategy suffixStrategy;
+
+	@BeforeEach
+	void setUp() {
+		suffixStrategy = new DefaultTransactionIdSuffixStrategy();
+	}
+
+	@Test
+	void acquireSuffixWithoutCache() {
+		String txIdPrefix = "txIdPrefix";
+		String suffix = suffixStrategy.acquireSuffix(txIdPrefix);
+		assertThat(suffix).isNotNull();
+	}
+
+	@Test
+	void acquireSuffixWithCache() {
+		String txIdPrefix = "txIdPrefix";
+		String suffix = "suffix";
+		assertThatNoException().isThrownBy(() -> suffixStrategy.releaseSuffix(txIdPrefix, suffix));
+	}
+
+
+	@Test
+	void acquireSuffixWithCacheExhausted() {
+		String txIdPrefix = "txIdPrefix";
+		suffixStrategy.setMaxCache(2);
+		String suffix1 = suffixStrategy.acquireSuffix(txIdPrefix);
+		String suffix2 = suffixStrategy.acquireSuffix(txIdPrefix);
+		assertThatExceptionOfType(NoProducerAvailableException.class)
+				.isThrownBy(() -> suffixStrategy.acquireSuffix(txIdPrefix))
+				.extracting(NoProducerAvailableException::getTxIdPrefix).isEqualTo(txIdPrefix);
+	}
+
+	@Test
+	void releaseSuffixWithCache() {
+		String txIdPrefix = "txIdPrefix";
+		suffixStrategy.setMaxCache(2);
+		String suffix = suffixStrategy.acquireSuffix(txIdPrefix);
+		assertThatNoException().isThrownBy(() -> suffixStrategy.releaseSuffix(txIdPrefix, suffix));
+	}
+
+	@SuppressWarnings("rawtypes")
+	@Test
+	void releaseAllSuffixesWithCache() {
+		String txIdPrefix = "txIdPrefix";
+		suffixStrategy.setMaxCache(2);
+		String suffix1 = suffixStrategy.acquireSuffix(txIdPrefix);
+		String suffix2 = suffixStrategy.acquireSuffix(txIdPrefix);
+		assertThatNoException().isThrownBy(() -> suffixStrategy.releaseSuffix(txIdPrefix, suffix1));
+		Map<?, ?> suffixCache = KafkaTestUtils.getPropertyValue(suffixStrategy, "suffixCache", Map.class);
+		assertThat(suffixCache).hasSize(1);
+		Queue queue = (Queue) suffixCache.get(txIdPrefix);
+		assertThat(queue).hasSize(1);
+		assertThat(queue.poll()).isEqualTo(suffix1);
+	}
+
+	@Test
+	void setMaxCacheIsNegative() {
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> suffixStrategy.setMaxCache(-1));
+	}
+
+	@Test
+	void setMaxCacheIsZero() {
+		assertThatNoException().isThrownBy(() -> suffixStrategy.setMaxCache(0));
+	}
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTransactionTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTransactionTests.java
@@ -38,6 +38,7 @@ import java.time.Duration;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Queue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.LinkedBlockingDeque;
@@ -93,17 +94,18 @@ import org.springframework.transaction.support.TransactionTemplate;
  *
  */
 @EmbeddedKafka(topics = { KafkaTemplateTransactionTests.STRING_KEY_TOPIC,
-		KafkaTemplateTransactionTests.LOCAL_TX_IN_TOPIC }, brokerProperties = {
-				"transaction.state.log.replication.factor=1", "transaction.state.log.min.isr=1" })
+		KafkaTemplateTransactionTests.LOCAL_TX_IN_TOPIC, KafkaTemplateTransactionTests.LOCAL_FIXED_TX_IN_TOPIC },
+		brokerProperties = { "transaction.state.log.replication.factor=1", "transaction.state.log.min.isr=1" })
 public class KafkaTemplateTransactionTests {
 
 	public static final String STRING_KEY_TOPIC = "stringKeyTopic";
 
 	public static final String LOCAL_TX_IN_TOPIC = "localTxInTopic";
 
+	public static final String LOCAL_FIXED_TX_IN_TOPIC = "localFixedTxInTopic";
+
 	private final EmbeddedKafkaBroker embeddedKafka = EmbeddedKafkaCondition.getBroker();
 
-	@SuppressWarnings("deprecation")
 	@Test
 	public void testLocalTransaction() {
 		Map<String, Object> senderProps = KafkaTestUtils.producerProps(embeddedKafka);
@@ -118,7 +120,7 @@ public class KafkaTemplateTransactionTests {
 		DefaultKafkaConsumerFactory<String, String> cf = new DefaultKafkaConsumerFactory<>(consumerProps);
 		cf.setKeyDeserializer(new StringDeserializer());
 		Consumer<String, String> consumer = cf.createConsumer();
-		embeddedKafka.consumeFromAllEmbeddedTopics(consumer);
+		embeddedKafka.consumeFromEmbeddedTopics(consumer, STRING_KEY_TOPIC, LOCAL_TX_IN_TOPIC);
 		template.executeInTransaction(kt -> kt.send(LOCAL_TX_IN_TOPIC, "one"));
 		ConsumerRecord<String, String> singleRecord = KafkaTestUtils.getSingleRecord(consumer, LOCAL_TX_IN_TOPIC);
 		template.executeInTransaction(t -> {
@@ -157,6 +159,70 @@ public class KafkaTemplateTransactionTests {
 		assertThat(pf.getCache("tx.template.override.")).hasSize(1);
 		pf.destroy();
 		assertThat(pf.getCache()).hasSize(0);
+	}
+
+	@SuppressWarnings({"unchecked", "rawtypes"})
+	@Test
+	public void testLocalTransactionIsFixed() {
+		Map<String, Object> senderProps = KafkaTestUtils.producerProps(embeddedKafka);
+		senderProps.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, "my.transaction.fixed.");
+		senderProps.put(ProducerConfig.CLIENT_ID_CONFIG, "customClientIdFixed");
+		DefaultKafkaProducerFactory<String, String> pf = new DefaultKafkaProducerFactory<>(senderProps);
+		pf.setKeySerializer(new StringSerializer());
+		DefaultTransactionIdSuffixStrategy suffixStrategy = new DefaultTransactionIdSuffixStrategy();
+		suffixStrategy.setMaxCache(3);
+		pf.setTransactionIdSuffixStrategy(suffixStrategy);
+		KafkaTemplate<String, String> template = new KafkaTemplate<>(pf);
+		template.setDefaultTopic(STRING_KEY_TOPIC);
+		Map<String, Object> consumerProps = KafkaTestUtils.consumerProps("testLocalTxFixed", "false", embeddedKafka);
+		consumerProps.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
+		DefaultKafkaConsumerFactory<String, String> cf = new DefaultKafkaConsumerFactory<>(consumerProps);
+		cf.setKeyDeserializer(new StringDeserializer());
+		Consumer<String, String> consumer = cf.createConsumer();
+		embeddedKafka.consumeFromEmbeddedTopics(consumer, STRING_KEY_TOPIC, LOCAL_FIXED_TX_IN_TOPIC);
+		template.executeInTransaction(kt -> kt.send(LOCAL_FIXED_TX_IN_TOPIC, "one")); // suffix range {0-2}
+		ConsumerRecord<String, String> singleRecord = KafkaTestUtils.getSingleRecord(consumer, LOCAL_FIXED_TX_IN_TOPIC);
+		template.executeInTransaction(t -> {
+			pf.createProducer("testCustomClientIdIsUniqueFixed").close(); // suffix range {3-5}
+			t.sendDefault("foo", "bar");
+			t.sendDefault("baz", "qux");
+			t.sendOffsetsToTransaction(Collections.singletonMap(
+					new TopicPartition(LOCAL_FIXED_TX_IN_TOPIC, singleRecord.partition()),
+					new OffsetAndMetadata(singleRecord.offset() + 1L)), consumer.groupMetadata());
+			assertThat(KafkaTestUtils.getPropertyValue(
+					KafkaTestUtils.getPropertyValue(template, "producers", Map.class).get(Thread.currentThread()),
+					"delegate.transactionManager.transactionalId")).isEqualTo("my.transaction.fixed.0");
+			return null;
+		});
+		ConsumerRecords<String, String> records = KafkaTestUtils.getRecords(consumer);
+		Iterator<ConsumerRecord<String, String>> iterator = records.iterator();
+		ConsumerRecord<String, String> record = iterator.next();
+		assertThat(record).has(Assertions.<ConsumerRecord<String, String>>allOf(key("foo"), value("bar")));
+		if (!iterator.hasNext()) {
+			records = KafkaTestUtils.getRecords(consumer);
+			iterator = records.iterator();
+		}
+		record = iterator.next();
+		assertThat(record).has(Assertions.<ConsumerRecord<String, String>>allOf(key("baz"), value("qux")));
+		// 2 log slots, 1 for the record, 1 for the commit
+		assertThat(consumer.position(new TopicPartition(LOCAL_FIXED_TX_IN_TOPIC, singleRecord.partition()))).isEqualTo(2L);
+		consumer.close();
+		assertThat(pf.getCache()).hasSize(1);
+		template.setTransactionIdPrefix("tx.template.override.fixed."); // suffix range {6-8}
+		template.executeInTransaction(t -> {
+			assertThat(KafkaTestUtils.getPropertyValue(
+					KafkaTestUtils.getPropertyValue(template, "producers", Map.class).get(Thread.currentThread()),
+					"delegate.transactionManager.transactionalId")).isEqualTo("tx.template.override.fixed.6");
+			return null;
+		});
+		assertThat(pf.getCache("tx.template.override.fixed.")).hasSize(1);
+		Map<?, ?> suffixCache = KafkaTestUtils.getPropertyValue(suffixStrategy, "suffixCache", Map.class);
+		assertThat((Queue) suffixCache.get("tx.template.override.fixed.")).hasSize(2);
+		assertThat(pf.getCache("testCustomClientIdIsUniqueFixed")).hasSize(1);
+		assertThat((Queue) suffixCache.get("testCustomClientIdIsUniqueFixed")).hasSize(2);
+		pf.destroy();
+		assertThat(pf.getCache()).hasSize(0);
+		assertThat(KafkaTestUtils.getPropertyValue(suffixStrategy, "suffixCache", Map.class)).hasSize(3);
 	}
 
 	@Test
@@ -403,7 +469,7 @@ public class KafkaTemplateTransactionTests {
 			public Producer<String, String> createProducer(@Nullable String txIdPrefixArg) {
 				CloseSafeProducer<String, String> closeSafeProducer = new CloseSafeProducer<>(producer,
 						(prod, timeout) -> {
-							prod.closeDelegate(timeout, Collections.emptyList());
+							prod.closeDelegate(timeout);
 							return true;
 						},
 						Duration.ofSeconds(1), "factory", 0);
@@ -447,7 +513,7 @@ public class KafkaTemplateTransactionTests {
 				}
 				KafkaTestUtils.getPropertyValue(this, "cache", Map.class).put("foo", cache);
 				CloseSafeProducer<String, String> closeSafeProducer = new CloseSafeProducer<>(producer,
-						this::cacheReturner, "foo", Duration.ofSeconds(1), "factory", 0);
+						this::cacheReturner, "foo", "1", Duration.ofSeconds(1), "factory", 0);
 				return closeSafeProducer;
 			}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTransactionTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTransactionTests.java
@@ -169,8 +169,7 @@ public class KafkaTemplateTransactionTests {
 		senderProps.put(ProducerConfig.CLIENT_ID_CONFIG, "customClientIdFixed");
 		DefaultKafkaProducerFactory<String, String> pf = new DefaultKafkaProducerFactory<>(senderProps);
 		pf.setKeySerializer(new StringSerializer());
-		DefaultTransactionIdSuffixStrategy suffixStrategy = new DefaultTransactionIdSuffixStrategy();
-		suffixStrategy.setMaxCache(3);
+		TransactionIdSuffixStrategy suffixStrategy = new DefaultTransactionIdSuffixStrategy(3);
 		pf.setTransactionIdSuffixStrategy(suffixStrategy);
 		KafkaTemplate<String, String> template = new KafkaTemplate<>(pf);
 		template.setDefaultTopic(STRING_KEY_TOPIC);

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/TransactionalContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/TransactionalContainerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 the original author or authors.
+ * Copyright 2017-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/TransactionalContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/TransactionalContainerTests.java
@@ -496,12 +496,11 @@ public class TransactionalContainerTests {
 		verify(pf).createProducer(isNull());
 	}
 
-	@SuppressWarnings({ "unchecked", "deprecation" })
+	@SuppressWarnings({ "unchecked"})
 	@Test
 	public void testRollbackRecord() throws Exception {
 		logger.info("Start testRollbackRecord");
 		Map<String, Object> props = KafkaTestUtils.consumerProps("txTest1", "false", embeddedKafka);
-//		props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092"); test fallback to EOSMode.ALPHA
 		props.put(ConsumerConfig.GROUP_ID_CONFIG, "group");
 		props.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
 		DefaultKafkaConsumerFactory<Integer, String> cf = new DefaultKafkaConsumerFactory<>(props);
@@ -512,7 +511,6 @@ public class TransactionalContainerTests {
 		containerProps.setFixTxOffsets(true);
 
 		Map<String, Object> senderProps = KafkaTestUtils.producerProps(embeddedKafka);
-//		senderProps.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
 		DefaultKafkaProducerFactory<Integer, String> pf = new DefaultKafkaProducerFactory<>(senderProps);
 		pf.setTransactionIdPrefix("rr.");
 


### PR DESCRIPTION
Introduce a new `TransactionSuffixManager` interface with `DefaultTransactionSuffixManager` implementation to restrict `transaction.id` in range for existing [PR](https://github.com/spring-projects/spring-kafka/pull/2913)

Resolves https://github.com/spring-projects/spring-kafka/issues/2852