### PR TITLE
Fix typo in javadoc

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerConfigurer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerConfigurer.java
@@ -22,7 +22,7 @@ import org.springframework.kafka.config.KafkaListenerEndpointRegistrar;
 /**
  * Optional interface to be implemented by Spring managed bean willing
  * to customize how Kafka listener endpoints are configured. Typically
- * used to defined the default
+ * used to define the default
  * {@link org.springframework.kafka.config.KafkaListenerContainerFactory
  * KafkaListenerContainerFactory} to use or for registering Kafka endpoints
  * in a <em>programmatic</em> fashion as opposed to the <em>declarative</em>

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaStreamsDefaultConfiguration.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaStreamsDefaultConfiguration.java
@@ -29,7 +29,7 @@ import org.springframework.kafka.config.StreamsBuilderFactoryBeanConfigurer;
  * {@code @Configuration} class that registers a {@link StreamsBuilderFactoryBean}
  * if {@link org.apache.kafka.streams.StreamsConfig} with the name
  * {@link KafkaStreamsDefaultConfiguration#DEFAULT_STREAMS_CONFIG_BEAN_NAME} is present
- * in the application context. Otherwise a {@link UnsatisfiedDependencyException} is thrown.
+ * in the application context. Otherwise, a {@link UnsatisfiedDependencyException} is thrown.
  *
  * <p>This configuration class is automatically imported when using the @{@link EnableKafkaStreams}
  * annotation. See {@link EnableKafkaStreams} Javadoc for complete usage.

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/PartitionOffset.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/PartitionOffset.java
@@ -36,7 +36,7 @@ public @interface PartitionOffset {
 	 * parsed as Integer). '*' indicates that the initial offset will be applied to all
 	 * partitions in the encompassing {@link TopicPartition} The string can contain a
 	 * comma-delimited list of partitions, or ranges of partitions (e.g.
-	 * {@code 0-5, 7, 10-15}, in which case, the offset will be applied to all of those
+	 * {@code 0-5, 7, 10-15}), in which case, the offset will be applied to all of those
 	 * partitions.
 	 * @return partition within the topic.
 	 */

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/TopicPartition.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/TopicPartition.java
@@ -42,7 +42,7 @@ public @interface TopicPartition {
 	/**
 	 * The partitions within the topic. Partitions specified here can't be duplicated in
 	 * {@link #partitionOffsets()}. Each string can contain a comma-delimited list of
-	 * partitions, or ranges of partitions (e.g. {@code 0-5, 7, 10-15}.
+	 * partitions, or ranges of partitions (e.g. {@code 0-5, 7, 10-15}).
 	 * @return the partitions within the topic. Property place holders and SpEL
 	 * expressions are supported, which must resolve to Integers (or Strings that can be
 	 * parsed as Integers).

--- a/spring-kafka/src/main/java/org/springframework/kafka/requestreply/AggregatingReplyingKafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/requestreply/AggregatingReplyingKafkaTemplate.java
@@ -91,7 +91,7 @@ public class AggregatingReplyingKafkaTemplate<K, V, R>
 	 * @param replyContainer the reply container.
 	 * @param releaseStrategy the release strategy which is a {@link BiPredicate} which is
 	 * passed the current list and a boolean to indicate if this is for a normal delivery
-	 * or a timeout (when {@link #setReturnPartialOnTimeout(boolean)} is true. The
+	 * or a timeout (when {@link #setReturnPartialOnTimeout(boolean)} is true). The
 	 * predicate may modify the list of records.
 	 * @since 2.3.5
 	 */


### PR DESCRIPTION
This PR simply fixes a typo in javadoc.
