### PR TITLE
fix a default method defect in ConsumerFactory

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/DltHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/DltHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation to determine the method the should process the DLT topic message.
+ * Annotation to determine the method that should process the DLT topic message.
  * The method can have the same parameters as a {@link KafkaListener} method can (Message, Acknowledgement, etc).
  *
  * The annotated method must be in the same class as the corresponding {@link KafkaListener} annotation.

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/ConsumerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/ConsumerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import org.apache.kafka.common.serialization.Deserializer;
 import org.springframework.lang.Nullable;
 
 /**
- * The strategy to produce a {@link Consumer} instance(s).
+ * The strategy to produce a {@link Consumer} instance.
  *
  * @param <K> the key type.
  * @param <V> the value type.
@@ -79,8 +79,10 @@ public interface ConsumerFactory<K, V> {
 	 * @return the consumer.
 	 * @since 2.1.1
 	 */
-	Consumer<K, V> createConsumer(@Nullable String groupId, @Nullable String clientIdPrefix,
-			@Nullable String clientIdSuffix);
+	default Consumer<K, V> createConsumer(@Nullable String groupId, @Nullable String clientIdPrefix,
+			@Nullable String clientIdSuffix) {
+		return createConsumer(groupId, clientIdPrefix, clientIdSuffix, null);
+	}
 
 	/**
 	 * Create a consumer with an explicit group id; in addition, the
@@ -94,11 +96,8 @@ public interface ConsumerFactory<K, V> {
 	 * @return the consumer.
 	 * @since 2.2.4
 	 */
-	default Consumer<K, V> createConsumer(@Nullable String groupId, @Nullable String clientIdPrefix,
-			@Nullable String clientIdSuffix, @Nullable Properties properties) {
-
-		return createConsumer(groupId, clientIdPrefix, clientIdSuffix);
-	}
+	Consumer<K, V> createConsumer(@Nullable String groupId, @Nullable String clientIdPrefix,
+			@Nullable String clientIdSuffix, @Nullable Properties properties);
 
 	/**
 	 * Return true if consumers created by this factory use auto commit.
@@ -155,7 +154,6 @@ public interface ConsumerFactory<K, V> {
 	 * @since 2.5.3
 	 */
 	default void addListener(int index, Listener<K, V> listener) {
-
 	}
 
 	/**
@@ -164,7 +162,6 @@ public interface ConsumerFactory<K, V> {
 	 * @since 2.5.3
 	 */
 	default void addListener(Listener<K, V> listener) {
-
 	}
 
 	/**
@@ -182,7 +179,6 @@ public interface ConsumerFactory<K, V> {
 	 * @since 2.5.3
 	 */
 	default void addPostProcessor(ConsumerPostProcessor<K, V> postProcessor) {
-
 	}
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
@@ -354,13 +354,6 @@ public class DefaultKafkaConsumerFactory<K, V> extends KafkaResourceFactory
 
 	@Override
 	public Consumer<K, V> createConsumer(@Nullable String groupId, @Nullable String clientIdPrefix,
-			@Nullable String clientIdSuffix) {
-
-		return createKafkaConsumer(groupId, clientIdPrefix, clientIdSuffix, null);
-	}
-
-	@Override
-	public Consumer<K, V> createConsumer(@Nullable String groupId, @Nullable String clientIdPrefix,
 			@Nullable final String clientIdSuffixArg, @Nullable Properties properties) {
 
 		return createKafkaConsumer(groupId, clientIdPrefix, clientIdSuffixArg, properties);

--- a/spring-kafka/src/main/java/org/springframework/kafka/security/jaas/KafkaJaasLoginModuleInitializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/security/jaas/KafkaJaasLoginModuleInitializer.java
@@ -162,8 +162,8 @@ public class KafkaJaasLoginModuleInitializer implements SmartInitializingSinglet
 		private final Configuration delegate;
 
 		InternalConfiguration(Map<String, AppConfigurationEntry[]> configurationEntries, Configuration delegate) {
-			Assert.notNull(configurationEntries, " cannot be null");
-			Assert.notEmpty(configurationEntries, " cannot be empty");
+			Assert.notNull(configurationEntries, "'configurationEntries' cannot be null");
+			Assert.notEmpty(configurationEntries, "'configurationEntries' cannot be empty");
 			this.configurationEntries = configurationEntries;
 			this.delegate = delegate;
 		}


### PR DESCRIPTION
in ConsumerFactory interface, the following two methods seems counter-intuitive:
```
Consumer<K, V> createConsumer(@Nullable String groupId, @Nullable String clientIdPrefix,
			@Nullable String clientIdSuffix);
default Consumer<K, V> createConsumer(@Nullable String groupId, @Nullable String clientIdPrefix,
			@Nullable String clientIdSuffix, @Nullable Properties properties) {

		return createConsumer(groupId, clientIdPrefix, clientIdSuffix);
	}
```
seems we should switch the `default` relationship the other way.

Also fixed some grammatical and logging defects in other classes
