### PR TITLE
Improve MockProducerFactory usability by wrapping  MockProducer with …

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/mock/MockProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/mock/MockProducerFactory.java
@@ -29,6 +29,7 @@ import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.ProducerFencedException;
+
 import org.springframework.core.log.LogAccessor;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.ProducerFactory;

--- a/spring-kafka/src/main/java/org/springframework/kafka/mock/MockProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/mock/MockProducerFactory.java
@@ -29,7 +29,6 @@ import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.ProducerFencedException;
-
 import org.springframework.core.log.LogAccessor;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.ProducerFactory;
@@ -80,8 +79,7 @@ public class MockProducerFactory<K, V> implements ProducerFactory<K, V> {
 	 * @param producerProvider the provider function.
 	 * @param defaultTxId the default transactional id.
 	 */
-	public MockProducerFactory(BiFunction<Boolean, String, MockProducer<K, V>> producerProvider,
-							   @Nullable String defaultTxId) {
+	public MockProducerFactory(BiFunction<Boolean, String, MockProducer<K, V>> producerProvider, @Nullable String defaultTxId) {
 
 		this.producerProvider = producerProvider;
 		this.defaultTxId = defaultTxId;
@@ -100,9 +98,8 @@ public class MockProducerFactory<K, V> implements ProducerFactory<K, V> {
 
 	@Override
 	public Producer<K, V> createProducer(@Nullable String txIdPrefix) {
-		return txIdPrefix == null && this.defaultTxId == null
-				? new CloseSafeMockProducer<>(this.producerProvider.apply(false, null))
-				: new CloseSafeMockProducer<>(this.producerProvider.apply(true, txIdPrefix == null ? this.defaultTxId : txIdPrefix));
+		return txIdPrefix == null && this.defaultTxId == null ? new CloseSafeMockProducer<>(this.producerProvider.apply(false, null)) :
+				new CloseSafeMockProducer<>(this.producerProvider.apply(true, txIdPrefix == null ? this.defaultTxId : txIdPrefix));
 	}
 
 	@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/mock/MockProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/mock/MockProducerFactory.java
@@ -111,76 +111,76 @@ public class MockProducerFactory<K, V> implements ProducerFactory<K, V> {
 
 	/**
 	 *
-	 * A wrapper class for the delegate, inspired by {@link DefaultKafkaProducerFactory.CloseSafeProducer}
+	 * A wrapper class for the delegate, inspired by {@link DefaultKafkaProducerFactory.CloseSafeProducer}.
 	 *
 	 * @param <K> the key type.
 	 * @param <V> the value type.
 	 *
 	 * @author Pawel Szymczyk
 	 */
-	static class CloseSafeMockProducer<K,V> implements Producer<K, V> {
+	static class CloseSafeMockProducer<K,V> implements Producer<K,V> {
 
 		private static final LogAccessor LOGGER = new LogAccessor(LogFactory.getLog(CloseSafeMockProducer.class));
 
 		private final MockProducer<K, V> delegate;
 
-		public CloseSafeMockProducer(MockProducer<K, V> delegate) {
+		CloseSafeMockProducer(MockProducer<K,V> delegate) {
 			this.delegate = delegate;
 		}
 
 		@Override
 		public void initTransactions() {
-			delegate.initTransactions();
+			this.delegate.initTransactions();
 		}
 
 		@Override
 		public void beginTransaction() throws ProducerFencedException {
-			delegate.beginTransaction();
+			this.delegate.beginTransaction();
 		}
 
 		@Override
 		public void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets, String consumerGroupId) throws ProducerFencedException {
-			delegate.sendOffsetsToTransaction(offsets, consumerGroupId);
+			this.delegate.sendOffsetsToTransaction(offsets, consumerGroupId);
 		}
 
 		@Override
 		public void sendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets, ConsumerGroupMetadata groupMetadata) throws ProducerFencedException {
-			delegate.sendOffsetsToTransaction(offsets, groupMetadata);
+			this.delegate.sendOffsetsToTransaction(offsets, groupMetadata);
 		}
 
 		@Override
 		public void commitTransaction() throws ProducerFencedException {
-			delegate.commitTransaction();
+			this.delegate.commitTransaction();
 		}
 
 		@Override
 		public void abortTransaction() throws ProducerFencedException {
-			delegate.abortTransaction();
+			this.delegate.abortTransaction();
 		}
 
 		@Override
 		public Future<RecordMetadata> send(ProducerRecord<K, V> record) {
-			return delegate.send(record);
+			return this.delegate.send(record);
 		}
 
 		@Override
 		public Future<RecordMetadata> send(ProducerRecord<K, V> record, Callback callback) {
-			return delegate.send(record, callback);
+			return this.delegate.send(record, callback);
 		}
 
 		@Override
 		public void flush() {
-			delegate.flush();
+			this.delegate.flush();
 		}
 
 		@Override
 		public List<PartitionInfo> partitionsFor(String topic) {
-			return delegate.partitionsFor(topic);
+			return this.delegate.partitionsFor(topic);
 		}
 
 		@Override
 		public Map<MetricName, ? extends Metric> metrics() {
-			return delegate.metrics();
+			return this.delegate.metrics();
 		}
 
 		@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/mock/MockProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/mock/MockProducerFactory.java
@@ -29,6 +29,7 @@ import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.ProducerFencedException;
+
 import org.springframework.core.log.LogAccessor;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.ProducerFactory;
@@ -189,7 +190,7 @@ public class MockProducerFactory<K, V> implements ProducerFactory<K, V> {
 
 		@Override
 		public void close(Duration timeout) {
-			LOGGER.debug(() -> "The closing of delegate producer " + delegate + "has been skipped.");
+			LOGGER.debug(() -> "The closing of delegate producer " + this.delegate + "has been skipped.");
 		}
 	}
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/mock/MockProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/mock/MockProducerFactory.java
@@ -16,20 +16,12 @@
 
 package org.springframework.kafka.mock;
 
-import java.time.Duration;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.Future;
-import java.util.function.BiFunction;
-import java.util.function.Supplier;
-
 import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.clients.producer.Producer;
-
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.Metric;
@@ -42,6 +34,13 @@ import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.lang.Nullable;
 
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Future;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+
 /**
  * Support the use of {@link MockProducer} in tests.
  *
@@ -51,7 +50,6 @@ import org.springframework.lang.Nullable;
  * @author Gary Russell
  * @author Pawel Szymczyk
  * @since 3.0.7
- *
  */
 public class MockProducerFactory<K, V> implements ProducerFactory<K, V> {
 
@@ -64,6 +62,7 @@ public class MockProducerFactory<K, V> implements ProducerFactory<K, V> {
 
 	/**
 	 * Create an instance that does not support transactional producers.
+	 *
 	 * @param producerProvider a {@link Supplier} for a {@link MockProducer}.
 	 */
 	public MockProducerFactory(Supplier<MockProducer<K, V>> producerProvider) {
@@ -76,11 +75,12 @@ public class MockProducerFactory<K, V> implements ProducerFactory<K, V> {
 	 * Create an instance that supports transactions, with the supplied producer provider {@link BiFunction}. The
 	 * function has two parameters, a boolean indicating whether a transactional producer
 	 * is being requested and, if true, the transaction id prefix for that producer.
+	 *
 	 * @param producerProvider the provider function.
 	 * @param defaultTxId the default transactional id.
 	 */
 	public MockProducerFactory(BiFunction<Boolean, String, MockProducer<K, V>> producerProvider,
-			@Nullable String defaultTxId) {
+							   @Nullable String defaultTxId) {
 
 		this.producerProvider = producerProvider;
 		this.defaultTxId = defaultTxId;
@@ -110,7 +110,6 @@ public class MockProducerFactory<K, V> implements ProducerFactory<K, V> {
 	}
 
 	/**
-	 *
 	 * A wrapper class for the delegate, inspired by {@link DefaultKafkaProducerFactory.CloseSafeProducer}.
 	 *
 	 * @param <K> the key type.
@@ -118,13 +117,13 @@ public class MockProducerFactory<K, V> implements ProducerFactory<K, V> {
 	 *
 	 * @author Pawel Szymczyk
 	 */
-	static class CloseSafeMockProducer<K,V> implements Producer<K,V> {
+	static class CloseSafeMockProducer<K, V> implements Producer<K, V> {
 
 		private static final LogAccessor LOGGER = new LogAccessor(LogFactory.getLog(CloseSafeMockProducer.class));
 
 		private final MockProducer<K, V> delegate;
 
-		CloseSafeMockProducer(MockProducer<K,V> delegate) {
+		CloseSafeMockProducer(MockProducer<K, V> delegate) {
 			this.delegate = delegate;
 		}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/mock/MockProducerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/mock/MockProducerFactoryTests.java
@@ -1,0 +1,24 @@
+package org.springframework.kafka.mock;
+
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.Test;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Pawel Szymczyk
+ */
+public class MockProducerFactoryTests {
+
+	@Test
+	void testSendingMultipleMessagesWithMockProducer() {
+		MockProducer<String, String> mockProducer = new MockProducer<>(true, new StringSerializer(), new StringSerializer());
+		MockProducerFactory<String, String> mockProducerFactory = new MockProducerFactory<>(() -> mockProducer);
+		KafkaTemplate<String, String> kafkaTemplate = new KafkaTemplate<>(mockProducerFactory);
+		kafkaTemplate.send("topic", "Hello");
+		kafkaTemplate.send("topic", "World");
+		assertThat(mockProducer.history()).hasSize(2);
+	}
+}


### PR DESCRIPTION
…CloseSafeMockProducer

Hi

In the current project, I've opted to use the `MockProducer` class and Spring support in the form of `MockProducerFactory`. Unfortunately, it turns out that after the first message is sent,  `KafkaTemplate` by default closes the provided `MockProducer` instance, making it impossible to send another message. I suggest a solution in which the factory wraps the MockProducer in a class that ignores the producer's closing.

Best regards,
Pawel
<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
