### PR TITLE
improvements in `MessagingMessageListenerAdapter` and `KafkaUtils`

### DIFF
--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -1083,7 +1083,6 @@ public class EnableKafkaIntegrationTests {
 		@Autowired
 		private EmbeddedKafkaBroker embeddedKafka;
 
-		@SuppressWarnings("unchecked")
 		@Bean
 		public MeterRegistry meterRegistry() {
 			return new SimpleMeterRegistry();


### PR DESCRIPTION
Improvements in `MessagingMessageListenerAdapter` and `KafkaUtils`

* improvements and clenaup in `MessagingMessageListenerAdapter` and `KafkaUtils`
* clenaup in `EnableKafkaIntegrationTests`

----

Submit the improvements work separately, because of issue #1189 is complicated:
* `@KafkaListener` `@KafkaHandler` support Async return
  * support `Mono` and `CompletableFuture` copy/paste from [AMQP-832](https://github.com/spring-projects/spring-amqp/issues/2374), 
  * support `Kotlin Continuation`, copy/paste from [GH-1210: Add Kotlin suspend functions support](https://github.com/spring-projects/spring-amqp/issues/1210)
  * Invoke KafkaListenerErrorHandler, copy/paste from [GH-2461: RabbitListenerErrorHandler with Async](https://github.com/spring-projects/spring-amqp/issues/2461)
* add warn log if the container is not configured for MANUAL acks and isAsyncAcks, copy/paste from [@RabbitListener async result polishing](https://github.com/spring-projects/spring-amqp/commit/ae06325b9d212eeaa571148219fd075b1890a1ea)
* when batch listener, skip fatal exceptions message,  copy/paste from [GH-1409: Fix Nacks for Async Replies](https://github.com/spring-projects/spring-amqp/issues/1409)
* detect async return than coerce the `AcknowledgeMode` to `MANUAL` and `isAsyncAcks` to true,  copy/paste from [GH-1409: Fix Nacks for Async Replies](https://github.com/spring-projects/spring-amqp/issues/1409)

That's Real Cool!!!