### PR TITLE
GH-1189: Asynchronous server-side processing in a request/reply scenario

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,7 @@ ext {
 	junit4Version = '4.13.2'
 	junitJupiterVersion = '5.10.1'
 	kafkaVersion = '3.6.1'
+	kotlinCoroutinesVersion = '1.7.3'
 	log4jVersion = '2.21.1'
 	micrometerDocsVersion = '1.0.2'
 	micrometerVersion = '1.12.1'
@@ -276,6 +277,7 @@ project ('spring-kafka') {
 		}
 		api "org.apache.kafka:kafka-clients:$kafkaVersion"
 		optionalApi "org.apache.kafka:kafka-streams:$kafkaVersion"
+		optionalApi "org.jetbrains.kotlinx:kotlinx-coroutines-reactor:$kotlinCoroutinesVersion"
 		optionalApi 'com.fasterxml.jackson.core:jackson-core'
 		optionalApi 'com.fasterxml.jackson.core:jackson-databind'
 		optionalApi 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8'

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/receiving-messages/async-returns.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/receiving-messages/async-returns.adoc
@@ -23,7 +23,7 @@ public Mono<Void> listen(String data) {
 }
 ----
 
-IMPORTANT: The listener container factory must be configured with manual ack mode and async ack to enable out-of-order commits; instead, the asynchronous completion will ack or nack the message when the async operation completes.
+IMPORTANT: The `AckMode` will be automatically set the `MANUAL` and enable out-of-order commits when async return types are detected; instead, the asynchronous completion will ack when the async operation completes.
 When the async result is completed with an error, whether the message is recover or not depends on the container error handler.
 If some exception occurs within the listener method that prevents creation of the async result object, you MUST catch that exception and return an appropriate return object that will cause the message to be ack or recover.
 

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/receiving-messages/async-returns.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/receiving-messages/async-returns.adoc
@@ -1,0 +1,31 @@
+[[async-returns]]
+= Asynchronous `@KafkaListener` Return Types
+
+`@KafkaListener` (and `@KafkaHandler`) methods can be specified with asynchronous return types `CompletableFuture<?>` and `Mono<?>`, letting the reply be sent asynchronously.
+
+[source, java]
+----
+@KafkaListener(id = "myListener", topics = "myTopic")
+public CompletableFuture<String> listen(String data) {
+    ...
+    CompletableFuture<String> future = new CompletableFuture<>();
+    future.complete("done");
+    return future;
+}
+----
+
+[source, java]
+----
+@KafkaListener(id = "myListener", topics = "myTopic")
+public Mono<Void> listen(String data) {
+    ...
+    return Mono.empty();
+}
+----
+
+IMPORTANT: The listener container factory must be configured with manual ack mode and async ack to enable out-of-order commits; instead, the asynchronous completion will ack or nack the message when the async operation completes.
+When the async result is completed with an error, whether the message is recover or not depends on the container error handler.
+If some exception occurs within the listener method that prevents creation of the async result object, you MUST catch that exception and return an appropriate return object that will cause the message to be ack or recover.
+
+If a `KafkaListenerErrorHandler` is configured on a listener with an async return type, the error handler is invoked after a failure.
+See xref:kafka/annotation-error-handling.adoc[Handling Exceptions] for more information about this error handler and its purpose.

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/receiving-messages/async-returns.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/receiving-messages/async-returns.adoc
@@ -27,5 +27,5 @@ IMPORTANT: The listener container factory must be configured with manual ack mod
 When the async result is completed with an error, whether the message is recover or not depends on the container error handler.
 If some exception occurs within the listener method that prevents creation of the async result object, you MUST catch that exception and return an appropriate return object that will cause the message to be ack or recover.
 
-If a `KafkaListenerErrorHandler` is configured on a listener with an async return type, the error handler is invoked after a failure.
+If a `KafkaListenerErrorHandler` is configured on a listener with an async return type (including Kotlin suspend functions), the error handler is invoked after a failure.
 See xref:kafka/annotation-error-handling.adoc[Handling Exceptions] for more information about this error handler and its purpose.

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -50,3 +50,9 @@ See xref:retrytopic/topic-naming.adoc[Topic Naming] for more information.
 
 When manually assigning partitions, with a `null` consumer `group.id`, the `AckMode` is now automatically coerced to `MANUAL`.
 See xref:tips.adoc#tip-assign-all-parts[Manually Assigning All Partitions] for more information.
+
+[[x31-async-return]]
+=== Async @KafkaListener Return
+
+`@KafkaListener` (and `@KafkaHandler`) methods can now return asynchronous return types `CompletableFuture<?>` and `Mono<?>`.
+See xref:kafka/receiving-messages/async-returns.adoc[Async Returns] for more information.

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/ContinuationHandlerMethodArgumentResolver.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/ContinuationHandlerMethodArgumentResolver.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.annotation;
+
+/**
+ * No-op resolver for method arguments of type {@link kotlin.coroutines.Continuation}.
+ * <p>
+ * This class is similar to
+ * {@link org.springframework.messaging.handler.annotation.reactive.ContinuationHandlerMethodArgumentResolver}
+ * but for regular {@link HandlerMethodArgumentResolver} contract.
+ *
+ * @author Wang Zhiyang
+ *
+ * @since 3.1
+ *
+ * @see org.springframework.messaging.handler.annotation.reactive.ContinuationHandlerMethodArgumentResolver
+ */
+import org.springframework.core.MethodParameter;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
+
+import reactor.core.publisher.Mono;
+
+public class ContinuationHandlerMethodArgumentResolver implements HandlerMethodArgumentResolver {
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return "kotlin.coroutines.Continuation".equals(parameter.getParameterType().getName());
+	}
+
+	@Override
+	public Object resolveArgument(MethodParameter parameter, Message<?> message) {
+		return Mono.empty();
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
@@ -1155,7 +1155,7 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 		}
 
 		private MessageHandlerMethodFactory createDefaultMessageHandlerMethodFactory() {
-			DefaultMessageHandlerMethodFactory defaultFactory = new DefaultMessageHandlerMethodFactory();
+			DefaultMessageHandlerMethodFactory defaultFactory = new KafkaMessageHandlerMethodFactory();
 			Validator validator = KafkaListenerAnnotationBeanPostProcessor.this.registrar.getValidator();
 			if (validator != null) {
 				defaultFactory.setValidator(validator);
@@ -1170,8 +1170,6 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 
 			List<HandlerMethodArgumentResolver> customArgumentsResolver =
 					new ArrayList<>(KafkaListenerAnnotationBeanPostProcessor.this.registrar.getCustomMethodArgumentResolvers());
-			// Has to be at the end - look at PayloadMethodArgumentResolver documentation
-			customArgumentsResolver.add(new KafkaNullAwarePayloadArgumentResolver(messageConverter, validator));
 			defaultFactory.setCustomArgumentResolvers(customArgumentsResolver);
 
 			defaultFactory.afterPropertiesSet();

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaMessageHandlerMethodFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaMessageHandlerMethodFactory.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.annotation;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+import org.springframework.core.KotlinDetector;
+import org.springframework.messaging.converter.MessageConverter;
+import org.springframework.messaging.handler.annotation.support.DefaultMessageHandlerMethodFactory;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
+import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolverComposite;
+import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
+import org.springframework.validation.Validator;
+
+/**
+ * Extension of the {@link DefaultMessageHandlerMethodFactory} for Spring Kafka requirements.
+ *
+ * @author Wang Zhiyang
+ *
+ * @since 3.1
+ */
+public class KafkaMessageHandlerMethodFactory extends DefaultMessageHandlerMethodFactory {
+
+	private final HandlerMethodArgumentResolverComposite argumentResolvers =
+			new HandlerMethodArgumentResolverComposite();
+
+	private MessageConverter messageConverter;
+
+	private Validator validator;
+
+	@Override
+	public void setMessageConverter(MessageConverter messageConverter) {
+		super.setMessageConverter(messageConverter);
+		this.messageConverter = messageConverter;
+	}
+
+	@Override
+	public void setValidator(Validator validator) {
+		super.setValidator(validator);
+		this.validator = validator;
+	}
+
+	@Override
+	protected List<HandlerMethodArgumentResolver> initArgumentResolvers() {
+		List<HandlerMethodArgumentResolver> resolvers = super.initArgumentResolvers();
+		if (KotlinDetector.isKotlinPresent()) {
+			// Insert before PayloadMethodArgumentResolver
+			resolvers.add(resolvers.size() - 1, new ContinuationHandlerMethodArgumentResolver());
+		}
+		// Has to be at the end - look at PayloadMethodArgumentResolver documentation
+		resolvers.add(resolvers.size() - 1, new KafkaNullAwarePayloadArgumentResolver(this.messageConverter, this.validator));
+		this.argumentResolvers.addResolvers(resolvers);
+		return resolvers;
+	}
+
+	@Override
+	public InvocableHandlerMethod createInvocableHandlerMethod(Object bean, Method method) {
+		InvocableHandlerMethod handlerMethod = new KotlinAwareInvocableHandlerMethod(bean, method);
+		handlerMethod.setMessageMethodArgumentResolvers(this.argumentResolvers);
+		return handlerMethod;
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KotlinAwareInvocableHandlerMethod.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KotlinAwareInvocableHandlerMethod.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.annotation;
+
+import java.lang.reflect.Method;
+
+import org.springframework.core.CoroutinesUtils;
+import org.springframework.core.KotlinDetector;
+import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
+
+/**
+ * An {@link InvocableHandlerMethod} extension for supporting Kotlin {@code suspend} function.
+ *
+ * @author Wang Zhiyang
+ *
+ * @since 3.1
+ */
+public class KotlinAwareInvocableHandlerMethod extends InvocableHandlerMethod {
+
+	public KotlinAwareInvocableHandlerMethod(Object bean, Method method) {
+		super(bean, method);
+	}
+
+	@Override
+	protected Object doInvoke(Object... args) throws Exception {
+		Method method = getBridgedMethod();
+		if (KotlinDetector.isSuspendingFunction(method)) {
+			return CoroutinesUtils.invokeSuspendingFunction(method, getBean(), args);
+		}
+		else {
+			return super.doInvoke(args);
+		}
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/MethodKafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/MethodKafkaListenerEndpoint.java
@@ -147,8 +147,8 @@ public class MethodKafkaListenerEndpoint<K, V> extends AbstractKafkaListenerEndp
 				}
 				String topic = destinations.length == 1 ? destinations[0] : "";
 				BeanFactory beanFactory = getBeanFactory();
-				if (beanFactory instanceof ConfigurableListableBeanFactory) {
-					topic = ((ConfigurableListableBeanFactory) beanFactory).resolveEmbeddedValue(topic);
+				if (beanFactory instanceof ConfigurableListableBeanFactory configurableListableBeanFactory) {
+					topic = configurableListableBeanFactory.resolveEmbeddedValue(topic);
 					if (topic != null) {
 						topic = resolve(topic);
 					}

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/MethodKafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/MethodKafkaListenerEndpoint.java
@@ -213,16 +213,16 @@ public class MethodKafkaListenerEndpoint<K, V> extends AbstractKafkaListenerEndp
 			if (batchToRecordAdapter != null) {
 				messageListener.setBatchToRecordAdapter(batchToRecordAdapter);
 			}
-			if (messageConverter instanceof BatchMessageConverter) {
-				messageListener.setBatchMessageConverter((BatchMessageConverter) messageConverter);
+			if (messageConverter instanceof BatchMessageConverter batchMessageConverter) {
+				messageListener.setBatchMessageConverter(batchMessageConverter);
 			}
 			listener = messageListener;
 		}
 		else {
 			RecordMessagingMessageListenerAdapter<K, V> messageListener = new RecordMessagingMessageListenerAdapter<K, V>(
 					this.bean, this.method, this.errorHandler);
-			if (messageConverter instanceof RecordMessageConverter) {
-				messageListener.setMessageConverter((RecordMessageConverter) messageConverter);
+			if (messageConverter instanceof RecordMessageConverter recordMessageConverter) {
+				messageListener.setMessageConverter(recordMessageConverter);
 			}
 			listener = messageListener;
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaListenerErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaListenerErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2019 the original author or authors.
+ * Copyright 2017-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,6 +72,7 @@ public interface KafkaListenerErrorHandler {
 	 * @return the return value is ignored unless the annotated method has a
 	 * {@code @SendTo} annotation.
 	 */
+	@Nullable
 	default Object handleError(Message<?> message, ListenerExecutionFailedException exception,
 			Consumer<?, ?> consumer, @Nullable Acknowledgment ack) {
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -104,6 +104,7 @@ import org.springframework.kafka.listener.ConsumerSeekAware.ConsumerSeekCallback
 import org.springframework.kafka.listener.ContainerProperties.AckMode;
 import org.springframework.kafka.listener.ContainerProperties.AssignmentCommitOption;
 import org.springframework.kafka.listener.ContainerProperties.EOSMode;
+import org.springframework.kafka.listener.adapter.HandlerMethodDetect;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.support.KafkaUtils;
@@ -159,6 +160,7 @@ import io.micrometer.observation.ObservationRegistry;
  * @author Tomaz Fernandes
  * @author Francois Rosiere
  * @author Daniel Gentes
+ * @author Wang Zhiyang
  */
 public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		extends AbstractMessageListenerContainer<K, V> implements ConsumerPauseResumeEventPublisher {
@@ -659,6 +661,8 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 
 		private final boolean wantsFullRecords;
 
+		private final boolean asyncReplies;
+
 		private final boolean autoCommit;
 
 		private final boolean isManualAck;
@@ -849,6 +853,8 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		ListenerConsumer(GenericMessageListener<?> listener, ListenerType listenerType,
 				ObservationRegistry observationRegistry) {
 
+			this.asyncReplies = listener instanceof HandlerMethodDetect hmd && hmd.isAsyncReplies()
+					|| this.containerProperties.isAsyncAcks();
 			AckMode ackMode = determineAckMode();
 			this.isManualAck = ackMode.equals(AckMode.MANUAL);
 			this.isCountAck = ackMode.equals(AckMode.COUNT)
@@ -859,12 +865,12 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			this.isAnyManualAck = this.isManualAck || this.isManualImmediateAck;
 			this.isRecordAck = ackMode.equals(AckMode.RECORD);
 			this.offsetsInThisBatch =
-					this.isAnyManualAck && this.containerProperties.isAsyncAcks()
-							? new HashMap<>()
+					this.isAnyManualAck && this.asyncReplies
+							? new ConcurrentHashMap<>()
 							: null;
 			this.deferredOffsets =
-					this.isAnyManualAck && this.containerProperties.isAsyncAcks()
-							? new HashMap<>()
+					this.isAnyManualAck && this.asyncReplies
+							? new ConcurrentHashMap<>()
 							: null;
 
 			this.observationRegistry = observationRegistry;
@@ -903,8 +909,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			else {
 				throw new IllegalArgumentException("Listener must be one of 'MessageListener', "
 						+ "'BatchMessageListener', or the variants that are consumer aware and/or "
-						+ "Acknowledging"
-						+ " not " + listener.getClass().getName());
+						+ "Acknowledging not " + listener.getClass().getName());
 			}
 			this.listenerType = listenerType;
 			this.isConsumerAwareListener = listenerType.equals(ListenerType.ACKNOWLEDGING_CONSUMER_AWARE)
@@ -927,18 +932,15 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 				this.logger.info(toString());
 			}
 			ApplicationContext applicationContext = getApplicationContext();
+			ClassLoader classLoader = applicationContext == null
+					? getClass().getClassLoader()
+					: applicationContext.getClassLoader();
 			this.checkNullKeyForExceptions = this.containerProperties.isCheckDeserExWhenKeyNull()
 					|| ErrorHandlingUtils.checkDeserializer(KafkaMessageListenerContainer.this.consumerFactory,
-							consumerProperties, false,
-							applicationContext == null
-									? getClass().getClassLoader()
-									: applicationContext.getClassLoader());
+							consumerProperties, false, classLoader);
 			this.checkNullValueForExceptions = this.containerProperties.isCheckDeserExWhenValueNull()
 					|| ErrorHandlingUtils.checkDeserializer(KafkaMessageListenerContainer.this.consumerFactory,
-							consumerProperties, true,
-							applicationContext == null
-									? getClass().getClassLoader()
-									: applicationContext.getClassLoader());
+							consumerProperties, true, classLoader);
 			this.syncCommitTimeout = determineSyncCommitTimeout();
 			if (this.containerProperties.getSyncCommitTimeout() == null) {
 				// update the property, so we can use it directly from code elsewhere
@@ -962,6 +964,9 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		private AckMode determineAckMode() {
 			AckMode ackMode = this.containerProperties.getAckMode();
 			if (this.consumerGroupId == null && KafkaMessageListenerContainer.this.topicPartitions != null) {
+				ackMode = AckMode.MANUAL;
+			}
+			if (this.asyncReplies && !(AckMode.MANUAL_IMMEDIATE.equals(ackMode) || AckMode.MANUAL.equals(ackMode))) {
 				ackMode = AckMode.MANUAL;
 			}
 			return ackMode;
@@ -3388,15 +3393,15 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			public void nack(Duration sleep) {
 				Assert.state(Thread.currentThread().equals(ListenerConsumer.this.consumerThread),
 						"nack() can only be called on the consumer thread");
-				Assert.state(!ListenerConsumer.this.containerProperties.isAsyncAcks(),
-						"nack() is not supported with out-of-order commits (asyncAcks=true)");
+				Assert.state(!ListenerConsumer.this.asyncReplies,
+						"nack() is not supported with out-of-order commits");
 				Assert.isTrue(!sleep.isNegative(), "sleep cannot be negative");
 				ListenerConsumer.this.nackSleepDurationMillis = sleep.toMillis();
 			}
 
 			@Override
-			public boolean isAsyncAcks() {
-				return !ListenerConsumer.this.containerProperties.isAsyncAcks();
+			public boolean isOutOfOrderCommit() {
+				return ListenerConsumer.this.asyncReplies;
 			}
 
 			@Override
@@ -3473,8 +3478,8 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			public void nack(int index, Duration sleep) {
 				Assert.state(Thread.currentThread().equals(ListenerConsumer.this.consumerThread),
 						"nack() can only be called on the consumer thread");
-				Assert.state(!ListenerConsumer.this.containerProperties.isAsyncAcks(),
-						"nack() is not supported with out-of-order commits (asyncAcks=true)");
+				Assert.state(!ListenerConsumer.this.asyncReplies,
+						"nack() is not supported with out-of-order commits");
 				Assert.isTrue(!sleep.isNegative(), "sleep cannot be negative");
 				Assert.isTrue(index >= 0 && index < this.records.count(), "index out of bounds");
 				ListenerConsumer.this.nackIndex = index;
@@ -3498,8 +3503,8 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			}
 
 			@Override
-			public boolean isAsyncAcks() {
-				return !ListenerConsumer.this.containerProperties.isAsyncAcks();
+			public boolean isOutOfOrderCommit() {
+				return ListenerConsumer.this.asyncReplies;
 			}
 
 			@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -3395,6 +3395,11 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			}
 
 			@Override
+			public boolean isAsyncAcks() {
+				return !ListenerConsumer.this.containerProperties.isAsyncAcks();
+			}
+
+			@Override
 			public String toString() {
 				return "Acknowledgment for " + KafkaUtils.format(this.cRecord);
 			}
@@ -3490,6 +3495,11 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 							tp -> new LinkedList<>()).add(cRecord);
 				}
 				processAcks(new ConsumerRecords<K, V>(newRecords));
+			}
+
+			@Override
+			public boolean isAsyncAcks() {
+				return !ListenerConsumer.this.containerProperties.isAsyncAcks();
 			}
 
 			@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/AdapterUtils.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/AdapterUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 the original author or authors.
+ * Copyright 2020-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 
 package org.springframework.kafka.listener.adapter;
 
+import java.util.concurrent.CompletableFuture;
+
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.TopicPartition;
@@ -24,6 +26,9 @@ import org.springframework.expression.ParserContext;
 import org.springframework.expression.common.TemplateParserContext;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.lang.Nullable;
+import org.springframework.util.ClassUtils;
+
+import reactor.core.publisher.Mono;
 
 /**
  * Utilities for listener adapters.
@@ -39,6 +44,9 @@ public final class AdapterUtils {
 	 * @since 2.2.15
 	 */
 	public static final ParserContext PARSER_CONTEXT = new TemplateParserContext("!{", "}");
+
+	private static final boolean MONO_PRESENT =
+			ClassUtils.isPresent("reactor.core.publisher.Mono", AdapterUtils.class.getClassLoader());
 
 	private AdapterUtils() {
 	}
@@ -84,6 +92,18 @@ public final class AdapterUtils {
 	public static String getDefaultReplyTopicExpression() {
 		return PARSER_CONTEXT.getExpressionPrefix() + "source.headers['"
 				+ KafkaHeaders.REPLY_TOPIC + "']" + PARSER_CONTEXT.getExpressionSuffix();
+	}
+
+	static boolean isAsyncReply(Class<?> resultType) {
+		return isMono(resultType) || isCompletableFuture(resultType);
+	}
+
+	static boolean isMono(Class<?> resultType) {
+		return MONO_PRESENT && Mono.class.isAssignableFrom(resultType);
+	}
+
+	static boolean isCompletableFuture(Class<?> resultType) {
+		return CompletableFuture.class.isAssignableFrom(resultType);
 	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/DelegatingInvocableHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/DelegatingInvocableHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 the original author or authors.
+ * Copyright 2016-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -335,6 +335,17 @@ public class DelegatingInvocableHandler {
 
 	public boolean hasDefaultHandler() {
 		return this.defaultHandler != null;
+	}
+
+	@Nullable
+	public InvocationResult getInvocationResultFor(Object result, Object inboundPayload) {
+
+		InvocableHandlerMethod handler = findHandlerForPayload(inboundPayload.getClass());
+		if (handler != null) {
+			return new InvocationResult(result, this.handlerSendTo.get(handler),
+					this.handlerReturnsMessage.get(handler));
+		}
+		return null;
 	}
 
 	private static final class PayloadValidator extends PayloadMethodArgumentResolver {

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/DelegatingInvocableHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/DelegatingInvocableHandler.java
@@ -55,6 +55,7 @@ import org.springframework.validation.Validator;
  * unambiguous.
  *
  * @author Gary Russell
+ * @author Wang Zhiyang
  *
  */
 public class DelegatingInvocableHandler {
@@ -86,6 +87,8 @@ public class DelegatingInvocableHandler {
 
 	private final PayloadValidator validator;
 
+	private final boolean asyncReplies;
+
 	/**
 	 * Construct an instance with the supplied handlers for the bean.
 	 * @param handlers the handlers.
@@ -116,6 +119,15 @@ public class DelegatingInvocableHandler {
 				? (ConfigurableListableBeanFactory) beanFactory
 				: null;
 		this.validator = validator == null ? null : new PayloadValidator(validator);
+		boolean asyncReplies = defaultHandler != null && isAsyncReply(defaultHandler);
+		for (InvocableHandlerMethod handlerMethod : handlers) {
+			asyncReplies |= isAsyncReply(handlerMethod);
+		}
+		this.asyncReplies = asyncReplies;
+	}
+
+	private boolean isAsyncReply(InvocableHandlerMethod method) {
+		return AdapterUtils.isAsyncReply(method.getMethod().getReturnType());
 	}
 
 	private void checkSpecial(@Nullable InvocableHandlerMethod handler) {
@@ -137,6 +149,15 @@ public class DelegatingInvocableHandler {
 	 */
 	public Object getBean() {
 		return this.bean;
+	}
+
+	/**
+	 * Return true if any handler method has an async reply type.
+	 * @return the asyncReply.
+	 * @since 3.2
+	 */
+	public boolean isAsyncReplies() {
+		return this.asyncReplies;
 	}
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/HandlerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/HandlerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2021 the original author or authors.
+ * Copyright 2015-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.kafka.listener.adapter;
 
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
 
@@ -96,6 +97,15 @@ public class HandlerAdapter {
 		else {
 			return this.delegatingHandler.getBean();
 		}
+	}
+
+	@Nullable
+	public InvocationResult getInvocationResultFor(Object result, @Nullable Object inboundPayload) {
+
+		if (this.delegatingHandler != null && inboundPayload != null) {
+			return this.delegatingHandler.getInvocationResultFor(result, inboundPayload);
+		}
+		return null;
 	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/HandlerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/HandlerAdapter.java
@@ -33,6 +33,8 @@ public class HandlerAdapter {
 
 	private final DelegatingInvocableHandler delegatingHandler;
 
+	private final boolean asyncReplies;
+
 	/**
 	 * Construct an instance with the provided method.
 	 * @param invokerHandlerMethod the method.
@@ -40,6 +42,7 @@ public class HandlerAdapter {
 	public HandlerAdapter(InvocableHandlerMethod invokerHandlerMethod) {
 		this.invokerHandlerMethod = invokerHandlerMethod;
 		this.delegatingHandler = null;
+		this.asyncReplies = AdapterUtils.isAsyncReply(invokerHandlerMethod.getMethod().getReturnType());
 	}
 
 	/**
@@ -49,6 +52,16 @@ public class HandlerAdapter {
 	public HandlerAdapter(DelegatingInvocableHandler delegatingHandler) {
 		this.invokerHandlerMethod = null;
 		this.delegatingHandler = delegatingHandler;
+		this.asyncReplies = delegatingHandler.isAsyncReplies();
+	}
+
+	/**
+	 * Return true if any handler method has an async reply type.
+	 * @return the asyncReply.
+	 * @since 3.2
+	 */
+	public boolean isAsyncReplies() {
+		return this.asyncReplies;
 	}
 
 	public Object invoke(Message<?> message, Object... providedArgs) throws Exception { //NOSONAR

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/HandlerMethodDetect.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/HandlerMethodDetect.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener.adapter;
+
+/**
+ * Auto-detect {@link HandlerAdapter} args and return type.
+ *
+ * @author Wang zhiyang
+ * @since 3.2
+ */
+public interface HandlerMethodDetect {
+
+	/**
+	 * Return true if this listener is request/reply and the replies are async.
+	 * @return true for async replies.
+	 * @since 3.2
+	 */
+	default boolean isAsyncReplies() {
+		return false;
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
@@ -90,7 +90,7 @@ import reactor.core.publisher.Mono;
  * @author Nathan Xu
  * @author Wang ZhiYang
  */
-public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerSeekAware {
+public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerSeekAware, HandlerMethodDetect {
 
 	private static final SpelExpressionParser PARSER = new SpelExpressionParser();
 
@@ -241,6 +241,10 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 	 */
 	public void setHandlerMethod(HandlerAdapter handlerMethod) {
 		this.handlerMethod = handlerMethod;
+	}
+
+	public boolean isAsyncReplies() {
+		return this.handlerMethod.isAsyncReplies();
 	}
 
 	protected boolean isConsumerRecordList() {
@@ -469,7 +473,7 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 			messageReturnType = this.messageReturnType;
 		}
 		if (result instanceof CompletableFuture<?> completable) {
-			if (acknowledgment == null || acknowledgment.isAsyncAcks()) {
+			if (acknowledgment == null || !acknowledgment.isOutOfOrderCommit()) {
 				this.logger.warn("Container 'Acknowledgment' must be async ack for Future<?> return type; "
 						+ "otherwise the container will ack the message immediately");
 			}
@@ -484,7 +488,7 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 			});
 		}
 		else if (monoPresent && result instanceof Mono<?> mono) {
-			if (acknowledgment == null || acknowledgment.isAsyncAcks()) {
+			if (acknowledgment == null || !acknowledgment.isOutOfOrderCommit()) {
 				this.logger.warn("Container 'Acknowledgment' must be async ack for Mono<?> return type " +
 						"(or Kotlin suspend function); otherwise the container will ack the message immediately");
 			}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/Acknowledgment.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/Acknowledgment.java
@@ -81,7 +81,7 @@ public interface Acknowledgment {
 		throw new UnsupportedOperationException("nack(index, sleep) is not supported by this Acknowledgment");
 	}
 
-	default boolean isAsyncAcks() {
+	default boolean isOutOfOrderCommit() {
 		return false;
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/Acknowledgment.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/Acknowledgment.java
@@ -81,4 +81,8 @@ public interface Acknowledgment {
 		throw new UnsupportedOperationException("nack(index, sleep) is not supported by this Acknowledgment");
 	}
 
+	default boolean isAsyncAcks() {
+		return false;
+	}
+
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/AsyncListenerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/AsyncListenerTests.java
@@ -1,0 +1,249 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.annotation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.listener.KafkaListenerErrorHandler;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import reactor.core.publisher.Mono;
+
+@SpringJUnitConfig
+@DirtiesContext
+@EmbeddedKafka(topics = {
+		AsyncListenerTests.FUTURE_TOPIC_1, AsyncListenerTests.FUTURE_TOPIC_BATCH_1,
+		AsyncListenerTests.MONO_TOPIC_1, AsyncListenerTests.MONO_TOPIC_BATCH_1,
+		AsyncListenerTests.SEND_TOPIC_1}, partitions = 1)
+public class AsyncListenerTests {
+
+	static final String FUTURE_TOPIC_1 = "future-topic-1";
+
+	static final String FUTURE_TOPIC_BATCH_1 = "future-topic-batch-1";
+
+	static final String MONO_TOPIC_1 = "mono-topic-1";
+
+	static final String MONO_TOPIC_BATCH_1 = "mono-topic-batch-1";
+
+	static final String SEND_TOPIC_1 = "send-topic-1";
+
+	@Autowired
+	private KafkaTemplate<String, String> kafkaTemplate;
+
+	@Autowired
+	private Config config;
+
+	@Test
+	public void testAsyncListener() throws Exception {
+
+		kafkaTemplate.send(FUTURE_TOPIC_1, "foo-1");
+		ConsumerRecord<String, String> cr1 = kafkaTemplate.receive(SEND_TOPIC_1, 0, 0);
+		assertThat(cr1.value()).isEqualTo("FOO-1");
+		kafkaTemplate.send(FUTURE_TOPIC_1, "bar-1");
+		cr1 = kafkaTemplate.receive(SEND_TOPIC_1, 0, 1);
+		assertThat(cr1.value()).isEqualTo("bar-1_eh");
+
+		kafkaTemplate.send(FUTURE_TOPIC_BATCH_1, "foo-2");
+		cr1 = kafkaTemplate.receive(SEND_TOPIC_1, 0, 2);
+		assertThat(cr1.value()).isEqualTo("1");
+		kafkaTemplate.send(FUTURE_TOPIC_BATCH_1, "bar-2");
+		cr1 = kafkaTemplate.receive(SEND_TOPIC_1, 0, 3);
+		assertThat(cr1.value()).isEqualTo("bar-2_beh");
+
+		kafkaTemplate.send(MONO_TOPIC_1, "foo-3");
+		cr1 = kafkaTemplate.receive(SEND_TOPIC_1, 0, 4);
+		assertThat(cr1.value()).isEqualTo("FOO-3");
+		kafkaTemplate.send(MONO_TOPIC_1, "bar-3");
+		assertThat(config.latch1.await(10, TimeUnit.SECONDS)).isEqualTo(true);
+		cr1 = kafkaTemplate.receive(SEND_TOPIC_1, 0, 5);
+		assertThat(cr1.value()).isEqualTo("bar-3_eh");
+
+
+		kafkaTemplate.send(MONO_TOPIC_BATCH_1, "foo-4");
+		cr1 = kafkaTemplate.receive(SEND_TOPIC_1, 0, 6);
+		assertThat(cr1.value()).isEqualTo("1");
+		kafkaTemplate.send(MONO_TOPIC_BATCH_1, "bar-4");
+		assertThat(config.latch2.await(10, TimeUnit.SECONDS)).isEqualTo(true);
+		cr1 = kafkaTemplate.receive(SEND_TOPIC_1, 0, 7);
+		assertThat(cr1.value()).isEqualTo("bar-4_beh");
+	}
+
+	public static class Listener {
+
+		private final AtomicBoolean future1 = new AtomicBoolean(true);
+
+		private final AtomicBoolean futureBatch1 = new AtomicBoolean(true);
+
+		private final AtomicBoolean mono1 = new AtomicBoolean(true);
+
+		private final AtomicBoolean monoBatch1 = new AtomicBoolean(true);
+
+		@KafkaListener(id = "future1", topics = FUTURE_TOPIC_1, errorHandler = "errorHandler")
+		@SendTo(SEND_TOPIC_1)
+		public CompletableFuture<String> listen1(String foo) {
+			CompletableFuture<String> future = new CompletableFuture<>();
+			if (future1.getAndSet(false)) {
+				future.complete(foo.toUpperCase());
+			}
+			else {
+				future.completeExceptionally(new RuntimeException("Future.exception()"));
+			}
+			return future;
+		}
+
+		@KafkaListener(id = "futureBatch1", topics = FUTURE_TOPIC_BATCH_1, errorHandler = "errorBatchHandler")
+		@SendTo(SEND_TOPIC_1)
+		public CompletableFuture<String> listen2(List<String> foo) {
+			CompletableFuture<String> future = new CompletableFuture<>();
+			if (futureBatch1.getAndSet(false)) {
+				future.complete(String.valueOf(foo.size()));
+			}
+			else {
+				future.completeExceptionally(new RuntimeException("Future.exception(batch)"));
+			}
+			return future;
+		}
+
+		@KafkaListener(id = "mono1", topics = MONO_TOPIC_1, errorHandler = "errorHandler")
+		@SendTo(SEND_TOPIC_1)
+		public Mono<String> listen3(String bar) {
+			if (mono1.getAndSet(false)) {
+				return Mono.just(bar.toUpperCase());
+			}
+			else {
+				return Mono.error(new RuntimeException("Mono.error()"));
+			}
+		}
+
+		@KafkaListener(id = "monoBatch1", topics = MONO_TOPIC_BATCH_1, errorHandler = "errorBatchHandler")
+		@SendTo(SEND_TOPIC_1)
+		public Mono<String> listen4(List<String> bar) {
+			if (monoBatch1.getAndSet(false)) {
+				return Mono.just(String.valueOf(bar.size()));
+			}
+			else {
+				return Mono.error(new RuntimeException("Mono.error(batch)"));
+			}
+		}
+
+	}
+
+	@Configuration
+	@EnableKafka
+	public static class Config {
+
+		private final CountDownLatch latch1 = new CountDownLatch(2);
+
+		private final CountDownLatch latch2 = new CountDownLatch(2);
+
+		@Autowired
+		private KafkaTemplate<String, String> kafkaTemplate;
+
+		@Bean
+		public Listener listener() {
+			return new Listener();
+		}
+
+		@Bean
+		public KafkaTemplate<String, String> template(EmbeddedKafkaBroker embeddedKafka) {
+			KafkaTemplate<String, String> template = new KafkaTemplate<>(producerFactory(embeddedKafka));
+			template.setConsumerFactory(consumerFactory(embeddedKafka));
+			return template;
+		}
+
+		@Bean
+		public ProducerFactory<String, String> producerFactory(EmbeddedKafkaBroker embeddedKafka) {
+			return new DefaultKafkaProducerFactory<>(producerConfigs(embeddedKafka));
+		}
+
+		@Bean
+		public Map<String, Object> producerConfigs(EmbeddedKafkaBroker embeddedKafka) {
+			return KafkaTestUtils.producerProps(embeddedKafka);
+		}
+
+		@Bean
+		public KafkaListenerErrorHandler errorHandler() {
+			return (message, exception) -> {
+				latch1.countDown();
+				return message.getPayload() + "_eh";
+			};
+		}
+
+		@Bean
+		public KafkaListenerErrorHandler errorBatchHandler() {
+			return (message, exception) -> {
+				latch2.countDown();
+				return message.getPayload() + "_beh";
+			};
+		}
+
+		@Bean
+		public DefaultKafkaConsumerFactory<String, String> consumerFactory(
+				EmbeddedKafkaBroker embeddedKafka) {
+			return new DefaultKafkaConsumerFactory<>(consumerConfigs(embeddedKafka));
+		}
+
+		@Bean
+		public Map<String, Object> consumerConfigs(EmbeddedKafkaBroker embeddedKafka) {
+			return KafkaTestUtils.consumerProps("test", "false", embeddedKafka);
+		}
+
+		@Bean
+		public ConcurrentKafkaListenerContainerFactory<String, String> kafkaBatchListenerContainerFactory(
+				EmbeddedKafkaBroker embeddedKafka) {
+			ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+			factory.setConsumerFactory(consumerFactory(embeddedKafka));
+			factory.setBatchListener(true);
+			factory.setReplyTemplate(kafkaTemplate);
+			return factory;
+		}
+
+		@Bean
+		public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory(
+				EmbeddedKafkaBroker embeddedKafka) {
+			ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+			factory.setConsumerFactory(consumerFactory(embeddedKafka));
+			factory.setReplyTemplate(kafkaTemplate);
+			return factory;
+		}
+
+	}
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
@@ -235,8 +235,7 @@ public class KafkaMessageListenerContainerTests {
 		container.setBeanName("delegate");
 		AtomicReference<List<TopicPartitionOffset>> offsets = new AtomicReference<>();
 		container.setApplicationEventPublisher(e -> {
-			if (e instanceof ConsumerStoppingEvent) {
-				ConsumerStoppingEvent event = (ConsumerStoppingEvent) e;
+			if (e instanceof ConsumerStoppingEvent event) {
 				offsets.set(event.getPartitions().stream()
 						.map(p -> new TopicPartitionOffset(p.topic(), p.partition(),
 								event.getConsumer().position(p, Duration.ofMillis(10_000))))

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/adapter/BatchMessagingMessageListenerAdapterTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/adapter/BatchMessagingMessageListenerAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,10 +17,17 @@
 package org.springframework.kafka.listener.adapter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.jupiter.api.Test;
@@ -38,6 +45,8 @@ import org.springframework.kafka.support.KafkaUtils;
 import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import reactor.core.publisher.Mono;
 
 /**
  * @author Gary Russell
@@ -60,6 +69,41 @@ public class BatchMessagingMessageListenerAdapterTests {
 		assertThat(foo.group).isEqualTo("test.group");
 	}
 
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testFutureResult(@Autowired KafkaListenerEndpointRegistry registry, @Autowired Bar bar) {
+
+		BatchMessagingMessageListenerAdapter<String, String> adapter =
+				spy((BatchMessagingMessageListenerAdapter<String, String>) registry
+						.getListenerContainer("bar").getContainerProperties().getMessageListener());
+		KafkaUtils.setConsumerGroupId("test.group.future");
+		List<ConsumerRecord<String, String>> list = new ArrayList<>();
+		list.add(new ConsumerRecord<>("bar", 0, 0L, null, "future_1"));
+		list.add(new ConsumerRecord<>("bar", 0, 1L, null, "future_2"));
+		list.add(new ConsumerRecord<>("bar", 1, 0L, null, "future_3"));
+		adapter.onMessage(list, null, null);
+		assertThat(bar.group).isEqualTo("test.group.future");
+		verify(adapter, times(1)).asyncSuccess(any(), any(), any(), anyBoolean());
+		verify(adapter, times(1)).acknowledge(any());
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	public void testMonoResult(@Autowired KafkaListenerEndpointRegistry registry, @Autowired Baz baz) {
+
+		BatchMessagingMessageListenerAdapter<String, String> adapter =
+				spy((BatchMessagingMessageListenerAdapter<String, String>) registry
+						.getListenerContainer("baz").getContainerProperties().getMessageListener());
+		KafkaUtils.setConsumerGroupId("test.group.mono");
+		List<ConsumerRecord<String, String>> list = new ArrayList<>();
+		list.add(new ConsumerRecord<>("baz", 0, 0L, null, "mono_1"));
+		list.add(new ConsumerRecord<>("baz", 0, 1L, null, "mono_2"));
+		adapter.onMessage(list, null, null);
+		assertThat(baz.group).isEqualTo("test.group.mono");
+		verify(adapter, times(1)).asyncSuccess(any(), any(), any(), anyBoolean());
+		verify(adapter, times(1)).acknowledge(any());
+	}
+
 	public static class Foo {
 
 		public volatile String value = "someValue";
@@ -68,10 +112,38 @@ public class BatchMessagingMessageListenerAdapterTests {
 
 		@KafkaListener(id = "foo", topics = "foo", autoStartup = "false")
 		public void listen(List<String> list, @Header(KafkaHeaders.GROUP_ID) String groupId) {
-			list.forEach(s -> {
-				this.value = s;
-			});
+			list.forEach(s -> this.value = s);
 			this.group = groupId;
+		}
+
+	}
+
+	public static class Bar {
+
+		public volatile String group;
+
+		@KafkaListener(id = "bar", topics = "bar", autoStartup = "false")
+		public CompletableFuture<String> listen(List<String> list, @Header(KafkaHeaders.GROUP_ID) String groupId) {
+
+			this.group = groupId;
+			CompletableFuture<String> future = new CompletableFuture<>();
+			future.complete("processed: " + list.size());
+			return future;
+		}
+
+	}
+
+	public static class Baz {
+
+		public volatile String value = "someValue";
+
+		public volatile String group;
+
+		@KafkaListener(id = "baz", topics = "baz", autoStartup = "false")
+		public Mono<Integer> listen(List<String> list, @Header(KafkaHeaders.GROUP_ID) String groupId) {
+
+			this.group = groupId;
+			return Mono.just(list.size());
 		}
 
 	}
@@ -85,11 +157,20 @@ public class BatchMessagingMessageListenerAdapterTests {
 			return new Foo();
 		}
 
+		@Bean
+		public Bar bar() {
+			return new Bar();
+		}
+
+		@Bean
+		public Baz baz() {
+			return new Baz();
+		}
+
 		@SuppressWarnings({ "rawtypes" })
 		@Bean
 		public ConsumerFactory consumerFactory() {
-			ConsumerFactory consumerFactory = mock(ConsumerFactory.class);
-			return consumerFactory;
+			return mock(ConsumerFactory.class);
 		}
 
 		@SuppressWarnings({ "rawtypes", "unchecked" })
@@ -100,6 +181,7 @@ public class BatchMessagingMessageListenerAdapterTests {
 			factory.setBatchListener(true);
 			return factory;
 		}
+
 	}
 
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapterTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapterTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 the original author or authors.
+ * Copyright 2016-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,16 @@
 package org.springframework.kafka.listener.adapter;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.BDDMockito.willReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.lang.reflect.Method;
+import java.util.concurrent.CompletableFuture;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.jupiter.api.Test;
@@ -32,6 +37,8 @@ import org.springframework.kafka.listener.ListenerExecutionFailedException;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.kafka.support.converter.RecordMessageConverter;
 import org.springframework.messaging.support.GenericMessage;
+
+import reactor.core.publisher.Mono;
 
 /**
  * @author Gary Russell
@@ -67,6 +74,37 @@ public class MessagingMessageListenerAdapterTests {
 	}
 
 	@Test
+	public void testCompletableFutureReturn() throws NoSuchMethodException {
+
+		Method method = getClass().getDeclaredMethod("future", String.class, Acknowledgment.class);
+		testAsyncResult(method, "bar");
+	}
+
+	@Test
+	public void testMonoReturn() throws NoSuchMethodException {
+
+		Method method = getClass().getDeclaredMethod("mono", String.class, Acknowledgment.class);
+		testAsyncResult(method, "baz");
+	}
+
+	private void testAsyncResult(Method method, String topic) {
+
+		KafkaListenerAnnotationBeanPostProcessor<String, String> bpp = new KafkaListenerAnnotationBeanPostProcessor<>();
+		RecordMessagingMessageListenerAdapter<String, String> adapter =
+				spy(new RecordMessagingMessageListenerAdapter<>(this, method));
+		adapter.setHandlerMethod(
+				new HandlerAdapter(bpp.getMessageHandlerMethodFactory().createInvocableHandlerMethod(this, method)));
+		ConsumerRecord<String, String> cr = new ConsumerRecord<>(topic, 0, 0L, null, "foo");
+		Acknowledgment ack = mock(Acknowledgment.class);
+		RecordMessageConverter converter = mock(RecordMessageConverter.class);
+		willReturn(new GenericMessage<>("foo")).given(converter).toMessage(cr, ack, null, String.class);
+		adapter.setMessageConverter(converter);
+		adapter.onMessage(cr, ack, null);
+		verify(adapter, times(1)).asyncSuccess(any(), any(), any(), anyBoolean());
+		verify(adapter, times(1)).acknowledge(any());
+	}
+
+	@Test
 	void testMissingAck() throws NoSuchMethodException, SecurityException {
 		KafkaListenerAnnotationBeanPostProcessor<String, String> bpp = new KafkaListenerAnnotationBeanPostProcessor<>();
 		Method method = getClass().getDeclaredMethod("test", Acknowledgment.class);
@@ -82,6 +120,18 @@ public class MessagingMessageListenerAdapterTests {
 
 	public void test(Acknowledgment ack) {
 
+	}
+
+	public CompletableFuture<String> future(String data, Acknowledgment ack) {
+
+		CompletableFuture<String> future = new CompletableFuture<>();
+		future.complete("processed" + data);
+		return future;
+	}
+
+	public Mono<String> mono(String data, Acknowledgment ack) {
+
+		return Mono.just(data);
 	}
 
 }

--- a/spring-kafka/src/test/kotlin/org/springframework/kafka/listener/EnableKafkaKotlinCoroutinesTests.kt
+++ b/spring-kafka/src/test/kotlin/org/springframework/kafka/listener/EnableKafkaKotlinCoroutinesTests.kt
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2016-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.consumer.ConsumerRecord
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.apache.kafka.common.serialization.StringSerializer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.annotation.EnableKafka
+import org.springframework.kafka.annotation.KafkaHandler
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory
+import org.springframework.kafka.core.ConsumerFactory
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory
+import org.springframework.kafka.core.DefaultKafkaProducerFactory
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.core.ProducerFactory
+import org.springframework.kafka.listener.KafkaListenerErrorHandler
+import org.springframework.kafka.test.EmbeddedKafkaBroker
+import org.springframework.kafka.test.context.EmbeddedKafka
+import org.springframework.messaging.handler.annotation.SendTo
+import org.springframework.test.annotation.DirtiesContext
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig
+import java.lang.Exception
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+
+/**
+ * Kotlin Annotated async return listener tests.
+ *
+ * @author Wang ZhiYang
+ *
+ * @since 3.1
+ */
+@SpringJUnitConfig
+@DirtiesContext
+@EmbeddedKafka(topics = ["kotlinAsyncTestTopic1", "kotlinAsyncTestTopic2",
+		"kotlinAsyncBatchTestTopic1", "kotlinAsyncBatchTestTopic2"])
+class EnableKafkaKotlinCoroutinesTests {
+
+	@Autowired
+	private lateinit var config: Config
+
+	@Autowired
+	private lateinit var template: KafkaTemplate<String, String>
+
+	@Test
+	fun `test listener`() {
+		this.template.send("kotlinAsyncTestTopic1", "foo")
+		assertThat(this.config.latch1.await(10, TimeUnit.SECONDS)).isTrue()
+		assertThat(this.config.received).isEqualTo("foo")
+	}
+
+	@Test
+	fun `test checkedEx`() {
+		this.template.send("kotlinAsyncTestTopic2", "fail")
+		assertThat(this.config.latch2.await(10, TimeUnit.SECONDS)).isTrue()
+		assertThat(this.config.error).isTrue()
+	}
+
+	@Test
+	fun `test batch listener`() {
+		this.template.send("kotlinAsyncBatchTestTopic1", "foo")
+		assertThat(this.config.batchLatch1.await(10, TimeUnit.SECONDS)).isTrue()
+		assertThat(this.config.batchReceived).isEqualTo("foo")
+	}
+
+	@Test
+	fun `test batch checkedEx`() {
+		this.template.send("kotlinAsyncBatchTestTopic2", "fail")
+		assertThat(this.config.batchLatch2.await(10, TimeUnit.SECONDS)).isTrue()
+		assertThat(this.config.batchError).isTrue()
+	}
+
+	@Test
+	fun `test checkedKh reply`() {
+		this.template.send("kotlinAsyncTestTopic3", "foo")
+		val cr = this.template.receive("sendTopic1", 0, 0, Duration.ofSeconds(30))
+		assertThat(cr.value()).isEqualTo("FOO")
+	}
+
+	@KafkaListener(id = "sendTopic", topics = ["kotlinAsyncTestTopic3"],
+			containerFactory = "kafkaListenerContainerFactory")
+	class Listener {
+
+		@KafkaHandler
+		@SendTo("sendTopic1")
+		suspend fun handler1(value: String) : String {
+			return value.uppercase()
+		}
+
+	}
+
+	@Configuration
+	@EnableKafka
+	class Config {
+
+		@Volatile
+		lateinit var received: String
+
+		@Volatile
+		lateinit var batchReceived: String
+
+		@Volatile
+		var error: Boolean = false
+
+		@Volatile
+		var batchError: Boolean = false
+
+		val latch1 = CountDownLatch(1)
+
+		val latch2 = CountDownLatch(1)
+
+		val batchLatch1 = CountDownLatch(1)
+
+		val batchLatch2 = CountDownLatch(1)
+
+		@Value("\${" + EmbeddedKafkaBroker.SPRING_EMBEDDED_KAFKA_BROKERS + "}")
+		private lateinit var brokerAddresses: String
+
+		@Bean
+		fun listener() : Listener {
+			return Listener()
+		}
+
+		@Bean
+		fun kpf(): ProducerFactory<String, String> {
+			val configs = HashMap<String, Any>()
+			configs[ProducerConfig.BOOTSTRAP_SERVERS_CONFIG] = this.brokerAddresses
+			configs[ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG] = StringSerializer::class.java
+			configs[ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG] = StringSerializer::class.java
+			return DefaultKafkaProducerFactory(configs)
+		}
+
+		@Bean
+		fun kcf(): ConsumerFactory<String, String> {
+			val configs = HashMap<String, Any>()
+			configs[ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG] = this.brokerAddresses
+			configs[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java
+			configs[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java
+			configs[ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG] = false
+			configs[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = "earliest"
+			return DefaultKafkaConsumerFactory(configs)
+		}
+
+		@Bean
+		fun kt(): KafkaTemplate<String, String> {
+			val kafkaTemplate = KafkaTemplate(kpf())
+			kafkaTemplate.setConsumerFactory(kcf())
+			return kafkaTemplate
+		}
+
+		@Bean
+		fun errorHandler() : KafkaListenerErrorHandler {
+			return KafkaListenerErrorHandler { message, _ ->
+				error = true;
+				latch2.countDown()
+				message.payload;
+			}
+		}
+
+		@Bean
+		fun errorHandlerBatch() : KafkaListenerErrorHandler {
+			return KafkaListenerErrorHandler { message, _ ->
+				batchError = true;
+				batchLatch2.countDown()
+				message.payload;
+			}
+		}
+
+		@Bean
+		fun kafkaListenerContainerFactory(): ConcurrentKafkaListenerContainerFactory<String, String> {
+			val factory: ConcurrentKafkaListenerContainerFactory<String, String>
+				= ConcurrentKafkaListenerContainerFactory()
+			factory.consumerFactory = kcf()
+			factory.setReplyTemplate(kt())
+			return factory
+		}
+
+		@Bean
+		fun kafkaBatchListenerContainerFactory(): ConcurrentKafkaListenerContainerFactory<String, String> {
+			val factory: ConcurrentKafkaListenerContainerFactory<String, String>
+					= ConcurrentKafkaListenerContainerFactory()
+			factory.isBatchListener = true
+			factory.consumerFactory = kcf()
+			return factory
+		}
+
+		@KafkaListener(id = "kotlin", topics = ["kotlinAsyncTestTopic1"],
+				containerFactory = "kafkaListenerContainerFactory")
+		suspend fun listen(value: String) {
+			this.received = value
+			this.latch1.countDown()
+		}
+
+		@KafkaListener(id = "kotlin-ex", topics = ["kotlinAsyncTestTopic2"],
+				containerFactory = "kafkaListenerContainerFactory", errorHandler = "errorHandler")
+		suspend fun listenEx(value: String) {
+			if (value == "fail") {
+				throw Exception("checked")
+			}
+		}
+
+		@KafkaListener(id = "kotlin-batch", topics = ["kotlinAsyncBatchTestTopic1"], containerFactory = "kafkaBatchListenerContainerFactory")
+		suspend fun batchListen(values: List<ConsumerRecord<String, String>>) {
+			this.batchReceived = values.first().value()
+			this.batchLatch1.countDown()
+		}
+
+		@KafkaListener(id = "kotlin-batch-ex", topics = ["kotlinAsyncBatchTestTopic2"],
+				containerFactory = "kafkaBatchListenerContainerFactory", errorHandler = "errorHandlerBatch")
+		suspend fun batchListenEx(values: List<ConsumerRecord<String, String>>) {
+			if (values.first().value() == "fail") {
+				throw Exception("checked")
+			}
+		}
+
+	}
+
+}


### PR DESCRIPTION
Resolves #1189 
* support `Mono` and `Future`
* support kotlin suspend
* support auto-delect async reply
* `@SendTo` for `@KafkaHandler` after error is handled

---

Refactor `MessagingMessageListenerAdapter`

* move `BatchMessagingMessageListenerAdapter#invoke` and `RecordMessagingMessageListenerAdapter#invoke` to `MessagingMessageListenerAdapter`
* move `KafkaListenerErrorHandler` to `MessagingMessageListenerAdapter`
* add `@Nullable` to `KafkaListenerErrorHandler#handleError`