### PR TITLE
GH-2974 Add NonNullApi and NonNullFields to package-info.java in 'annotation' package

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/DltHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/DltHandler.java
@@ -28,8 +28,9 @@ import java.lang.annotation.Target;
 
 /**
  * Annotation to determine the method that should process the DLT topic message.
- * The method can have the same parameters as a {@link KafkaListener} method can (Message, Acknowledgement, etc).
+ * The method can have the same parameters as a {@link KafkaListener} method can have (Message, Acknowledgement, etc).
  *
+ * <p>
  * The annotated method must be in the same class as the corresponding {@link KafkaListener} annotation.
  *
  * @author Tomaz Fernandes

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/EnableKafkaRetryTopic.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/EnableKafkaRetryTopic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -55,6 +55,7 @@ import org.springframework.kafka.retrytopic.RetryTopicConfigurationSupport;
  * bean. This annotation is meta-annotated with {@code @EnableKafka} so it is not
  * necessary to specify both.
  *
+ * <p>
  * To configure the feature's components, extend the
  * {@link RetryTopicConfigurationSupport} class and override the appropriate methods on a
  * {@link Configuration @Configuration} class, such as:

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaNullAwarePayloadArgumentResolver.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaNullAwarePayloadArgumentResolver.java
@@ -20,6 +20,7 @@ import java.util.List;
 
 import org.springframework.core.MethodParameter;
 import org.springframework.kafka.support.KafkaNull;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.converter.MessageConverter;
 import org.springframework.messaging.handler.annotation.support.PayloadMethodArgumentResolver;
@@ -59,7 +60,7 @@ public class KafkaNullAwarePayloadArgumentResolver extends PayloadMethodArgument
 	}
 
 	@Override
-	protected boolean isEmptyPayload(Object payload) {
+	protected boolean isEmptyPayload(@Nullable Object payload) {
 		return payload == null || payload instanceof KafkaNull;
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryTopicConfigurationProvider.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryTopicConfigurationProvider.java
@@ -33,6 +33,7 @@ import org.springframework.core.annotation.MergedAnnotations.SearchStrategy;
 import org.springframework.core.annotation.RepeatableContainers;
 import org.springframework.core.log.LogAccessor;
 import org.springframework.kafka.retrytopic.RetryTopicConfiguration;
+import org.springframework.lang.Nullable;
 
 
 /**
@@ -42,9 +43,11 @@ import org.springframework.kafka.retrytopic.RetryTopicConfiguration;
  * one from a {@link RetryableTopic} annotation, or from the bean container if no
  * annotation is available.
  *
+ * <p>
  * If beans are found in the container there's a check to determine whether or not the
  * provided topics should be handled by any of such instances.
  *
+ * <p>
  * If the annotation is provided, a
  * {@link org.springframework.kafka.annotation.DltHandler} annotated method is looked up.
  *
@@ -58,10 +61,13 @@ import org.springframework.kafka.retrytopic.RetryTopicConfiguration;
  */
 public class RetryTopicConfigurationProvider {
 
+	@Nullable
 	private final BeanFactory beanFactory;
 
+	@Nullable
 	private final BeanExpressionResolver resolver;
 
+	@Nullable
 	private final BeanExpressionContext expressionContext;
 
 	private static final LogAccessor LOGGER = new LogAccessor(LogFactory.getLog(RetryTopicConfigurationProvider.class));
@@ -71,7 +77,7 @@ public class RetryTopicConfigurationProvider {
 	 * expression context.
 	 * @param beanFactory the bean factory.
 	 */
-	public RetryTopicConfigurationProvider(BeanFactory beanFactory) {
+	public RetryTopicConfigurationProvider(@Nullable BeanFactory beanFactory) {
 		this(beanFactory, new StandardBeanExpressionResolver(), beanFactory instanceof ConfigurableBeanFactory
 				? new BeanExpressionContext((ConfigurableBeanFactory) beanFactory, null)
 				: null); // NOSONAR
@@ -83,13 +89,14 @@ public class RetryTopicConfigurationProvider {
 	 * @param resolver the bean expression resolver.
 	 * @param expressionContext the bean expression context.
 	 */
-	public RetryTopicConfigurationProvider(BeanFactory beanFactory, BeanExpressionResolver resolver,
-			BeanExpressionContext expressionContext) {
+	public RetryTopicConfigurationProvider(@Nullable BeanFactory beanFactory, @Nullable BeanExpressionResolver resolver,
+			@Nullable BeanExpressionContext expressionContext) {
 
 		this.beanFactory = beanFactory;
 		this.resolver = resolver;
 		this.expressionContext = expressionContext;
 	}
+	@Nullable
 	public RetryTopicConfiguration findRetryConfigurationFor(String[] topics, Method method, Object bean) {
 		RetryableTopic annotation = MergedAnnotations.from(method, SearchStrategy.TYPE_HIERARCHY,
 					RepeatableContainers.none())
@@ -102,6 +109,7 @@ public class RetryTopicConfigurationProvider {
 				: maybeGetFromContext(topics);
 	}
 
+	@Nullable
 	private RetryTopicConfiguration maybeGetFromContext(String[] topics) {
 		if (this.beanFactory == null || !ListableBeanFactory.class.isAssignableFrom(this.beanFactory.getClass())) {
 			LOGGER.warn("No ListableBeanFactory found, skipping RetryTopic configuration.");

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/package-info.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/package-info.java
@@ -1,4 +1,6 @@
 /**
  * Package for kafka annotations
  */
+@org.springframework.lang.NonNullApi
+@org.springframework.lang.NonNullFields
 package org.springframework.kafka.annotation;

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicComponentFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicComponentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import org.springframework.kafka.listener.KafkaConsumerBackoffManager;
 import org.springframework.kafka.listener.ListenerContainerRegistry;
 import org.springframework.kafka.listener.MessageListenerContainer;
 import org.springframework.kafka.listener.adapter.KafkaBackoffAwareMessageListenerAdapter;
+import org.springframework.lang.Nullable;
 
 /**
  * Provide the component instances that will be used with
@@ -154,7 +155,7 @@ public class RetryTopicComponentFactory {
 	 * @param applicationContext the application context.
 	 * @return the instance.
 	 */
-	public KafkaBackOffManagerFactory kafkaBackOffManagerFactory(ListenerContainerRegistry registry,
+	public KafkaBackOffManagerFactory kafkaBackOffManagerFactory(@Nullable ListenerContainerRegistry registry,
 			ApplicationContext applicationContext) {
 
 		return new ContainerPartitionPausingBackOffManagerFactory(registry, applicationContext);

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationSupport.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -310,7 +310,7 @@ public class RetryTopicConfigurationSupport implements ApplicationContextAware, 
 	@Bean(name = KafkaListenerConfigUtils.KAFKA_CONSUMER_BACK_OFF_MANAGER_BEAN_NAME)
 	public KafkaConsumerBackoffManager kafkaConsumerBackoffManager(ApplicationContext applicationContext,
 			@Qualifier(KafkaListenerConfigUtils.KAFKA_LISTENER_ENDPOINT_REGISTRY_BEAN_NAME)
-					ListenerContainerRegistry registry,
+					@Nullable ListenerContainerRegistry registry,
 					ObjectProvider<RetryTopicComponentFactory> componentFactoryProvider,
 					@Nullable RetryTopicSchedulerWrapper wrapper,
 					@Nullable TaskScheduler taskScheduler) {
@@ -325,7 +325,7 @@ public class RetryTopicConfigurationSupport implements ApplicationContextAware, 
 	}
 
 	private void configurePartitionPausingFactory(ContainerPartitionPausingBackOffManagerFactory factory,
-			ListenerContainerRegistry registry, @Nullable TaskScheduler scheduler) {
+			@Nullable ListenerContainerRegistry registry, @Nullable TaskScheduler scheduler) {
 
 		Assert.notNull(scheduler, "Either a RetryTopicSchedulerWrapper or TaskScheduler bean is required");
 		factory.setBackOffHandler(new ContainerPausingBackOffHandler(
@@ -346,8 +346,10 @@ public class RetryTopicConfigurationSupport implements ApplicationContextAware, 
 	 */
 	public static class BlockingRetriesConfigurer {
 
+		@Nullable
 		private BackOff backOff;
 
+		@Nullable
 		private Class<? extends Exception>[] retryableExceptions;
 
 		/**
@@ -378,10 +380,12 @@ public class RetryTopicConfigurationSupport implements ApplicationContextAware, 
 			return this;
 		}
 
+		@Nullable
 		BackOff getBackOff() {
 			return this.backOff;
 		}
 
+		@Nullable
 		Class<? extends Exception>[] getRetryableExceptions() {
 			return this.retryableExceptions;
 		}
@@ -393,10 +397,13 @@ public class RetryTopicConfigurationSupport implements ApplicationContextAware, 
 	 */
 	public static class CustomizersConfigurer {
 
+		@Nullable
 		private Consumer<DefaultErrorHandler> errorHandlerCustomizer;
 
+		@Nullable
 		private Consumer<ConcurrentMessageListenerContainer<?, ?>> listenerContainerCustomizer;
 
+		@Nullable
 		private Consumer<DeadLetterPublishingRecoverer> deadLetterPublishingRecovererCustomizer;
 
 		/**
@@ -406,6 +413,7 @@ public class RetryTopicConfigurationSupport implements ApplicationContextAware, 
 		 * @return the configurer.
 		 * @see DefaultErrorHandler
 		 */
+		@SuppressWarnings("unused")
 		public CustomizersConfigurer customizeErrorHandler(Consumer<DefaultErrorHandler> errorHandlerCustomizer) {
 			this.errorHandlerCustomizer = errorHandlerCustomizer;
 			return this;
@@ -433,14 +441,17 @@ public class RetryTopicConfigurationSupport implements ApplicationContextAware, 
 			return this;
 		}
 
+		@Nullable
 		Consumer<DefaultErrorHandler> getErrorHandlerCustomizer() {
 			return this.errorHandlerCustomizer;
 		}
 
+		@Nullable
 		Consumer<ConcurrentMessageListenerContainer<?, ?>> getListenerContainerCustomizer() {
 			return this.listenerContainerCustomizer;
 		}
 
+		@Nullable
 		Consumer<DeadLetterPublishingRecoverer> getDeadLetterPublishingRecovererCustomizer() {
 			return this.deadLetterPublishingRecovererCustomizer;
 		}


### PR DESCRIPTION
almost all of the nullness vulnerability has been fixed except that gigantic `org.springframework.kafka.annotation.KafkaListenerAnnotationBeanPostProcessor` class, which is left for future PR(s).
