### PR TITLE
GH-2981: Suppress abortTransaction in KafkaTemplate

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
@@ -657,9 +657,14 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 		catch (SkipAbortException e) { // NOSONAR - exception flow control
 			throw ((RuntimeException) e.getCause()); // NOSONAR - lost stack trace
 		}
-		catch (Exception e) {
-			producer.abortTransaction();
-			throw e;
+		catch (Exception ex) {
+			try {
+				producer.abortTransaction();
+			}
+			catch (Exception abortException) {
+				ex.addSuppressed(abortException);
+			}
+			throw ex;
 		}
 		finally {
 			this.producers.remove(currentThread);


### PR DESCRIPTION
Fixes: #2981

When `producer.abortTransaction()` fails, the original exception is lost

* Catch an exception on `producer.abortTransaction()` and `ex.addSuppressed(abortException)`

**Cherry-pick to `3.0.x`**

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
