### PR TITLE
GH-2978: Propagate number of partitions to KRaft broker

### DIFF
--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaKraftBroker.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaKraftBroker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 the original author or authors.
+ * Copyright 2018-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -199,7 +199,7 @@ public class EmbeddedKafkaKraftBroker implements EmbeddedKafkaBroker {
 	public void afterPropertiesSet() {
 		if (this.initialized.compareAndSet(false, true)) {
 			overrideExitMethods();
-			addDefaultBrokerPropsIfAbsent(this.brokerProperties, this.count);
+			addDefaultBrokerPropsIfAbsent();
 			start();
 		}
 	}
@@ -252,10 +252,11 @@ public class EmbeddedKafkaKraftBroker implements EmbeddedKafkaBroker {
 		this.cluster = null;
 	}
 
-	private void addDefaultBrokerPropsIfAbsent(Properties brokerConfig, int numBrokers) {
-		brokerConfig.putIfAbsent(KafkaConfig.DeleteTopicEnableProp(), "true");
-		brokerConfig.putIfAbsent(KafkaConfig.GroupInitialRebalanceDelayMsProp(), "0");
-		brokerConfig.putIfAbsent(KafkaConfig.OffsetsTopicReplicationFactorProp(), String.valueOf(numBrokers));
+	private void addDefaultBrokerPropsIfAbsent() {
+		this.brokerProperties.putIfAbsent(KafkaConfig.DeleteTopicEnableProp(), "true");
+		this.brokerProperties.putIfAbsent(KafkaConfig.GroupInitialRebalanceDelayMsProp(), "0");
+		this.brokerProperties.putIfAbsent(KafkaConfig.OffsetsTopicReplicationFactorProp(), "" + this.count);
+		this.brokerProperties.putIfAbsent(KafkaConfig.NumPartitionsProp(), "" + this.partitionsPerTopic);
 	}
 
 	private void logDir(Properties brokerConfigProperties) {


### PR DESCRIPTION
Fixes: #2978

If we don't create topics manually, that can be done automatically on the broker side according to its configuration.

For that goal the `EmbeddedKafkaKraftBroker` is missing to populate `KafkaConfig.NumPartitionsProp(): "" + this.partitionsPerTopic` broker property from `@EmbeddedKafka` configuration

* Propagate `partitionsPerTopic` option down to the embedded broker(s) in the `EmbeddedKafkaKraftBroker`
* Some other simple refactoring in the `EmbeddedKafkaKraftBroker`
* Verify the option propagated via new unit test in the `KafkaTestUtilsTests.topicAutomaticallyCreatedWithProperNumberOfPartitions()`

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
