### PR TITLE
fix invalid reference link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To generate IDEA metadata (.iml and .ipr files), do the following:
 # Resources
 
 For more information, please visit the Spring Kafka website at:
-[Reference Manual](https://docs.spring.io/spring-kafka/docs/current/reference/html/)
+[Reference Manual](https://docs.spring.io/spring-kafka/reference/index.html)
 
 # Contributing to Spring Kafka
 


### PR DESCRIPTION
<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->

Resolves https://github.com/spring-projects/spring-kafka/issues/3005

Invalid reference manual link in README
* before: [https://docs.spring.io/spring-kafka/docs/current/reference/html/](https://docs.spring.io/spring-kafka/docs/current/reference/html/)
* after: [https://docs.spring.io/spring-kafka/reference/index.html](https://docs.spring.io/spring-kafka/reference/index.html)
