### PR TITLE
Implementation Deserializer.deserialize(String, Headers, ByteBuffer)

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingByTopicDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingByTopicDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2021 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.kafka.support.serializer;
 
+import java.nio.ByteBuffer;
 import java.util.Map;
 import java.util.regex.Pattern;
 
@@ -26,6 +27,8 @@ import org.apache.kafka.common.serialization.Deserializer;
  * A {@link Deserializer} that delegates to other deserializers based on the topic name.
  *
  * @author Gary Russell
+ * @author Wang Zhiyang
+ *
  * @since 2.8
  *
  */
@@ -72,6 +75,11 @@ public class DelegatingByTopicDeserializer extends DelegatingByTopicSerializatio
 
 	@Override
 	public Object deserialize(String topic, Headers headers, byte[] data) {
+		return findDelegate(topic).deserialize(topic, headers, data);
+	}
+
+	@Override
+	public Object deserialize(String topic, Headers headers, ByteBuffer data) {
 		return findDelegate(topic).deserialize(topic, headers, data);
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 the original author or authors.
+ * Copyright 2016-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,6 +52,7 @@ import com.fasterxml.jackson.databind.ObjectWriter;
  * @author Artem Bilan
  * @author Gary Russell
  * @author Elliot Kennedy
+ * @author Wang Zhiyang
  */
 public class JsonSerializer<T> implements Serializer<T> {
 
@@ -156,20 +157,19 @@ public class JsonSerializer<T> implements Serializer<T> {
 		setUseTypeMapperForKey(isKey);
 		if (configs.containsKey(ADD_TYPE_INFO_HEADERS)) {
 			Object config = configs.get(ADD_TYPE_INFO_HEADERS);
-			if (config instanceof Boolean) {
-				this.addTypeInfo = (Boolean) config;
+			if (config instanceof Boolean configBoolean) {
+				this.addTypeInfo = configBoolean;
 			}
-			else if (config instanceof String) {
-				this.addTypeInfo = Boolean.valueOf((String) config);
+			else if (config instanceof String configString) {
+				this.addTypeInfo = Boolean.parseBoolean(configString);
 			}
 			else {
 				throw new IllegalStateException(ADD_TYPE_INFO_HEADERS + " must be Boolean or String");
 			}
 		}
 		if (configs.containsKey(TYPE_MAPPINGS) && !this.typeMapperExplicitlySet
-				&& this.typeMapper instanceof AbstractJavaTypeMapper) {
-			((AbstractJavaTypeMapper) this.typeMapper)
-					.setIdClassMapping(createMappings((String) configs.get(TYPE_MAPPINGS)));
+				&& this.typeMapper instanceof AbstractJavaTypeMapper abstractJavaTypeMapper) {
+			abstractJavaTypeMapper.setIdClassMapping(createMappings((String) configs.get(TYPE_MAPPINGS)));
 		}
 		this.configured = true;
 	}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/RetryingDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/RetryingDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 
 package org.springframework.kafka.support.serializer;
 
+import java.nio.ByteBuffer;
 import java.util.Map;
 
 import org.apache.kafka.common.header.Headers;
@@ -31,6 +32,8 @@ import org.springframework.util.Assert;
  * @param <T> Type to be deserialized into.
  *
  * @author Gary Russell
+ * @author Wang Zhiyang
+ *
  * @since 2.3
  *
  */
@@ -54,16 +57,17 @@ public class RetryingDeserializer<T> implements Deserializer<T> {
 
 	@Override
 	public T deserialize(String topic, byte[] data) {
-		return this.retryOperations.execute(context -> {
-			return this.delegate.deserialize(topic, data);
-		});
+		return this.retryOperations.execute(context -> this.delegate.deserialize(topic, data));
 	}
 
 	@Override
 	public T deserialize(String topic, Headers headers, byte[] data) {
-		return this.retryOperations.execute(context -> {
-			return this.delegate.deserialize(topic, headers, data);
-		});
+		return this.retryOperations.execute(context -> this.delegate.deserialize(topic, headers, data));
+	}
+
+	@Override
+	public T deserialize(String topic, Headers headers, ByteBuffer data) {
+		return this.retryOperations.execute(context -> this.delegate.deserialize(topic, headers, data));
 	}
 
 	@Override

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/DelegatingSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/DelegatingSerializationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -140,13 +141,12 @@ public class DelegatingSerializationTests {
 		headers.remove(DelegatingSerializer.VALUE_SERIALIZATION_SELECTOR);
 		DelegatingSerializer spySe = spy(serializer);
 		serialized = spySe.serialize("foo", headers, 42L);
-		serialized = spySe.serialize("foo", headers, 42L);
 		verify(spySe, times(1)).trySerdes(42L);
 		assertThat(headers.lastHeader(DelegatingSerializer.VALUE_SERIALIZATION_SELECTOR).value())
 				.isEqualTo(Long.class.getName().getBytes());
 		DelegatingDeserializer spyDe = spy(deserializer);
 		assertThat(spyDe.deserialize("foo", headers, serialized)).isEqualTo(42L);
-		spyDe.deserialize("foo", headers, serialized);
+		assertThat(spyDe.deserialize("foo", headers, ByteBuffer.wrap(serialized))).isEqualTo(42L);
 		verify(spyDe, times(1)).trySerdes(Long.class.getName());
 
 		// The DKHM will jsonize the value; test that we ignore the quotes
@@ -158,6 +158,7 @@ public class DelegatingSerializationTests {
 		serialized = serializer.serialize("foo", headers, "bar");
 		assertThat(serialized).isEqualTo(new byte[]{ 'b', 'a', 'r' });
 		assertThat(deserializer.deserialize("foo", headers, serialized)).isEqualTo("bar");
+		assertThat(deserializer.deserialize("foo", headers, ByteBuffer.wrap(serialized))).isEqualTo("bar");
 	}
 
 	private void doTestKeys(DelegatingSerializer serializer, DelegatingDeserializer deserializer) {
@@ -179,13 +180,12 @@ public class DelegatingSerializationTests {
 		headers.remove(DelegatingSerializer.KEY_SERIALIZATION_SELECTOR);
 		DelegatingSerializer spySe = spy(serializer);
 		serialized = spySe.serialize("foo", headers, 42L);
-		serialized = spySe.serialize("foo", headers, 42L);
 		verify(spySe, times(1)).trySerdes(42L);
 		assertThat(headers.lastHeader(DelegatingSerializer.KEY_SERIALIZATION_SELECTOR).value())
 				.isEqualTo(Long.class.getName().getBytes());
 		DelegatingDeserializer spyDe = spy(deserializer);
 		assertThat(spyDe.deserialize("foo", headers, serialized)).isEqualTo(42L);
-		spyDe.deserialize("foo", headers, serialized);
+		assertThat(spyDe.deserialize("foo", headers, ByteBuffer.wrap(serialized))).isEqualTo(42L);
 		verify(spyDe, times(1)).trySerdes(Long.class.getName());
 
 		// The DKHM will jsonize the value; test that we ignore the quotes
@@ -197,6 +197,7 @@ public class DelegatingSerializationTests {
 		serialized = serializer.serialize("foo", headers, "bar");
 		assertThat(serialized).isEqualTo(new byte[]{ 'b', 'a', 'r' });
 		assertThat(deserializer.deserialize("foo", headers, serialized)).isEqualTo("bar");
+		assertThat(deserializer.deserialize("foo", headers, ByteBuffer.wrap(serialized))).isEqualTo("bar");
 	}
 
 	@Test
@@ -206,7 +207,7 @@ public class DelegatingSerializationTests {
 		headers.add(new RecordHeader(DelegatingSerializer.VALUE_SERIALIZATION_SELECTOR, "junk".getBytes()));
 		byte[] data = "foo".getBytes();
 		assertThat(spy.deserialize("foo", headers, data)).isSameAs(data);
-		spy.deserialize("foo", headers, data);
+		assertThat(spy.deserialize("foo", headers, ByteBuffer.wrap(data))).isEqualTo(data);
 		verify(spy, times(1)).trySerdes("junk");
 	}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/ToStringSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/ToStringSerializationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 the original author or authors.
+ * Copyright 2016-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.kafka.support.serializer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.HashMap;
@@ -35,6 +36,7 @@ import org.springframework.lang.Nullable;
  *
  * @author Alexei Klenin
  * @author Gary Russell
+ *
  * @since 2.5
  */
 public class ToStringSerializationTests {
@@ -167,6 +169,18 @@ public class ToStringSerializationTests {
 				.hasFieldOrPropertyWithValue("first", "toto")
 				.hasFieldOrPropertyWithValue("second", 123)
 				.hasFieldOrPropertyWithValue("third", true);
+
+		/* Given */
+		ByteBuffer byteBuffer = StandardCharsets.UTF_8.encode("foo:456:true");
+
+		/* When */
+		Object entityFromByteBuffer = deserializer.deserialize("my-topic", null, byteBuffer);
+
+		/* Then */
+		assertThat(entityFromByteBuffer)
+				.hasFieldOrPropertyWithValue("first", "foo")
+				.hasFieldOrPropertyWithValue("second", 456)
+				.hasFieldOrPropertyWithValue("third", true);
 	}
 
 	@Test
@@ -187,6 +201,18 @@ public class ToStringSerializationTests {
 		assertThat(entity)
 				.hasFieldOrPropertyWithValue("first", "toto")
 				.hasFieldOrPropertyWithValue("second", 123)
+				.hasFieldOrPropertyWithValue("third", true);
+
+		/* Given */
+		ByteBuffer byteBuffer = StandardCharsets.UTF_8.encode("foo:456:true");
+
+		/* When */
+		Object entityFromByteBuffer = deserializer.deserialize("my-topic", null, byteBuffer);
+
+		/* Then */
+		assertThat(entityFromByteBuffer)
+				.hasFieldOrPropertyWithValue("first", "foo")
+				.hasFieldOrPropertyWithValue("second", 456)
 				.hasFieldOrPropertyWithValue("third", true);
 	}
 
@@ -211,13 +237,28 @@ public class ToStringSerializationTests {
 				.isInstanceOf(DummyEntity.class)
 				.hasFieldOrPropertyWithValue("stringValue", "toto")
 				.hasFieldOrPropertyWithValue("intValue", 123);
+
+		/* Given */
+		ByteBuffer byteBuffer = StandardCharsets.UTF_8.encode("foo:456:true");
+
+		/* When */
+		Object entityFromByteBuffer = deserializer.deserialize("my-topic", headers, byteBuffer);
+
+		/* Then */
+		assertThat(entityFromByteBuffer)
+				.isNotNull()
+				.isInstanceOf(DummyEntity.class)
+				.hasFieldOrPropertyWithValue("stringValue", "foo")
+				.hasFieldOrPropertyWithValue("intValue", 456);
 	}
 
 	@Test
+	@DisplayName("Test deserialization using headers when data is null")
 	void nullValue() {
 		ParseStringDeserializer<Object> deserializer =
 				new ParseStringDeserializer<>(ToStringSerializationTests::parseWithHeaders);
 		assertThat(deserializer.deserialize("foo", new RecordHeaders(), (byte[]) null)).isNull();
+		assertThat(deserializer.deserialize("foo", new RecordHeaders(), (ByteBuffer) null)).isNull();
 	}
 
 	@Test


### PR DESCRIPTION
adapt apache kafka feature, reduce `CompletedFetch#parseRecord()` memory copy, details see https://issues.apache.org/jira/browse/KAFKA-14944