### PR TITLE
Deprecated ListenerContainerFactoryConfigurer.Configuration

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfiguration.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 the original author or authors.
+ * Copyright 2018-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,8 @@ import org.springframework.lang.Nullable;
  *
  * @author Tomaz Fernandes
  * @author Gary Russell
+ * @author Wang Zhiyang
+ *
  * @since 2.7
  *
  */
@@ -44,8 +46,6 @@ public class RetryTopicConfiguration {
 
 	private final ListenerContainerFactoryResolver.Configuration factoryResolverConfig;
 
-	private final ListenerContainerFactoryConfigurer.Configuration factoryConfigurerConfig;
-
 	@Nullable
 	private final Integer concurrency;
 
@@ -54,14 +54,12 @@ public class RetryTopicConfiguration {
 							TopicCreation kafkaTopicAutoCreationConfig,
 							AllowDenyCollectionManager<String> topicAllowListManager,
 							ListenerContainerFactoryResolver.Configuration factoryResolverConfig,
-							ListenerContainerFactoryConfigurer.Configuration factoryConfigurerConfig,
 							@Nullable Integer concurrency) {
 		this.destinationTopicProperties = destinationTopicProperties;
 		this.dltHandlerMethod = dltHandlerMethod;
 		this.kafkaTopicAutoCreationConfig = kafkaTopicAutoCreationConfig;
 		this.topicAllowListManager = topicAllowListManager;
 		this.factoryResolverConfig = factoryResolverConfig;
-		this.factoryConfigurerConfig = factoryConfigurerConfig;
 		this.concurrency = concurrency;
 	}
 
@@ -75,10 +73,6 @@ public class RetryTopicConfiguration {
 
 	public ListenerContainerFactoryResolver.Configuration forContainerFactoryResolver() {
 		return this.factoryResolverConfig;
-	}
-
-	public ListenerContainerFactoryConfigurer.Configuration forContainerFactoryConfigurer() {
-		return this.factoryConfigurerConfig;
 	}
 
 	public EndpointHandlerMethod getDltHandlerMethod() {

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationBuilder.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationBuilder.java
@@ -45,6 +45,8 @@ import org.springframework.util.Assert;
  * @author Tomaz Fernandes
  * @author Gary Russell
  * @author Adrian Chlebosz
+ * @author Wang Zhiyang
+ *
  * @since 2.7
  *
  */
@@ -581,9 +583,6 @@ public class RetryTopicConfigurationBuilder {
 
 		List<Long> backOffValues = new BackOffValuesGenerator(this.maxAttempts, this.backOffPolicy).generateValues();
 
-		ListenerContainerFactoryConfigurer.Configuration factoryConfigurerConfig =
-				new ListenerContainerFactoryConfigurer.Configuration(backOffValues);
-
 		List<DestinationTopic.Properties> destinationTopicProperties =
 				new DestinationTopicPropertiesFactory(this.retryTopicSuffix, this.dltSuffix, backOffValues,
 						buildClassifier(), this.topicCreationConfiguration.getNumPartitions(),
@@ -593,7 +592,7 @@ public class RetryTopicConfigurationBuilder {
 								.createProperties();
 		return new RetryTopicConfiguration(destinationTopicProperties,
 				this.dltHandlerMethod, this.topicCreationConfiguration, allowListManager,
-				factoryResolverConfig, factoryConfigurerConfig, this.concurrency);
+				factoryResolverConfig, this.concurrency);
 	}
 
 	private BinaryExceptionClassifier buildClassifier() {

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 the original author or authors.
+ * Copyright 2018-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -210,6 +210,8 @@ import org.springframework.lang.Nullable;
  * @author Tomaz Fernandes
  * @author Fabio da Silva Jr.
  * @author Gary Russell
+ * @author Wang Zhiyang
+ *
  * @since 2.7
  *
  * @see RetryTopicConfigurationBuilder
@@ -403,9 +405,7 @@ public class RetryTopicConfigurer implements BeanFactoryAware {
 				.resolveFactoryForMainEndpoint(providedFactory, defaultFactoryBeanName,
 						configuration.forContainerFactoryResolver());
 
-		return this.listenerContainerFactoryConfigurer
-				.decorateFactoryWithoutSettingContainerProperties(resolvedFactory,
-						configuration.forContainerFactoryConfigurer());
+		return this.listenerContainerFactoryConfigurer.decorateFactory(resolvedFactory);
 	}
 
 	private KafkaListenerContainerFactory<?> resolveAndConfigureFactoryForRetryEndpoint(
@@ -416,8 +416,7 @@ public class RetryTopicConfigurer implements BeanFactoryAware {
 		ConcurrentKafkaListenerContainerFactory<?, ?> resolvedFactory =
 				this.containerFactoryResolver.resolveFactoryForRetryEndpoint(providedFactory, defaultFactoryBeanName,
 				configuration.forContainerFactoryResolver());
-		return this.listenerContainerFactoryConfigurer
-				.decorateFactory(resolvedFactory, configuration.forContainerFactoryConfigurer());
+		return this.listenerContainerFactoryConfigurer.decorateFactory(resolvedFactory);
 	}
 
 	private void throwIfMultiMethodEndpoint(MethodKafkaListenerEndpoint<?, ?> mainEndpoint) {

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 the original author or authors.
+ * Copyright 2018-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,6 +56,8 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 /**
  * @author Tomaz Fernandes
+ * @author Wang Zhiyang
+ *
  * @since 2.7
  */
 @ExtendWith(MockitoExtension.class)
@@ -113,9 +115,6 @@ class RetryTopicConfigurerTests {
 
 	@Mock
 	private ConsumerRecord<?, ?> consumerRecordMessage;
-
-	@Mock
-	private ListenerContainerFactoryConfigurer.Configuration lcfcConfiguration;
 
 	@Mock
 	private Object objectMessage;
@@ -220,14 +219,10 @@ class RetryTopicConfigurerTests {
 		given(dltDestinationProperties.suffix()).willReturn(dltSuffix);
 		given(mainDestinationProperties.isMainEndpoint()).willReturn(true);
 		given(mainEndpoint.getTopics()).willReturn(topics);
-		given(configuration.forContainerFactoryConfigurer()).willReturn(lcfcConfiguration);
 
 		willReturn(containerFactory).given(containerFactoryResolver).resolveFactoryForRetryEndpoint(containerFactory,
 				defaultFactoryBeanName, factoryResolverConfig);
-		willReturn(containerFactory).given(this.listenerContainerFactoryConfigurer).decorateFactory(containerFactory,
-				lcfcConfiguration);
-		willReturn(containerFactory).given(this.listenerContainerFactoryConfigurer).decorateFactoryWithoutSettingContainerProperties(containerFactory,
-				lcfcConfiguration);
+		willReturn(containerFactory).given(this.listenerContainerFactoryConfigurer).decorateFactory(containerFactory);
 
 		RetryTopicConfigurer configurer = new RetryTopicConfigurer(destinationTopicProcessor, containerFactoryResolver,
 				listenerContainerFactoryConfigurer, new SuffixingRetryTopicNamesProviderFactory());


### PR DESCRIPTION
Deprecated `Configuration` and related public method in `ListenerContainerFactoryConfigurer`, remove args `Configuration` that method not public.