### PR TITLE
Remove AbstractMessageListenerContainer.isPaused

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
@@ -67,6 +67,7 @@ import org.springframework.util.StringUtils;
  * @author Marius Bogoevici
  * @author Artem Bilan
  * @author Tomaz Fernandes
+ * @author Wang Zhiyang
  */
 public abstract class AbstractMessageListenerContainer<K, V>
 		implements GenericMessageListenerContainer<K, V>, BeanNameAware, ApplicationEventPublisherAware,
@@ -269,6 +270,7 @@ public abstract class AbstractMessageListenerContainer<K, V>
 		return this.running;
 	}
 
+	@Deprecated(since = "3.2", forRemoval = true)
 	protected boolean isPaused() {
 		return this.paused;
 	}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
@@ -58,6 +58,7 @@ import org.springframework.util.Assert;
  * @author Artem Bilan
  * @author Vladimir Tsanev
  * @author Tomaz Fernandes
+ * @author Wang Zhiyang
  */
 public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageListenerContainer<K, V> {
 
@@ -185,7 +186,7 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 	public boolean isContainerPaused() {
 		this.lifecycleLock.lock();
 		try {
-			boolean paused = isPaused();
+			boolean paused = isPauseRequested();
 			if (paused) {
 				for (AbstractMessageListenerContainer<K, V> container : this.containers) {
 					if (!container.isContainerPaused()) {
@@ -249,7 +250,7 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 				KafkaMessageListenerContainer<K, V> container =
 						constructContainer(containerProperties, topicPartitions, i);
 				configureChildContainer(i, container);
-				if (isPaused()) {
+				if (isPauseRequested()) {
 					container.pause();
 				}
 				container.start();

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -300,7 +300,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 
 	@Override
 	public boolean isContainerPaused() {
-		return isPaused() && this.listenerConsumer != null && this.listenerConsumer.isConsumerPaused();
+		return isPauseRequested() && this.listenerConsumer != null && this.listenerConsumer.isConsumerPaused();
 	}
 
 	@Override
@@ -1639,7 +1639,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 						KafkaMessageListenerContainer.this.emergencyStop.run();
 					}
 					TopicPartition firstPart = this.remainingRecords.partitions().iterator().next();
-					boolean isPaused = isPaused() || isPartitionPauseRequested(firstPart);
+					boolean isPaused = isPauseRequested() || isPartitionPauseRequested(firstPart);
 					this.logger.debug(() -> "First pending after error: " + firstPart + "; paused: " + isPaused);
 					if (!isPaused) {
 						records = this.remainingRecords;
@@ -1759,7 +1759,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 				this.pausedForAsyncAcks = true;
 				this.logger.debug(() -> "Pausing for incomplete async acks: " + this.offsetsInThisBatch);
 			}
-			if (!this.consumerPaused && (isPaused() || this.pausedForAsyncAcks)
+			if (!this.consumerPaused && (isPauseRequested() || this.pausedForAsyncAcks)
 					|| this.pauseForPending) {
 
 				Collection<TopicPartition> assigned = getAssignedPartitions();
@@ -1800,7 +1800,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 				this.pausedForAsyncAcks = false;
 				this.logger.debug("Resuming after manual async acks cleared");
 			}
-			if (this.consumerPaused && !isPaused() && !this.pausedForAsyncAcks) {
+			if (this.consumerPaused && !isPauseRequested() && !this.pausedForAsyncAcks) {
 				this.logger.debug(() -> "Resuming consumption from: " + this.consumer.paused());
 				Collection<TopicPartition> paused = new LinkedList<>(this.consumer.paused());
 				paused.removeAll(this.pausedPartitions);
@@ -2605,7 +2605,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		}
 
 		private boolean checkImmediatePause(Iterator<ConsumerRecord<K, V>> iterator) {
-			if (isPaused() && this.pauseImmediate) {
+			if (isPauseRequested() && this.pauseImmediate) {
 				Map<TopicPartition, List<ConsumerRecord<K, V>>> remaining = new LinkedHashMap<>();
 				while (iterator.hasNext()) {
 					ConsumerRecord<K, V> next = iterator.next();
@@ -3622,7 +3622,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 						pending = true;
 					}
 				}
-				if ((pending || isPaused() || ListenerConsumer.this.remainingRecords != null)
+				if ((pending || isPauseRequested() || ListenerConsumer.this.remainingRecords != null)
 						&& !partitions.isEmpty()) {
 
 					ListenerConsumer.this.consumer.pause(partitions);

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
@@ -142,6 +142,7 @@ import org.springframework.util.backoff.FixedBackOff;
  * @author Ray Chuan Tay
  * @author Daniel Gentes
  * @author Soby Chacko
+ * @author Wang Zhiyang
  */
 @EmbeddedKafka(topics = { KafkaMessageListenerContainerTests.topic1, KafkaMessageListenerContainerTests.topic2,
 		KafkaMessageListenerContainerTests.topic3, KafkaMessageListenerContainerTests.topic4,
@@ -2630,7 +2631,7 @@ public class KafkaMessageListenerContainerTests {
 		inOrder.verify(consumer).seekToEnd(Collections.singletonList(iterator.next()));
 		assertThat(container.isContainerPaused()).isFalse();
 		container.pause();
-		assertThat(container.isPaused()).isTrue();
+		assertThat(container.isPauseRequested()).isTrue();
 		assertThat(pauseLatch1.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(container.isContainerPaused()).isTrue();
 		assertThat(pollWhilePausedLatch.await(10, TimeUnit.SECONDS)).isTrue();


### PR DESCRIPTION
Use AbstractMessageListenerContainer method `isPauseRequested` uniformly instead of `isPaused()`.