### PR TITLE
GH-3011: Support enforced consumer rebalance

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/nav.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/nav.adoc
@@ -21,6 +21,7 @@
 **** xref:kafka/receiving-messages/kafkalistener-lifecycle.adoc[]
 **** xref:kafka/receiving-messages/validation.adoc[]
 **** xref:kafka/receiving-messages/rebalance-listeners.adoc[]
+**** xref:kafka/receiving-messages/enforced-rebalance.adoc[]
 **** xref:kafka/receiving-messages/annotation-send-to.adoc[]
 **** xref:kafka/receiving-messages/filtering.adoc[]
 **** xref:kafka/receiving-messages/retrying-deliveries.adoc[]

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/receiving-messages/enforced-rebalance.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/receiving-messages/enforced-rebalance.adoc
@@ -1,0 +1,34 @@
+[[enforced-rebalance]]
+= Enforcing Consumer Rebalance
+
+Kafka clients now support an option to trigger an https://cwiki.apache.org/confluence/display/KAFKA/KIP-568%3A+Explicit+rebalance+triggering+on+the+Consumer[enforced rebalance].
+Starting with version `3.1.2`, Spring for Apache Kafka provides an option to invoke this API on the Kafka consumer via the message listner container.
+When calling this API, it is simply alerting the Kafka consumer to trigger an enforced rebalance; the actual rebalance will only occur as part of the next `poll()` operation.
+If there is already a rebalance in progress, calling an enforced rebalance is a NO-OP.
+The caller must wait for the current rebalance to complete before invoking another one.
+See the javadocs for `enfroceRebalance` for more details.
+
+The following code snippet shows the essence of enforcing a rebalance using the message listener container.
+
+[source, java]
+----
+@KafkaListener(id = "my.id", topics = "my-topic")
+void listen(ConsumerRecord<String, String> in) {
+    System.out.println("From KafkaListener: " + in);
+}
+
+@Bean
+public ApplicationRunner runner(KafkaTemplate<String, Object> template, KafkaListenerEndpointRegistry registry) {
+    return args -> {
+        final MessageListenerContainer listenerContainer = registry.getListenerContainer("my.id");
+        System.out.println("Enforcing a rebalance");
+        Thread.sleep(5_000);
+        listenerContainer.enforceRebalance();
+        Thread.sleep(5_000);
+    };
+}
+----
+
+As the code above shows, the application uses the `KafkaListenerEndpointRegistry` to gain access to the message listener container and then calling the `enforceRebalnce` API on it.  
+When calling the `enforceRebalance` on the listener container, it delegates the call to the underlying Kafka consumer.
+The Kafka consumer will trigger a rebalance as part of the next `poll()` operation.

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/receiving-messages/enforced-rebalance.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/receiving-messages/enforced-rebalance.adoc
@@ -2,7 +2,7 @@
 = Enforcing Consumer Rebalance
 
 Kafka clients now support an option to trigger an https://cwiki.apache.org/confluence/display/KAFKA/KIP-568%3A+Explicit+rebalance+triggering+on+the+Consumer[enforced rebalance].
-Starting with version `3.1.2`, Spring for Apache Kafka provides an option to invoke this API on the Kafka consumer via the message listner container.
+Starting with version `3.1.2`, Spring for Apache Kafka provides an option to invoke this API on the Kafka consumer via the message listener container.
 When calling this API, it is simply alerting the Kafka consumer to trigger an enforced rebalance; the actual rebalance will only occur as part of the next `poll()` operation.
 If there is already a rebalance in progress, calling an enforced rebalance is a NO-OP.
 The caller must wait for the current rebalance to complete before invoking another one.

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 the original author or authors.
+ * Copyright 2016-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 import java.util.regex.Pattern;
@@ -68,6 +69,7 @@ import org.springframework.util.StringUtils;
  * @author Artem Bilan
  * @author Tomaz Fernandes
  * @author Wang Zhiyang
+ * @author Soby Chacko
  */
 public abstract class AbstractMessageListenerContainer<K, V>
 		implements GenericMessageListenerContainer<K, V>, BeanNameAware, ApplicationEventPublisherAware,
@@ -134,6 +136,8 @@ public abstract class AbstractMessageListenerContainer<K, V>
 
 	@Nullable
 	private KafkaAdmin kafkaAdmin;
+
+	protected AtomicBoolean enforceRebalanceRequested = new AtomicBoolean();
 
 	/**
 	 * Construct an instance with the provided factory and properties.
@@ -617,6 +621,15 @@ public abstract class AbstractMessageListenerContainer<K, V>
 		finally {
 			this.lifecycleLock.unlock();
 		}
+	}
+
+	@Override
+	public void enforceRebalance() {
+		this.enforceRebalanceRequested.set(true);
+	}
+
+	protected boolean isEnforceRebalanceRequested() {
+		return this.enforceRebalanceRequested.get();
 	}
 
 	@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
@@ -625,12 +625,6 @@ public abstract class AbstractMessageListenerContainer<K, V>
 	}
 
 	@Override
-	public void enforceRebalance() {
-		throw new UnsupportedOperationException("enforceRebalance() is supposed to be implemented " +
-				"by concrete implementations only.");
-	}
-
-	@Override
 	public void pause() {
 		this.paused = true;
 	}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
@@ -92,6 +92,8 @@ public abstract class AbstractMessageListenerContainer<K, V>
 
 	protected final ReentrantLock lifecycleLock = new ReentrantLock(); // NOSONAR
 
+	protected final AtomicBoolean enforceRebalanceRequested = new AtomicBoolean();
+
 	private final Set<TopicPartition> pauseRequestedPartitions = ConcurrentHashMap.newKeySet();
 
 	@NonNull
@@ -137,7 +139,6 @@ public abstract class AbstractMessageListenerContainer<K, V>
 	@Nullable
 	private KafkaAdmin kafkaAdmin;
 
-	protected final AtomicBoolean enforceRebalanceRequested = new AtomicBoolean();
 
 	/**
 	 * Construct an instance with the provided factory and properties.
@@ -625,7 +626,8 @@ public abstract class AbstractMessageListenerContainer<K, V>
 
 	@Override
 	public void enforceRebalance() {
-		this.enforceRebalanceRequested.set(true);
+		throw new UnsupportedOperationException("enforceRebalance() is supposed to be implemented " +
+				"by concrete implementations only.");
 	}
 
 	@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
@@ -137,7 +137,7 @@ public abstract class AbstractMessageListenerContainer<K, V>
 	@Nullable
 	private KafkaAdmin kafkaAdmin;
 
-	protected AtomicBoolean enforceRebalanceRequested = new AtomicBoolean();
+	protected final AtomicBoolean enforceRebalanceRequested = new AtomicBoolean();
 
 	/**
 	 * Construct an instance with the provided factory and properties.
@@ -626,10 +626,6 @@ public abstract class AbstractMessageListenerContainer<K, V>
 	@Override
 	public void enforceRebalance() {
 		this.enforceRebalanceRequested.set(true);
-	}
-
-	protected boolean isEnforceRebalanceRequested() {
-		return this.enforceRebalanceRequested.get();
 	}
 
 	@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
@@ -397,7 +397,8 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 	public void enforceRebalance() {
 		this.lifecycleLock.lock();
 		try {
-			// Since enforceRebalance only needs to be applied against a single container, we randomly pick the first one.
+			// Since the rebalance is for the whole consumer group, there is no need to
+			// initiate this operation for every single container in the group.
 			final KafkaMessageListenerContainer<K, V> listenerContainer = this.containers.get(0);
 			listenerContainer.enforceRebalance();
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 the original author or authors.
+ * Copyright 2015-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -390,6 +390,19 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 				exec = new SimpleAsyncTaskExecutor(getListenerId() + ".authRestart");
 			}
 			exec.execute(() -> start());
+		}
+	}
+
+	@Override
+	public void enforceRebalance() {
+		this.lifecycleLock.lock();
+		try {
+			// Since enforceRebalance only needs to be applied against a single container, we randomly pick the first one.
+			final KafkaMessageListenerContainer<K, V> listenerContainer = this.containers.get(0);
+			listenerContainer.enforceRebalance();
+		}
+		finally {
+			this.lifecycleLock.unlock();
 		}
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -316,7 +316,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 
 	@Override
 	public void enforceRebalance() {
-		super.enforceRebalance();
+		this.thisOrParentContainer.enforceRebalanceRequested.set(true);
 		KafkaMessageListenerContainer<K, V>.ListenerConsumer consumer = this.listenerConsumer;
 		if (consumer != null) {
 			consumer.wakeIfNecessary();
@@ -1751,15 +1751,15 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 
 		private void enforceRebalanceIfNecessary() {
 			try {
-				if (KafkaMessageListenerContainer.this.enforceRebalanceRequested.get()) {
+				if (KafkaMessageListenerContainer.this.thisOrParentContainer.enforceRebalanceRequested.get()) {
 					final String enforcedRebalanceReason = String.format("Enforced rebalance requested for container: %s",
 							KafkaMessageListenerContainer.this.getListenerId());
-					KafkaMessageListenerContainer.this.logger.info(enforcedRebalanceReason);
+					ListenerConsumer.this.logger.info(enforcedRebalanceReason);
 					this.consumer.enforceRebalance(enforcedRebalanceReason);
 				}
 			}
 			finally {
-				KafkaMessageListenerContainer.this.enforceRebalanceRequested.set(false);
+				KafkaMessageListenerContainer.this.thisOrParentContainer.enforceRebalanceRequested.set(false);
 			}
 		}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -1752,9 +1752,9 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		private void enforceRebalanceIfNecessary() {
 			try {
 				if (KafkaMessageListenerContainer.this.thisOrParentContainer.enforceRebalanceRequested.get()) {
-					final String enforcedRebalanceReason = String.format("Enforced rebalance requested for container: %s",
+					String enforcedRebalanceReason = String.format("Enforced rebalance requested for container: %s",
 							KafkaMessageListenerContainer.this.getListenerId());
-					ListenerConsumer.this.logger.info(enforcedRebalanceReason);
+					this.logger.info(enforcedRebalanceReason);
 					this.consumer.enforceRebalance(enforcedRebalanceReason);
 				}
 			}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/MessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/MessageListenerContainer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 the original author or authors.
+ * Copyright 2016-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ import org.springframework.lang.Nullable;
  * @author Vladimir Tsanev
  * @author Tomaz Fernandes
  * @author Francois Rosiere
+ * @author Soby Chacko
  */
 public interface MessageListenerContainer extends SmartLifecycle, DisposableBean {
 
@@ -83,6 +84,16 @@ public interface MessageListenerContainer extends SmartLifecycle, DisposableBean
 	@Nullable
 	default Map<String, Collection<TopicPartition>> getAssignmentsByClientId() {
 		throw new UnsupportedOperationException("This container doesn't support retrieving its assigned partitions");
+	}
+
+	/**
+	 * Alerting the consumer to trigger an enforced rebalance. The actual enforce will happen
+	 * when the next poll() operation is invoked.
+	 * @since 3.1.2
+	 * @see org.apache.kafka.clients.consumer.KafkaConsumer#enforceRebalance()
+	 */
+	default void enforceRebalance() {
+		throw new UnsupportedOperationException("This container doesn't support enforced rebalance");
 	}
 
 	/**

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ContainerEnforceRebalanceTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ContainerEnforceRebalanceTests.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+/**
+ * @author Soby Chacko
+ */
+@SpringJUnitConfig
+@DirtiesContext
+@EmbeddedKafka(topics = "enforce-rebalance-topic")
+public class ContainerEnforceRebalanceTests {
+
+	@Test
+	void enforceRebalance(@Autowired Config config, @Autowired KafkaTemplate<Integer, String> template,
+						@Autowired KafkaListenerEndpointRegistry registry) throws InterruptedException {
+		template.send("enforce-rebalance-topic", "my-data");
+		final MessageListenerContainer listenerContainer = registry.getListenerContainer("enforce-rebalance-grp");
+		assertThat(config.listenerLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(listenerContainer).isNotNull();
+		listenerContainer.enforceRebalance();
+		// The test is expecting partition revoke once and assign twice.
+		assertThat(config.partitionRevokedLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(config.partitionAssignedLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		final List<? extends KafkaMessageListenerContainer<?, ?>> containers =
+				((ConcurrentMessageListenerContainer<?, ?>) listenerContainer).getContainers();
+		assertThat(containers.get(0).enforceRebalanceRequested).isFalse();
+	}
+
+	@Configuration
+	@EnableKafka
+	public static class Config {
+
+		@Autowired
+		EmbeddedKafkaBroker broker;
+
+		CountDownLatch partitionRevokedLatch = new CountDownLatch(1);
+		CountDownLatch partitionAssignedLatch = new CountDownLatch(2);
+
+		CountDownLatch listenerLatch = new CountDownLatch(1);
+
+		@KafkaListener(id = "enforce-rebalance-grp", topics = "enforce-rebalance-topic")
+		void listen(ConsumerRecord<Integer, String> ignored) {
+			listenerLatch.countDown();
+		}
+
+		@Bean
+		KafkaTemplate<Integer, String> template(ProducerFactory<Integer, String> pf) {
+			return new KafkaTemplate<>(pf);
+		}
+
+		@Bean
+		ProducerFactory<Integer, String> pf() {
+			return new DefaultKafkaProducerFactory<>(KafkaTestUtils.producerProps(this.broker));
+		}
+
+		@Bean
+		ConcurrentKafkaListenerContainerFactory<Integer, String> kafkaListenerContainerFactory(
+				ConsumerFactory<Integer, String> cf) {
+			ConcurrentKafkaListenerContainerFactory<Integer, String> factory =
+					new ConcurrentKafkaListenerContainerFactory<>();
+			factory.setConsumerFactory(cf);
+			factory.getContainerProperties().setConsumerRebalanceListener(new ConsumerAwareRebalanceListener() {
+				@Override
+				public void onPartitionsAssigned(Consumer<?, ?> consumer, Collection<TopicPartition> partitions) {
+					partitionAssignedLatch.countDown();
+				}
+
+				@Override
+				public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
+					partitionRevokedLatch.countDown();
+				}
+			});
+			return factory;
+		}
+
+		@Bean
+		ConsumerFactory<Integer, String> cf() {
+			return new DefaultKafkaConsumerFactory<>(
+					KafkaTestUtils.consumerProps("enforce-rebalance-topic", "false", this.broker));
+		}
+	}
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ContainerEnforceRebalanceTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ContainerEnforceRebalanceTests.java
@@ -21,7 +21,6 @@ import static org.awaitility.Awaitility.await;
 
 import java.time.Duration;
 import java.util.Collection;
-import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -65,12 +64,11 @@ public class ContainerEnforceRebalanceTests {
 		assertThat(config.listenerLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(listenerContainer).isNotNull();
 		listenerContainer.enforceRebalance();
+		assertThat(((ConcurrentMessageListenerContainer<?, ?>) listenerContainer).enforceRebalanceRequested).isTrue();
 		// The test is expecting partition revoke once and assign twice.
 		assertThat(config.partitionRevokedLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(config.partitionAssignedLatch.await(10, TimeUnit.SECONDS)).isTrue();
-		final List<? extends KafkaMessageListenerContainer<?, ?>> containers =
-				((ConcurrentMessageListenerContainer<?, ?>) listenerContainer).getContainers();
-		assertThat(containers.get(0).enforceRebalanceRequested).isFalse();
+		assertThat(((ConcurrentMessageListenerContainer<?, ?>) listenerContainer).enforceRebalanceRequested).isFalse();
 		listenerContainer.pause();
 		await().timeout(Duration.ofSeconds(10)).untilAsserted(() -> assertThat(listenerContainer.isPauseRequested()).isTrue());
 		await().timeout(Duration.ofSeconds(10)).untilAsserted(() -> assertThat(listenerContainer.isContainerPaused()).isTrue());

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
@@ -2511,7 +2511,6 @@ public class KafkaMessageListenerContainerTests {
 
 		container.start();
 		container.enforceRebalance();
-		assertThat(container.isEnforceRebalanceRequested()).isTrue();
 		assertThat(enforceRebalanceLatch.await(10, TimeUnit.SECONDS)).isTrue();
 	}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
@@ -2489,7 +2489,7 @@ public class KafkaMessageListenerContainerTests {
 	@Test
 	void enforceRabalanceOnTheConsumer() throws Exception {
 		ConsumerFactory<Integer, String> cf = mock();
-		ContainerProperties containerProps = new ContainerProperties("foo");
+		ContainerProperties containerProps = new ContainerProperties("enforce-rebalance-test-topic");
 		containerProps.setGroupId("grp");
 		containerProps.setAckMode(AckMode.RECORD);
 		containerProps.setClientId("clientId");

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
@@ -2486,6 +2486,35 @@ public class KafkaMessageListenerContainerTests {
 		logger.info("Stop rebalance after failed record");
 	}
 
+	@Test
+	void enforceRabalanceOnTheConsumer() throws Exception {
+		ConsumerFactory<Integer, String> cf = mock();
+		ContainerProperties containerProps = new ContainerProperties("foo");
+		containerProps.setGroupId("grp");
+		containerProps.setAckMode(AckMode.RECORD);
+		containerProps.setClientId("clientId");
+		containerProps.setIdleBetweenPolls(10000L);
+
+		Consumer<Integer, String> consumer = mock();
+		given(cf.createConsumer(eq("grp"), eq("clientId"), isNull(), any())).willReturn(consumer);
+
+		CountDownLatch enforceRebalanceLatch = new CountDownLatch(1);
+		containerProps.setMessageListener((MessageListener<Object, Object>) data -> {
+		});
+		KafkaMessageListenerContainer<Integer, String> container =
+				new KafkaMessageListenerContainer<>(cf, containerProps);
+		willAnswer(i -> {
+			enforceRebalanceLatch.countDown();
+			container.stop();
+			return null;
+		}).given(consumer).enforceRebalance(any());
+
+		container.start();
+		container.enforceRebalance();
+		assertThat(container.isEnforceRebalanceRequested()).isTrue();
+		assertThat(enforceRebalanceLatch.await(10, TimeUnit.SECONDS)).isTrue();
+	}
+
 	@SuppressWarnings({ "unchecked" })
 	@Test
 	public void testPauseResumeAndConsumerSeekAware() throws Exception {


### PR DESCRIPTION
Fixes: #3011

Kafka consumer API supports an enforced rebalance. Provide an option via the message listener container to trigger this operation.