### PR TITLE
GH-2942: Kafka Streams queryable stores

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/streams.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/streams.adoc
@@ -315,10 +315,61 @@ public DeadLetterPublishingRecoverer recoverer() {
 
 Of course, the `recoverer()` bean can be your own implementation of `ConsumerRecordRecoverer`.
 
+[[kafka-streams-iq-support]]
+== Interactive Query Support
+
+Starting with version 3.2, Spring for Apache Kafka provides basic facilities required for interactive queries in Kafka Streams.
+Interactive queries are useful in stateful Kafka Streams applications since they provide a way to constantly query the stateful stores in the application.
+Thus, if an application wants to materialize the current view of the system under consideration, interactive queries provide a way to do that.
+To learn more about interacive queries, see this https://kafka.apache.org/36/documentation/streams/developer-guide/interactive-queries.html[article].
+The support in Spring for Apache Kafka is centered around an API called `KafkaStreamsInteractiveQueryService` which is a facade around interactive queries APIs in Kafka Streams library.
+An application can create an instance of this service as a bean and then later on use it to retrieve the state store by its name.
+
+The following code snippet shows an example.
+
+[source, java]
+----
+@Bean
+public KafkaStreamsInteractiveQueryService kafkaStreamsInteractiveQueryService(StreamsBuilderFactoryBean streamsBuilderFactoryBean) {
+    final KafkaStreamsInteractiveQueryService kafkaStreamsInteractiveQueryService =
+            new KafkaStreamsInteractiveQueryService(streamsBuilderFactoryBean);
+    return kafkaStreamsInteractiveQueryService;
+}
+----
+
+Assuming that a Kafka Streams application has a state store called `app-store`, then that store can be retrieved via the `KafkStreamsInteractiveQuery` API as show below.
+
+[source, java]
+----
+@Autowired
+private KafkaStreamsInteractiveQueryService interactiveQueryService;
+
+ReadOnlyKeyValueStore<Object, Object>  appStore = interactiveQueryService.retrieveQueryableStore("app-store", QueryableStoreTypes.keyValueStore());
+----
+
+Once an application gains access to the state store, then it can query from it for key-value information.
+
+In this case, the state store that the application uses is a read-only key value store.
+There are other types of state stores that a Kafka Streams application can use.
+For instance, if an application prefers to query a window based store, it can build that store in the Kafka Streams application business logic and then later on retrieve it.
+Because of this reason, the API to retrieve the queryable store in `KafkaStreamsInteractiveQueryService` has a generic store type signature, so that the end-user can assign the proper type.
+
+Here is the type signature from the API.
+
+[source, java]
+----
+public <T> T retrieveQueryableStore(String storeName, QueryableStoreType<T> storeType)
+----
+
+When calling this method, the user can specifially ask for the proper state store type, as we have done in the above example.
+
+NOTE: `KafkaStreamsInteractiveQueryService` API in Spring for Apache Kafka only supports providing access to local key-value stores at the moment.
+
+
 [[kafka-streams-example]]
 == Kafka Streams Example
 
-The following example combines all the topics we have covered in this chapter:
+The following example combines the various topics we have covered in this chapter:
 
 [source, java]
 ----

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -7,6 +7,17 @@
 This section covers the changes made from version 3.1 to version 3.2.
 For changes in earlier version, see xref:appendix/change-history.adoc[Change History].
 
+[[x32-kafka-streams-iqs-support]]
+=== Kafka Streams Interactive Query Support
+
+A new API `KafkaStreamsInteractiveQuerySupport` for accessing queryable stores used in Kafka Streams interactive queries.
+See xref:streams.adoc#kafka-streams-iq-support[Kafka Streams Interactive Support] for more details.
+
+A new `TransactionIdSuffixStrategy` interface was introduced to manage `transactional.id` suffix.
+The default implementation is `DefaultTransactionIdSuffixStrategy` when setting `maxCache` greater than zero can reuse `transactional.id` within a specific range, otherwise suffixes will be generated on the fly by incrementing a counter.
+See xref:kafka/transactions.adoc#transaction-id-suffix-fixed[Fixed TransactionIdSuffix] for more information.
+
+
 [[x32-tiss]]
 === TransactionIdSuffixStrategy
 

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -13,9 +13,6 @@ For changes in earlier version, see xref:appendix/change-history.adoc[Change His
 A new API `KafkaStreamsInteractiveQuerySupport` for accessing queryable stores used in Kafka Streams interactive queries.
 See xref:streams.adoc#kafka-streams-iq-support[Kafka Streams Interactive Support] for more details.
 
-A new `TransactionIdSuffixStrategy` interface was introduced to manage `transactional.id` suffix.
-The default implementation is `DefaultTransactionIdSuffixStrategy` when setting `maxCache` greater than zero can reuse `transactional.id` within a specific range, otherwise suffixes will be generated on the fly by incrementing a counter.
-See xref:kafka/transactions.adoc#transaction-id-suffix-fixed[Fixed TransactionIdSuffix] for more information.
 
 
 [[x32-tiss]]

--- a/spring-kafka/src/main/java/org/springframework/kafka/streams/KafkaStreamsInteractiveQueryService.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/streams/KafkaStreamsInteractiveQueryService.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.streams;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StoreQueryParameters;
+import org.apache.kafka.streams.state.QueryableStoreType;
+
+import org.springframework.kafka.config.StreamsBuilderFactoryBean;
+import org.springframework.retry.RetryPolicy;
+import org.springframework.retry.backoff.FixedBackOffPolicy;
+import org.springframework.retry.policy.SimpleRetryPolicy;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.util.Assert;
+
+/**
+ * Provide a wrapper API around the interactive query stores in Kafka Streams.
+ * Using this API, an application can gain access to a named state store in the
+ * {@link KafkaStreams} under consideration.
+ *
+ * @author Soby Chacko
+ * @since 3.2.0
+ */
+public class KafkaStreamsInteractiveQueryService {
+
+	private static final int DEFAULT_MAX_ATTEMPTS = 1;
+	/**
+	 * {@link StreamsBuilderFactoryBean} that provides {@link KafkaStreams} where the state store is retrieved from.
+	 */
+	private final StreamsBuilderFactoryBean streamsBuilderFactoryBean;
+
+	/**
+	 * {@link RetryTemplate} to be used by the interative query service.
+	 */
+	private RetryTemplate retryTemplate = new RetryTemplate();
+
+	/**
+	 * Underlying {@link KafkaStreams} from {@link StreamsBuilderFactoryBean}.
+	 */
+	private KafkaStreams kafkaStreams;
+
+	/**
+	 * Constructs an instance for querying state stores from the KafkaStreams in the {@link StreamsBuilderFactoryBean}.
+	 *
+	 * @param streamsBuilderFactoryBean {@link StreamsBuilderFactoryBean} for {@link KafkaStreams}.
+	 */
+	public KafkaStreamsInteractiveQueryService(StreamsBuilderFactoryBean streamsBuilderFactoryBean) {
+		this.streamsBuilderFactoryBean = streamsBuilderFactoryBean;
+	}
+
+	/**
+	 * Retrieve and return a queryable store by name created in the application.
+	 *
+	 * @param storeName name of the queryable store
+	 * @param storeType type of the queryable store
+	 * @param <T> generic type for the queryable store
+	 * @return queryable store.
+	 */
+	public <T> T retrieveQueryableStore(String storeName, QueryableStoreType<T> storeType) {
+		if (this.kafkaStreams == null) {
+			this.kafkaStreams = this.streamsBuilderFactoryBean.getKafkaStreams();
+		}
+		Assert.notNull(this.kafkaStreams, "KafkaStreams cannot be null");
+		StoreQueryParameters<T> storeQueryParams = StoreQueryParameters.fromNameAndType(storeName, storeType);
+		AtomicReference<StoreQueryParameters<T>> storeQueryParametersReference = new AtomicReference<>(storeQueryParams);
+
+		return getRetryTemplate().execute(context -> {
+			try {
+				return this.kafkaStreams.store(storeQueryParametersReference.get());
+			}
+			catch (Exception e) {
+				throw new IllegalStateException("Error retrieving state store: " + storeName, e);
+			}
+		});
+	}
+
+	private RetryTemplate getRetryTemplate() {
+		if (this.retryTemplate == null) {
+			this.retryTemplate = new RetryTemplate();
+			retryTemplate.setBackOffPolicy(new FixedBackOffPolicy());
+			RetryPolicy retryPolicy = new SimpleRetryPolicy(DEFAULT_MAX_ATTEMPTS);
+			retryTemplate.setRetryPolicy(retryPolicy);
+		}
+		return this.retryTemplate;
+	}
+
+	public void setRetryTemplate(RetryTemplate retryTemplate) {
+		this.retryTemplate = retryTemplate;
+	}
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/streams/KafkaStreamsInteractiveQueryService.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/streams/KafkaStreamsInteractiveQueryService.java
@@ -69,7 +69,6 @@ public class KafkaStreamsInteractiveQueryService {
 
 	/**
 	 * Retrieve and return a queryable store by name created in the application.
-	 *
 	 * @param storeName name of the queryable store
 	 * @param storeType type of the queryable store
 	 * @param <T> generic type for the queryable store
@@ -79,7 +78,8 @@ public class KafkaStreamsInteractiveQueryService {
 		if (this.kafkaStreams == null) {
 			this.kafkaStreams = this.streamsBuilderFactoryBean.getKafkaStreams();
 		}
-		Assert.notNull(this.kafkaStreams, "KafkaStreams cannot be null");
+		Assert.notNull(this.kafkaStreams, "KafkaStreams cannot be null. " +
+				"Make sure that the corresponding StreamsBuilderFactoryBean has started properly.");
 		StoreQueryParameters<T> storeQueryParams = StoreQueryParameters.fromNameAndType(storeName, storeType);
 
 		return this.retryTemplate.execute(context -> {
@@ -91,4 +91,5 @@ public class KafkaStreamsInteractiveQueryService {
 			}
 		});
 	}
+
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/streams/KafkaStreamsInteractiveQueryServiceTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/streams/KafkaStreamsInteractiveQueryServiceTests.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.streams;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StoreQueryParameters;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.kstream.Grouped;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.processor.WallclockTimestampExtractor;
+import org.apache.kafka.streams.state.QueryableStoreTypes;
+import org.apache.kafka.streams.state.ReadOnlyKeyValueStore;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.annotation.EnableKafkaStreams;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.annotation.KafkaStreamsDefaultConfiguration;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.config.KafkaListenerContainerFactory;
+import org.springframework.kafka.config.KafkaStreamsConfiguration;
+import org.springframework.kafka.config.StreamsBuilderFactoryBean;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.EmbeddedKafkaKraftBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.retry.RetryPolicy;
+import org.springframework.retry.backoff.FixedBackOffPolicy;
+import org.springframework.retry.policy.SimpleRetryPolicy;
+import org.springframework.retry.support.RetryTemplate;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+/**
+ * @author Soby Chacko
+ * @since 3.2.0
+ */
+@SpringJUnitConfig
+@DirtiesContext
+@EmbeddedKafka(partitions = 1,
+		topics = { "iqs-test-in", "iqs-test-out" })
+class KafkaStreamsInteractiveQueryServiceTests {
+
+	public static final String IQS_TEST_IN = "iqs-test-in";
+	public static final String IQS_TEST_OUT = "iqs-test-out";
+	public static final String STATE_STORE = "my-state-store";
+	public static final String NON_EXISTENT_STORE = "my-non-existent-store";
+
+	@Autowired
+	private EmbeddedKafkaKraftBroker embeddedKafka;
+
+	@Autowired
+	private StreamsBuilderFactoryBean streamsBuilderFactoryBean;
+
+	@Autowired
+	private KafkaTemplate<Integer, String> kafkaTemplate;
+
+	@Autowired
+	private KafkaStreamsInteractiveQueryService interactiveQueryService;
+
+	@Autowired
+	private CompletableFuture<ConsumerRecord<?, String>> resultFuture;
+
+	@Test
+	void retrieveQueryableStore() throws Exception {
+		this.kafkaTemplate.sendDefault(123, "123");
+		this.kafkaTemplate.flush();
+
+		ConsumerRecord<?, String> result = resultFuture.get(600, TimeUnit.SECONDS);
+		assertThat(result).isNotNull();
+
+		final ReadOnlyKeyValueStore<Object, Object> objectObjectReadOnlyKeyValueStore = this.interactiveQueryService
+				.retrieveQueryableStore(STATE_STORE,
+						QueryableStoreTypes.keyValueStore());
+
+		assertThat(objectObjectReadOnlyKeyValueStore.get(123)).isNotNull();
+		assertThat((Long) objectObjectReadOnlyKeyValueStore.get(123) >= 1L).isTrue();
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void retrieveNonExistentStateStoreAndVerifyRetries() throws Exception {
+		this.kafkaTemplate.sendDefault(123, "123");
+		this.kafkaTemplate.flush();
+
+		ConsumerRecord<?, String> result = resultFuture.get(600, TimeUnit.SECONDS);
+		assertThat(result).isNotNull();
+
+		assertThat(this.streamsBuilderFactoryBean.getKafkaStreams()).isNotNull();
+		final KafkaStreams kafkaStreams = spy(this.streamsBuilderFactoryBean.getKafkaStreams());
+		assertThat(kafkaStreams).isNotNull();
+
+		Field kafkaStreamsField = KafkaStreamsInteractiveQueryService.class.getDeclaredField("kafkaStreams");
+		kafkaStreamsField.setAccessible(true);
+		kafkaStreamsField.set(interactiveQueryService, kafkaStreams);
+
+		Throwable exc = null;
+		try {
+			this.interactiveQueryService
+					.retrieveQueryableStore(NON_EXISTENT_STORE, QueryableStoreTypes.keyValueStore());
+		}
+		catch (Exception e) {
+			exc = e;
+		}
+		assertThat(exc).isNotNull();
+		assertThat(exc.getMessage()).contains("Error retrieving state store: my-non-existent-store");
+
+		verify(kafkaStreams, times(3)).store(any(StoreQueryParameters.class));
+	}
+
+	@Configuration
+	@EnableKafka
+	@EnableKafkaStreams
+	public static class KafkaStreamsConfig {
+
+		@Value("${" + EmbeddedKafkaBroker.SPRING_EMBEDDED_KAFKA_BROKERS + "}")
+		private String brokerAddresses;
+
+		@Bean
+		public ProducerFactory<Integer, String> producerFactory() {
+			return new DefaultKafkaProducerFactory<>(producerConfigs());
+		}
+
+		@Bean
+		public Map<String, Object> producerConfigs() {
+			return KafkaTestUtils.producerProps(this.brokerAddresses);
+		}
+
+		@Bean
+		public KafkaTemplate<Integer, String> template() {
+			KafkaTemplate<Integer, String> kafkaTemplate = new KafkaTemplate<>(producerFactory(), true);
+			kafkaTemplate.setDefaultTopic("iqs-test-in");
+			return kafkaTemplate;
+		}
+
+		@Bean
+		public Map<String, Object> consumerConfigs() {
+			return KafkaTestUtils.consumerProps(this.brokerAddresses, "testGroup",
+					"false");
+		}
+
+		@Bean
+		public ConsumerFactory<Integer, String> consumerFactory() {
+			return new DefaultKafkaConsumerFactory<>(consumerConfigs());
+		}
+
+		@Bean
+		public KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<Integer, String>>
+		kafkaListenerContainerFactory() {
+
+			ConcurrentKafkaListenerContainerFactory<Integer, String> factory =
+					new ConcurrentKafkaListenerContainerFactory<>();
+			factory.setConsumerFactory(consumerFactory());
+			return factory;
+		}
+
+		@Bean(name = KafkaStreamsDefaultConfiguration.DEFAULT_STREAMS_CONFIG_BEAN_NAME)
+		public KafkaStreamsConfiguration kStreamsConfigs() {
+			Map<String, Object> props = new HashMap<>();
+			props.put(StreamsConfig.APPLICATION_ID_CONFIG, "iqs-testStreams");
+			props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, this.brokerAddresses);
+			props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.Integer().getClass().getName());
+			props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
+			props.put(StreamsConfig.DEFAULT_TIMESTAMP_EXTRACTOR_CLASS_CONFIG,
+					WallclockTimestampExtractor.class.getName());
+			props.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, "100");
+			return new KafkaStreamsConfiguration(props);
+		}
+
+		@Bean
+		public KStream<Integer, String> kStream(StreamsBuilder kStreamBuilder) {
+			KStream<Integer, String> input = kStreamBuilder.stream(IQS_TEST_IN);
+			final KStream<Integer, String> outbound = input.filter((key, value) -> key == 123)
+					.map((key, value) -> new KeyValue<>(123, value))
+					.groupByKey(Grouped.with(new Serdes.IntegerSerde(),
+							new Serdes.StringSerde()))
+					.count(Materialized.as(STATE_STORE)).toStream()
+					.map((key, value) -> new KeyValue<>(key, "Count for ID 123: " + value));
+			outbound.to(IQS_TEST_OUT);
+			return outbound;
+		}
+
+		@Bean
+		public KafkaStreamsInteractiveQueryService kafkaStreamsInteractiveQueryService(StreamsBuilderFactoryBean streamsBuilderFactoryBean) {
+			final KafkaStreamsInteractiveQueryService kafkaStreamsInteractiveQueryService =
+					new KafkaStreamsInteractiveQueryService(streamsBuilderFactoryBean);
+			RetryTemplate retryTemplate = new RetryTemplate();
+			retryTemplate.setBackOffPolicy(new FixedBackOffPolicy());
+			RetryPolicy retryPolicy = new SimpleRetryPolicy(3);
+			retryTemplate.setRetryPolicy(retryPolicy);
+			kafkaStreamsInteractiveQueryService.setRetryTemplate(retryTemplate);
+			return kafkaStreamsInteractiveQueryService;
+		}
+
+		@Bean
+		public CompletableFuture<ConsumerRecord<?, String>> resultFuture() {
+			return new CompletableFuture<>();
+		}
+
+		@KafkaListener(topics = "iqs-test-out")
+		public void listener(ConsumerRecord<?, String> payload) {
+			resultFuture().complete(payload);
+		}
+	}
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/streams/KafkaStreamsInteractiveQueryServiceTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/streams/KafkaStreamsInteractiveQueryServiceTests.java
@@ -114,7 +114,7 @@ class KafkaStreamsInteractiveQueryServiceTests {
 		ConsumerRecord<?, String> result = resultFuture.get(600, TimeUnit.SECONDS);
 		assertThat(result).isNotNull();
 
-		final ReadOnlyKeyValueStore<Object, Object> objectObjectReadOnlyKeyValueStore = this.interactiveQueryService
+		ReadOnlyKeyValueStore<Object, Object> objectObjectReadOnlyKeyValueStore = this.interactiveQueryService
 				.retrieveQueryableStore(STATE_STORE,
 						QueryableStoreTypes.keyValueStore());
 
@@ -131,7 +131,7 @@ class KafkaStreamsInteractiveQueryServiceTests {
 		assertThat(result).isNotNull();
 
 		assertThat(this.streamsBuilderFactoryBean.getKafkaStreams()).isNotNull();
-		final KafkaStreams kafkaStreams = spy(this.streamsBuilderFactoryBean.getKafkaStreams());
+		KafkaStreams kafkaStreams = spy(this.streamsBuilderFactoryBean.getKafkaStreams());
 		assertThat(kafkaStreams).isNotNull();
 
 		Field kafkaStreamsField = KafkaStreamsInteractiveQueryService.class.getDeclaredField("kafkaStreams");

--- a/spring-kafka/src/test/java/org/springframework/kafka/streams/KafkaStreamsInteractiveQueryServiceTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/streams/KafkaStreamsInteractiveQueryServiceTests.java
@@ -17,6 +17,7 @@
 package org.springframework.kafka.streams;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -83,8 +84,11 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 class KafkaStreamsInteractiveQueryServiceTests {
 
 	public static final String IQS_TEST_IN = "iqs-test-in";
+
 	public static final String IQS_TEST_OUT = "iqs-test-out";
+
 	public static final String STATE_STORE = "my-state-store";
+
 	public static final String NON_EXISTENT_STORE = "my-non-existent-store";
 
 	@Autowired
@@ -114,8 +118,7 @@ class KafkaStreamsInteractiveQueryServiceTests {
 				.retrieveQueryableStore(STATE_STORE,
 						QueryableStoreTypes.keyValueStore());
 
-		assertThat(objectObjectReadOnlyKeyValueStore.get(123)).isNotNull();
-		assertThat((Long) objectObjectReadOnlyKeyValueStore.get(123) >= 1L).isTrue();
+		assertThat((Long) objectObjectReadOnlyKeyValueStore.get(123)).isGreaterThanOrEqualTo(1);
 	}
 
 	@SuppressWarnings("unchecked")
@@ -135,16 +138,12 @@ class KafkaStreamsInteractiveQueryServiceTests {
 		kafkaStreamsField.setAccessible(true);
 		kafkaStreamsField.set(interactiveQueryService, kafkaStreams);
 
-		Throwable exc = null;
-		try {
-			this.interactiveQueryService
+		assertThatExceptionOfType(IllegalStateException.class)
+				.isThrownBy(() -> {
+					this.interactiveQueryService
 					.retrieveQueryableStore(NON_EXISTENT_STORE, QueryableStoreTypes.keyValueStore());
-		}
-		catch (Exception e) {
-			exc = e;
-		}
-		assertThat(exc).isNotNull();
-		assertThat(exc.getMessage()).contains("Error retrieving state store: my-non-existent-store");
+				})
+				.withMessageContaining("Error retrieving state store: my-non-existent-store");
 
 		verify(kafkaStreams, times(3)).store(any(StoreQueryParameters.class));
 	}

--- a/spring-kafka/src/test/java/org/springframework/kafka/streams/KafkaStreamsInteractiveQueryServiceTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/streams/KafkaStreamsInteractiveQueryServiceTests.java
@@ -241,5 +241,7 @@ class KafkaStreamsInteractiveQueryServiceTests {
 		public void listener(ConsumerRecord<?, String> payload) {
 			resultFuture().complete(payload);
 		}
+
 	}
+
 }


### PR DESCRIPTION
Fixes: #2942

This is an initial iteration for providing a basic API around interactive query service in Kafka Streams. In this iteration, we introduce a single API for retrieving the queryable state store from the Kafka Streams topology, namely, retrieveQueryableStore.

