### PR TITLE
GH-3001: default clientIds with application name

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/connecting.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/connecting.adoc
@@ -58,3 +58,37 @@ These listeners can be used, for example, to create and bind a Micrometer `Kafka
 
 The framework provides listeners that do exactly that; see xref:kafka/micrometer.adoc#micrometer-native[Micrometer Native Metrics].
 
+[[default-client-id-prefixes]]
+== Default client ID prefixes
+
+Starting with version 3.2, for Spring Boot applications which define an application name using the `spring.application.name` property, this name is now used
+as a default prefix for auto-generated client IDs for these client types:
+
+- consumer clients which don't use a consumer group
+- producer clients
+- admin clients
+
+This makes it easier to identify these clients at server side for troubleshooting or applying quotas.
+
+.Example client ids resulting for a Spring Boot application with `spring.application.name=myapp`
+[%autowidth]
+|===
+|Client Type |Without application name |With application name
+
+|consumer without consumer group
+|consumer-null-1
+|myapp-consumer-1
+
+|consumer with consumer group "mygroup"
+|consumer-mygroup-1
+|consumer-mygroup-1
+
+|producer
+|producer-1
+|myapp-producer-1
+
+|admin
+|adminclient-1
+|myapp-admin-1
+|===
+

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -67,3 +67,9 @@ See xref:kafka/seek.adoc#seek[Seek API Docs] for more details.
 When this constructor is used, the framework calls the function with the input argument of the current consumer offset position.
 See xref:kafka/seek.adoc#seek[Seek API Docs] for more details.
 
+[[x32-default-clientid-prefix]]
+=== Spring Boot application name as default client ID prefix
+
+For Spring Boot applications which define an application name, this name is now used
+as a default prefix for auto-generated client IDs for certain client types.
+See xref:kafka/connecting.adoc#default-client-id-prefixes[Default client ID prefixes] for more details.


### PR DESCRIPTION
Fixes: #GH-3001

Use Spring Boot's `spring.application.name` property as part of the default clientIds for Consumers, Producers and AdminClients. Helps with identifying problematic clients at server side.

* Only use as a fallback if clientId wasn't specified explicitly
* Do not use for Consumers with a specified groupId because KafkaConsumer will use the groupId as clientId which already is an identifiable default