### PR TITLE
GH-3057: ReactiveKafkaConsumerTemplate missing receiveBatch method

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/reactive/ReactiveKafkaConsumerTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/reactive/ReactiveKafkaConsumerTemplate.java
@@ -72,8 +72,8 @@ public class ReactiveKafkaConsumerTemplate<K, V> {
 		return this.kafkaReceiver.receive();
 	}
 
-	public Flux<ReceiverRecord<K, V>> receiveBatch() {
-		return this.kafkaReceiver.receiveBatch().concatMap(Function.identity());
+	public Flux<Flux<ReceiverRecord<K, V>>> receiveBatch() {
+		return this.kafkaReceiver.receiveBatch();
 	}
 
 	public Flux<ConsumerRecord<K, V>> receiveAutoAck() {

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/reactive/ReactiveKafkaConsumerTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/reactive/ReactiveKafkaConsumerTemplate.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,6 +50,7 @@ import reactor.util.function.Tuples;
  *
  * @author Mark Norkin
  * @author Adrian Chlebosz
+ * @author Marcus Voltolim
  *
  * @since 2.3.0
  */
@@ -69,6 +70,10 @@ public class ReactiveKafkaConsumerTemplate<K, V> {
 
 	public Flux<ReceiverRecord<K, V>> receive() {
 		return this.kafkaReceiver.receive();
+	}
+
+	public Flux<ReceiverRecord<K, V>> receiveBatch() {
+		return this.kafkaReceiver.receiveBatch().concatMap(Function.identity());
 	}
 
 	public Flux<ConsumerRecord<K, V>> receiveAutoAck() {


### PR DESCRIPTION
* Adding wrapper method `receiveBatch` in ReactiveKafkaConsumerTemplate.

Closes #3057

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
