### PR TITLE
GH-2775: Deprecate ContainerProperties properties transactionManager

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/container-props.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/container-props.adoc
@@ -123,6 +123,10 @@ Also see `idleBeforeDataMultiplier`.
 |None
 |Used to override any arbitrary consumer properties configured on the consumer factory.
 
+|[[kafkaAwareTransactionManager]]<<kafkaAwareTransactionManager,`kafkaAwareTransactionManager`>>
+|`null`
+|See xref:kafka/transactions.adoc[Transactions].
+
 |[[listenerTaskExecutor]]<<listenerTaskExecutor,`listenerTaskExecutor`>>
 |`SimpleAsyncTaskExecutor`
 |A task executor to run the consumer threads.
@@ -232,7 +236,7 @@ Mutually exclusive; at least one must be provided; enforced by `ContainerPropert
 
 |[[transactionManager]]<<transactionManager,`transactionManager`>>
 |`null`
-|See xref:kafka/transactions.adoc[Transactions].
+|Deprecated since 3.2, see <<kafkaAwareTransactionManager>>, xref:kafka/transactions.adoc#transaction-synchronization[Other transaction managers].
 |===
 
 [[alc-props]]

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -36,6 +36,12 @@ Rules for the redirection are set either via the `RetryableTopic.exceptionBasedD
 Custom DLTs are created automatically as well as other retry and dead-letter topics.
 See xref:retrytopic/features.adoc#exc-based-custom-dlt-routing[Routing of messages to custom DLTs based on thrown exceptions] for more information.
 
+[[x32-cp-ptm]]
+=== Deprecated ContainerProperties property transactionManager
+
+Deprecated ContainerProperties property transactionManager and add new property kafkaAwareTransactionManager, narrower type TransactionManager to KafkaAwareTransactionManager and Other transaction managers see xref:kafka/transactions.adoc#transaction-synchronization[Transaction Synchronization].
+See xref:kafka/container-props.adoc#kafkaAwareTransactionManager[ContainerProperties#kafkaAwareTransactionManager]
+
 [[x32-after-rollback-processing]]
 === After Rollback Processing
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -696,12 +696,16 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 
 		private final CommonErrorHandler commonErrorHandler;
 
-		private final PlatformTransactionManager transactionManager = this.containerProperties.getTransactionManager();
+		@Deprecated(since = "3.2", forRemoval = true)
+		@SuppressWarnings("removal")
+		private final PlatformTransactionManager transactionManager =
+				this.containerProperties.getKafkaAwareTransactionManager() != null ?
+						this.containerProperties.getKafkaAwareTransactionManager() :
+						this.containerProperties.getTransactionManager();
 
-		@SuppressWarnings(RAWTYPES)
-		private final KafkaAwareTransactionManager kafkaTxManager =
-				this.transactionManager instanceof KafkaAwareTransactionManager
-						? ((KafkaAwareTransactionManager) this.transactionManager) : null;
+		private final KafkaAwareTransactionManager<?, ?> kafkaTxManager =
+				this.transactionManager instanceof KafkaAwareTransactionManager<?, ?> kafkaAwareTransactionManager ?
+						kafkaAwareTransactionManager : null;
 
 		private final TransactionTemplate transactionTemplate;
 
@@ -3034,7 +3038,6 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			doSendOffsets(this.producer, commits);
 		}
 
-		@SuppressWarnings("deprecation")
 		private void doSendOffsets(Producer<?, ?> prod, Map<TopicPartition, OffsetAndMetadata> commits) {
 			prod.sendOffsetsToTransaction(commits, this.consumer.groupMetadata());
 			if (this.fixTxOffsets) {

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
@@ -355,7 +355,7 @@ public class DefaultKafkaConsumerFactoryTests {
 			latch.countDown();
 		});
 		KafkaTransactionManager<Integer, String> tm = new KafkaTransactionManager<>(pfTx);
-		containerProps.setTransactionManager(tm);
+		containerProps.setKafkaAwareTransactionManager(tm);
 		KafkaMessageListenerContainer<Integer, String> container = new KafkaMessageListenerContainer<>(cf,
 				containerProps);
 		container.start();
@@ -406,7 +406,7 @@ public class DefaultKafkaConsumerFactoryTests {
 			latch.countDown();
 		});
 		KafkaTransactionManager<Integer, String> tm = new KafkaTransactionManager<>(pfTx);
-		containerProps.setTransactionManager(tm);
+		containerProps.setKafkaAwareTransactionManager(tm);
 		KafkaMessageListenerContainer<Integer, String> container = new KafkaMessageListenerContainer<>(cf,
 				containerProps);
 		container.start();

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/CommitOnAssignmentTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/CommitOnAssignmentTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 the original author or authors.
+ * Copyright 2020-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -120,7 +120,7 @@ public class CommitOnAssignmentTests {
 			latch.countDown();
 			return null;
 		}).given(producer).sendOffsetsToTransaction(any(), any(ConsumerGroupMetadata.class));
-		props.setTransactionManager(tm);
+		props.setKafkaAwareTransactionManager(tm);
 		this.registry.start();
 		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
 	}
@@ -135,8 +135,7 @@ public class CommitOnAssignmentTests {
 		KafkaTransactionManager tm = new KafkaTransactionManager<>(pf);
 		Producer producer = mock(Producer.class);
 		given(pf.createProducer(any())).willReturn(producer);
-		CountDownLatch latch = new CountDownLatch(1);
-		props.setTransactionManager(tm);
+		props.setKafkaAwareTransactionManager(tm);
 		this.registry.start();
 		assertThat(this.config.commitLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		verify(producer, never()).sendOffsetsToTransaction(any(), any(ConsumerGroupMetadata.class));

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerMockTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerMockTests.java
@@ -561,7 +561,7 @@ public class ConcurrentMessageListenerContainerMockTests {
 		given(tm.getProducerFactory()).willReturn(pf);
 		Producer producer = mock(Producer.class);
 		given(pf.createProducer()).willReturn(producer);
-		containerProperties.setTransactionManager(tm);
+		containerProperties.setKafkaAwareTransactionManager(tm);
 		List<String> order = new ArrayList<>();
 		CountDownLatch latch = new CountDownLatch(option == null ? 2 : 3);
 		willAnswer(inv -> {
@@ -688,7 +688,6 @@ public class ConcurrentMessageListenerContainerMockTests {
 			.willReturn(consumer);
 		ContainerProperties containerProperties = new ContainerProperties("foo");
 		containerProperties.setGroupId("grp");
-		AtomicReference<List<ConsumerRecord<String, String>>> received = new AtomicReference<>();
 		containerProperties.setMessageListener((MessageListener) rec -> {
 		});
 		containerProperties.setMissingTopicsFatal(false);

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
@@ -3951,7 +3951,7 @@ public class KafkaMessageListenerContainerTests {
 
 	@ParameterizedTest(name = "{index} testInvokeBatchInterceptorAllSkipped early intercept {0}")
 	@ValueSource(booleans = { true, false })
-	@SuppressWarnings({"unchecked"})
+	@SuppressWarnings({ "unchecked", "deprecation" })
 	public void testInvokeBatchInterceptorAllSkipped(boolean early) throws Exception {
 		ConsumerFactory<Integer, String> cf = mock(ConsumerFactory.class);
 		Consumer<Integer, String> consumer = mock(Consumer.class);

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ManualNackBatchTxTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ManualNackBatchTxTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 the original author or authors.
+ * Copyright 2017-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -279,7 +279,7 @@ public class ManualNackBatchTxTests {
 			factory.setConsumerFactory(consumerFactory());
 			factory.getContainerProperties().setAckMode(AckMode.MANUAL);
 			factory.getContainerProperties().setMissingTopicsFatal(false);
-			factory.getContainerProperties().setTransactionManager(tm());
+			factory.getContainerProperties().setKafkaAwareTransactionManager(tm());
 			factory.setBatchListener(true);
 			return factory;
 		}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentOnErrorBatchModeTXTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentOnErrorBatchModeTXTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 the original author or authors.
+ * Copyright 2017-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -247,7 +247,7 @@ public class SeekToCurrentOnErrorBatchModeTXTests {
 			factory.setConsumerFactory(consumerFactory());
 			factory.setCommonErrorHandler(new DefaultErrorHandler());
 			factory.getContainerProperties().setAckMode(AckMode.BATCH);
-			factory.getContainerProperties().setTransactionManager(tm());
+			factory.getContainerProperties().setKafkaAwareTransactionManager(tm());
 			return factory;
 		}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentOnErrorRecordModeTXTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentOnErrorRecordModeTXTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2021 the original author or authors.
+ * Copyright 2017-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -248,7 +248,7 @@ public class SeekToCurrentOnErrorRecordModeTXTests {
 			factory.setConsumerFactory(consumerFactory());
 			factory.setCommonErrorHandler(new DefaultErrorHandler());
 			factory.getContainerProperties().setAckMode(AckMode.RECORD);
-			factory.getContainerProperties().setTransactionManager(tm());
+			factory.getContainerProperties().setKafkaAwareTransactionManager(tm());
 			return factory;
 		}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/SubBatchPerPartitionTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/SubBatchPerPartitionTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 the original author or authors.
+ * Copyright 2017-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -62,10 +62,10 @@ import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.kafka.transaction.KafkaAwareTransactionManager;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.annotation.DirtiesContext.ClassMode;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
-import org.springframework.transaction.PlatformTransactionManager;
 
 /**
  * @author Gary Russell
@@ -156,7 +156,7 @@ public class SubBatchPerPartitionTests {
 
 		containerProps = new ContainerProperties("sbpp");
 		containerProps.setMessageListener(mock(MessageListener.class));
-		containerProps.setTransactionManager(mock(PlatformTransactionManager.class));
+		containerProps.setKafkaAwareTransactionManager(mock(KafkaAwareTransactionManager.class));
 		container = new KafkaMessageListenerContainer<>(cf, containerProps);
 		container.start();
 		assertThat(KafkaTestUtils.getPropertyValue(container, "listenerConsumer.subBatchPerPartition"))

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/SubBatchPerPartitionTxRollbackTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/SubBatchPerPartitionTxRollbackTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 the original author or authors.
+ * Copyright 2017-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -220,7 +220,7 @@ public class SubBatchPerPartitionTxRollbackTests {
 			ConcurrentKafkaListenerContainerFactory factory = new ConcurrentKafkaListenerContainerFactory();
 			factory.setConsumerFactory(consumerFactory());
 			factory.getContainerProperties().setAckMode(AckMode.BATCH);
-			factory.getContainerProperties().setTransactionManager(tm());
+			factory.getContainerProperties().setKafkaAwareTransactionManager(tm());
 			factory.setBatchListener(true);
 			factory.getContainerProperties().setSubBatchPerPartition(true);
 			return factory;

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/SubBatchPerPartitionTxTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/SubBatchPerPartitionTxTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 the original author or authors.
+ * Copyright 2017-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -206,7 +206,7 @@ public class SubBatchPerPartitionTxTests {
 			ConcurrentKafkaListenerContainerFactory factory = new ConcurrentKafkaListenerContainerFactory();
 			factory.setConsumerFactory(consumerFactory());
 			factory.getContainerProperties().setAckMode(AckMode.BATCH);
-			factory.getContainerProperties().setTransactionManager(tm());
+			factory.getContainerProperties().setKafkaAwareTransactionManager(tm());
 			factory.getContainerProperties().setSubBatchPerPartition(true);
 			factory.setBatchListener(true);
 			return factory;

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/TransactionalContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/TransactionalContainerTests.java
@@ -221,7 +221,7 @@ public class TransactionalContainerTests {
 		ContainerProperties props = new ContainerProperties("foo");
 		props.setAckMode(ackMode);
 		props.setGroupId("group");
-		props.setTransactionManager(tm);
+		props.setKafkaAwareTransactionManager(tm);
 		props.setAssignmentCommitOption(AssignmentCommitOption.ALWAYS);
 		props.setEosMode(eosMode);
 		props.setStopContainerWhenFenced(stopWhenFenced);
@@ -329,7 +329,7 @@ public class TransactionalContainerTests {
 		ContainerProperties props = new ContainerProperties(new TopicPartitionOffset("foo", 0),
 				new TopicPartitionOffset("foo", 1));
 		props.setGroupId("group");
-		props.setTransactionManager(tm);
+		props.setKafkaAwareTransactionManager(tm);
 		props.setDeliveryAttemptHeader(true);
 		final KafkaTemplate template = new KafkaTemplate(pf);
 		AtomicReference<Header> delivery = new AtomicReference();
@@ -400,7 +400,7 @@ public class TransactionalContainerTests {
 		ContainerProperties props = new ContainerProperties(new TopicPartitionOffset("foo", 0),
 				new TopicPartitionOffset("foo", 1));
 		props.setGroupId("group");
-		props.setTransactionManager(tm);
+		props.setKafkaAwareTransactionManager(tm);
 		props.setSubBatchPerPartition(false);
 		final KafkaTemplate template = new KafkaTemplate(pf);
 		props.setMessageListener((BatchMessageListener) recordlist -> {
@@ -529,7 +529,7 @@ public class TransactionalContainerTests {
 
 		@SuppressWarnings({ "rawtypes" })
 		KafkaTransactionManager tm = new KafkaTransactionManager(pf);
-		containerProps.setTransactionManager(tm);
+		containerProps.setKafkaAwareTransactionManager(tm);
 		KafkaMessageListenerContainer<Integer, String> container =
 				new KafkaMessageListenerContainer<>(cf, containerProps);
 		container.setBeanName("testRollbackRecord");
@@ -600,7 +600,7 @@ public class TransactionalContainerTests {
 		testFixLagGuts(topic7, 2);
 	}
 
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings({"unchecked"})
 	private void testFixLagGuts(String topic, int whichTm) throws InterruptedException {
 		Map<String, Object> props = KafkaTestUtils.consumerProps("txTest2", "false", embeddedKafka);
 		props.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
@@ -617,7 +617,7 @@ public class TransactionalContainerTests {
 		case 0:
 			break;
 		case 1:
-			containerProps.setTransactionManager(new KafkaTransactionManager<>(pf));
+			containerProps.setKafkaAwareTransactionManager(new KafkaTransactionManager<>(pf));
 			break;
 		case 2:
 			containerProps.setTransactionManager(new SomeOtherTransactionManager());
@@ -656,7 +656,7 @@ public class TransactionalContainerTests {
 		pf.destroy();
 	}
 
-	@SuppressWarnings({ "unchecked"})
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testMaxFailures() throws Exception {
 		String group = "groupInARBP";
@@ -682,7 +682,7 @@ public class TransactionalContainerTests {
 
 		@SuppressWarnings({ "rawtypes" })
 		KafkaTransactionManager tm = new KafkaTransactionManager(pf);
-		containerProps.setTransactionManager(tm);
+		containerProps.setKafkaAwareTransactionManager(tm);
 		KafkaMessageListenerContainer<Integer, String> container =
 				new KafkaMessageListenerContainer<>(cf, containerProps);
 		container.setBeanName("testMaxFailures");
@@ -787,9 +787,8 @@ public class TransactionalContainerTests {
 			}
 		});
 
-		@SuppressWarnings({ "rawtypes" })
-		KafkaTransactionManager tm = new KafkaTransactionManager(pf);
-		containerProps.setTransactionManager(tm);
+		KafkaTransactionManager<Object, Object> tm = new KafkaTransactionManager<>(pf);
+		containerProps.setKafkaAwareTransactionManager(tm);
 		KafkaMessageListenerContainer<Integer, String> container =
 				new KafkaMessageListenerContainer<>(cf, containerProps);
 		container.setBeanName("testBatchListenerMaxFailures");
@@ -908,7 +907,7 @@ public class TransactionalContainerTests {
 
 		@SuppressWarnings({ "rawtypes" })
 		KafkaTransactionManager tm = new KafkaTransactionManager(pf);
-		containerProps.setTransactionManager(tm);
+		containerProps.setKafkaAwareTransactionManager(tm);
 		KafkaMessageListenerContainer<Integer, String> container =
 				new KafkaMessageListenerContainer<>(cf, containerProps);
 		container.setBeanName("testRollbackNoRetries");
@@ -944,7 +943,6 @@ public class TransactionalContainerTests {
 		assertThat(stopLatch.await(10, TimeUnit.SECONDS)).isTrue();
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	public void testBatchListenerRecoverAfterRollbackProcessorCrash() throws Exception {
 		Map<String, Object> props = KafkaTestUtils.consumerProps("testBatchListenerRollbackNoRetries", "false", embeddedKafka);
@@ -971,9 +969,8 @@ public class TransactionalContainerTests {
 			}
 		});
 
-		@SuppressWarnings({ "rawtypes" })
-		KafkaTransactionManager tm = new KafkaTransactionManager(pf);
-		containerProps.setTransactionManager(tm);
+		KafkaTransactionManager<Object, Object> tm = new KafkaTransactionManager<>(pf);
+		containerProps.setKafkaAwareTransactionManager(tm);
 		KafkaMessageListenerContainer<Integer, String> container =
 				new KafkaMessageListenerContainer<>(cf, containerProps);
 		container.setBeanName("testBatchListenerRollbackNoRetries");
@@ -1049,7 +1046,7 @@ public class TransactionalContainerTests {
 		ContainerProperties props = new ContainerProperties(new TopicPartitionOffset("foo", 0),
 				new TopicPartitionOffset("foo", 1));
 		props.setGroupId("group");
-		props.setTransactionManager(tm);
+		props.setKafkaAwareTransactionManager(tm);
 		DefaultTransactionDefinition def = new DefaultTransactionDefinition();
 		def.setTimeout(42);
 		def.setName("myTx");
@@ -1085,7 +1082,6 @@ public class TransactionalContainerTests {
 		assertThatIllegalStateException().isThrownBy(container::start);
 	}
 
-	@SuppressWarnings("serial")
 	public static class SomeOtherTransactionManager extends AbstractPlatformTransactionManager {
 
 		@Override


### PR DESCRIPTION
Use `KafkaAwareTransactionManager` to properly manage Kafka transactions.

* Deprecated properties transactionManager and add kafkaAwareTransactionManager at ContainerProperties.
* Modify transaction unit test to `setKafkaAwareTransactionManager.

Resolves #2775