### PR TITLE
Non-Blocking Retries cannot combine with container transactions.

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/transactions.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/transactions.adoc
@@ -79,6 +79,9 @@ Instead, use a `KafkaTransactionManager` in the container to start the Kafka tra
 
 See xref:tips.adoc#ex-jdbc-sync[Examples of Kafka Transactions with Other Transaction Managers] for an example application that chains JDBC and Kafka transactions.
 
+IMPORTANT: xref:retrytopic.adoc[Non-Blocking Retries] cannot combine with xref:kafka/transactions.adoc#container-transaction-manager[Container Transactions].
+When listener code threw exception, container transactions commit success and record sending to the retryable topic.
+
 [[kafkatemplate-local-transactions]]
 == `KafkaTemplate` Local Transactions
 

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/transactions.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/transactions.adoc
@@ -80,7 +80,7 @@ Instead, use a `KafkaTransactionManager` in the container to start the Kafka tra
 See xref:tips.adoc#ex-jdbc-sync[Examples of Kafka Transactions with Other Transaction Managers] for an example application that chains JDBC and Kafka transactions.
 
 IMPORTANT: xref:retrytopic.adoc[Non-Blocking Retries] cannot combine with xref:kafka/transactions.adoc#container-transaction-manager[Container Transactions].
-When listener code threw exception, container transactions commit success and record sending to the retryable topic.
+When the listener code throws an exception, container transaction commit succeeds, and the record is sent to the retryable topic.
 
 [[kafkatemplate-local-transactions]]
 == `KafkaTemplate` Local Transactions

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/retrytopic.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/retrytopic.adoc
@@ -9,3 +9,4 @@ Since 2.7 Spring for Apache Kafka offers support for that via the `@RetryableTop
 
 IMPORTANT: Non-blocking retries are not supported with xref:kafka/receiving-messages/listener-annotation.adoc#batch-listeners[Batch Listeners].
 
+IMPORTANT: Non-Blocking Retries cannot combine with xref:kafka/transactions.adoc#container-transaction-manager[Container Transactions].


### PR DESCRIPTION
Retry topic will break container txns atomicity

1. container txns commit success.
2. Message send to retryable topic retry again.

* Add adoc to notice.

See #2934