### PR TITLE
GH-3076: Set `batchFailed` state in `ListenerConsumer` even if no `commonErrorHandler` is configured

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -163,6 +163,7 @@ import io.micrometer.observation.ObservationRegistry;
  * @author Daniel Gentes
  * @author Soby Chacko
  * @author Wang Zhiyang
+ * @author Raphael Rösch
  */
 public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		extends AbstractMessageListenerContainer<K, V> implements ConsumerPauseResumeEventPublisher {
@@ -2276,13 +2277,13 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 				}
 			}
 			catch (RuntimeException e) {
+				this.batchFailed = true;
 				failureTimer(sample, null);
 				batchInterceptAfter(records, e);
 				if (this.commonErrorHandler == null) {
 					throw e;
 				}
 				try {
-					this.batchFailed = true;
 					invokeBatchErrorHandler(records, recordList, e);
 					commitOffsetsIfNeededAfterHandlingError(records);
 				}


### PR DESCRIPTION
This PR is naïve approach to solve #3076 (i am not sure about possible side effects/consequences of this change)