### PR TITLE
GH-3078: Compute Seek Position from Current Offset

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/seek.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/seek.adoc
@@ -34,6 +34,8 @@ The callback has the following methods:
 ----
 void seek(String topic, int partition, long offset);
 
+void seek(String topic, int partition, Function<Long, Long> offsetComputeFunction);
+
 void seekToBeginning(String topic, int partition);
 
 void seekToBeginning(Collection<TopicPartitions> partitions);
@@ -48,6 +50,11 @@ void seekToTimestamp(String topic, int partition, long timestamp);
 
 void seekToTimestamp(Collection<TopicPartition> topicPartitions, long timestamp);
 ----
+
+The two different variants of the `seek` methods provide a way to seek to an arbitrary offset.
+The method that takes a `Function` as an argument to compute the offset was added in version `3.2` of the framework.
+This function provides access to the current offset (the current position returned by the consumer, which is the next offset to be fetched).
+The user can decide what offset to seek to based on the current offset in the consumer as part of the function definition.
 
 `seekRelative` was added in version 2.3, to perform relative seeks.
 

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/seek.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/seek.adoc
@@ -52,7 +52,7 @@ void seekToTimestamp(Collection<TopicPartition> topicPartitions, long timestamp)
 ----
 
 The two different variants of the `seek` methods provide a way to seek to an arbitrary offset.
-The method that takes a `Function` as an argument to compute the offset was added in version `3.2` of the framework.
+The method that takes a `Function` as an argument to compute the offset was added in version 3.2 of the framework.
 This function provides access to the current offset (the current position returned by the consumer, which is the next offset to be fetched).
 The user can decide what offset to seek to based on the current offset in the consumer as part of the function definition.
 

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -51,3 +51,9 @@ See xref:kafka/annotation-error-handling.adoc#after-rollback[After-rollback Proc
 === Change @RetryableTopic SameIntervalTopicReuseStrategy default value
 Change `@RetryableTopic` property `SameIntervalTopicReuseStrategy` default value to `SINGLE_TOPIC`.
 See xref:retrytopic/topic-naming.adoc#single-topic-maxinterval-delay[Single Topic for maxInterval Exponential Delay].
+
+[[x32-seek-offset-compute-fn]]
+=== New API method to seek to an offset based on a user provided function
+`ConsumerCallback` provides a new API to seek to an offset based on a user-defined function, which takes the current offset in the consumer as an argument.
+See xref:kafka/seek.adoc#seek/[Seek API Docs] for more details.
+

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -55,5 +55,5 @@ See xref:retrytopic/topic-naming.adoc#single-topic-maxinterval-delay[Single Topi
 [[x32-seek-offset-compute-fn]]
 === New API method to seek to an offset based on a user provided function
 `ConsumerCallback` provides a new API to seek to an offset based on a user-defined function, which takes the current offset in the consumer as an argument.
-See xref:kafka/seek.adoc#seek/[Seek API Docs] for more details.
+See xref:kafka/seek.adoc#seek[Seek API Docs] for more details.
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerSeekAware.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerSeekAware.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 the original author or authors.
+ * Copyright 2016-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.kafka.listener;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.function.Function;
 
 import org.apache.kafka.common.TopicPartition;
 
@@ -27,6 +28,7 @@ import org.apache.kafka.common.TopicPartition;
  * seek operation.
  *
  * @author Gary Russell
+ * @author Soby Chacko
  * @since 1.1
  *
  */
@@ -104,6 +106,23 @@ public interface ConsumerSeekAware {
 		 * @param offset the offset (absolute).
 		 */
 		void seek(String topic, int partition, long offset);
+
+		/**
+		 * Perform a seek operation based on the given function to compute the offset to seek to.
+		 * The function provides the user with access to the current offset in the consumer which
+		 * is the current position, i.e, the next offset to be fetched.
+		 * When called from {@link ConsumerSeekAware#onPartitionsAssigned(Map, ConsumerSeekCallback)}
+		 * or from {@link ConsumerSeekAware#onIdleContainer(Map, ConsumerSeekCallback)}
+		 * perform the seek immediately on the consumer. When called from elsewhere,
+		 * queue the seek operation to the consumer. The queued seek will occur after any
+		 * pending offset commits. The consumer must be currently assigned the specified
+		 * partition.
+		 * @param topic the topic.
+		 * @param partition the partition.
+		 * @param offsetComputeFunction function to compute the absolute offset to seek to.
+		 * @since 3.2.0
+		 */
+		void seek(String topic, int partition, Function<Long, Long> offsetComputeFunction);
 
 		/**
 		 * Perform a seek to beginning operation. When called from

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -3324,6 +3324,12 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		}
 
 		@Override
+		public void seek(String topic, int partition, Function<Long, Long> offsetComputeFunction) {
+			this.seeks.add(new TopicPartitionOffset(topic, partition, offsetComputeFunction.apply(
+					this.consumer.position(new TopicPartition(topic, partition)))));
+		}
+
+		@Override
 		public void seekToBeginning(String topic, int partition) {
 			this.seeks.add(new TopicPartitionOffset(topic, partition, SeekPosition.BEGINNING));
 		}
@@ -3765,6 +3771,13 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			@Override
 			public void seek(String topic, int partition, long offset) {
 				ListenerConsumer.this.consumer.seek(new TopicPartition(topic, partition), offset);
+			}
+
+			@Override
+			public void seek(String topic, int partition, Function<Long, Long> offsetComputeFunction) {
+				ListenerConsumer.this.consumer.seek(new TopicPartition(topic, partition),
+						offsetComputeFunction.apply(
+								ListenerConsumer.this.consumer.position(new TopicPartition(topic, partition))));
 			}
 
 			@Override


### PR DESCRIPTION
Fixes: #3078

 * Provide a new API method in `ConsumerSeekCallback` to seek to an offset based on the current offset. This is accomplished by a user-defined function where the user can make decision on the offset to seek to based on the current offset which is available via the function's input.
 * Adding tests, docs.
