### PR TITLE
GH-3012: Non-blocking retries support @KafkaListener on class level

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/retrytopic.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/retrytopic.adoc
@@ -7,7 +7,7 @@ Version 2.9 changed the mechanism to bootstrap infrastructure beans; see xref:re
 Achieving non-blocking retry / dlt functionality with Kafka usually requires setting up extra topics and creating and configuring the corresponding listeners.
 Since 2.7 Spring for Apache Kafka offers support for that via the `@RetryableTopic` annotation and `RetryTopicConfiguration` class to simplify that bootstrapping.
 
-Since 3.2 Non-Blocking Retries support xref:kafka/receiving-messages/class-level-kafkalistener.adoc[@KafkaListener on a Class].
+Since 3.2, Spring for Apache Kafka supports non-blocking retries with xref:kafka/receiving-messages/class-level-kafkalistener.adoc[@KafkaListener on a Class].
 
 IMPORTANT: Non-blocking retries are not supported with xref:kafka/receiving-messages/listener-annotation.adoc#batch-listeners[Batch Listeners].
 

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/retrytopic.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/retrytopic.adoc
@@ -7,6 +7,8 @@ Version 2.9 changed the mechanism to bootstrap infrastructure beans; see xref:re
 Achieving non-blocking retry / dlt functionality with Kafka usually requires setting up extra topics and creating and configuring the corresponding listeners.
 Since 2.7 Spring for Apache Kafka offers support for that via the `@RetryableTopic` annotation and `RetryTopicConfiguration` class to simplify that bootstrapping.
 
+Since 3.2 Non-Blocking Retries support xref:kafka/receiving-messages/class-level-kafkalistener.adoc[@KafkaListener on a Class].
+
 IMPORTANT: Non-blocking retries are not supported with xref:kafka/receiving-messages/listener-annotation.adoc#batch-listeners[Batch Listeners].
 
 IMPORTANT: Non-Blocking Retries cannot combine with xref:kafka/transactions.adoc#container-transaction-manager[Container Transactions].

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/retrytopic/retry-config.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/retrytopic/retry-config.adoc
@@ -28,6 +28,21 @@ public void processMessage(MyPojo message) {
 }
 ----
 
+Since 3.2, `@RetryableTopic` support @KafkaListener on a class would be:
+[source,java]
+----
+@RetryableTopic(listenerContainerFactory = "my-retry-topic-factory")
+@KafkaListener(topics = "my-annotated-topic")
+public class ClassLevelRetryListener {
+
+    @KafkaHandler
+    public void processMessage(MyPojo message) {
+        // ... message processing
+    }
+
+}
+----
+
 You can specify a method in the same class to process the dlt messages by annotating it with the `@DltHandler` annotation.
 If no DltHandler method is provided a default consumer is created which only logs the consumption.
 

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/retrytopic/retry-config.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/retrytopic/retry-config.adoc
@@ -28,7 +28,7 @@ public void processMessage(MyPojo message) {
 }
 ----
 
-Since 3.2, `@RetryableTopic` support @KafkaListener on a class would be:
+Since 3.2, `@RetryableTopic` support for @KafkaListener on a class would be:
 [source,java]
 ----
 @RetryableTopic(listenerContainerFactory = "my-retry-topic-factory")

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -55,6 +55,10 @@ See xref:kafka/annotation-error-handling.adoc#after-rollback[After-rollback Proc
 Change `@RetryableTopic` property `SameIntervalTopicReuseStrategy` default value to `SINGLE_TOPIC`.
 See xref:retrytopic/topic-naming.adoc#single-topic-maxinterval-delay[Single Topic for maxInterval Exponential Delay].
 
+=== Non-blocking retries support class level @KafkaListener
+Non-blocking retries support xref:kafka/receiving-messages/class-level-kafkalistener.adoc[@KafkaListener on a Class].
+See xref:retrytopic.adoc[Non-Blocking Retries].
+
 === Support process @RetryableTopic on a class in RetryTopicConfigurationProvider.
 Provides a new public API to find `RetryTopicConfiguration`.
 See xref:retrytopic/retry-config.adoc#find-retry-topic-config[Find RetryTopicConfiguration]

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
@@ -185,6 +185,7 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 
 	private String defaultContainerFactoryBeanName = DEFAULT_KAFKA_LISTENER_CONTAINER_FACTORY_BEAN_NAME;
 
+	@Nullable
 	private ApplicationContext applicationContext;
 
 	private BeanFactory beanFactory;
@@ -197,6 +198,7 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 
 	private AnnotationEnhancer enhancer;
 
+	@Nullable
 	private RetryTopicConfigurer retryTopicConfigurer;
 
 	@Override
@@ -273,9 +275,11 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 	public synchronized void setBeanFactory(BeanFactory beanFactory) {
 		this.beanFactory = beanFactory;
 		if (beanFactory instanceof ConfigurableListableBeanFactory clbf) {
-			this.resolver = clbf.getBeanExpressionResolver();
-			this.expressionContext = new BeanExpressionContext((ConfigurableListableBeanFactory) beanFactory,
-					this.listenerScope);
+			BeanExpressionResolver beanExpressionResolver = clbf.getBeanExpressionResolver();
+			if (beanExpressionResolver != null) {
+				this.resolver = beanExpressionResolver;
+			}
+			this.expressionContext = new BeanExpressionContext(clbf, this.listenerScope);
 		}
 	}
 
@@ -333,9 +337,11 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 
 		// Actually register all listeners
 		this.registrar.afterPropertiesSet();
-		Map<String, ContainerGroupSequencer> sequencers =
-				this.applicationContext.getBeansOfType(ContainerGroupSequencer.class, false, false);
-		sequencers.values().forEach(ContainerGroupSequencer::initialize);
+		if (this.applicationContext != null) {
+			Map<String, ContainerGroupSequencer> sequencers =
+					this.applicationContext.getBeansOfType(ContainerGroupSequencer.class, false, false);
+			sequencers.values().forEach(ContainerGroupSequencer::initialize);
+		}
 	}
 
 	private void buildEnhancer() {
@@ -368,36 +374,36 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 		if (!this.nonAnnotatedClasses.contains(bean.getClass())) {
 			Class<?> targetClass = AopUtils.getTargetClass(bean);
 			Collection<KafkaListener> classLevelListeners = findListenerAnnotations(targetClass);
-			final boolean hasClassLevelListeners = !classLevelListeners.isEmpty();
-			final List<Method> multiMethods = new ArrayList<>();
 			Map<Method, Set<KafkaListener>> annotatedMethods = MethodIntrospector.selectMethods(targetClass,
 					(MethodIntrospector.MetadataLookup<Set<KafkaListener>>) method -> {
 						Set<KafkaListener> listenerMethods = findListenerAnnotations(method);
 						return (!listenerMethods.isEmpty() ? listenerMethods : null);
 					});
-			if (hasClassLevelListeners) {
-				Set<Method> methodsWithHandler = MethodIntrospector.selectMethods(targetClass,
-						(ReflectionUtils.MethodFilter) method ->
-								AnnotationUtils.findAnnotation(method, KafkaHandler.class) != null);
-				multiMethods.addAll(methodsWithHandler);
-			}
-			if (annotatedMethods.isEmpty() && !hasClassLevelListeners) {
+			final boolean hasClassLevelListeners = !classLevelListeners.isEmpty();
+			final boolean hasMethodLevelListeners = !annotatedMethods.isEmpty();
+			if (!hasMethodLevelListeners && !hasClassLevelListeners) {
 				this.nonAnnotatedClasses.add(bean.getClass());
 				this.logger.trace(() -> "No @KafkaListener annotations found on bean type: " + bean.getClass());
 			}
 			else {
-				// Non-empty set of methods
-				for (Map.Entry<Method, Set<KafkaListener>> entry : annotatedMethods.entrySet()) {
-					Method method = entry.getKey();
-					for (KafkaListener listener : entry.getValue()) {
-						processKafkaListener(listener, method, bean, beanName);
+				if (hasMethodLevelListeners) {
+					// Non-empty set of methods
+					for (Map.Entry<Method, Set<KafkaListener>> entry : annotatedMethods.entrySet()) {
+						Method method = entry.getKey();
+						for (KafkaListener listener : entry.getValue()) {
+							processKafkaListener(listener, method, bean, beanName);
+						}
 					}
+					this.logger.debug(() -> annotatedMethods.size() + " @KafkaListener methods processed on bean '"
+							+ beanName + "': " + annotatedMethods);
 				}
-				this.logger.debug(() -> annotatedMethods.size() + " @KafkaListener methods processed on bean '"
-						+ beanName + "': " + annotatedMethods);
-			}
-			if (hasClassLevelListeners) {
-				processMultiMethodListeners(classLevelListeners, multiMethods, bean, beanName);
+				if (hasClassLevelListeners) {
+					Set<Method> methodsWithHandler = MethodIntrospector.selectMethods(targetClass,
+							(ReflectionUtils.MethodFilter) method ->
+									AnnotationUtils.findAnnotation(method, KafkaHandler.class) != null);
+					final List<Method> multiMethods = new ArrayList<>(methodsWithHandler);
+					processMultiMethodListeners(classLevelListeners, multiMethods, targetClass, bean, beanName);
+				}
 			}
 		}
 		return bean;
@@ -444,7 +450,7 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 	}
 
 	private synchronized void processMultiMethodListeners(Collection<KafkaListener> classLevelListeners,
-			List<Method> multiMethods, Object bean, String beanName) {
+			List<Method> multiMethods, Class<?> clazz, Object bean, String beanName) {
 
 		List<Method> checkedMethods = new ArrayList<>();
 		Method defaultMethod = null;
@@ -454,7 +460,7 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 			if (annotation != null && annotation.isDefault()) {
 				final Method toAssert = defaultMethod;
 				Assert.state(toAssert == null, () -> "Only one @KafkaHandler can be marked 'isDefault', found: "
-						+ toAssert.toString() + " and " + method.toString());
+						+ toAssert.toString() + " and " + method);
 				defaultMethod = checked;
 			}
 			checkedMethods.add(checked);
@@ -462,12 +468,7 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 		for (KafkaListener classLevelListener : classLevelListeners) {
 			MultiMethodKafkaListenerEndpoint<K, V> endpoint =
 					new MultiMethodKafkaListenerEndpoint<>(checkedMethods, defaultMethod, bean);
-			String beanRef = classLevelListener.beanRef();
-			this.listenerScope.addListener(beanRef, bean);
-			endpoint.setId(getEndpointId(classLevelListener));
-			processListener(endpoint, classLevelListener, bean, beanName, resolveTopics(classLevelListener),
-					resolveTopicPartitions(classLevelListener));
-			this.listenerScope.removeListener(beanRef);
+			processMainAndRetryListeners(classLevelListener, bean, beanName, endpoint, null, clazz);
 		}
 	}
 
@@ -477,39 +478,34 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 		Method methodToUse = checkProxy(method, bean);
 		MethodKafkaListenerEndpoint<K, V> endpoint = new MethodKafkaListenerEndpoint<>();
 		endpoint.setMethod(methodToUse);
+		processMainAndRetryListeners(kafkaListener, bean, beanName, endpoint, methodToUse, null);
+	}
+
+	private void processMainAndRetryListeners(KafkaListener kafkaListener, Object bean, String beanName,
+			MethodKafkaListenerEndpoint<K, V> endpoint, @Nullable Method methodToUse, @Nullable Class<?> clazz) {
 
 		String beanRef = kafkaListener.beanRef();
 		this.listenerScope.addListener(beanRef, bean);
 		endpoint.setId(getEndpointId(kafkaListener));
 		String[] topics = resolveTopics(kafkaListener);
 		TopicPartitionOffset[] tps = resolveTopicPartitions(kafkaListener);
-		if (!processMainAndRetryListeners(kafkaListener, bean, beanName, methodToUse, endpoint, topics, tps)) {
+		if (!processMainAndRetryListeners(kafkaListener, bean, beanName, endpoint, topics, tps, methodToUse, clazz)) {
 			processListener(endpoint, kafkaListener, bean, beanName, topics, tps);
 		}
 		this.listenerScope.removeListener(beanRef);
 	}
 
 	private boolean processMainAndRetryListeners(KafkaListener kafkaListener, Object bean, String beanName,
-			Method methodToUse, MethodKafkaListenerEndpoint<K, V> endpoint, String[] topics,
-			TopicPartitionOffset[] tps) {
+			MethodKafkaListenerEndpoint<K, V> endpoint, String[] topics, TopicPartitionOffset[] tps,
+			@Nullable Method methodToUse, @Nullable Class<?> clazz) {
 
-		String[] retryableCandidates = topics;
-		if (retryableCandidates.length == 0 && tps.length > 0) {
-			retryableCandidates = Arrays.stream(tps)
-					.map(tp -> tp.getTopic())
-					.distinct()
-					.toList()
-					.toArray(new String[0]);
-		}
-
+		String[] retryableCandidates = getTopicsFromTopicPartitionOffset(topics, tps);
 		RetryTopicConfiguration retryTopicConfiguration = new RetryTopicConfigurationProvider(this.beanFactory,
 				this.resolver, this.expressionContext)
-				.findRetryConfigurationFor(retryableCandidates, methodToUse, bean);
-
+				.findRetryConfigurationFor(retryableCandidates, methodToUse, clazz, bean);
 		if (retryTopicConfiguration == null) {
-			String[] candidates = retryableCandidates;
 			this.logger.debug(() ->
-					"No retry topic configuration found for topics " + Arrays.toString(candidates));
+					"No retry topic configuration found for topics " + Arrays.toString(retryableCandidates));
 			return false;
 		}
 
@@ -523,6 +519,18 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 				.processMainAndRetryListeners(endpointProcessor, endpoint, retryTopicConfiguration,
 						this.registrar, factory, this.defaultContainerFactoryBeanName);
 		return true;
+	}
+
+	private String[] getTopicsFromTopicPartitionOffset(String[] topics, TopicPartitionOffset[] tps) {
+		String[] retryableCandidates = topics;
+		if (retryableCandidates.length == 0 && tps.length > 0) {
+			retryableCandidates = Arrays.stream(tps)
+					.map(TopicPartitionOffset::getTopic)
+					.distinct()
+					.toList()
+					.toArray(new String[0]);
+		}
+		return retryableCandidates;
 	}
 
 	private RetryTopicConfigurer getRetryTopicConfigurer() {
@@ -804,7 +812,8 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 		}
 	}
 
-	private String getEndpointGroupId(KafkaListener kafkaListener, String id) {
+	@Nullable
+	private String getEndpointGroupId(KafkaListener kafkaListener, @Nullable String id) {
 		String groupId = null;
 		if (StringUtils.hasText(kafkaListener.groupId())) {
 			groupId = resolveExpressionAsString(kafkaListener.groupId(), "groupId");
@@ -1086,8 +1095,7 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 
 	private <T> Collection<T> getBeansOfType(Class<T> type) {
 		if (KafkaListenerAnnotationBeanPostProcessor.this.beanFactory instanceof ListableBeanFactory lbf) {
-			return lbf.getBeansOfType(type)
-					.values();
+			return lbf.getBeansOfType(type).values();
 		}
 		else {
 			return Collections.emptySet();
@@ -1241,7 +1249,7 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 
 	}
 
-	private final class BytesToNumberConverter implements ConditionalGenericConverter {
+	private static final class BytesToNumberConverter implements ConditionalGenericConverter {
 
 		BytesToNumberConverter() {
 		}
@@ -1265,6 +1273,9 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 		@Nullable
 		public Object convert(@Nullable Object source, TypeDescriptor sourceType, TypeDescriptor targetType) {
 			byte[] bytes = (byte[]) source;
+			if (bytes == null) {
+				return null;
+			}
 			if (targetType.getType().equals(long.class) || targetType.getType().equals(Long.class)) {
 				Assert.state(bytes.length >= 8, "At least 8 bytes needed to convert a byte[] to a long"); // NOSONAR
 				return ByteBuffer.wrap(bytes).getLong();

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
@@ -379,8 +379,8 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 						Set<KafkaListener> listenerMethods = findListenerAnnotations(method);
 						return (!listenerMethods.isEmpty() ? listenerMethods : null);
 					});
-			final boolean hasClassLevelListeners = !classLevelListeners.isEmpty();
-			final boolean hasMethodLevelListeners = !annotatedMethods.isEmpty();
+			boolean hasClassLevelListeners = !classLevelListeners.isEmpty();
+			boolean hasMethodLevelListeners = !annotatedMethods.isEmpty();
 			if (!hasMethodLevelListeners && !hasClassLevelListeners) {
 				this.nonAnnotatedClasses.add(bean.getClass());
 				this.logger.trace(() -> "No @KafkaListener annotations found on bean type: " + bean.getClass());
@@ -401,7 +401,7 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 					Set<Method> methodsWithHandler = MethodIntrospector.selectMethods(targetClass,
 							(ReflectionUtils.MethodFilter) method ->
 									AnnotationUtils.findAnnotation(method, KafkaHandler.class) != null);
-					final List<Method> multiMethods = new ArrayList<>(methodsWithHandler);
+					List<Method> multiMethods = new ArrayList<>(methodsWithHandler);
 					processMultiMethodListeners(classLevelListeners, multiMethods, targetClass, bean, beanName);
 				}
 			}
@@ -458,7 +458,7 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 			Method checked = checkProxy(method, bean);
 			KafkaHandler annotation = AnnotationUtils.findAnnotation(method, KafkaHandler.class);
 			if (annotation != null && annotation.isDefault()) {
-				final Method toAssert = defaultMethod;
+				Method toAssert = defaultMethod;
 				Assert.state(toAssert == null, () -> "Only one @KafkaHandler can be marked 'isDefault', found: "
 						+ toAssert.toString() + " and " + method);
 				defaultMethod = checked;
@@ -745,7 +745,7 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 	private void resolveContainerPostProcessor(MethodKafkaListenerEndpoint<?, ?> endpoint,
 			KafkaListener kafkaListener) {
 
-		final String containerPostProcessor = kafkaListener.containerPostProcessor();
+		String containerPostProcessor = kafkaListener.containerPostProcessor();
 		if (StringUtils.hasText(containerPostProcessor)) {
 			endpoint.setContainerPostProcessor(this.beanFactory.getBean(containerPostProcessor,
 					ContainerPostProcessor.class));

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistry.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistry.java
@@ -44,6 +44,7 @@ import org.springframework.kafka.listener.ContainerGroup;
 import org.springframework.kafka.listener.ListenerContainerRegistry;
 import org.springframework.kafka.listener.MessageListenerContainer;
 import org.springframework.kafka.support.EndpointHandlerMethod;
+import org.springframework.kafka.support.EndpointHandlerMultiMethod;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -274,7 +275,17 @@ public class KafkaListenerEndpointRegistry implements ListenerContainerRegistry,
 	protected MessageListenerContainer createListenerContainer(KafkaListenerEndpoint endpoint,
 			KafkaListenerContainerFactory<?> factory) {
 
-		if (endpoint instanceof MethodKafkaListenerEndpoint<?, ?> mkle) {
+		if (endpoint instanceof MultiMethodKafkaListenerEndpoint<?, ?> mmkle) {
+			Object bean = mmkle.getBean();
+			if (bean instanceof EndpointHandlerMultiMethod ehmm) {
+				ehmm = new EndpointHandlerMultiMethod(ehmm.resolveBean(this.applicationContext),
+						ehmm.getDefaultMethod(), ehmm.getMethods());
+				mmkle.setBean(ehmm.resolveBean(this.applicationContext));
+				mmkle.setDefaultMethod(ehmm.getDefaultMethod());
+				mmkle.setMethods(ehmm.getMethods());
+			}
+		}
+		else if (endpoint instanceof MethodKafkaListenerEndpoint<?, ?> mkle) {
 			Object bean = mkle.getBean();
 			if (bean instanceof EndpointHandlerMethod ehm) {
 				ehm = new EndpointHandlerMethod(ehm.resolveBean(this.applicationContext), ehm.getMethodName());

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
@@ -165,6 +165,19 @@ import org.springframework.lang.Nullable;
  *         }</code>
  *     }</code>
  *</pre>
+ * <p> Since 3.2 , {@link org.springframework.kafka.annotation.RetryableTopic} annotation support
+ * {@link org.springframework.kafka.annotation.KafkaListener} annotated class, such as:
+ * <pre>
+ *     <code>@RetryableTopic(attempts = 3,
+ *     		backoff = @Backoff(delay = 700, maxDelay = 12000, multiplier = 3))</code>
+ *     <code>@KafkaListener(topics = "my-annotated-topic")
+ *     static class ListenerBean {
+ *         <code> @KafkaHandler
+ *         public void processMessage(MyPojo message) {
+ *        		// ... message processing
+ *         }</code>
+ *     }</code>
+ *</pre>
  * <p> Or through meta-annotations, such as:
  * <pre>
  *     <code>@RetryableTopic(backoff = @Backoff(delay = 700, maxDelay = 12000, multiplier = 3))</code>

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
@@ -165,7 +165,7 @@ import org.springframework.lang.Nullable;
  *         }</code>
  *     }</code>
  *</pre>
- * <p> Since 3.2 , {@link org.springframework.kafka.annotation.RetryableTopic} annotation support
+ * <p> Since 3.2, {@link org.springframework.kafka.annotation.RetryableTopic} annotation supports
  * {@link org.springframework.kafka.annotation.KafkaListener} annotated class, such as:
  * <pre>
  *     <code>@RetryableTopic(attempts = 3,

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/ExistingRetryTopicClassLevelIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/ExistingRetryTopicClassLevelIntegrationTests.java
@@ -77,7 +77,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 		ExistingRetryTopicClassLevelIntegrationTests.MAIN_TOPIC_WITH_PARTITION_INFO,
 		ExistingRetryTopicClassLevelIntegrationTests.RETRY_TOPIC_WITH_PARTITION_INFO}, partitions = 4)
 @TestPropertySource(properties = "two.attempts=2")
-public class ExistingRetryTopicClassLevelIntegrationTests {
+class ExistingRetryTopicClassLevelIntegrationTests {
 
 	public final static String MAIN_TOPIC_WITH_NO_PARTITION_INFO = "main-topic-1";
 
@@ -216,12 +216,12 @@ public class ExistingRetryTopicClassLevelIntegrationTests {
 	static class RetryTopicConfigurations {
 
 		@Bean
-		public MainTopicListenerWithPartition mainTopicListenerWithPartition() {
+		MainTopicListenerWithPartition mainTopicListenerWithPartition() {
 			return new MainTopicListenerWithPartition();
 		}
 
 		@Bean
-		public MainTopicListenerWithoutPartition mainTopicListenerWithoutPartition() {
+		MainTopicListenerWithoutPartition mainTopicListenerWithoutPartition() {
 			return new MainTopicListenerWithoutPartition();
 		}
 
@@ -242,20 +242,20 @@ public class ExistingRetryTopicClassLevelIntegrationTests {
 	}
 
 	@Configuration
-	public static class RuntimeConfig {
+	static class RuntimeConfig {
 
 		@Bean(name = "internalBackOffClock")
-		public Clock clock() {
+		Clock clock() {
 			return Clock.systemUTC();
 		}
 
 		@Bean
-		public TaskExecutor taskExecutor() {
+		TaskExecutor taskExecutor() {
 			return new ThreadPoolTaskExecutor();
 		}
 
 		@Bean(destroyMethod = "destroy")
-		public TaskExecutorManager taskExecutorManager(ThreadPoolTaskExecutor taskExecutor) {
+		TaskExecutorManager taskExecutorManager(ThreadPoolTaskExecutor taskExecutor) {
 			return new TaskExecutorManager(taskExecutor);
 		}
 	}
@@ -273,13 +273,13 @@ public class ExistingRetryTopicClassLevelIntegrationTests {
 	}
 
 	@Configuration
-	public static class KafkaProducerConfig {
+	static class KafkaProducerConfig {
 
 		@Autowired
 		EmbeddedKafkaBroker broker;
 
 		@Bean
-		public ProducerFactory<String, String> producerFactory() {
+		ProducerFactory<String, String> producerFactory() {
 			Map<String, Object> configProps = new HashMap<>();
 			configProps.put(
 					ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
@@ -294,27 +294,27 @@ public class ExistingRetryTopicClassLevelIntegrationTests {
 		}
 
 		@Bean
-		public KafkaTemplate<String, String> kafkaTemplate() {
+		KafkaTemplate<String, String> kafkaTemplate() {
 			return new KafkaTemplate<>(producerFactory());
 		}
 	}
 
 	@EnableKafka
 	@Configuration
-	public static class KafkaConsumerConfig extends RetryTopicConfigurationSupport {
+	static class KafkaConsumerConfig extends RetryTopicConfigurationSupport {
 
 		@Autowired
 		EmbeddedKafkaBroker broker;
 
 		@Bean
-		public KafkaAdmin kafkaAdmin() {
+		KafkaAdmin kafkaAdmin() {
 			Map<String, Object> configs = new HashMap<>();
 			configs.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, this.broker.getBrokersAsString());
 			return new KafkaAdmin(configs);
 		}
 
 		@Bean
-		public ConsumerFactory<String, String> consumerFactory() {
+		ConsumerFactory<String, String> consumerFactory() {
 			Map<String, Object> props = new HashMap<>();
 			props.put(
 					ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
@@ -336,7 +336,7 @@ public class ExistingRetryTopicClassLevelIntegrationTests {
 		}
 
 		@Bean
-		public ConcurrentKafkaListenerContainerFactory<String, String> retryTopicListenerContainerFactory(
+		ConcurrentKafkaListenerContainerFactory<String, String> retryTopicListenerContainerFactory(
 				ConsumerFactory<String, String> consumerFactory) {
 
 			ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
@@ -352,7 +352,7 @@ public class ExistingRetryTopicClassLevelIntegrationTests {
 		}
 
 		@Bean
-		public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory(
+		ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory(
 				ConsumerFactory<String, String> consumerFactory) {
 
 			ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/ExistingRetryTopicClassLevelIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/ExistingRetryTopicClassLevelIntegrationTests.java
@@ -1,0 +1,371 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.retrytopic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import java.time.Clock;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.IntStream;
+
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.annotation.KafkaHandler;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.annotation.RetryableTopic;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaAdmin;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+
+/**
+ * Tests for <a href="https://github.com/spring-projects/spring-kafka/issues/1828">...</a>
+ *
+ * @author Wang Zhiyang
+ *
+ * @since 3.2
+ */
+@SpringJUnitConfig
+@DirtiesContext
+@EmbeddedKafka(topics = {ExistingRetryTopicClassLevelIntegrationTests.MAIN_TOPIC_WITH_NO_PARTITION_INFO,
+		ExistingRetryTopicClassLevelIntegrationTests.RETRY_TOPIC_WITH_NO_PARTITION_INFO,
+		ExistingRetryTopicClassLevelIntegrationTests.MAIN_TOPIC_WITH_PARTITION_INFO,
+		ExistingRetryTopicClassLevelIntegrationTests.RETRY_TOPIC_WITH_PARTITION_INFO}, partitions = 4)
+@TestPropertySource(properties = "two.attempts=2")
+public class ExistingRetryTopicClassLevelIntegrationTests {
+
+	public final static String MAIN_TOPIC_WITH_NO_PARTITION_INFO = "main-topic-1";
+
+	public final static String RETRY_TOPIC_WITH_NO_PARTITION_INFO = "main-topic-1-retry-1";
+
+	public final static String MAIN_TOPIC_WITH_PARTITION_INFO = "main-topic-2";
+
+	public final static String RETRY_TOPIC_WITH_PARTITION_INFO = "main-topic-2-retry-1";
+
+	private final static String MAIN_TOPIC_CONTAINER_FACTORY = "kafkaListenerContainerFactory";
+
+	@Autowired
+	private KafkaTemplate<String, String> kafkaTemplate;
+
+	@Autowired
+	CountByPartitionContainer countByPartitionContainerWithoutPartition;
+
+	@Autowired
+	CountByPartitionContainer countByPartitionContainerWithPartition;
+
+	@Autowired
+	private CountDownLatchContainer latchContainer;
+
+	@Test
+	@DisplayName("When a @RetryableTopic listener class, with autoCreateTopic=false and NO PARTITION info called, " +
+			"should send messages to be retried across partitions for a retry topic")
+	void whenNoPartitionInfoProvided_shouldRetryMainTopicCoveringAllPartitionOfRetryTopic() {
+
+		send3MessagesToPartitionWithKey(0, "foo", MAIN_TOPIC_WITH_NO_PARTITION_INFO, this.countByPartitionContainerWithoutPartition);
+		send3MessagesToPartitionWithKey(1, "bar", MAIN_TOPIC_WITH_NO_PARTITION_INFO, this.countByPartitionContainerWithoutPartition);
+		send3MessagesToPartitionWithKey(2, "buzz", MAIN_TOPIC_WITH_NO_PARTITION_INFO, this.countByPartitionContainerWithoutPartition);
+		send3MessagesToPartitionWithKey(3, "fizz", MAIN_TOPIC_WITH_NO_PARTITION_INFO, this.countByPartitionContainerWithoutPartition);
+
+		assertThat(awaitLatch(latchContainer.countDownLatch1)).isTrue();
+		assertThat(countByPartitionContainerWithoutPartition.mainTopicMessageCountByPartition)
+				.isEqualTo(countByPartitionContainerWithoutPartition.retryTopicMessageCountByPartition);
+	}
+
+	@Test
+	@DisplayName("When a @RetryableTopic listener class, with autoCreateTopic=false and WITH PARTITION info called, " +
+			"should send messages to be retried across partitions for a retry topic")
+	void whenPartitionInfoProvided_shouldRetryMainTopicCoveringAllPartitionOfRetryTopic() {
+
+		send3MessagesToPartitionWithKey(0, "foo", MAIN_TOPIC_WITH_PARTITION_INFO, this.countByPartitionContainerWithPartition);
+		send3MessagesToPartitionWithKey(1, "bar", MAIN_TOPIC_WITH_PARTITION_INFO, this.countByPartitionContainerWithPartition);
+		send3MessagesToPartitionWithKey(2, "buzz", MAIN_TOPIC_WITH_PARTITION_INFO, this.countByPartitionContainerWithPartition);
+		send3MessagesToPartitionWithKey(3, "fizz", MAIN_TOPIC_WITH_PARTITION_INFO, this.countByPartitionContainerWithPartition);
+
+		assertThat(awaitLatch(latchContainer.countDownLatch2)).isTrue();
+		assertThat(countByPartitionContainerWithPartition.mainTopicMessageCountByPartition)
+				.isEqualTo(countByPartitionContainerWithPartition.retryTopicMessageCountByPartition);
+	}
+
+	private void send3MessagesToPartitionWithKey(int partition, String messageKey, String mainTopic, CountByPartitionContainer countByPartitionContainer) {
+		IntStream.range(0, 3).forEach(messageNumber -> {
+			String data = "Test-partition-" + partition + "-messages-" + messageNumber;
+			kafkaTemplate.send(mainTopic, partition, messageKey, data);
+			countByPartitionContainer.mainTopicMessageCountByPartition.merge(String.valueOf(partition), 1, Integer::sum);
+		});
+	}
+
+	private boolean awaitLatch(CountDownLatch latch) {
+		try {
+			return latch.await(60, TimeUnit.SECONDS);
+		}
+		catch (Exception e) {
+			fail(e.getMessage());
+			throw new RuntimeException(e);
+		}
+	}
+
+	@RetryableTopic(autoCreateTopics = "false", dltStrategy = DltStrategy.NO_DLT,
+			attempts = "${two.attempts}", backoff = @Backoff(0), kafkaTemplate = "kafkaTemplate")
+	@KafkaListener(id = "firstTopicId", topics = MAIN_TOPIC_WITH_NO_PARTITION_INFO, containerFactory = MAIN_TOPIC_CONTAINER_FACTORY)
+	static class MainTopicListenerWithoutPartition {
+
+		@Autowired
+		CountDownLatchContainer container;
+
+		@Autowired
+		CountByPartitionContainer countByPartitionContainerWithoutPartition;
+
+		@KafkaHandler
+		public void listenFirst(String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic,
+								@Header(KafkaHeaders.ORIGINAL_PARTITION) String originalPartition,
+								@Header(KafkaHeaders.RECEIVED_PARTITION) String receivedPartition) {
+
+			if (receivedTopic.contains("-retry")) {
+				countByPartitionContainerWithoutPartition.retryTopicMessageCountByPartition.merge(receivedPartition, 1, Integer::sum);
+				container.countDownLatch1.countDown();
+			}
+
+			throw new RuntimeException("Woooops... in topic " + receivedTopic);
+		}
+
+	}
+
+	@RetryableTopic(autoCreateTopics = "false", numPartitions = "4", dltStrategy = DltStrategy.NO_DLT,
+			attempts = "${two.attempts}", backoff = @Backoff(0), kafkaTemplate = "kafkaTemplate")
+	@KafkaListener(id = "secondTopicId", topics = MAIN_TOPIC_WITH_PARTITION_INFO, containerFactory = MAIN_TOPIC_CONTAINER_FACTORY)
+	static class MainTopicListenerWithPartition {
+
+		@Autowired
+		CountDownLatchContainer container;
+
+		@Autowired
+		CountByPartitionContainer countByPartitionContainerWithPartition;
+
+		@KafkaHandler
+		public void listenSecond(String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic,
+								@Header(KafkaHeaders.ORIGINAL_PARTITION) String originalPartition,
+								@Header(KafkaHeaders.RECEIVED_PARTITION) String receivedPartition) {
+
+			if (receivedTopic.contains("-retry")) {
+				countByPartitionContainerWithPartition.retryTopicMessageCountByPartition.merge(receivedPartition, 1, Integer::sum);
+				container.countDownLatch2.countDown();
+			}
+
+			throw new RuntimeException("Woooops... in topic " + receivedTopic);
+		}
+	}
+
+	static class CountDownLatchContainer {
+
+		CountDownLatch countDownLatch1 = new CountDownLatch(12);
+		CountDownLatch countDownLatch2 = new CountDownLatch(12);
+	}
+
+	static class CountByPartitionContainer {
+
+		Map<String, Integer> mainTopicMessageCountByPartition = new HashMap<>();
+		Map<String, Integer> retryTopicMessageCountByPartition = new HashMap<>();
+	}
+
+	@Configuration
+	static class RetryTopicConfigurations {
+
+		@Bean
+		public MainTopicListenerWithPartition mainTopicListenerWithPartition() {
+			return new MainTopicListenerWithPartition();
+		}
+
+		@Bean
+		public MainTopicListenerWithoutPartition mainTopicListenerWithoutPartition() {
+			return new MainTopicListenerWithoutPartition();
+		}
+
+		@Bean
+		CountDownLatchContainer latchContainer() {
+			return new CountDownLatchContainer();
+		}
+
+		@Bean
+		CountByPartitionContainer countByPartitionContainerWithoutPartition() {
+			return new CountByPartitionContainer();
+		}
+
+		@Bean
+		CountByPartitionContainer countByPartitionContainerWithPartition() {
+			return new CountByPartitionContainer();
+		}
+	}
+
+	@Configuration
+	public static class RuntimeConfig {
+
+		@Bean(name = "internalBackOffClock")
+		public Clock clock() {
+			return Clock.systemUTC();
+		}
+
+		@Bean
+		public TaskExecutor taskExecutor() {
+			return new ThreadPoolTaskExecutor();
+		}
+
+		@Bean(destroyMethod = "destroy")
+		public TaskExecutorManager taskExecutorManager(ThreadPoolTaskExecutor taskExecutor) {
+			return new TaskExecutorManager(taskExecutor);
+		}
+	}
+
+	static class TaskExecutorManager {
+		private final ThreadPoolTaskExecutor taskExecutor;
+
+		TaskExecutorManager(ThreadPoolTaskExecutor taskExecutor) {
+			this.taskExecutor = taskExecutor;
+		}
+
+		void destroy() {
+			this.taskExecutor.shutdown();
+		}
+	}
+
+	@Configuration
+	public static class KafkaProducerConfig {
+
+		@Autowired
+		EmbeddedKafkaBroker broker;
+
+		@Bean
+		public ProducerFactory<String, String> producerFactory() {
+			Map<String, Object> configProps = new HashMap<>();
+			configProps.put(
+					ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
+					this.broker.getBrokersAsString());
+			configProps.put(
+					ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+					StringSerializer.class);
+			configProps.put(
+					ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+					StringSerializer.class);
+			return new DefaultKafkaProducerFactory<>(configProps);
+		}
+
+		@Bean
+		public KafkaTemplate<String, String> kafkaTemplate() {
+			return new KafkaTemplate<>(producerFactory());
+		}
+	}
+
+	@EnableKafka
+	@Configuration
+	public static class KafkaConsumerConfig extends RetryTopicConfigurationSupport {
+
+		@Autowired
+		EmbeddedKafkaBroker broker;
+
+		@Bean
+		public KafkaAdmin kafkaAdmin() {
+			Map<String, Object> configs = new HashMap<>();
+			configs.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, this.broker.getBrokersAsString());
+			return new KafkaAdmin(configs);
+		}
+
+		@Bean
+		public ConsumerFactory<String, String> consumerFactory() {
+			Map<String, Object> props = new HashMap<>();
+			props.put(
+					ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
+					this.broker.getBrokersAsString());
+			props.put(
+					ConsumerConfig.GROUP_ID_CONFIG,
+					"groupId");
+			props.put(
+					ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+					StringDeserializer.class);
+			props.put(
+					ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+					StringDeserializer.class);
+			props.put(
+					ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG, false);
+			props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+			return new DefaultKafkaConsumerFactory<>(props);
+		}
+
+		@Bean
+		public ConcurrentKafkaListenerContainerFactory<String, String> retryTopicListenerContainerFactory(
+				ConsumerFactory<String, String> consumerFactory) {
+
+			ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+			ContainerProperties props = factory.getContainerProperties();
+			props.setIdleEventInterval(100L);
+			props.setPollTimeout(50L);
+			props.setIdlePartitionEventInterval(100L);
+			factory.setConsumerFactory(consumerFactory);
+			factory.setConcurrency(1);
+			factory.setContainerCustomizer(
+					container -> container.getContainerProperties().setIdlePartitionEventInterval(100L));
+			return factory;
+		}
+
+		@Bean
+		public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory(
+				ConsumerFactory<String, String> consumerFactory) {
+
+			ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+			factory.setConsumerFactory(consumerFactory);
+			factory.setConcurrency(1);
+			return factory;
+		}
+
+		@Bean
+		TaskScheduler sched() {
+			return new ThreadPoolTaskScheduler();
+		}
+
+	}
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicClassLevelExceptionRoutingIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicClassLevelExceptionRoutingIntegrationTests.java
@@ -72,13 +72,13 @@ import org.springframework.util.backoff.FixedBackOff;
 @SpringJUnitConfig
 @DirtiesContext
 @EmbeddedKafka
-public class RetryTopicClassLevelExceptionRoutingIntegrationTests {
+class RetryTopicClassLevelExceptionRoutingIntegrationTests {
 
-	public final static String BLOCKING_AND_TOPIC_RETRY = "blocking-and-topic-retry";
-	public final static String ONLY_RETRY_VIA_BLOCKING = "only-retry-blocking-topic";
-	public final static String ONLY_RETRY_VIA_TOPIC = "only-retry-topic";
-	public final static String USER_FATAL_EXCEPTION_TOPIC = "user-fatal-topic";
-	public final static String FRAMEWORK_FATAL_EXCEPTION_TOPIC = "framework-fatal-topic";
+	final static String BLOCKING_AND_TOPIC_RETRY = "blocking-and-topic-retry";
+	final static String ONLY_RETRY_VIA_BLOCKING = "only-retry-blocking-topic";
+	final static String ONLY_RETRY_VIA_TOPIC = "only-retry-topic";
+	final static String USER_FATAL_EXCEPTION_TOPIC = "user-fatal-topic";
+	final static String FRAMEWORK_FATAL_EXCEPTION_TOPIC = "framework-fatal-topic";
 
 	@Autowired
 	private KafkaTemplate<String, String> kafkaTemplate;
@@ -108,14 +108,14 @@ public class RetryTopicClassLevelExceptionRoutingIntegrationTests {
 	}
 
 	@Test
-	public void shouldGoStraightToDltIfUserProvidedFatal() {
+	void shouldGoStraightToDltIfUserProvidedFatal() {
 		kafkaTemplate.send(USER_FATAL_EXCEPTION_TOPIC, "Test message to " + USER_FATAL_EXCEPTION_TOPIC);
 		assertThat(awaitLatch(latchContainer.fatalUserLatch)).isTrue();
 		assertThat(awaitLatch(latchContainer.annotatedDltUserFatalLatch)).isTrue();
 	}
 
 	@Test
-	public void shouldGoStraightToDltIfFrameworkProvidedFatal() {
+	void shouldGoStraightToDltIfFrameworkProvidedFatal() {
 		kafkaTemplate.send(FRAMEWORK_FATAL_EXCEPTION_TOPIC, "Testing topic with annotation 1");
 		assertThat(awaitLatch(latchContainer.fatalFrameworkLatch)).isTrue();
 		assertThat(awaitLatch(latchContainer.annotatedDltFrameworkFatalLatch)).isTrue();
@@ -275,26 +275,26 @@ public class RetryTopicClassLevelExceptionRoutingIntegrationTests {
 
 	}
 
-	public static class ShouldRetryOnlyByTopicException extends RuntimeException {
-		public ShouldRetryOnlyByTopicException(String msg) {
+	static class ShouldRetryOnlyByTopicException extends RuntimeException {
+		ShouldRetryOnlyByTopicException(String msg) {
 			super(msg);
 		}
 	}
 
-	public static class ShouldSkipBothRetriesException extends RuntimeException {
-		public ShouldSkipBothRetriesException(String msg) {
+	static class ShouldSkipBothRetriesException extends RuntimeException {
+		ShouldSkipBothRetriesException(String msg) {
 			super(msg);
 		}
 	}
 
-	public static class ShouldRetryOnlyBlockingException extends RuntimeException {
-		public ShouldRetryOnlyBlockingException(String msg) {
+	static class ShouldRetryOnlyBlockingException extends RuntimeException {
+		ShouldRetryOnlyBlockingException(String msg) {
 			super(msg);
 		}
 	}
 
-	public static class ShouldRetryViaBothException extends RuntimeException {
-		public ShouldRetryViaBothException(String msg) {
+	static class ShouldRetryViaBothException extends RuntimeException {
+		ShouldRetryViaBothException(String msg) {
 			super(msg);
 		}
 	}
@@ -305,7 +305,7 @@ public class RetryTopicClassLevelExceptionRoutingIntegrationTests {
 		private static final String DLT_METHOD_NAME = "processDltMessage";
 
 		@Bean
-		public RetryTopicConfiguration blockingAndTopic(KafkaTemplate<String, String> template) {
+		RetryTopicConfiguration blockingAndTopic(KafkaTemplate<String, String> template) {
 			return RetryTopicConfigurationBuilder
 					.newInstance()
 					.fixedBackOff(50)
@@ -315,7 +315,7 @@ public class RetryTopicClassLevelExceptionRoutingIntegrationTests {
 		}
 
 		@Bean
-		public RetryTopicConfiguration onlyTopic(KafkaTemplate<String, String> template) {
+		RetryTopicConfiguration onlyTopic(KafkaTemplate<String, String> template) {
 			return RetryTopicConfigurationBuilder
 					.newInstance()
 					.fixedBackOff(50)
@@ -327,27 +327,27 @@ public class RetryTopicClassLevelExceptionRoutingIntegrationTests {
 		}
 
 		@Bean
-		public BlockingAndTopicRetriesListener blockingAndTopicRetriesListener() {
+		BlockingAndTopicRetriesListener blockingAndTopicRetriesListener() {
 			return new BlockingAndTopicRetriesListener();
 		}
 
 		@Bean
-		public OnlyRetryViaTopicListener onlyRetryViaTopicListener() {
+		OnlyRetryViaTopicListener onlyRetryViaTopicListener() {
 			return new OnlyRetryViaTopicListener();
 		}
 
 		@Bean
-		public UserFatalTopicListener userFatalTopicListener() {
+		UserFatalTopicListener userFatalTopicListener() {
 			return new UserFatalTopicListener();
 		}
 
 		@Bean
-		public OnlyRetryBlockingListener onlyRetryBlockingListener() {
+		OnlyRetryBlockingListener onlyRetryBlockingListener() {
 			return new OnlyRetryBlockingListener();
 		}
 
 		@Bean
-		public FrameworkFatalTopicListener frameworkFatalTopicListener() {
+		FrameworkFatalTopicListener frameworkFatalTopicListener() {
 			return new FrameworkFatalTopicListener();
 		}
 
@@ -374,7 +374,7 @@ public class RetryTopicClassLevelExceptionRoutingIntegrationTests {
 	}
 
 	@Configuration
-	public static class RoutingTestsConfigurationSupport extends RetryTopicConfigurationSupport {
+	static class RoutingTestsConfigurationSupport extends RetryTopicConfigurationSupport {
 
 		@Override
 		protected void configureBlockingRetries(BlockingRetriesConfigurer blockingRetries) {
@@ -390,13 +390,13 @@ public class RetryTopicClassLevelExceptionRoutingIntegrationTests {
 	}
 
 	@Configuration
-	public static class KafkaProducerConfig {
+	static class KafkaProducerConfig {
 
 		@Autowired
 		EmbeddedKafkaBroker broker;
 
 		@Bean
-		public ProducerFactory<String, String> producerFactory() {
+		ProducerFactory<String, String> producerFactory() {
 			Map<String, Object> configProps = new HashMap<>();
 			configProps.put(
 					ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
@@ -411,27 +411,27 @@ public class RetryTopicClassLevelExceptionRoutingIntegrationTests {
 		}
 
 		@Bean
-		public KafkaTemplate<String, String> kafkaTemplate() {
+		KafkaTemplate<String, String> kafkaTemplate() {
 			return new KafkaTemplate<>(producerFactory());
 		}
 	}
 
 	@EnableKafka
 	@Configuration
-	public static class KafkaConsumerConfig {
+	static class KafkaConsumerConfig {
 
 		@Autowired
 		EmbeddedKafkaBroker broker;
 
 		@Bean
-		public KafkaAdmin kafkaAdmin() {
+		KafkaAdmin kafkaAdmin() {
 			Map<String, Object> configs = new HashMap<>();
 			configs.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, this.broker.getBrokersAsString());
 			return new KafkaAdmin(configs);
 		}
 
 		@Bean
-		public ConsumerFactory<String, String> consumerFactory() {
+		ConsumerFactory<String, String> consumerFactory() {
 			Map<String, Object> props = new HashMap<>();
 			props.put(
 					ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
@@ -453,7 +453,7 @@ public class RetryTopicClassLevelExceptionRoutingIntegrationTests {
 		}
 
 		@Bean
-		public ConcurrentKafkaListenerContainerFactory<String, String> retryTopicListenerContainerFactory(
+		ConcurrentKafkaListenerContainerFactory<String, String> retryTopicListenerContainerFactory(
 				ConsumerFactory<String, String> consumerFactory) {
 
 			ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
@@ -469,7 +469,7 @@ public class RetryTopicClassLevelExceptionRoutingIntegrationTests {
 		}
 
 		@Bean
-		public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory(
+		ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory(
 				ConsumerFactory<String, String> consumerFactory) {
 
 			ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicClassLevelExceptionRoutingIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicClassLevelExceptionRoutingIntegrationTests.java
@@ -1,0 +1,482 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.retrytopic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.DltHandler;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.annotation.KafkaHandler;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.annotation.RetryableTopic;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaAdmin;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.kafka.support.converter.ConversionException;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.util.backoff.FixedBackOff;
+
+
+/**
+ * Test class level non-blocking retries.
+ *
+ * @author Wang Zhiyang
+ *
+ * @since 3.2
+ */
+@SpringJUnitConfig
+@DirtiesContext
+@EmbeddedKafka
+public class RetryTopicClassLevelExceptionRoutingIntegrationTests {
+
+	public final static String BLOCKING_AND_TOPIC_RETRY = "blocking-and-topic-retry";
+	public final static String ONLY_RETRY_VIA_BLOCKING = "only-retry-blocking-topic";
+	public final static String ONLY_RETRY_VIA_TOPIC = "only-retry-topic";
+	public final static String USER_FATAL_EXCEPTION_TOPIC = "user-fatal-topic";
+	public final static String FRAMEWORK_FATAL_EXCEPTION_TOPIC = "framework-fatal-topic";
+
+	@Autowired
+	private KafkaTemplate<String, String> kafkaTemplate;
+
+	@Autowired
+	private CountDownLatchContainer latchContainer;
+
+	@Test
+	void shouldRetryViaBlockingAndTopics() {
+		kafkaTemplate.send(BLOCKING_AND_TOPIC_RETRY, "Test message to " + BLOCKING_AND_TOPIC_RETRY);
+		assertThat(awaitLatch(latchContainer.blockingAndTopicsLatch)).isTrue();
+		assertThat(awaitLatch(latchContainer.dltProcessorLatch)).isTrue();
+	}
+
+	@Test
+	void shouldRetryOnlyViaBlocking() {
+		kafkaTemplate.send(ONLY_RETRY_VIA_BLOCKING, "Test message to ");
+		assertThat(awaitLatch(latchContainer.onlyRetryViaBlockingLatch)).isTrue();
+		assertThat(awaitLatch(latchContainer.annotatedDltOnlyBlockingLatch)).isTrue();
+	}
+
+	@Test
+	void shouldRetryOnlyViaTopic() {
+		kafkaTemplate.send(ONLY_RETRY_VIA_TOPIC, "Test message to " + ONLY_RETRY_VIA_TOPIC);
+		assertThat(awaitLatch(latchContainer.onlyRetryViaTopicLatch)).isTrue();
+		assertThat(awaitLatch(latchContainer.dltProcessorWithErrorLatch)).isTrue();
+	}
+
+	@Test
+	public void shouldGoStraightToDltIfUserProvidedFatal() {
+		kafkaTemplate.send(USER_FATAL_EXCEPTION_TOPIC, "Test message to " + USER_FATAL_EXCEPTION_TOPIC);
+		assertThat(awaitLatch(latchContainer.fatalUserLatch)).isTrue();
+		assertThat(awaitLatch(latchContainer.annotatedDltUserFatalLatch)).isTrue();
+	}
+
+	@Test
+	public void shouldGoStraightToDltIfFrameworkProvidedFatal() {
+		kafkaTemplate.send(FRAMEWORK_FATAL_EXCEPTION_TOPIC, "Testing topic with annotation 1");
+		assertThat(awaitLatch(latchContainer.fatalFrameworkLatch)).isTrue();
+		assertThat(awaitLatch(latchContainer.annotatedDltFrameworkFatalLatch)).isTrue();
+	}
+
+	private static void countdownIfCorrectInvocations(AtomicInteger invocations, int expected, CountDownLatch latch) {
+		int actual = invocations.get();
+		if (actual == expected) {
+			latch.countDown();
+		}
+	}
+
+	private boolean awaitLatch(CountDownLatch latch) {
+		try {
+			return latch.await(30, TimeUnit.SECONDS);
+		}
+		catch (Exception e) {
+			fail(e.getMessage());
+			throw new RuntimeException(e);
+		}
+	}
+
+	static class BlockingAndTopicRetriesListener {
+
+		@Autowired
+		CountDownLatchContainer container;
+
+		@KafkaListener(id = "firstTopicId", topics = BLOCKING_AND_TOPIC_RETRY)
+		public void listen(String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic) {
+			container.blockingAndTopicsLatch.countDown();
+			container.blockingAndTopicsListenerInvocations.incrementAndGet();
+			throw new ShouldRetryViaBothException("Woooops... in topic " + receivedTopic);
+		}
+	}
+
+	static class DltProcessor {
+
+		@Autowired
+		CountDownLatchContainer container;
+
+		public void processDltMessage(Object message) {
+			countdownIfCorrectInvocations(container.blockingAndTopicsListenerInvocations, 12,
+					container.dltProcessorLatch);
+		}
+	}
+
+	@KafkaListener(topics = ONLY_RETRY_VIA_TOPIC)
+	static class OnlyRetryViaTopicListener {
+
+		@Autowired
+		CountDownLatchContainer container;
+
+		@KafkaHandler
+		public void listenAgain(String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic) {
+			container.onlyRetryViaTopicLatch.countDown();
+			container.onlyRetryViaTopicListenerInvocations.incrementAndGet();
+			throw new ShouldRetryOnlyByTopicException("Another woooops... " + receivedTopic);
+		}
+	}
+
+	static class DltProcessorWithError {
+
+		@Autowired
+		CountDownLatchContainer container;
+
+		public void processDltMessage(Object message) {
+			countdownIfCorrectInvocations(container.onlyRetryViaTopicListenerInvocations,
+					3, container.dltProcessorWithErrorLatch);
+			throw new RuntimeException("Dlt Error!");
+		}
+	}
+
+	@RetryableTopic(exclude = ShouldRetryOnlyBlockingException.class, traversingCauses = "true",
+			backoff = @Backoff(50), kafkaTemplate = "kafkaTemplate")
+	@KafkaListener(topics = ONLY_RETRY_VIA_BLOCKING)
+	static class OnlyRetryBlockingListener {
+
+		@Autowired
+		CountDownLatchContainer container;
+
+		@KafkaHandler
+		public void listenWithAnnotation(String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic) {
+			container.onlyRetryViaBlockingLatch.countDown();
+			container.onlyRetryViaBlockingListenerInvocations.incrementAndGet();
+			throw new ShouldRetryOnlyBlockingException("User provided fatal exception!" + receivedTopic);
+		}
+
+		@DltHandler
+		public void annotatedDltMethod(Object message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic) {
+			countdownIfCorrectInvocations(container.onlyRetryViaBlockingListenerInvocations, 4,
+					container.annotatedDltOnlyBlockingLatch);
+		}
+	}
+
+	@RetryableTopic(backoff = @Backoff(50), kafkaTemplate = "kafkaTemplate")
+	@KafkaListener(topics = USER_FATAL_EXCEPTION_TOPIC)
+	static class UserFatalTopicListener {
+
+		@Autowired
+		CountDownLatchContainer container;
+
+		@KafkaHandler
+		public void listenWithAnnotation(String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic) {
+			container.fatalUserLatch.countDown();
+			container.userFatalListenerInvocations.incrementAndGet();
+			throw new ShouldSkipBothRetriesException("User provided fatal exception!" + receivedTopic);
+		}
+
+		@DltHandler
+		public void annotatedDltMethod(Object message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic) {
+			countdownIfCorrectInvocations(container.userFatalListenerInvocations, 1,
+					container.annotatedDltUserFatalLatch);
+		}
+	}
+
+	@RetryableTopic(backoff = @Backoff(50))
+	@KafkaListener(topics = FRAMEWORK_FATAL_EXCEPTION_TOPIC)
+	static class FrameworkFatalTopicListener {
+
+		@Autowired
+		CountDownLatchContainer container;
+
+
+		@KafkaHandler
+		public void listenWithAnnotation(String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic) {
+			container.fatalFrameworkLatch.countDown();
+			container.fatalFrameworkListenerInvocations.incrementAndGet();
+			throw new ConversionException("Woooops... in topic " + receivedTopic, new RuntimeException("Test RTE"));
+		}
+
+		@DltHandler
+		public void annotatedDltMethod(Object message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic) {
+			countdownIfCorrectInvocations(container.fatalFrameworkListenerInvocations, 1,
+					container.annotatedDltFrameworkFatalLatch);
+			throw new ConversionException("Woooops... in topic " + receivedTopic, new RuntimeException("Test RTE"));
+		}
+	}
+
+	static class CountDownLatchContainer {
+
+		CountDownLatch blockingAndTopicsLatch = new CountDownLatch(12);
+		CountDownLatch onlyRetryViaBlockingLatch = new CountDownLatch(4);
+		CountDownLatch onlyRetryViaTopicLatch = new CountDownLatch(3);
+		CountDownLatch fatalUserLatch = new CountDownLatch(1);
+		CountDownLatch fatalFrameworkLatch = new CountDownLatch(1);
+		CountDownLatch annotatedDltOnlyBlockingLatch = new CountDownLatch(1);
+		CountDownLatch annotatedDltUserFatalLatch = new CountDownLatch(1);
+		CountDownLatch annotatedDltFrameworkFatalLatch = new CountDownLatch(1);
+		CountDownLatch dltProcessorLatch = new CountDownLatch(1);
+		CountDownLatch dltProcessorWithErrorLatch = new CountDownLatch(1);
+
+		AtomicInteger blockingAndTopicsListenerInvocations = new AtomicInteger();
+		AtomicInteger onlyRetryViaTopicListenerInvocations = new AtomicInteger();
+		AtomicInteger onlyRetryViaBlockingListenerInvocations = new AtomicInteger();
+		AtomicInteger userFatalListenerInvocations = new AtomicInteger();
+		AtomicInteger fatalFrameworkListenerInvocations = new AtomicInteger();
+
+	}
+
+	public static class ShouldRetryOnlyByTopicException extends RuntimeException {
+		public ShouldRetryOnlyByTopicException(String msg) {
+			super(msg);
+		}
+	}
+
+	public static class ShouldSkipBothRetriesException extends RuntimeException {
+		public ShouldSkipBothRetriesException(String msg) {
+			super(msg);
+		}
+	}
+
+	public static class ShouldRetryOnlyBlockingException extends RuntimeException {
+		public ShouldRetryOnlyBlockingException(String msg) {
+			super(msg);
+		}
+	}
+
+	public static class ShouldRetryViaBothException extends RuntimeException {
+		public ShouldRetryViaBothException(String msg) {
+			super(msg);
+		}
+	}
+
+	@Configuration
+	static class RetryTopicConfigurations {
+
+		private static final String DLT_METHOD_NAME = "processDltMessage";
+
+		@Bean
+		public RetryTopicConfiguration blockingAndTopic(KafkaTemplate<String, String> template) {
+			return RetryTopicConfigurationBuilder
+					.newInstance()
+					.fixedBackOff(50)
+					.includeTopic(BLOCKING_AND_TOPIC_RETRY)
+					.dltHandlerMethod("dltProcessor", DLT_METHOD_NAME)
+					.create(template);
+		}
+
+		@Bean
+		public RetryTopicConfiguration onlyTopic(KafkaTemplate<String, String> template) {
+			return RetryTopicConfigurationBuilder
+					.newInstance()
+					.fixedBackOff(50)
+					.includeTopic(ONLY_RETRY_VIA_TOPIC)
+					.sameIntervalTopicReuseStrategy(SameIntervalTopicReuseStrategy.SINGLE_TOPIC)
+					.doNotRetryOnDltFailure()
+					.dltHandlerMethod("dltProcessorWithError", DLT_METHOD_NAME)
+					.create(template);
+		}
+
+		@Bean
+		public BlockingAndTopicRetriesListener blockingAndTopicRetriesListener() {
+			return new BlockingAndTopicRetriesListener();
+		}
+
+		@Bean
+		public OnlyRetryViaTopicListener onlyRetryViaTopicListener() {
+			return new OnlyRetryViaTopicListener();
+		}
+
+		@Bean
+		public UserFatalTopicListener userFatalTopicListener() {
+			return new UserFatalTopicListener();
+		}
+
+		@Bean
+		public OnlyRetryBlockingListener onlyRetryBlockingListener() {
+			return new OnlyRetryBlockingListener();
+		}
+
+		@Bean
+		public FrameworkFatalTopicListener frameworkFatalTopicListener() {
+			return new FrameworkFatalTopicListener();
+		}
+
+		@Bean
+		CountDownLatchContainer latchContainer() {
+			return new CountDownLatchContainer();
+		}
+
+		@Bean
+		DltProcessor dltProcessor() {
+			return new DltProcessor();
+		}
+
+		@Bean
+		DltProcessorWithError dltProcessorWithError() {
+			return new DltProcessorWithError();
+		}
+
+		@Bean
+		TaskScheduler sched() {
+			return new ThreadPoolTaskScheduler();
+		}
+
+	}
+
+	@Configuration
+	public static class RoutingTestsConfigurationSupport extends RetryTopicConfigurationSupport {
+
+		@Override
+		protected void configureBlockingRetries(BlockingRetriesConfigurer blockingRetries) {
+			blockingRetries
+					.retryOn(ShouldRetryOnlyBlockingException.class, ShouldRetryViaBothException.class)
+					.backOff(new FixedBackOff(50, 3));
+		}
+
+		@Override
+		protected void manageNonBlockingFatalExceptions(List<Class<? extends Throwable>> nonBlockingFatalExceptions) {
+			nonBlockingFatalExceptions.add(ShouldSkipBothRetriesException.class);
+		}
+	}
+
+	@Configuration
+	public static class KafkaProducerConfig {
+
+		@Autowired
+		EmbeddedKafkaBroker broker;
+
+		@Bean
+		public ProducerFactory<String, String> producerFactory() {
+			Map<String, Object> configProps = new HashMap<>();
+			configProps.put(
+					ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
+					this.broker.getBrokersAsString());
+			configProps.put(
+					ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+					StringSerializer.class);
+			configProps.put(
+					ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+					StringSerializer.class);
+			return new DefaultKafkaProducerFactory<>(configProps);
+		}
+
+		@Bean
+		public KafkaTemplate<String, String> kafkaTemplate() {
+			return new KafkaTemplate<>(producerFactory());
+		}
+	}
+
+	@EnableKafka
+	@Configuration
+	public static class KafkaConsumerConfig {
+
+		@Autowired
+		EmbeddedKafkaBroker broker;
+
+		@Bean
+		public KafkaAdmin kafkaAdmin() {
+			Map<String, Object> configs = new HashMap<>();
+			configs.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, this.broker.getBrokersAsString());
+			return new KafkaAdmin(configs);
+		}
+
+		@Bean
+		public ConsumerFactory<String, String> consumerFactory() {
+			Map<String, Object> props = new HashMap<>();
+			props.put(
+					ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
+					this.broker.getBrokersAsString());
+			props.put(
+					ConsumerConfig.GROUP_ID_CONFIG,
+					"groupId");
+			props.put(
+					ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+					StringDeserializer.class);
+			props.put(
+					ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+					StringDeserializer.class);
+			props.put(
+					ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG, false);
+			props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+			return new DefaultKafkaConsumerFactory<>(props);
+		}
+
+		@Bean
+		public ConcurrentKafkaListenerContainerFactory<String, String> retryTopicListenerContainerFactory(
+				ConsumerFactory<String, String> consumerFactory) {
+
+			ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+			ContainerProperties props = factory.getContainerProperties();
+			props.setIdleEventInterval(100L);
+			props.setPollTimeout(50L);
+			props.setIdlePartitionEventInterval(100L);
+			factory.setConsumerFactory(consumerFactory);
+			factory.setConcurrency(1);
+			factory.setContainerCustomizer(
+					container -> container.getContainerProperties().setIdlePartitionEventInterval(100L));
+			return factory;
+		}
+
+		@Bean
+		public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory(
+				ConsumerFactory<String, String> consumerFactory) {
+
+			ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+			factory.setConsumerFactory(consumerFactory);
+			factory.setConcurrency(1);
+			return factory;
+		}
+
+	}
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicClassLevelIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicClassLevelIntegrationTests.java
@@ -1,0 +1,849 @@
+/*
+ * Copyright 2021-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.retrytopic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.awaitility.Awaitility.await;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.DltHandler;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.annotation.KafkaHandler;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.annotation.PartitionOffset;
+import org.springframework.kafka.annotation.RetryableTopic;
+import org.springframework.kafka.annotation.TopicPartition;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
+import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaAdmin;
+import org.springframework.kafka.core.KafkaAdmin.NewTopics;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.listener.ContainerProperties.AckMode;
+import org.springframework.kafka.listener.KafkaListenerErrorHandler;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.converter.CompositeMessageConverter;
+import org.springframework.messaging.converter.GenericMessageConverter;
+import org.springframework.messaging.converter.SmartMessageConverter;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.stereotype.Component;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+
+/**
+ * Test class level non-blocking retries.
+ *
+ * @author Wang Zhiyang
+ *
+ * @since 3.2
+ */
+@SpringJUnitConfig
+@DirtiesContext
+@EmbeddedKafka(topics = { RetryTopicClassLevelIntegrationTests.FIRST_TOPIC,
+		RetryTopicClassLevelIntegrationTests.SECOND_TOPIC,
+		RetryTopicClassLevelIntegrationTests.THIRD_TOPIC,
+		RetryTopicClassLevelIntegrationTests.FOURTH_TOPIC,
+		RetryTopicClassLevelIntegrationTests.TWO_LISTENERS_TOPIC,
+		RetryTopicClassLevelIntegrationTests.MANUAL_TOPIC })
+@TestPropertySource(properties = { "five.attempts=5", "kafka.template=customKafkaTemplate"})
+public class RetryTopicClassLevelIntegrationTests {
+
+	public final static String FIRST_TOPIC = "myRetryTopic1";
+
+	public final static String SECOND_TOPIC = "myRetryTopic2";
+
+	public final static String THIRD_TOPIC = "myRetryTopic3";
+
+	public final static String FOURTH_TOPIC = "myRetryTopic4";
+
+	public final static String TWO_LISTENERS_TOPIC = "myRetryTopic5";
+
+	public final static String MANUAL_TOPIC = "myRetryTopic6";
+
+	public final static String NOT_RETRYABLE_EXCEPTION_TOPIC = "noRetryTopic";
+
+	public final static String FIRST_REUSE_RETRY_TOPIC = "reuseRetry1";
+
+	public final static String SECOND_REUSE_RETRY_TOPIC = "reuseRetry2";
+
+	public final static String THIRD_REUSE_RETRY_TOPIC = "reuseRetry3";
+
+	private final static String MAIN_TOPIC_CONTAINER_FACTORY = "kafkaListenerContainerFactory";
+
+	@Autowired
+	private KafkaTemplate<String, String> kafkaTemplate;
+
+	@Autowired
+	private CountDownLatchContainer latchContainer;
+
+	@Autowired
+	DestinationTopicContainer topicContainer;
+
+	@Test
+	void shouldRetryFirstTopic(@Autowired KafkaListenerEndpointRegistry registry) {
+		kafkaTemplate.send(FIRST_TOPIC, "Testing topic 1");
+		assertThat(topicContainer.getNextDestinationTopicFor("firstTopicId", FIRST_TOPIC).getDestinationName())
+				.isEqualTo("myRetryTopic1-retry");
+		assertThat(awaitLatch(latchContainer.countDownLatch1)).isTrue();
+		assertThat(awaitLatch(latchContainer.customDltCountdownLatch)).isTrue();
+		assertThat(awaitLatch(latchContainer.customErrorHandlerCountdownLatch)).isTrue();
+		assertThat(awaitLatch(latchContainer.customMessageConverterCountdownLatch)).isTrue();
+		registry.getListenerContainerIds().stream()
+				.filter(id -> id.startsWith("first"))
+				.forEach(id -> {
+					ConcurrentMessageListenerContainer<?, ?> container = (ConcurrentMessageListenerContainer<?, ?>) registry
+							.getListenerContainer(id);
+					if (id.equals("firstTopicId")) {
+						assertThat(container.getConcurrency()).isEqualTo(2);
+					}
+					else {
+						assertThat(container.getConcurrency())
+								.describedAs("Expected %s to have concurrency", id)
+								.isEqualTo(1);
+					}
+				});
+	}
+
+	@Test
+	void shouldRetrySecondTopic() {
+		kafkaTemplate.send(SECOND_TOPIC, "Testing topic 2");
+		assertThat(awaitLatch(latchContainer.countDownLatch2)).isTrue();
+		assertThat(awaitLatch(latchContainer.customDltCountdownLatch)).isTrue();
+	}
+
+	@Test
+	void shouldRetryThirdTopicWithTimeout(@Autowired KafkaAdmin admin,
+			@Autowired KafkaListenerEndpointRegistry registry) throws Exception {
+
+		kafkaTemplate.send(THIRD_TOPIC, "Testing topic 3");
+		assertThat(awaitLatch(latchContainer.countDownLatch3)).isTrue();
+		assertThat(awaitLatch(latchContainer.countDownLatchDltOne)).isTrue();
+		Map<String, TopicDescription> topics = admin.describeTopics(THIRD_TOPIC, THIRD_TOPIC + "-dlt", FOURTH_TOPIC);
+		assertThat(topics.get(THIRD_TOPIC).partitions()).hasSize(2);
+		assertThat(topics.get(THIRD_TOPIC + "-dlt").partitions()).hasSize(3);
+		assertThat(topics.get(FOURTH_TOPIC).partitions()).hasSize(2);
+		AtomicReference<Method> method = new AtomicReference<>();
+		org.springframework.util.ReflectionUtils.doWithMethods(KafkaAdmin.class, m -> {
+			m.setAccessible(true);
+			method.set(m);
+		}, m -> m.getName().equals("newTopics"));
+		@SuppressWarnings("unchecked")
+		Collection<NewTopic> weededTopics = (Collection<NewTopic>) method.get().invoke(admin);
+		AtomicInteger weeded = new AtomicInteger();
+		weededTopics.forEach(topic -> {
+			if (topic.name().equals(THIRD_TOPIC) || topic.name().equals(FOURTH_TOPIC)) {
+				assertThat(topic).isExactlyInstanceOf(NewTopic.class);
+				weeded.incrementAndGet();
+			}
+		});
+		assertThat(weeded.get()).isEqualTo(2);
+		registry.getListenerContainerIds().stream()
+				.filter(id -> id.startsWith("third"))
+				.forEach(id -> {
+					ConcurrentMessageListenerContainer<?, ?> container =
+							(ConcurrentMessageListenerContainer<?, ?>) registry.getListenerContainer(id);
+					if (id.equals("thirdTopicId")) {
+						assertThat(container.getConcurrency()).isEqualTo(2);
+					}
+					else {
+						assertThat(container.getConcurrency())
+								.describedAs("Expected %s to have concurrency", id)
+								.isEqualTo(1);
+					}
+				});
+	}
+
+	@Test
+	void shouldRetryFourthTopicWithNoDlt() {
+		kafkaTemplate.send(FOURTH_TOPIC, "Testing topic 4");
+		assertThat(awaitLatch(latchContainer.countDownLatch4)).isTrue();
+	}
+
+	@Test
+	void shouldRetryFifthTopicWithTwoListenersAndManualAssignment(@Autowired FifthTopicListener1 listener1,
+			@Autowired FifthTopicListener2 listener2) {
+
+		kafkaTemplate.send(TWO_LISTENERS_TOPIC, 0, "0", "Testing topic 5 - 0");
+		kafkaTemplate.send(TWO_LISTENERS_TOPIC, 1, "0", "Testing topic 5 - 1");
+		assertThat(awaitLatch(latchContainer.countDownLatch51)).isTrue();
+		assertThat(awaitLatch(latchContainer.countDownLatch52)).isTrue();
+		assertThat(awaitLatch(latchContainer.countDownLatchDltThree)).isTrue();
+		assertThat(awaitLatch(latchContainer.countDownLatchDltFour)).isTrue();
+		assertThat(listener1.topics).containsExactly(TWO_LISTENERS_TOPIC, TWO_LISTENERS_TOPIC
+				+ "-listener1-0", TWO_LISTENERS_TOPIC + "-listener1-1", TWO_LISTENERS_TOPIC + "-listener1-2",
+				TWO_LISTENERS_TOPIC + "-listener1-dlt");
+		assertThat(listener2.topics).containsExactly(TWO_LISTENERS_TOPIC, TWO_LISTENERS_TOPIC
+				+ "-listener2-0", TWO_LISTENERS_TOPIC + "-listener2-1", TWO_LISTENERS_TOPIC + "-listener2-2",
+				TWO_LISTENERS_TOPIC + "-listener2-dlt");
+	}
+
+	@Test
+	void shouldRetryManualTopicWithDefaultDlt(@Autowired KafkaListenerEndpointRegistry registry,
+			@Autowired ConsumerFactory<String, String> cf) {
+
+		kafkaTemplate.send(MANUAL_TOPIC, "Testing topic 6");
+		assertThat(awaitLatch(latchContainer.countDownLatch6)).isTrue();
+		registry.getListenerContainerIds().stream()
+				.filter(id -> id.startsWith("manual"))
+				.forEach(id -> {
+					ConcurrentMessageListenerContainer<?, ?> container =
+							(ConcurrentMessageListenerContainer<?, ?>) registry.getListenerContainer(id);
+					assertThat(container).extracting("commonErrorHandler")
+							.extracting("seekAfterError", InstanceOfAssertFactories.BOOLEAN)
+							.isFalse();
+				});
+		Consumer<String, String> consumer = cf.createConsumer("manual-dlt", "");
+		Set<org.apache.kafka.common.TopicPartition> tp =
+				Set.of(new org.apache.kafka.common.TopicPartition(MANUAL_TOPIC + "-dlt", 0));
+		consumer.assign(tp);
+		try {
+			await().untilAsserted(() -> {
+				OffsetAndMetadata offsetAndMetadata = consumer.committed(tp).get(tp.iterator().next());
+				assertThat(offsetAndMetadata).isNotNull();
+				assertThat(offsetAndMetadata.offset()).isEqualTo(1L);
+			});
+		}
+		finally {
+			consumer.close();
+		}
+	}
+
+	@Test
+	void shouldFirstReuseRetryTopic(@Autowired FirstReuseRetryTopicListener listener1,
+			@Autowired SecondReuseRetryTopicListener listener2, @Autowired ThirdReuseRetryTopicListener listener3) {
+
+		kafkaTemplate.send(FIRST_REUSE_RETRY_TOPIC, "Testing reuse topic 1");
+		kafkaTemplate.send(SECOND_REUSE_RETRY_TOPIC, "Testing reuse topic 2");
+		kafkaTemplate.send(THIRD_REUSE_RETRY_TOPIC, "Testing reuse topic 3");
+		assertThat(awaitLatch(latchContainer.countDownLatchReuseOne)).isTrue();
+		assertThat(awaitLatch(latchContainer.countDownLatchReuseTwo)).isTrue();
+		assertThat(awaitLatch(latchContainer.countDownLatchReuseThree)).isTrue();
+		assertThat(listener1.topics).containsExactly(FIRST_REUSE_RETRY_TOPIC,
+				FIRST_REUSE_RETRY_TOPIC + "-retry");
+		assertThat(listener2.topics).containsExactly(SECOND_REUSE_RETRY_TOPIC,
+				SECOND_REUSE_RETRY_TOPIC + "-retry-30", SECOND_REUSE_RETRY_TOPIC + "-retry-60",
+				SECOND_REUSE_RETRY_TOPIC + "-retry-100", SECOND_REUSE_RETRY_TOPIC + "-retry-100");
+		assertThat(listener3.topics).containsExactly(THIRD_REUSE_RETRY_TOPIC,
+				THIRD_REUSE_RETRY_TOPIC + "-retry", THIRD_REUSE_RETRY_TOPIC + "-retry",
+				THIRD_REUSE_RETRY_TOPIC + "-retry", THIRD_REUSE_RETRY_TOPIC + "-retry");
+	}
+
+	@Test
+	public void shouldGoStraightToDlt() {
+		kafkaTemplate.send(NOT_RETRYABLE_EXCEPTION_TOPIC, "Testing topic with annotation 1");
+		assertThat(awaitLatch(latchContainer.countDownLatchNoRetry)).isTrue();
+		assertThat(awaitLatch(latchContainer.countDownLatchDltTwo)).isTrue();
+	}
+
+	private boolean awaitLatch(CountDownLatch latch) {
+		try {
+			return latch.await(60, TimeUnit.SECONDS);
+		}
+		catch (Exception e) {
+			fail(e.getMessage());
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Component
+	@KafkaListener(id = "firstTopicId", topics = FIRST_TOPIC, containerFactory = MAIN_TOPIC_CONTAINER_FACTORY,
+			errorHandler = "myCustomErrorHandler", contentTypeConverter = "myCustomMessageConverter",
+			concurrency = "2")
+	static class FirstTopicListener {
+
+		@Autowired
+		DestinationTopicContainer topicContainer;
+
+		@Autowired
+		CountDownLatchContainer container;
+
+		@KafkaHandler
+		public void listen(String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic) {
+			container.countDownLatch1.countDown();
+			throw new RuntimeException("Woooops... in topic " + receivedTopic);
+		}
+
+	}
+
+	@Component
+	@KafkaListener(topics = SECOND_TOPIC, containerFactory = MAIN_TOPIC_CONTAINER_FACTORY)
+	static class SecondTopicListener {
+
+		@Autowired
+		CountDownLatchContainer container;
+
+		@KafkaHandler
+		public void listenAgain(String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic) {
+			container.countDownIfNotKnown(receivedTopic, container.countDownLatch2);
+			throw new IllegalStateException("Another woooops... " + receivedTopic);
+		}
+	}
+
+	@Component
+	@RetryableTopic(attempts = "${five.attempts}",
+			backoff = @Backoff(delay = 250, maxDelay = 1000, multiplier = 1.5),
+			numPartitions = "#{3}",
+			timeout = "${missing.property:2000}",
+			include = MyRetryException.class, kafkaTemplate = "${kafka.template}",
+			topicSuffixingStrategy = TopicSuffixingStrategy.SUFFIX_WITH_INDEX_VALUE,
+			concurrency = "1")
+	@KafkaListener(id = "thirdTopicId", topics = THIRD_TOPIC, containerFactory = MAIN_TOPIC_CONTAINER_FACTORY,
+			concurrency = "2")
+	static class ThirdTopicListener {
+
+		@Autowired
+		CountDownLatchContainer container;
+
+		@KafkaHandler
+		public void listenWithAnnotation(String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic) {
+			container.countDownIfNotKnown(receivedTopic, container.countDownLatch3);
+			throw new MyRetryException("Annotated woooops... " + receivedTopic);
+		}
+
+		@DltHandler
+		public void annotatedDltMethod(Object message) {
+			container.countDownLatchDltOne.countDown();
+		}
+	}
+
+	@Component
+	@RetryableTopic(dltStrategy = DltStrategy.NO_DLT, attempts = "4", backoff = @Backoff(300),
+			sameIntervalTopicReuseStrategy = SameIntervalTopicReuseStrategy.MULTIPLE_TOPICS,
+			kafkaTemplate = "${kafka.template}")
+	@KafkaListener(topics = FOURTH_TOPIC, containerFactory = MAIN_TOPIC_CONTAINER_FACTORY)
+	static class FourthTopicListener {
+
+		@Autowired
+		CountDownLatchContainer container;
+
+		@KafkaHandler
+		public void listenNoDlt(String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic) {
+			container.countDownIfNotKnown(receivedTopic, container.countDownLatch4);
+			throw new IllegalStateException("Another woooops... " + receivedTopic);
+		}
+
+		@DltHandler
+		public void shouldNotGetHere() {
+			fail("Dlt should not be processed!");
+		}
+	}
+
+	@RetryableTopic(attempts = "4",
+			backoff = @Backoff(250),
+			numPartitions = "2",
+			retryTopicSuffix = "-listener1", dltTopicSuffix = "-listener1-dlt",
+			topicSuffixingStrategy = TopicSuffixingStrategy.SUFFIX_WITH_INDEX_VALUE,
+			sameIntervalTopicReuseStrategy = SameIntervalTopicReuseStrategy.MULTIPLE_TOPICS,
+			kafkaTemplate = "${kafka.template}")
+	@KafkaListener(id = "fifthTopicId1", topicPartitions = {@TopicPartition(topic = TWO_LISTENERS_TOPIC,
+			partitionOffsets = @PartitionOffset(partition = "0", initialOffset = "0"))},
+			containerFactory = MAIN_TOPIC_CONTAINER_FACTORY)
+	static class FifthTopicListener1 {
+
+		final List<String> topics = Collections.synchronizedList(new ArrayList<>());
+
+		@Autowired
+		CountDownLatchContainer container;
+
+		@KafkaHandler
+		public void listenWithAnnotation(String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic) {
+			this.topics.add(receivedTopic);
+			container.countDownIfNotKnown(receivedTopic, container.countDownLatch51);
+			throw new RuntimeException("Annotated woooops... " + receivedTopic);
+		}
+
+		@DltHandler
+		public void annotatedDltMethod(ConsumerRecord<?, ?> record) {
+			this.topics.add(record.topic());
+			container.countDownLatchDltThree.countDown();
+		}
+
+	}
+
+	@RetryableTopic(attempts = "4",
+			backoff = @Backoff(250),
+			numPartitions = "2",
+			retryTopicSuffix = "-listener2", dltTopicSuffix = "-listener2-dlt",
+			topicSuffixingStrategy = TopicSuffixingStrategy.SUFFIX_WITH_INDEX_VALUE,
+			sameIntervalTopicReuseStrategy = SameIntervalTopicReuseStrategy.MULTIPLE_TOPICS,
+			kafkaTemplate = "${kafka.template}")
+	@KafkaListener(id = "fifthTopicId2", topicPartitions = {@TopicPartition(topic = TWO_LISTENERS_TOPIC,
+			partitionOffsets = @PartitionOffset(partition = "1", initialOffset = "0"))},
+			containerFactory = MAIN_TOPIC_CONTAINER_FACTORY)
+	static class FifthTopicListener2 {
+
+		final List<String> topics = Collections.synchronizedList(new ArrayList<>());
+
+		@Autowired
+		CountDownLatchContainer container;
+
+		@KafkaHandler
+		public void listenWithAnnotation2(String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic) {
+			this.topics.add(receivedTopic);
+			container.countDownLatch52.countDown();
+			throw new RuntimeException("Annotated woooops... " + receivedTopic);
+		}
+
+		@DltHandler
+		public void annotatedDltMethod(ConsumerRecord<?, ?> record) {
+			this.topics.add(record.topic());
+			container.countDownLatchDltFour.countDown();
+		}
+
+	}
+
+	@Component
+	@RetryableTopic(attempts = "4", backoff = @Backoff(50),
+			sameIntervalTopicReuseStrategy = SameIntervalTopicReuseStrategy.MULTIPLE_TOPICS)
+	@KafkaListener(id = "manual", topics = MANUAL_TOPIC, containerFactory = MAIN_TOPIC_CONTAINER_FACTORY)
+	static class SixthTopicDefaultDLTListener {
+
+		@Autowired
+		CountDownLatchContainer container;
+
+		@KafkaHandler
+		public void listenNoDlt(String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic,
+				@SuppressWarnings("unused") Acknowledgment ack) {
+
+			container.countDownIfNotKnown(receivedTopic, container.countDownLatch6);
+			throw new IllegalStateException("Another woooops... " + receivedTopic);
+		}
+
+	}
+
+	@Component
+	@RetryableTopic(attempts = "3", numPartitions = "3", exclude = MyDontRetryException.class,
+			backoff = @Backoff(delay = 50, maxDelay = 100, multiplier = 3),
+			traversingCauses = "true", kafkaTemplate = "${kafka.template}")
+	@KafkaListener(topics = NOT_RETRYABLE_EXCEPTION_TOPIC, containerFactory = MAIN_TOPIC_CONTAINER_FACTORY)
+	static class NoRetryTopicListener {
+
+		@Autowired
+		CountDownLatchContainer container;
+
+
+		@KafkaHandler
+		public void listenWithAnnotation2(String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic) {
+			container.countDownIfNotKnown(receivedTopic, container.countDownLatchNoRetry);
+			throw new MyDontRetryException("Annotated second woooops... " + receivedTopic);
+		}
+
+		@DltHandler
+		public void annotatedDltMethod(Object message) {
+			container.countDownLatchDltTwo.countDown();
+		}
+	}
+
+	@Component
+	@RetryableTopic(attempts = "2", backoff = @Backoff(50))
+	@KafkaListener(id = "reuseRetry1", topics = FIRST_REUSE_RETRY_TOPIC,
+			containerFactory = "retryTopicListenerContainerFactory")
+	static class FirstReuseRetryTopicListener {
+
+		final List<String> topics = Collections.synchronizedList(new ArrayList<>());
+
+		@Autowired
+		CountDownLatchContainer container;
+
+		@KafkaHandler
+		public void listen1(String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic) {
+			this.topics.add(receivedTopic);
+			container.countDownLatchReuseOne.countDown();
+			throw new RuntimeException("Another woooops... " + receivedTopic);
+		}
+
+	}
+
+	@Component
+	@RetryableTopic(attempts = "5", backoff = @Backoff(delay = 30, maxDelay = 100, multiplier = 2))
+	@KafkaListener(id = "reuseRetry2", topics = SECOND_REUSE_RETRY_TOPIC,
+			containerFactory = "retryTopicListenerContainerFactory")
+	static class SecondReuseRetryTopicListener {
+
+		final List<String> topics = Collections.synchronizedList(new ArrayList<>());
+
+		@Autowired
+		CountDownLatchContainer container;
+
+		@KafkaHandler
+		public void listen2(String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic) {
+			this.topics.add(receivedTopic);
+			container.countDownLatchReuseTwo.countDown();
+			throw new RuntimeException("Another woooops... " + receivedTopic);
+		}
+
+	}
+
+	@Component
+	@RetryableTopic(attempts = "5", backoff = @Backoff(delay = 1, maxDelay = 5, multiplier = 1.4))
+	@KafkaListener(id = "reuseRetry3", topics = THIRD_REUSE_RETRY_TOPIC,
+			containerFactory = "retryTopicListenerContainerFactory")
+	static class ThirdReuseRetryTopicListener {
+
+		final List<String> topics = Collections.synchronizedList(new ArrayList<>());
+
+		@Autowired
+		CountDownLatchContainer container;
+
+		@KafkaHandler
+		public void listen3(String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic) {
+			this.topics.add(receivedTopic);
+			container.countDownLatchReuseThree.countDown();
+			throw new RuntimeException("Another woooops... " + receivedTopic);
+		}
+
+	}
+
+	@Component
+	static class CountDownLatchContainer {
+
+		CountDownLatch countDownLatch1 = new CountDownLatch(5);
+		CountDownLatch countDownLatch2 = new CountDownLatch(3);
+		CountDownLatch countDownLatch3 = new CountDownLatch(3);
+		CountDownLatch countDownLatch4 = new CountDownLatch(4);
+		CountDownLatch countDownLatch51 = new CountDownLatch(4);
+		CountDownLatch countDownLatch52 = new CountDownLatch(4);
+		CountDownLatch countDownLatch6 = new CountDownLatch(4);
+		CountDownLatch countDownLatchNoRetry = new CountDownLatch(1);
+		CountDownLatch countDownLatchDltOne = new CountDownLatch(1);
+		CountDownLatch countDownLatchDltTwo = new CountDownLatch(1);
+		CountDownLatch countDownLatchDltThree = new CountDownLatch(1);
+		CountDownLatch countDownLatchDltFour = new CountDownLatch(1);
+		CountDownLatch countDownLatchReuseOne = new CountDownLatch(2);
+		CountDownLatch countDownLatchReuseTwo = new CountDownLatch(5);
+		CountDownLatch countDownLatchReuseThree = new CountDownLatch(5);
+		CountDownLatch customDltCountdownLatch = new CountDownLatch(1);
+		CountDownLatch customErrorHandlerCountdownLatch = new CountDownLatch(6);
+		CountDownLatch customMessageConverterCountdownLatch = new CountDownLatch(6);
+
+		final List<String> knownTopics = new ArrayList<>();
+
+		private void countDownIfNotKnown(String receivedTopic, CountDownLatch countDownLatch) {
+			synchronized (knownTopics) {
+				if (!knownTopics.contains(receivedTopic)) {
+					knownTopics.add(receivedTopic);
+					countDownLatch.countDown();
+				}
+			}
+		}
+	}
+
+	@Component
+	static class MyCustomDltProcessor {
+
+		@Autowired
+		KafkaTemplate<String, String> kafkaTemplate;
+
+		@Autowired
+		CountDownLatchContainer container;
+
+		public void processDltMessage(Object message) {
+			container.customDltCountdownLatch.countDown();
+			throw new RuntimeException("Dlt Error!");
+		}
+	}
+
+	@SuppressWarnings("serial")
+	public static class MyRetryException extends RuntimeException {
+		public MyRetryException(String msg) {
+			super(msg);
+		}
+	}
+
+	@SuppressWarnings("serial")
+	public static class MyDontRetryException extends RuntimeException {
+		public MyDontRetryException(String msg) {
+			super(msg);
+		}
+	}
+
+	@Configuration
+	static class RetryTopicConfigurations extends RetryTopicConfigurationSupport {
+
+		private static final String DLT_METHOD_NAME = "processDltMessage";
+
+		@Bean
+		public RetryTopicConfiguration firstRetryTopic(KafkaTemplate<String, String> template) {
+			return RetryTopicConfigurationBuilder
+					.newInstance()
+					.fixedBackOff(50)
+					.maxAttempts(5)
+					.concurrency(1)
+					.useSingleTopicForSameIntervals()
+					.includeTopic(FIRST_TOPIC)
+					.doNotRetryOnDltFailure()
+					.dltHandlerMethod("myCustomDltProcessor", DLT_METHOD_NAME)
+					.create(template);
+		}
+
+		@Bean
+		public RetryTopicConfiguration secondRetryTopic(KafkaTemplate<String, String> template) {
+			return RetryTopicConfigurationBuilder
+					.newInstance()
+					.exponentialBackoff(500, 2, 10000)
+					.retryOn(Arrays.asList(IllegalStateException.class, IllegalAccessException.class))
+					.traversingCauses()
+					.includeTopic(SECOND_TOPIC)
+					.doNotRetryOnDltFailure()
+					.dltHandlerMethod("myCustomDltProcessor", DLT_METHOD_NAME)
+					.create(template);
+		}
+
+		@Bean
+		public FirstTopicListener firstTopicListener() {
+			return new FirstTopicListener();
+		}
+
+		@Bean
+		public KafkaListenerErrorHandler myCustomErrorHandler(CountDownLatchContainer container) {
+			return (message, exception) -> {
+				container.customErrorHandlerCountdownLatch.countDown();
+				throw exception;
+			};
+		}
+
+		@Bean
+		public SmartMessageConverter myCustomMessageConverter(CountDownLatchContainer container) {
+			return new CompositeMessageConverter(Collections.singletonList(new GenericMessageConverter())) {
+
+				@Override
+				public Object fromMessage(Message<?> message, Class<?> targetClass, Object conversionHint) {
+					container.customMessageConverterCountdownLatch.countDown();
+					return super.fromMessage(message, targetClass, conversionHint);
+				}
+			};
+		}
+
+		@Bean
+		public SecondTopicListener secondTopicListener() {
+			return new SecondTopicListener();
+		}
+
+		@Bean
+		public ThirdTopicListener thirdTopicListener() {
+			return new ThirdTopicListener();
+		}
+
+		@Bean
+		public FourthTopicListener fourthTopicListener() {
+			return new FourthTopicListener();
+		}
+
+		@Bean
+		public FifthTopicListener1 fifthTopicListener1() {
+			return new FifthTopicListener1();
+		}
+
+		@Bean
+		public FifthTopicListener2 fifthTopicListener2() {
+			return new FifthTopicListener2();
+		}
+
+		@Bean
+		SixthTopicDefaultDLTListener manualTopicListener() {
+			return new SixthTopicDefaultDLTListener();
+		}
+
+		@Bean
+		public NoRetryTopicListener noRetryTopicListener() {
+			return new NoRetryTopicListener();
+		}
+
+		@Bean
+		public FirstReuseRetryTopicListener firstReuseRetryTopicListener() {
+			return new FirstReuseRetryTopicListener();
+		}
+
+		@Bean
+		public SecondReuseRetryTopicListener secondReuseRetryTopicListener() {
+			return new SecondReuseRetryTopicListener();
+		}
+
+		@Bean
+		public ThirdReuseRetryTopicListener thirdReuseRetryTopicListener() {
+			return new ThirdReuseRetryTopicListener();
+		}
+
+		@Bean
+		CountDownLatchContainer latchContainer() {
+			return new CountDownLatchContainer();
+		}
+
+		@Bean
+		MyCustomDltProcessor myCustomDltProcessor() {
+			return new MyCustomDltProcessor();
+		}
+	}
+
+	@Configuration
+	public static class KafkaProducerConfig {
+
+		@Autowired
+		EmbeddedKafkaBroker broker;
+
+		@Bean
+		public ProducerFactory<String, String> producerFactory() {
+			Map<String, Object> configProps = new HashMap<>();
+			configProps.put(
+					ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
+					this.broker.getBrokersAsString());
+			configProps.put(
+					ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+					StringSerializer.class);
+			configProps.put(
+					ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+					StringSerializer.class);
+			return new DefaultKafkaProducerFactory<>(configProps);
+		}
+
+		@Bean("customKafkaTemplate")
+		public KafkaTemplate<String, String> kafkaTemplate() {
+			return new KafkaTemplate<>(producerFactory());
+		}
+	}
+
+	@EnableKafka
+	@Configuration
+	public static class KafkaConsumerConfig {
+
+		@Autowired
+		EmbeddedKafkaBroker broker;
+
+		@Bean
+		public KafkaAdmin kafkaAdmin() {
+			Map<String, Object> configs = new HashMap<>();
+			configs.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, this.broker.getBrokersAsString());
+			return new KafkaAdmin(configs);
+		}
+
+		@Bean
+		public NewTopic topic() {
+			return TopicBuilder.name(THIRD_TOPIC).partitions(2).replicas(1).build();
+		}
+
+		@Bean
+		public NewTopics topics() {
+			return new NewTopics(TopicBuilder.name(FOURTH_TOPIC).partitions(2).replicas(1).build());
+		}
+
+		@Bean
+		public ConsumerFactory<String, String> consumerFactory() {
+			Map<String, Object> props = new HashMap<>();
+			props.put(
+					ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
+					this.broker.getBrokersAsString());
+			props.put(
+					ConsumerConfig.GROUP_ID_CONFIG,
+					"groupId");
+			props.put(
+					ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+					StringDeserializer.class);
+			props.put(
+					ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+					StringDeserializer.class);
+			props.put(
+					ConsumerConfig.ALLOW_AUTO_CREATE_TOPICS_CONFIG, false);
+			props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+			return new DefaultKafkaConsumerFactory<>(props);
+		}
+
+		@Bean
+		public ConcurrentKafkaListenerContainerFactory<String, String> retryTopicListenerContainerFactory(
+				ConsumerFactory<String, String> consumerFactory) {
+
+			ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+			ContainerProperties props = factory.getContainerProperties();
+			props.setIdleEventInterval(100L);
+			props.setPollTimeout(50L);
+			props.setIdlePartitionEventInterval(100L);
+			factory.setConsumerFactory(consumerFactory);
+			factory.setConcurrency(1);
+			factory.setContainerCustomizer(
+					container -> container.getContainerProperties().setIdlePartitionEventInterval(100L));
+			return factory;
+		}
+
+		@Bean
+		public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory(
+				ConsumerFactory<String, String> consumerFactory) {
+
+			ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+			factory.setConsumerFactory(consumerFactory);
+			factory.setConcurrency(1);
+			factory.setContainerCustomizer(container -> {
+				if (container.getListenerId().startsWith("manual")) {
+					container.getContainerProperties().setAckMode(AckMode.MANUAL);
+					container.getContainerProperties().setAsyncAcks(true);
+				}
+			});
+			return factory;
+		}
+
+		@Bean
+		TaskScheduler sched() {
+			return new ThreadPoolTaskScheduler();
+		}
+
+	}
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicClassLevelIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicClassLevelIntegrationTests.java
@@ -105,7 +105,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 		RetryTopicClassLevelIntegrationTests.TWO_LISTENERS_TOPIC,
 		RetryTopicClassLevelIntegrationTests.MANUAL_TOPIC })
 @TestPropertySource(properties = { "five.attempts=5", "kafka.template=customKafkaTemplate"})
-public class RetryTopicClassLevelIntegrationTests {
+class RetryTopicClassLevelIntegrationTests {
 
 	public final static String FIRST_TOPIC = "myRetryTopic1";
 
@@ -288,7 +288,7 @@ public class RetryTopicClassLevelIntegrationTests {
 	}
 
 	@Test
-	public void shouldGoStraightToDlt() {
+	void shouldGoStraightToDlt() {
 		kafkaTemplate.send(NOT_RETRYABLE_EXCEPTION_TOPIC, "Testing topic with annotation 1");
 		assertThat(awaitLatch(latchContainer.countDownLatchNoRetry)).isTrue();
 		assertThat(awaitLatch(latchContainer.countDownLatchDltTwo)).isTrue();
@@ -603,15 +603,15 @@ public class RetryTopicClassLevelIntegrationTests {
 	}
 
 	@SuppressWarnings("serial")
-	public static class MyRetryException extends RuntimeException {
-		public MyRetryException(String msg) {
+	static class MyRetryException extends RuntimeException {
+		MyRetryException(String msg) {
 			super(msg);
 		}
 	}
 
 	@SuppressWarnings("serial")
-	public static class MyDontRetryException extends RuntimeException {
-		public MyDontRetryException(String msg) {
+	static class MyDontRetryException extends RuntimeException {
+		MyDontRetryException(String msg) {
 			super(msg);
 		}
 	}
@@ -622,7 +622,7 @@ public class RetryTopicClassLevelIntegrationTests {
 		private static final String DLT_METHOD_NAME = "processDltMessage";
 
 		@Bean
-		public RetryTopicConfiguration firstRetryTopic(KafkaTemplate<String, String> template) {
+		RetryTopicConfiguration firstRetryTopic(KafkaTemplate<String, String> template) {
 			return RetryTopicConfigurationBuilder
 					.newInstance()
 					.fixedBackOff(50)
@@ -636,7 +636,7 @@ public class RetryTopicClassLevelIntegrationTests {
 		}
 
 		@Bean
-		public RetryTopicConfiguration secondRetryTopic(KafkaTemplate<String, String> template) {
+		RetryTopicConfiguration secondRetryTopic(KafkaTemplate<String, String> template) {
 			return RetryTopicConfigurationBuilder
 					.newInstance()
 					.exponentialBackoff(500, 2, 10000)
@@ -649,12 +649,12 @@ public class RetryTopicClassLevelIntegrationTests {
 		}
 
 		@Bean
-		public FirstTopicListener firstTopicListener() {
+		FirstTopicListener firstTopicListener() {
 			return new FirstTopicListener();
 		}
 
 		@Bean
-		public KafkaListenerErrorHandler myCustomErrorHandler(CountDownLatchContainer container) {
+		KafkaListenerErrorHandler myCustomErrorHandler(CountDownLatchContainer container) {
 			return (message, exception) -> {
 				container.customErrorHandlerCountdownLatch.countDown();
 				throw exception;
@@ -662,7 +662,7 @@ public class RetryTopicClassLevelIntegrationTests {
 		}
 
 		@Bean
-		public SmartMessageConverter myCustomMessageConverter(CountDownLatchContainer container) {
+		SmartMessageConverter myCustomMessageConverter(CountDownLatchContainer container) {
 			return new CompositeMessageConverter(Collections.singletonList(new GenericMessageConverter())) {
 
 				@Override
@@ -674,27 +674,27 @@ public class RetryTopicClassLevelIntegrationTests {
 		}
 
 		@Bean
-		public SecondTopicListener secondTopicListener() {
+		SecondTopicListener secondTopicListener() {
 			return new SecondTopicListener();
 		}
 
 		@Bean
-		public ThirdTopicListener thirdTopicListener() {
+		ThirdTopicListener thirdTopicListener() {
 			return new ThirdTopicListener();
 		}
 
 		@Bean
-		public FourthTopicListener fourthTopicListener() {
+		FourthTopicListener fourthTopicListener() {
 			return new FourthTopicListener();
 		}
 
 		@Bean
-		public FifthTopicListener1 fifthTopicListener1() {
+		FifthTopicListener1 fifthTopicListener1() {
 			return new FifthTopicListener1();
 		}
 
 		@Bean
-		public FifthTopicListener2 fifthTopicListener2() {
+		FifthTopicListener2 fifthTopicListener2() {
 			return new FifthTopicListener2();
 		}
 
@@ -704,22 +704,22 @@ public class RetryTopicClassLevelIntegrationTests {
 		}
 
 		@Bean
-		public NoRetryTopicListener noRetryTopicListener() {
+		NoRetryTopicListener noRetryTopicListener() {
 			return new NoRetryTopicListener();
 		}
 
 		@Bean
-		public FirstReuseRetryTopicListener firstReuseRetryTopicListener() {
+		FirstReuseRetryTopicListener firstReuseRetryTopicListener() {
 			return new FirstReuseRetryTopicListener();
 		}
 
 		@Bean
-		public SecondReuseRetryTopicListener secondReuseRetryTopicListener() {
+		SecondReuseRetryTopicListener secondReuseRetryTopicListener() {
 			return new SecondReuseRetryTopicListener();
 		}
 
 		@Bean
-		public ThirdReuseRetryTopicListener thirdReuseRetryTopicListener() {
+		ThirdReuseRetryTopicListener thirdReuseRetryTopicListener() {
 			return new ThirdReuseRetryTopicListener();
 		}
 
@@ -735,13 +735,13 @@ public class RetryTopicClassLevelIntegrationTests {
 	}
 
 	@Configuration
-	public static class KafkaProducerConfig {
+	static class KafkaProducerConfig {
 
 		@Autowired
 		EmbeddedKafkaBroker broker;
 
 		@Bean
-		public ProducerFactory<String, String> producerFactory() {
+		ProducerFactory<String, String> producerFactory() {
 			Map<String, Object> configProps = new HashMap<>();
 			configProps.put(
 					ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
@@ -756,37 +756,37 @@ public class RetryTopicClassLevelIntegrationTests {
 		}
 
 		@Bean("customKafkaTemplate")
-		public KafkaTemplate<String, String> kafkaTemplate() {
+		KafkaTemplate<String, String> kafkaTemplate() {
 			return new KafkaTemplate<>(producerFactory());
 		}
 	}
 
 	@EnableKafka
 	@Configuration
-	public static class KafkaConsumerConfig {
+	static class KafkaConsumerConfig {
 
 		@Autowired
 		EmbeddedKafkaBroker broker;
 
 		@Bean
-		public KafkaAdmin kafkaAdmin() {
+		KafkaAdmin kafkaAdmin() {
 			Map<String, Object> configs = new HashMap<>();
 			configs.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, this.broker.getBrokersAsString());
 			return new KafkaAdmin(configs);
 		}
 
 		@Bean
-		public NewTopic topic() {
+		NewTopic topic() {
 			return TopicBuilder.name(THIRD_TOPIC).partitions(2).replicas(1).build();
 		}
 
 		@Bean
-		public NewTopics topics() {
+		NewTopics topics() {
 			return new NewTopics(TopicBuilder.name(FOURTH_TOPIC).partitions(2).replicas(1).build());
 		}
 
 		@Bean
-		public ConsumerFactory<String, String> consumerFactory() {
+		ConsumerFactory<String, String> consumerFactory() {
 			Map<String, Object> props = new HashMap<>();
 			props.put(
 					ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
@@ -808,7 +808,7 @@ public class RetryTopicClassLevelIntegrationTests {
 		}
 
 		@Bean
-		public ConcurrentKafkaListenerContainerFactory<String, String> retryTopicListenerContainerFactory(
+		ConcurrentKafkaListenerContainerFactory<String, String> retryTopicListenerContainerFactory(
 				ConsumerFactory<String, String> consumerFactory) {
 
 			ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
@@ -824,7 +824,7 @@ public class RetryTopicClassLevelIntegrationTests {
 		}
 
 		@Bean
-		public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory(
+		ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory(
 				ConsumerFactory<String, String> consumerFactory) {
 
 			ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();


### PR DESCRIPTION
Fixes: #3012

* Non-blocking retries support `@KafkaListener` on class level, include `@RetryableTopic`, `@DltHandler`, `RetryTopicConfiguration`, `RetryTopicConfigurationSupport`.
* Doc and test Non-blocking retries support `@KafkaListener` on class level.

---

Part 1:  Support process annotation `@RetryableTopic` and `@DltHandler` when `@RetryableTopic` annotated on class, see #3107.
Part 2:  `RetryTopicConfigurer#processAndRegisterEndpoint` support `MultiMethodKafkaListenerEndpoint`, see #3112.
Part 3:  `@EnableKafka` integration feature that non-blocking retries support `@KafkaListener` on class level,  see #3105.