### PR TITLE
Correct class naming convention for 'hat' in serializer/deserializer Doc

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/serdes.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/serdes.adoc
@@ -138,10 +138,10 @@ The following example creates a set of mappings:
 [source, java]
 ----
 senderProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
-senderProps.put(JsonSerializer.TYPE_MAPPINGS, "cat:com.mycat.Cat, hat:com.myhat.hat");
+senderProps.put(JsonSerializer.TYPE_MAPPINGS, "cat:com.mycat.Cat, hat:com.myhat.Hat");
 ...
 consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
-consumerProps.put(JsonDeSerializer.TYPE_MAPPINGS, "cat:com.yourcat.Cat, hat:com.yourhat.hat");
+consumerProps.put(JsonDeSerializer.TYPE_MAPPINGS, "cat:com.yourcat.Cat, hat:com.yourhat.Hat");
 ----
 
 IMPORTANT: The corresponding objects must be compatible.


### PR DESCRIPTION
This PR proposes a documentation update for the Spring Kafka project to correct the class naming convention for the 'hat' class in serializer and deserializer configurations. 

The current documentation uses `com.myhat.hat`, which doesn't adhere to Java naming conventions. This PR rectifies this inconsistency by updating the class name to `com.myhat.Hat`.

