### PR TITLE
GH-3108: Unsafe access to consumer in seek API

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -57,3 +57,9 @@ See xref:retrytopic/topic-naming.adoc#single-topic-maxinterval-delay[Single Topi
 `ConsumerCallback` provides a new API to seek to an offset based on a user-defined function, which takes the current offset in the consumer as an argument.
 See xref:kafka/seek.adoc#seek[Seek API Docs] for more details.
 
+[[x32-topic-partition-offset-constructor]]
+=== New constructor in TopicPartitionOffset that accepts a function to compute the offset to seek to
+`TopicPartitionOffset` has a new constructor that takes a user-provided function to compute the offset to seek to.
+When this constructor is used, the framework calls the function with the input argument of the current consumer offset position.
+See xref:kafka/seek.adoc#seek[Seek API Docs] for more details.
+

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -3005,10 +3005,14 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 					SeekPosition position = offset.getPosition();
 					TopicPartition topicPartition = offset.getTopicPartition();
 					Long whereTo = offset.getOffset();
+					Function<Long, Long> offsetComputeFunction = offset.getOffsetComputeFunction();
 					if (position == null) {
 						if (offset.isRelativeToCurrent()) {
 							whereTo += this.consumer.position(topicPartition);
 							whereTo = Math.max(whereTo, 0);
+						}
+						else if (offsetComputeFunction != null) {
+							whereTo = offsetComputeFunction.apply(this.consumer.position(topicPartition));
 						}
 						this.consumer.seek(topicPartition, whereTo);
 					}
@@ -3262,8 +3266,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 
 		@Override
 		public void seek(String topic, int partition, Function<Long, Long> offsetComputeFunction) {
-			this.seeks.add(new TopicPartitionOffset(topic, partition, offsetComputeFunction.apply(
-					this.consumer.position(new TopicPartition(topic, partition)))));
+			this.seeks.add(new TopicPartitionOffset(topic, partition, offsetComputeFunction));
 		}
 
 		@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/TopicPartitionOffset.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/TopicPartitionOffset.java
@@ -216,7 +216,7 @@ public class TopicPartitionOffset {
 	}
 
 	public Function<Long, Long> getOffsetComputeFunction() {
-		return offsetComputeFunction;
+		return this.offsetComputeFunction;
 	}
 
 	@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/TopicPartitionOffset.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/TopicPartitionOffset.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,7 @@
 package org.springframework.kafka.support;
 
 import java.util.Objects;
+import java.util.function.Function;
 
 import org.apache.kafka.common.TopicPartition;
 
@@ -41,6 +42,7 @@ import org.springframework.lang.Nullable;
  *
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Soby Chacko
  *
  * @since 2.3
  */
@@ -77,6 +79,8 @@ public class TopicPartitionOffset {
 
 	private boolean relativeToCurrent;
 
+	private Function<Long, Long> offsetComputeFunction;
+
 	/**
 	 * Construct an instance with no initial offset management.
 	 * @param topic the topic.
@@ -96,6 +100,19 @@ public class TopicPartitionOffset {
 	 */
 	public TopicPartitionOffset(String topic, int partition, Long offset) {
 		this(topic, partition, offset, false);
+	}
+
+	/**
+	 * Construct an instance with the provided function to compute the offset.
+	 * @param topic the topic.
+	 * @param partition the partition.
+	 * @param offsetComputeFunction function to compute the offset.
+	 * @since 3.2.0
+	 */
+	public TopicPartitionOffset(String topic, int partition, Function<Long, Long> offsetComputeFunction) {
+		this.topicPartition = new TopicPartition(topic, partition);
+		this.offsetComputeFunction = offsetComputeFunction;
+		this.position = null;
 	}
 
 	/**
@@ -196,6 +213,10 @@ public class TopicPartitionOffset {
 
 	public SeekPosition getPosition() {
 		return this.position;
+	}
+
+	public Function<Long, Long> getOffsetComputeFunction() {
+		return offsetComputeFunction;
 	}
 
 	@Override


### PR DESCRIPTION
Fixes: #3108

* When the seek API that uses the user-provided function to compute the offset to seek, there is a concurrency issue in which the Kafka consumer is used unsafely.

See this for details: https://github.com/spring-projects/spring-kafka/issues/3078#issuecomment-1983759811

