### PR TITLE
@RetryableTopic support KL annotated on class part 2

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -56,6 +56,13 @@ See xref:retrytopic/topic-naming.adoc#single-topic-maxinterval-delay[Single Topi
 Provides a new public API to find `RetryTopicConfiguration`.
 See xref:retrytopic/retry-config.adoc#find-retry-topic-config[Find RetryTopicConfiguration]
 
+=== RetryTopicConfigurer support process MultiMethodKafkaListenerEndpoint.
+The `RetryTopicConfigurer` support process and register `MultiMethodKafkaListenerEndpoint`.
+The `MultiMethodKafkaListenerEndpoint` provider `getter/setter` for properties `defaultMethod` and `methods`.
+Modify the `EndpointCustomizer` that strictly for `MethodKafkaListenerEndpoint` types.
+The `EndpointHandlerMethod` add new constructors construct an instance for the provided bean.
+Provides new class `EndpointHandlerMultiMethod` to handler multi method for retrying endpoints.
+
 [[x32-seek-offset-compute-fn]]
 === New API method to seek to an offset based on a user provided function
 `ConsumerCallback` provides a new API to seek to an offset based on a user-defined function, which takes the current offset in the consumer as an argument.

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -58,7 +58,7 @@ See xref:retrytopic/retry-config.adoc#find-retry-topic-config[Find RetryTopicCon
 
 === RetryTopicConfigurer support process MultiMethodKafkaListenerEndpoint.
 The `RetryTopicConfigurer` support process and register `MultiMethodKafkaListenerEndpoint`.
-The `MultiMethodKafkaListenerEndpoint` provider `getter/setter` for properties `defaultMethod` and `methods`.
+The `MultiMethodKafkaListenerEndpoint` provides `getter/setter` for properties `defaultMethod` and `methods`.
 Modify the `EndpointCustomizer` that strictly for `MethodKafkaListenerEndpoint` types.
 The `EndpointHandlerMethod` add new constructors construct an instance for the provided bean.
 Provides new class `EndpointHandlerMultiMethod` to handler multi method for retrying endpoints.

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/MultiMethodKafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/MultiMethodKafkaListenerEndpoint.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 the original author or authors.
+ * Copyright 2016-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,15 +35,16 @@ import org.springframework.validation.Validator;
  * @param <V> the value type.
  *
  * @author Gary Russell
+ * @author Wang Zhiyang
  *
  * @see org.springframework.kafka.annotation.KafkaHandler
  * @see DelegatingInvocableHandler
  */
 public class MultiMethodKafkaListenerEndpoint<K, V> extends MethodKafkaListenerEndpoint<K, V> {
 
-	private final List<Method> methods;
+	private List<Method> methods;
 
-	private final Method defaultMethod;
+	private Method defaultMethod;
 
 	private Validator validator;
 
@@ -58,6 +59,43 @@ public class MultiMethodKafkaListenerEndpoint<K, V> extends MethodKafkaListenerE
 		this.methods = methods;
 		this.defaultMethod = defaultMethod;
 		setBean(bean);
+	}
+
+
+	/**
+	 * Get a method list.
+	 * @return the method list.
+	 * @since 3.2
+	 */
+	public List<Method> getMethods() {
+		return this.methods;
+	}
+
+	/**
+	 * Set a method list.
+	 * @param methods the methods.
+	 * @since 3.2
+	 */
+	public void setMethods(List<Method> methods) {
+		this.methods = methods;
+	}
+
+	/**
+	 * Get a default method.
+	 * @return the default method.
+	 * @since 3.2
+	 */
+	public Method getDefaultMethod() {
+		return this.defaultMethod;
+	}
+
+	/**
+	 * Set a default method.
+	 * @param defaultMethod the default method.
+	 * @since 3.2
+	 */
+	public void setDefaultMethod(Method defaultMethod) {
+		this.defaultMethod = defaultMethod;
 	}
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/EndpointCustomizer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/EndpointCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,21 +24,25 @@ import org.springframework.kafka.config.MethodKafkaListenerEndpoint;
  * Customizes main, retry and DLT endpoints in the Retry Topic functionality
  * and returns the resulting topic names.
  *
+ * @param <T> the listener endpoint type.
+ *
  * @author Tomaz Fernandes
+ * @author Wang Zhiyang
+ *
  * @since 2.7.2
  *
  * @see EndpointCustomizerFactory
  *
  */
 @FunctionalInterface
-public interface EndpointCustomizer {
+public interface EndpointCustomizer<T extends MethodKafkaListenerEndpoint<?, ?>> {
 
 	/**
 	 * Customize the endpoint and return the topic names generated for this endpoint.
 	 * @param listenerEndpoint The main, retry or DLT endpoint to be customized.
 	 * @return A collection containing the topic names generated for this endpoint.
 	 */
-	Collection<TopicNamesHolder> customizeEndpointAndCollectTopics(MethodKafkaListenerEndpoint<?, ?> listenerEndpoint);
+	Collection<TopicNamesHolder> customizeEndpointAndCollectTopics(T listenerEndpoint);
 
 	class TopicNamesHolder {
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/EndpointCustomizerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/EndpointCustomizerFactory.java
@@ -16,6 +16,7 @@
 
 package org.springframework.kafka.retrytopic;
 
+import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.stream.Stream;
@@ -68,6 +69,36 @@ public class EndpointCustomizerFactory {
 		return addSuffixesAndMethod(this.destinationProperties);
 	}
 
+	/**
+	 * Create MethodKafkaListenerEndpoint's EndpointCustomizer, but not support MultiMethodKafkaListenerEndpoint.
+	 * Replace by {@link #addSuffixesAndMethod(DestinationTopic.Properties)}
+	 * @param properties the destination-topic's properties.
+	 * @param bean the bean.
+	 * @param method the method.
+	 * @return the endpoint customizer.
+	 */
+	@Deprecated(since = "3.2", forRemoval = true)
+	@SuppressWarnings("rawtypes")
+	protected EndpointCustomizer addSuffixesAndMethod(DestinationTopic.Properties properties, Object bean,
+			Method method) {
+
+		RetryTopicNamesProviderFactory.RetryTopicNamesProvider namesProvider =
+				this.retryTopicNamesProviderFactory.createRetryTopicNamesProvider(properties);
+		return endpoint -> {
+			Collection<EndpointCustomizer.TopicNamesHolder> topics =
+					customizeAndRegisterTopics(namesProvider, endpoint);
+			configurationEndpoint(endpoint, namesProvider, properties, bean);
+			endpoint.setMethod(method);
+			return topics;
+		};
+	}
+
+	/**
+	 * Create MethodKafkaListenerEndpoint's EndpointCustomizer and support MultiMethodKafkaListenerEndpoint.
+	 * @param properties the destination-topic's properties.
+	 * @return the endpoint customizer.
+	 * @since 3.2
+	 */
 	protected EndpointCustomizer<MethodKafkaListenerEndpoint<?, ?>> addSuffixesAndMethod(
 			DestinationTopic.Properties properties) {
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/EndpointHandlerMethod.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/EndpointHandlerMethod.java
@@ -41,7 +41,7 @@ public class EndpointHandlerMethod {
 
 	private final Object beanOrClass;
 
-	private final String methodName;
+	private String methodName;
 
 	private Object bean;
 
@@ -52,6 +52,12 @@ public class EndpointHandlerMethod {
 		Assert.notNull(methodName, () -> "No method name for destination bean class provided!");
 		this.beanOrClass = beanOrClass;
 		this.methodName = methodName;
+	}
+
+	public EndpointHandlerMethod(Object bean) {
+		Assert.notNull(bean, () -> "No bean for destination provided!");
+		this.bean = bean;
+		this.beanOrClass = bean.getClass();
 	}
 
 	public EndpointHandlerMethod(Object bean, Method method) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/EndpointHandlerMethod.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/EndpointHandlerMethod.java
@@ -54,6 +54,11 @@ public class EndpointHandlerMethod {
 		this.methodName = methodName;
 	}
 
+	/**
+	 * Construct an instance for the provided bean.
+	 * @param bean the bean.
+	 * @since 3.2
+	 */
 	public EndpointHandlerMethod(Object bean) {
 		Assert.notNull(bean, () -> "No bean for destination provided!");
 		this.bean = bean;

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/EndpointHandlerMultiMethod.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/EndpointHandlerMultiMethod.java
@@ -33,25 +33,46 @@ public class EndpointHandlerMultiMethod extends EndpointHandlerMethod {
 
 	private List<Method> methods;
 
+	/**
+	 * Construct an instance for the provided bean, defaultMethod and methods.
+	 * @param bean the bean.
+	 * @param defaultMethod the defaultMethod.
+	 * @param methods the methods.
+	 */
 	public EndpointHandlerMultiMethod(Object bean, Method defaultMethod, List<Method> methods) {
 		super(bean);
 		this.defaultMethod = defaultMethod;
 		this.methods = methods;
 	}
 
-
+	/**
+	 * Return the method list.
+	 * @return the method list.
+	 */
 	public List<Method> getMethods() {
 		return this.methods;
 	}
 
+	/**
+	 * Set the method list.
+	 * @param methods the method list.
+	 */
 	public void setMethods(List<Method> methods) {
 		this.methods = methods;
 	}
 
+	/**
+	 * Return the default method.
+	 * @return the default method.
+	 */
 	public Method getDefaultMethod() {
 		return this.defaultMethod;
 	}
 
+	/**
+	 * Set the default method.
+	 * @param defaultMethod the default method.
+	 */
 	public void setDefaultMethod(Method defaultMethod) {
 		this.defaultMethod = defaultMethod;
 	}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/EndpointHandlerMultiMethod.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/EndpointHandlerMultiMethod.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+/**
+ * Handler multi method for retrying endpoints.
+ *
+ * @author Wang Zhiyang
+ *
+ * @since 3.2
+ *
+ */
+public class EndpointHandlerMultiMethod extends EndpointHandlerMethod {
+
+	private Method defaultMethod;
+
+	private List<Method> methods;
+
+	public EndpointHandlerMultiMethod(Object bean, Method defaultMethod, List<Method> methods) {
+		super(bean);
+		this.defaultMethod = defaultMethod;
+		this.methods = methods;
+	}
+
+
+	public List<Method> getMethods() {
+		return this.methods;
+	}
+
+	public void setMethods(List<Method> methods) {
+		this.methods = methods;
+	}
+
+	public Method getDefaultMethod() {
+		return this.defaultMethod;
+	}
+
+	public void setDefaultMethod(Method defaultMethod) {
+		this.defaultMethod = defaultMethod;
+	}
+
+}


### PR DESCRIPTION
* `EndpointCustomizerFactory` adaptor `MultiMethodKafkaListenerEndpoint`.
* `RetryTopicConfigurer.processAndRegisterEndpoint` support `@KafkaListener` on a class.
* Add new class `EndpointHandlerMultiMethod` to handler multi method for retrying endpoints.

part2 of #3105 and this contributes to fixing https://github.com/spring-projects/spring-kafka/pull/3105 eventually.