### PR TITLE
GH-3114: DeserializationException propagation

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/DefaultKafkaHeaderMapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/DefaultKafkaHeaderMapper.java
@@ -31,6 +31,7 @@ import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeader;
 
+import org.springframework.kafka.support.serializer.SerializationUtils;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
@@ -48,6 +49,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  *
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Soby Chacko
  *
  * @since 1.3
  *
@@ -313,6 +315,11 @@ public class DefaultKafkaHeaderMapper extends AbstractKafkaHeaderMapper {
 			}
 			else if (headerName.equals(KafkaHeaders.LISTENER_INFO) && matchesForInbound(headerName)) {
 				headers.put(headerName, new String(header.value(), getCharset()));
+			}
+			else if ((headerName.equals(SerializationUtils.KEY_DESERIALIZER_EXCEPTION_HEADER) ||
+					headerName.equals(SerializationUtils.VALUE_DESERIALIZER_EXCEPTION_HEADER))
+					&& matchesForInbound(headerName)) {
+				headers.put(headerName, header);
 			}
 			else if (!(headerName.equals(JSON_TYPES)) && matchesForInbound(headerName)) {
 				if (jsonTypes.containsKey(headerName)) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/DefaultKafkaHeaderMapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/DefaultKafkaHeaderMapper.java
@@ -31,7 +31,6 @@ import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeader;
 
-import org.springframework.kafka.support.serializer.SerializationUtils;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
@@ -316,9 +315,8 @@ public class DefaultKafkaHeaderMapper extends AbstractKafkaHeaderMapper {
 			else if (headerName.equals(KafkaHeaders.LISTENER_INFO) && matchesForInbound(headerName)) {
 				headers.put(headerName, new String(header.value(), getCharset()));
 			}
-			else if ((headerName.equals(SerializationUtils.KEY_DESERIALIZER_EXCEPTION_HEADER) ||
-					headerName.equals(SerializationUtils.VALUE_DESERIALIZER_EXCEPTION_HEADER))
-					&& matchesForInbound(headerName)) {
+			else if (headerName.equals(KafkaUtils.KEY_DESERIALIZER_EXCEPTION_HEADER) ||
+					headerName.equals(KafkaUtils.VALUE_DESERIALIZER_EXCEPTION_HEADER)) {
 				headers.put(headerName, header);
 			}
 			else if (!(headerName.equals(JSON_TYPES)) && matchesForInbound(headerName)) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/KafkaUtils.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/KafkaUtils.java
@@ -47,19 +47,19 @@ public final class KafkaUtils {
 
 	/**
 	 * Header name for deserialization exceptions.
-	 * @since 3.2
+	 * @since 3.0.15
 	 */
 	public static final String DESERIALIZER_EXCEPTION_HEADER_PREFIX = "springDeserializerException";
 
 	/**
 	 * Header name for deserialization exceptions.
-	 * @since 3.2
+	 * @since 3.0.15
 	 */
 	public static final String KEY_DESERIALIZER_EXCEPTION_HEADER = DESERIALIZER_EXCEPTION_HEADER_PREFIX + "Key";
 
 	/**
 	 * Header name for deserialization exceptions.
-	 * @since 3.2
+	 * @since 3.0.15
 	 */
 	public static final String VALUE_DESERIALIZER_EXCEPTION_HEADER = DESERIALIZER_EXCEPTION_HEADER_PREFIX + "Value";
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/KafkaUtils.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/KafkaUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 the original author or authors.
+ * Copyright 2018-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,11 +38,31 @@ import org.springframework.util.ClassUtils;
  *
  * @author Gary Russell
  * @author Wang ZhiYang
+ * @author Soby Chacko
  *
  * @since 2.2
  *
  */
 public final class KafkaUtils {
+
+	/**
+	 * Header name for deserialization exceptions.
+	 * @since 3.2
+	 */
+	public static final String DESERIALIZER_EXCEPTION_HEADER_PREFIX = "springDeserializerException";
+
+	/**
+	 * Header name for deserialization exceptions.
+	 * @since 3.2
+	 */
+	public static final String KEY_DESERIALIZER_EXCEPTION_HEADER = DESERIALIZER_EXCEPTION_HEADER_PREFIX + "Key";
+
+	/**
+	 * Header name for deserialization exceptions.
+	 * @since 3.2
+	 */
+	public static final String VALUE_DESERIALIZER_EXCEPTION_HEADER = DESERIALIZER_EXCEPTION_HEADER_PREFIX + "Value";
+
 
 	private static Function<ProducerRecord<?, ?>, String> prFormatter = ProducerRecord::toString;
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/SerializationUtils.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/SerializationUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 the original author or authors.
+ * Copyright 2020-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,19 +50,19 @@ public final class SerializationUtils {
 	 * Header name for deserialization exceptions.
 	 * @since 2.8
 	 */
-	public static final String DESERIALIZER_EXCEPTION_HEADER_PREFIX = "springDeserializerException";
+	public static final String DESERIALIZER_EXCEPTION_HEADER_PREFIX = KafkaUtils.DESERIALIZER_EXCEPTION_HEADER_PREFIX;
 
 	/**
 	 * Header name for deserialization exceptions.
 	 * @since 2.8
 	 */
-	public static final String KEY_DESERIALIZER_EXCEPTION_HEADER = DESERIALIZER_EXCEPTION_HEADER_PREFIX + "Key";
+	public static final String KEY_DESERIALIZER_EXCEPTION_HEADER = KafkaUtils.KEY_DESERIALIZER_EXCEPTION_HEADER;
 
 	/**
 	 * Header name for deserialization exceptions.
 	 * @since 2.8
 	 */
-	public static final String VALUE_DESERIALIZER_EXCEPTION_HEADER = DESERIALIZER_EXCEPTION_HEADER_PREFIX + "Value";
+	public static final String VALUE_DESERIALIZER_EXCEPTION_HEADER = KafkaUtils.VALUE_DESERIALIZER_EXCEPTION_HEADER;
 
 	private SerializationUtils() {
 	}

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/SerializationTestUtils.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/SerializationTestUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 the original author or authors.
+ * Copyright 2023-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,10 +16,16 @@
 
 package org.springframework.kafka.support.serializer;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectOutputStream;
+import java.io.UncheckedIOException;
+
 import org.apache.kafka.common.header.Header;
 
 /**
  * @author Gary Russell
+ * @author Soby Chacko
  * @since 2.9.11
  *
  */
@@ -30,6 +36,27 @@ public final class SerializationTestUtils {
 
 	public static Header deserializationHeader(String key, byte[] value) {
 		return new DeserializationExceptionHeader(key, value);
+	}
+
+	public static byte[] header(boolean isKey) {
+		return header(createDeserEx(isKey));
+	}
+
+	public static DeserializationException createDeserEx(boolean isKey) {
+		return new DeserializationException(
+				isKey ? "testK" : "testV",
+				isKey ? "key".getBytes() : "value".getBytes(), isKey, null);
+	}
+
+	public static byte[] header(DeserializationException deserEx) {
+		ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		try {
+			new ObjectOutputStream(baos).writeObject(deserEx);
+		}
+		catch (IOException e) {
+			throw new UncheckedIOException(e);
+		}
+		return baos.toByteArray();
 	}
 
 }


### PR DESCRIPTION
Fixes: #3114

* Since DeserializationExceptionHeader is currently porpagated as a `byte[]`, it encounters some issues when processing the header especially in batch listeners. Fixing this by providing the deserialization header without `byte[]` conversion
* Adding test to verify
* Refactoring in SerializationTestUtils

