### PR TITLE
GH-3135 : Adding new `ListenerContainerRegistry.getListenerContainersMatchingId(Predicate)` for easier usage. 

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/receiving-messages/kafkalistener-lifecycle.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/receiving-messages/kafkalistener-lifecycle.adoc
@@ -42,20 +42,18 @@ An example of late registration is a bean with a `@KafkaListener` in prototype s
 Starting with version 2.8.7, you can set the registry's `alwaysStartAfterRefresh` property to `false` and then the container's `autoStartup` property will define whether or not the container is started.
 
 [[get-listener-containers-matching]]
-== Retrieve MessageListenerContainer instances Matching a Predicate
+== Retrieve MessageListenerContainers with by matching a Predicate
 
-Starting with version 3.2, the `ListenerContainerRegistry` interface and `KafkaListenerEndpointRegistry`
-implementation provides a method to retrieve all `MessageListenerContainer` instances that match a given predicate.
-The `idMatcher` parameter is a `Predicate<String>` that defines the condition to match the container ID.
+Introduced in version 3.2, the `KafkaListenerEndpointRegistry` now includes a method
+`getListenerContainersMatching` to fetch `MessageListenerContainer` instances based on specific ID criteria.
+This method accepts a `Predicate<String>` as the `idMatcher` argument, allowing for dynamic filtering based on container IDs.
 
-Usage scenarios include filtering and modifying containers for specific configuration characteristics,
-operational states, implemented in the container IDs.
+This functionality is useful for managing listener containers that meet certain conditions, such as
+specific configuration settings or operational states reflected in their IDs.
 
-For example, the following code retrieves all containers that have an ID that starts with `"productListener-retry-"`:
+For instance, to select listener containers for retry whose IDs begin with `"productListener-retry-"`, use:
 
-[source, java]
-----
-Collection<MessageListenerContainer> listeners =
-            registry.getListenerContainersMatching(id -> id.startsWith("-retry-"));
-----
-
+```java
+Collection<MessageListenerContainer> matchingContainers =
+    registry.getListenerContainersMatching(id -> id.startsWith("productListener-retry-"));
+```

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/receiving-messages/kafkalistener-lifecycle.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/receiving-messages/kafkalistener-lifecycle.adoc
@@ -41,3 +41,21 @@ IMPORTANT: Endpoints registered after the application context has been refreshed
 An example of late registration is a bean with a `@KafkaListener` in prototype scope where an instance is created after the context is initialized.
 Starting with version 2.8.7, you can set the registry's `alwaysStartAfterRefresh` property to `false` and then the container's `autoStartup` property will define whether or not the container is started.
 
+[[get-listener-containers-matching]]
+== Retrieve MessageListenerContainer instances Matching a Predicate
+
+Starting with version 3.2, the `ListenerContainerRegistry` interface and `KafkaListenerEndpointRegistry`
+implementation provides a method to retrieve all `MessageListenerContainer` instances that match a given predicate.
+The `idMatcher` parameter is a `Predicate<String>` that defines the condition to match the container ID.
+
+Usage scenarios include filtering and modifying containers for specific configuration characteristics,
+operational states, implemented in the container IDs.
+
+For example, the following code retrieves all containers that have an ID that starts with `"productListener-retry-"`:
+
+[source, java]
+----
+Collection<MessageListenerContainer> listeners =
+            registry.getListenerContainersMatching(id -> id.startsWith("-retry-"));
+----
+

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/receiving-messages/kafkalistener-lifecycle.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/receiving-messages/kafkalistener-lifecycle.adoc
@@ -41,19 +41,38 @@ IMPORTANT: Endpoints registered after the application context has been refreshed
 An example of late registration is a bean with a `@KafkaListener` in prototype scope where an instance is created after the context is initialized.
 Starting with version 2.8.7, you can set the registry's `alwaysStartAfterRefresh` property to `false` and then the container's `autoStartup` property will define whether or not the container is started.
 
-[[get-listener-containers-matching]]
-== Retrieve MessageListenerContainers with by matching a Predicate
+[[retrieving-message-listener-containers]]
 
-Introduced in version 3.2, the `KafkaListenerEndpointRegistry` now includes a method
-`getListenerContainersMatching` to fetch `MessageListenerContainer` instances based on specific ID criteria.
-This method accepts a `Predicate<String>` as the `idMatcher` argument, allowing for dynamic filtering based on container IDs.
+== Retrieving MessageListenerContainers from KafkaListenerEndpointRegistry
 
-This functionality is useful for managing listener containers that meet certain conditions, such as
-specific configuration settings or operational states reflected in their IDs.
+The `KafkaListenerEndpointRegistry` provides methods for retrieving `MessageListenerContainer` instances to accommodate a range of management scenarios:
 
-For instance, to select listener containers for retry whose IDs begin with `"productListener-retry-"`, use:
+**All Containers**: For operations that cover all listener containers, use `getListenerContainers()` to retrieve a comprehensive collection.
 
-```java
-Collection<MessageListenerContainer> matchingContainers =
-    registry.getListenerContainersMatching(id -> id.startsWith("productListener-retry-"));
-```
+[source, java]
+----
+Collection<MessageListenerContainer> allContainers = registry.getListenerContainers();
+----
+
+**Specific Container by ID**: To manage an individual container, `getListenerContainer(String id)` enables retrieval by its id.
+
+[source, java]
+----
+MessageListenerContainer specificContainer = registry.getListenerContainer("myContainerId");
+----
+
+**Containers Matching Predicate**: Introduced in version 3.2, `getListenerContainersMatching(Predicate<String> idMatcher)` allows for dynamic filtering of containers.
+This method is useful for selecting containers that adhere to specific criteria, such as configuration settings or operational states.
+For example, to find containers designated for retries:
+
+[source, java]
+----
+// Prefix matching?
+Collection<MessageListenerContainer> filteredContainers = registry.getListenerContainersMatching(id -> id.startsWith("productListener-retry-"));
+// Regex matching?
+Collection<MessageListenerContainer> filteredContainers = registry.getListenerContainersMatching(myPattern::matches);
+// Pre-built Set of IDs?
+Collection<MessageListenerContainer> filteredContainers = registry.getListenerContainersMatching(myIdSet::contains);
+----
+
+Utilize these methods to efficiently manage and query `MessageListenerContainer` instances within your application.

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/receiving-messages/kafkalistener-lifecycle.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/receiving-messages/kafkalistener-lifecycle.adoc
@@ -61,18 +61,29 @@ Collection<MessageListenerContainer> allContainers = registry.getListenerContain
 MessageListenerContainer specificContainer = registry.getListenerContainer("myContainerId");
 ----
 
-**Containers Matching Predicate**: Introduced in version 3.2, `getListenerContainersMatching(Predicate<String> idMatcher)` allows for dynamic filtering of containers.
-This method is useful for selecting containers that adhere to specific criteria, such as configuration settings or operational states.
-For example, to find containers designated for retries:
+**Dynamic Container Filtering**: Introduced in version 3.2, two overloaded `getListenerContainersMatching` methods enable refined selection of containers.
+One method takes a `Predicate<String>` for ID-based filtering as a parameter, while the other takes a `BiPredicate<String, MessageListenerContainer>`
+for more advanced criteria that may include container properties or state as a parameter.
 
 [source, java]
 ----
-// Prefix matching?
-Collection<MessageListenerContainer> filteredContainers = registry.getListenerContainersMatching(id -> id.startsWith("productListener-retry-"));
-// Regex matching?
-Collection<MessageListenerContainer> filteredContainers = registry.getListenerContainersMatching(myPattern::matches);
-// Pre-built Set of IDs?
-Collection<MessageListenerContainer> filteredContainers = registry.getListenerContainersMatching(myIdSet::contains);
+// Prefix matching (Predicate<String>)
+Collection<MessageListenerContainer> filteredContainers =
+    registry.getListenerContainersMatching(id -> id.startsWith("productListener-retry-"));
+
+// Regex matching (Predicate<String>)
+Collection<MessageListenerContainer> regexFilteredContainers =
+    registry.getListenerContainersMatching(myPattern::matches);
+
+// Pre-built Set of IDs (Predicate<String>)
+Collection<MessageListenerContainer> setFilteredContainers =
+    registry.getListenerContainersMatching(myIdSet::contains);
+
+// Advanced Filtering: ID prefix and running state (BiPredicate<String, MessageListenerContainer>)
+Collection<MessageListenerContainer> advancedFilteredContainers =
+    registry.getListenerContainersMatching(
+        (id, container) -> id.startsWith("specificPrefix-") && container.isRunning()
+    );
 ----
 
 Utilize these methods to efficiently manage and query `MessageListenerContainer` instances within your application.

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -85,10 +85,11 @@ as a default prefix for auto-generated client IDs for certain client types.
 See xref:kafka/connecting.adoc#default-client-id-prefixes[Default client ID prefixes] for more details.
 
 [[get-listener-containers-matching]]
-=== ListenerContainerRegistry's new getListenerContainersMatching(Predicate<String> idMatcher) method
+== Retrieve MessageListenerContainers with by matching a Predicate
 
-Introduces a new method `getListenerContainersMatching` since version 3.2, which returns all `MessageListenerContainer`
-instances whose ID matches a specified (non-null) `Predicate<String>`. This addition provides a flexible way to
-retrieve containers by more complex criteria than just a direct ID match.
+Starting with version 3.2, the `ListenerContainerRegistry` introduces the `getListenerContainersMatching` method.
+This method filters `MessageListenerContainer` instances based on a `Predicate<String>` applied to their IDs.
+It's designed for scenarios requiring more nuanced selection than simple ID matching,
+offering a powerful tool for dynamic container management.
 
-See xref:kafka/receiving-messages/kafkalistener-lifecycle.adoc#get-listener-containers-matching[ `@KafkaListener` Lifecycle Management API Docs] for more details.
+See xref:kafka/receiving-messages/kafkalistener-lifecycle.adoc#get-listener-containers-matching[`@KafkaListener` Lifecycle Management's API Docs] for more information.

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -87,22 +87,8 @@ See xref:kafka/connecting.adoc#default-client-id-prefixes[Default client ID pref
 [[get-listener-containers-matching]]
 == Enhanced Retrieval of MessageListenerContainers
 
-Introduced in version 3.2, the `ListenerContainerRegistry` provides advanced methods for dynamically filtering `MessageListenerContainer` instances, enhancing management capabilities.
-
-Two filtering methods are available:
-
-- **Filter by ID**: Using `getListenerContainersMatching(Predicate<String> idMatcher)`, you can filter containers by their IDs, ideal for ID-centric selection criteria.
-
-- **Advanced Filter by ID and Properties**: The `getListenerContainersMatching(BiPredicate<String, MessageListenerContainer>)` method allows for more sophisticated filtering, taking into account both the container's ID and its properties. This enables detailed filtering based on the container's state, configuration, or other relevant characteristics.
-
-```java
-// Example: Filter containers by ID
-Collection<MessageListenerContainer> filteredContainers =
-    registry.getListenerContainersMatching(id -> id.startsWith("specificPrefix-"));
-
-// Example: Advanced filter by ID and container state
-Collection<MessageListenerContainer> advancedFilteredContainers =
-    registry.getListenerContainersMatching((id, container) -> id.startsWith("specificPrefix-") && container.isRunning());
-```
+`ListenerContainerRegistry` provides two new API's dynamically find and filter `MessageListenerContainer` instances.
+`getListenerContainersMatching(Predicate<String> idMatcher)` to filter by ID and the other is
+`getListenerContainersMatching(BiPredicate<String, MessageListenerContainer> matcher)` to filter by ID and container properties.
 
 See xref:kafka/receiving-messages/kafkalistener-lifecycle.adoc#retrieving-message-listener-containers[`@KafkaListener` Lifecycle Management's API Docs] for more information.

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -83,3 +83,12 @@ See xref:kafka/seek.adoc#seek[Seek API Docs] for more details.
 For Spring Boot applications which define an application name, this name is now used
 as a default prefix for auto-generated client IDs for certain client types.
 See xref:kafka/connecting.adoc#default-client-id-prefixes[Default client ID prefixes] for more details.
+
+[[get-listener-containers-matching]]
+=== ListenerContainerRegistry's new getListenerContainersMatching(Predicate<String> idMatcher) method
+
+Introduces a new method `getListenerContainersMatching` since version 3.2, which returns all `MessageListenerContainer`
+instances whose ID matches a specified (non-null) `Predicate<String>`. This addition provides a flexible way to
+retrieve containers by more complex criteria than just a direct ID match.
+
+See xref:kafka/receiving-messages/kafkalistener-lifecycle.adoc#get-listener-containers-matching[ `@KafkaListener` Lifecycle Management API Docs] for more details.

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -85,11 +85,24 @@ as a default prefix for auto-generated client IDs for certain client types.
 See xref:kafka/connecting.adoc#default-client-id-prefixes[Default client ID prefixes] for more details.
 
 [[get-listener-containers-matching]]
-== Retrieve MessageListenerContainers with by matching a Predicate
+== Enhanced Retrieval of MessageListenerContainers
 
-Starting with version 3.2, the `ListenerContainerRegistry` introduces the `getListenerContainersMatching` method.
-This method filters `MessageListenerContainer` instances based on a `Predicate<String>` applied to their IDs.
-It's designed for scenarios requiring more nuanced selection than simple ID matching,
-offering a powerful tool for dynamic container management.
+Introduced in version 3.2, the `ListenerContainerRegistry` provides advanced methods for dynamically filtering `MessageListenerContainer` instances, enhancing management capabilities.
 
-See xref:kafka/receiving-messages/kafkalistener-lifecycle.adoc#get-listener-containers-matching[`@KafkaListener` Lifecycle Management's API Docs] for more information.
+Two filtering methods are available:
+
+- **Filter by ID**: Using `getListenerContainersMatching(Predicate<String> idMatcher)`, you can filter containers by their IDs, ideal for ID-centric selection criteria.
+
+- **Advanced Filter by ID and Properties**: The `getListenerContainersMatching(BiPredicate<String, MessageListenerContainer>)` method allows for more sophisticated filtering, taking into account both the container's ID and its properties. This enables detailed filtering based on the container's state, configuration, or other relevant characteristics.
+
+```java
+// Example: Filter containers by ID
+Collection<MessageListenerContainer> filteredContainers =
+    registry.getListenerContainersMatching(id -> id.startsWith("specificPrefix-"));
+
+// Example: Advanced filter by ID and container state
+Collection<MessageListenerContainer> advancedFilteredContainers =
+    registry.getListenerContainersMatching((id, container) -> id.startsWith("specificPrefix-") && container.isRunning());
+```
+
+Refer to the [`@KafkaListener` Lifecycle Management's API Docs](kafka/receiving-messages/kafkalistener-lifecycle.adoc#get-listener-containers-matching) for detailed usage and further information.

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -105,4 +105,4 @@ Collection<MessageListenerContainer> advancedFilteredContainers =
     registry.getListenerContainersMatching((id, container) -> id.startsWith("specificPrefix-") && container.isRunning());
 ```
 
-Refer to the [`@KafkaListener` Lifecycle Management's API Docs](kafka/receiving-messages/kafkalistener-lifecycle.adoc#get-listener-containers-matching) for detailed usage and further information.
+See xref:kafka/receiving-messages/kafkalistener-lifecycle.adoc#retrieving-message-listener-containers[`@KafkaListener` Lifecycle Management's API Docs] for more information.

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistry.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistry.java
@@ -159,7 +159,6 @@ public class KafkaListenerEndpointRegistry implements ListenerContainerRegistry,
 			.toList();
 	}
 
-
 	@Override
 	@Nullable
 	public MessageListenerContainer getUnregisteredListenerContainer(String id) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistry.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistry.java
@@ -26,7 +26,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import org.apache.commons.logging.LogFactory;
 
@@ -125,16 +124,16 @@ public class KafkaListenerEndpointRegistry implements ListenerContainerRegistry,
 	 * @return the containers or empty {@link Collection} if no container with that id exists
 	 * @see #getListenerContainerIds()
 	 * @see #getListenerContainer(String)
+	 * @since 3.2
 	 */
 	@Override
 	public Collection<MessageListenerContainer> getListenerContainersMatching(Predicate<String> idMatcher) {
 		Assert.notNull(idMatcher, "'idMatcher' cannot be null");
-		List<MessageListenerContainer> matchingContainers = this.listenerContainers.entrySet()
+		return this.listenerContainers.entrySet()
 			.stream()
 			.filter(entry -> idMatcher.test(entry.getKey()))
 			.map(Map.Entry::getValue)
-			.collect(Collectors.toList());
-		return Collections.unmodifiableCollection(matchingContainers);
+			.toList();
 	}
 
 	@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistry.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistry.java
@@ -122,9 +122,9 @@ public class KafkaListenerEndpointRegistry implements ListenerContainerRegistry,
 	 * empty {@link Collection} if no such container exists.
 	 * @param idMatcher the predicate to match container id with
 	 * @return the containers or empty {@link Collection} if no container with that id exists
+	 * @since 3.2
 	 * @see #getListenerContainerIds()
 	 * @see #getListenerContainer(String)
-	 * @since 3.2
 	 */
 	@Override
 	public Collection<MessageListenerContainer> getListenerContainersMatching(Predicate<String> idMatcher) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistry.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistry.java
@@ -25,6 +25,8 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import org.apache.commons.logging.LogFactory;
 
@@ -67,6 +69,7 @@ import org.springframework.util.StringUtils;
  * @author Gary Russell
  * @author Asi Bross
  * @author Wang Zhiyang
+ * @author Joo Hyuk Kim
  *
  * @see KafkaListenerEndpoint
  * @see MessageListenerContainer
@@ -113,6 +116,25 @@ public class KafkaListenerEndpointRegistry implements ListenerContainerRegistry,
 	public MessageListenerContainer getListenerContainer(String id) {
 		Assert.hasText(id, "Container identifier must not be empty");
 		return this.listenerContainers.get(id);
+	}
+
+	/**
+	 * Return all {@link MessageListenerContainer} instances with id matching the predicate or
+	 * empty {@link Collection} if no such container exists.
+	 * @param idMatcher the predicate to match container id with
+	 * @return the containers or empty {@link Collection} if no container with that id exists
+	 * @see #getListenerContainerIds()
+	 * @see #getListenerContainer(String)
+	 */
+	@Override
+	public Collection<MessageListenerContainer> getListenerContainersMatching(Predicate<String> idMatcher) {
+		Assert.notNull(idMatcher, "'idMatcher' cannot be null");
+		List<MessageListenerContainer> matchingContainers = this.listenerContainers.entrySet()
+			.stream()
+			.filter(entry -> idMatcher.test(entry.getKey()))
+			.map(Map.Entry::getValue)
+			.collect(Collectors.toList());
+		return Collections.unmodifiableCollection(matchingContainers);
 	}
 
 	@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistry.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistry.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 
 import org.apache.commons.logging.LogFactory;
@@ -135,6 +136,29 @@ public class KafkaListenerEndpointRegistry implements ListenerContainerRegistry,
 			.map(Map.Entry::getValue)
 			.toList();
 	}
+
+	/**
+	 * Return all {@link MessageListenerContainer} instances that satisfy the given bi-predicate.
+	 * The {@code BiPredicate<String, MessageListenerContainer>} takes the container id and the container itself as arguments.
+	 * This allows for more sophisticated filtering, including properties or state of the container itself.
+	 * @param idAndContainerMatcher the bi-predicate to match the container id and the container
+	 * @return the containers that match the bi-predicate criteria or an empty {@link Collection} if no matching containers exist
+	 * @since 3.2
+	 * @see #getListenerContainerIds()
+	 * @see #getListenerContainersMatching(Predicate)
+	 */
+	@Override
+	public Collection<MessageListenerContainer> getListenerContainersMatching(
+		BiPredicate<String, MessageListenerContainer> idAndContainerMatcher
+	) {
+		Assert.notNull(idAndContainerMatcher, "'idAndContainerMatcher' cannot be null");
+		return this.listenerContainers.entrySet()
+			.stream()
+			.filter(entry -> idAndContainerMatcher.test(entry.getKey(), entry.getValue()))
+			.map(Map.Entry::getValue)
+			.toList();
+	}
+
 
 	@Override
 	@Nullable

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ListenerContainerRegistry.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ListenerContainerRegistry.java
@@ -26,6 +26,7 @@ import org.springframework.lang.Nullable;
  * A registry for listener containers.
  *
  * @author Gary Russell
+ * @author Joo Hyuk Kim
  * @since 2.7
  *
  */
@@ -49,6 +50,7 @@ public interface ListenerContainerRegistry {
 	 * @return the containers or empty {@link Collection} if no container with that id exists
 	 * @see #getListenerContainerIds()
 	 * @see #getListenerContainer(String)
+	 * @since 3.2
 	 */
 	Collection<MessageListenerContainer> getListenerContainersMatching(Predicate<String> idMatcher);
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ListenerContainerRegistry.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ListenerContainerRegistry.java
@@ -48,9 +48,9 @@ public interface ListenerContainerRegistry {
 	 * empty {@link Collection} if no such container exists.
 	 * @param idMatcher the predicate to match the container id with
 	 * @return the containers or empty {@link Collection} if no container with that id exists
+	 * @since 3.2
 	 * @see #getListenerContainerIds()
 	 * @see #getListenerContainer(String)
-	 * @since 3.2
 	 */
 	Collection<MessageListenerContainer> getListenerContainersMatching(Predicate<String> idMatcher);
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ListenerContainerRegistry.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ListenerContainerRegistry.java
@@ -65,7 +65,8 @@ public interface ListenerContainerRegistry {
 	 * @see #getListenerContainerIds()
 	 * @see #getListenerContainersMatching(Predicate)
 	 */
-	Collection<MessageListenerContainer> getListenerContainersMatching(BiPredicate<String, MessageListenerContainer> idAndContainerMatcher);
+	Collection<MessageListenerContainer> getListenerContainersMatching(
+		BiPredicate<String, MessageListenerContainer> idAndContainerMatcher);
 
 	/**
 	 * Return the {@link MessageListenerContainer} with the specified id or {@code null}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ListenerContainerRegistry.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ListenerContainerRegistry.java
@@ -18,6 +18,7 @@ package org.springframework.kafka.listener;
 
 import java.util.Collection;
 import java.util.Set;
+import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 
 import org.springframework.lang.Nullable;
@@ -53,6 +54,18 @@ public interface ListenerContainerRegistry {
 	 * @see #getListenerContainer(String)
 	 */
 	Collection<MessageListenerContainer> getListenerContainersMatching(Predicate<String> idMatcher);
+
+	/**
+	 * Return all {@link MessageListenerContainer} instances that satisfy the given bi-predicate.
+	 * The {@code BiPredicate<String, MessageListenerContainer>} takes the container id and the container itself as arguments.
+	 * This allows for more sophisticated filtering, including properties or state of the container itself.
+	 * @param idAndContainerMatcher the bi-predicate to match the container id and the container
+	 * @return the containers that match the bi-predicate criteria or an empty {@link Collection} if no matching containers exist
+	 * @since 3.2
+	 * @see #getListenerContainerIds()
+	 * @see #getListenerContainersMatching(Predicate)
+	 */
+	Collection<MessageListenerContainer> getListenerContainersMatching(BiPredicate<String, MessageListenerContainer> idAndContainerMatcher);
 
 	/**
 	 * Return the {@link MessageListenerContainer} with the specified id or {@code null}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ListenerContainerRegistry.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ListenerContainerRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package org.springframework.kafka.listener;
 
 import java.util.Collection;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import org.springframework.lang.Nullable;
 
@@ -40,6 +41,16 @@ public interface ListenerContainerRegistry {
 	 */
 	@Nullable
 	MessageListenerContainer getListenerContainer(String id);
+
+	/**
+	 * Return all {@link MessageListenerContainer} instances with id matching the predicate or
+	 * empty {@link Collection} if no such container exists.
+	 * @param idMatcher the predicate to match the container id with
+	 * @return the containers or empty {@link Collection} if no container with that id exists
+	 * @see #getListenerContainerIds()
+	 * @see #getListenerContainer(String)
+	 */
+	Collection<MessageListenerContainer> getListenerContainersMatching(Predicate<String> idMatcher);
 
 	/**
 	 * Return the {@link MessageListenerContainer} with the specified id or {@code null}

--- a/spring-kafka/src/test/java/org/springframework/kafka/config/KafkaListenerEndpointRegistryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/config/KafkaListenerEndpointRegistryTests.java
@@ -75,6 +75,7 @@ public class KafkaListenerEndpointRegistryTests {
             .withMessage("'idMatcher' cannot be null");
     }
 
+	@DisplayName("getListenerContainersMatching should return unmodifiable list")
 	@Test
     void testGetListenerContainersMatchingReturnsUnmodifiableList() {
         // Given

--- a/spring-kafka/src/test/java/org/springframework/kafka/config/KafkaListenerEndpointRegistryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/config/KafkaListenerEndpointRegistryTests.java
@@ -23,8 +23,7 @@ import java.util.Map;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
@@ -42,6 +41,7 @@ import org.springframework.kafka.listener.MessageListenerContainer;
 
 /**
  * @author Gary Russell
+ * @author Joo Hyuk Kim
  * @since 2.8.9
  *
  */
@@ -84,7 +84,8 @@ public class KafkaListenerEndpointRegistryTests {
         // When
         Collection<MessageListenerContainer> listeners = registry.getListenerContainersMatching(s -> true);
         // Then
-        assertThrows(UnsupportedOperationException.class, () -> listeners.add(mock(MessageListenerContainer.class)));
+		assertThatExceptionOfType(UnsupportedOperationException.class)
+			.isThrownBy(() -> listeners.add(mock(MessageListenerContainer.class)));
     }
 
 
@@ -123,11 +124,11 @@ public class KafkaListenerEndpointRegistryTests {
 		);
 	}
 
-	private void registerWithListenerIds(KafkaListenerEndpointRegistry registry, List<String> names) {
+	private static void registerWithListenerIds(KafkaListenerEndpointRegistry registry, List<String> names) {
 		names.forEach(name -> registerListenerWithId(registry, name));
 	}
 
-	private void registerListenerWithId(KafkaListenerEndpointRegistry registry, String id) {
+	private static void registerListenerWithId(KafkaListenerEndpointRegistry registry, String id) {
 		KafkaListenerEndpoint endpoint = mock(KafkaListenerEndpoint.class);
 		@SuppressWarnings("unchecked")
 		KafkaListenerContainerFactory<MessageListenerContainer> factory = mock(KafkaListenerContainerFactory.class);

--- a/spring-kafka/src/test/java/org/springframework/kafka/config/KafkaListenerEndpointRegistryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/config/KafkaListenerEndpointRegistryTests.java
@@ -16,34 +16,30 @@
 
 package org.springframework.kafka.config;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Predicate;
-import java.util.stream.Stream;
-
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.kafka.listener.ListenerContainerRegistry;
+
 import org.springframework.kafka.listener.MessageListenerContainer;
 
 /**
  * @author Gary Russell
  * @author Joo Hyuk Kim
  * @since 2.8.9
- *
  */
 public class KafkaListenerEndpointRegistryTests {
 
@@ -64,30 +60,29 @@ public class KafkaListenerEndpointRegistryTests {
 	}
 
 	@DisplayName("getListenerContainersMatching throws on null predicate")
-    @Test
-    void getListenerContainersMatchingThrowsOnNullPredicate() {
+	@Test
+	void getListenerContainersMatchingThrowsOnNullPredicate() {
 		// Given
-        KafkaListenerEndpointRegistry registry = new KafkaListenerEndpointRegistry();
+		KafkaListenerEndpointRegistry registry = new KafkaListenerEndpointRegistry();
 		// When
 		// Then
-        assertThatIllegalArgumentException()
+		assertThatIllegalArgumentException()
 			.isThrownBy(() -> registry.getListenerContainersMatching(null))
-            .withMessage("'idMatcher' cannot be null");
-    }
+			.withMessage("'idMatcher' cannot be null");
+	}
 
 	@DisplayName("getListenerContainersMatching should return unmodifiable list")
 	@Test
-    void testGetListenerContainersMatchingReturnsUnmodifiableList() {
-        // Given
-        KafkaListenerEndpointRegistry registry = new KafkaListenerEndpointRegistry();
-        registerListenerWithId(registry, "foo");
-        // When
-        Collection<MessageListenerContainer> listeners = registry.getListenerContainersMatching(s -> true);
-        // Then
+	void testGetListenerContainersMatchingReturnsUnmodifiableList() {
+		// Given
+		KafkaListenerEndpointRegistry registry = new KafkaListenerEndpointRegistry();
+		registerListenerWithId(registry, "foo");
+		// When
+		Collection<MessageListenerContainer> listeners = registry.getListenerContainersMatching(s -> true);
+		// Then
 		assertThatExceptionOfType(UnsupportedOperationException.class)
 			.isThrownBy(() -> listeners.add(mock(MessageListenerContainer.class)));
-    }
-
+	}
 
 
 	@ParameterizedTest(name = "getListenerContainersMatching({0}, {1}) = {2}")

--- a/spring-kafka/src/test/java/org/springframework/kafka/config/KafkaListenerEndpointRegistryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/config/KafkaListenerEndpointRegistryTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,28 @@
 
 package org.springframework.kafka.config;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.kafka.listener.ListenerContainerRegistry;
 import org.springframework.kafka.listener.MessageListenerContainer;
 
 /**
@@ -47,4 +63,76 @@ public class KafkaListenerEndpointRegistryTests {
 		assertThat(unregistered).isSameAs(container);
 	}
 
+	@DisplayName("getListenerContainersMatching throws on null predicate")
+    @Test
+    void getListenerContainersMatchingThrowsOnNullPredicate() {
+		// Given
+        KafkaListenerEndpointRegistry registry = new KafkaListenerEndpointRegistry();
+		// When
+		// Then
+        assertThatIllegalArgumentException()
+			.isThrownBy(() -> registry.getListenerContainersMatching(null))
+            .withMessage("'idMatcher' cannot be null");
+    }
+
+	@Test
+    void testGetListenerContainersMatchingReturnsUnmodifiableList() {
+        // Given
+        KafkaListenerEndpointRegistry registry = new KafkaListenerEndpointRegistry();
+        registerListenerWithId(registry, "foo");
+        // When
+        Collection<MessageListenerContainer> listeners = registry.getListenerContainersMatching(s -> true);
+        // Then
+        assertThrows(UnsupportedOperationException.class, () -> listeners.add(mock(MessageListenerContainer.class)));
+    }
+
+
+
+	@ParameterizedTest(name = "getListenerContainersMatching({0}, {1}) = {2}")
+	@MethodSource("paramsForGetListenerContainersMatching")
+	void getListenerContainersMatching(List<String> names, Predicate<String> idMatcher, int expectedCount) {
+		// Given
+		KafkaListenerEndpointRegistry registry = new KafkaListenerEndpointRegistry();
+		registerWithListenerIds(registry, names);
+		// When
+		Collection<MessageListenerContainer> listeners = registry.getListenerContainersMatching(idMatcher);
+		// Then
+		assertThat(listeners).hasSize(expectedCount);
+	}
+
+	/**
+	 * Provides parameters for the getListenerContainersMatching test.
+	 * Each set of parameters includes a list of names, a predicate, and the expected count of matching containers.
+	 *
+	 * @return Stream of Arguments for the parameterized test.
+	 */
+	private static Stream<Arguments> paramsForGetListenerContainersMatching() {
+		List<String> names = List.of("foo", "bar", "baz");
+		return Stream.of(
+			// Test case: Two names start with "b"
+			Arguments.of(names, (Predicate<String>) id -> id.startsWith("b"), 2),
+			// Test case: One name starts with "f"
+			Arguments.of(names, (Predicate<String>) id -> id.startsWith("f"), 1),
+			// Corner case: Empty list
+			Arguments.of(new ArrayList<>(), (Predicate<String>) id -> id.startsWith("b"), 0),
+			// Corner case: All names match as the predicate always returns true
+			Arguments.of(names, (Predicate<String>) id -> true, 3),
+			// Corner case: No names match as the predicate always returns false
+			Arguments.of(names, (Predicate<String>) id -> false, 0)
+		);
+	}
+
+	private void registerWithListenerIds(KafkaListenerEndpointRegistry registry, List<String> names) {
+		names.forEach(name -> registerListenerWithId(registry, name));
+	}
+
+	private void registerListenerWithId(KafkaListenerEndpointRegistry registry, String id) {
+		KafkaListenerEndpoint endpoint = mock(KafkaListenerEndpoint.class);
+		@SuppressWarnings("unchecked")
+		KafkaListenerContainerFactory<MessageListenerContainer> factory = mock(KafkaListenerContainerFactory.class);
+		given(endpoint.getId()).willReturn(id);
+		MessageListenerContainer container = mock(MessageListenerContainer.class);
+		given(factory.createListenerContainer(endpoint)).willReturn(container);
+		registry.registerListenerContainer(endpoint, factory);
+	}
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/config/KafkaListenerEndpointRegistryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/config/KafkaListenerEndpointRegistryTests.java
@@ -179,4 +179,5 @@ public class KafkaListenerEndpointRegistryTests {
 		given(factory.createListenerContainer(endpoint)).willReturn(container);
 		registry.registerListenerContainer(endpoint, factory);
 	}
+
 }


### PR DESCRIPTION
Resolves #3135 