### PR TITLE
Introduce Confluent ParallelConsumer to Spring Kafka

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -73,6 +73,7 @@ ext {
 	springRetryVersion = '2.0.5'
 	springVersion = '6.1.5'
 	zookeeperVersion = '3.8.4'
+	parallelConsumerVersion = '0.5.2.8'
 
 	idPrefix = 'kafka'
 
@@ -288,6 +289,9 @@ project ('spring-kafka') {
 		optionalApi ('com.fasterxml.jackson.module:jackson-module-kotlin') {
 			exclude group: 'org.jetbrains.kotlin'
 		}
+
+		// Parallel Consumer
+		api "io.confluent.parallelconsumer:parallel-consumer-core:$parallelConsumerVersion"
 
 		// Spring Data projection message binding support
 		optionalApi ("org.springframework.data:spring-data-commons") {

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/EnableParallelConsumer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/EnableParallelConsumer.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.annotation;
+
+import org.springframework.context.annotation.Import;
+import org.springframework.kafka.config.ParallelConsumerConfiguration;
+import org.springframework.kafka.config.ParallelConsumerImportSelector;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * If you want to import {@link ParallelConsumerConfiguration} to your application,
+ * you just annotated {@link EnableParallelConsumer} to your spring application.
+ * @author ...
+ * @since 3.2.0
+ */
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Import(ParallelConsumerImportSelector.class)
+public @interface EnableParallelConsumer {
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/ParallelConsumerConfig.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/ParallelConsumerConfig.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2014-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.config;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.consumer.Consumer;
+
+import io.confluent.parallelconsumer.ParallelConsumerOptions;
+import io.confluent.parallelconsumer.ParallelConsumerOptions.ProcessingOrder;
+import org.springframework.util.StringUtils;
+import org.springframework.kafka.annotation.EnableParallelConsumer;
+
+/**
+ * ParallelConsumerConfig is for config of {@link io.confluent.parallelconsumer}.
+ * This will be registered as Spring Bean when {@link EnableParallelConsumer} is annotated to your spring application.
+ * @author ...
+ * @since 3.2.0
+ */
+
+public class ParallelConsumerConfig {
+
+
+	private static final String PARALLEL_CONSUMER_MAX_CONCURRENCY = "PARALLEL_CONSUMER_MAX_CONCURRENCY";
+	private static final String PARALLEL_CONSUMER_ORDERING = "PARALLEL_CONSUMER_ORDERING";
+	private static final String ALLOW_EAGER_PROCESSING_DURING_TRANSACTION_COMMIT = "ALLOW_EAGER_PROCESSING_DURING_TRANSACTION_COMMIT";
+	private static final String COMMIT_LOCK_ACQUISITION_TIMEOUT = "COMMIT_LOCK_ACQUISITION_TIMEOUT";
+	private static final String COMMIT_INTERVAL = "COMMIT_INTERVAL";
+	private final Map<String, String> properties = new HashMap<>();
+
+	public ParallelConsumerConfig() {
+
+		final String maxConcurrency = System.getenv(PARALLEL_CONSUMER_MAX_CONCURRENCY);
+		final String ordering = System.getenv(PARALLEL_CONSUMER_ORDERING);
+		final String allowEagerProcessingDuringTransactionCommit = System.getenv(ALLOW_EAGER_PROCESSING_DURING_TRANSACTION_COMMIT);
+		final String commitLockAcquisitionTimeout = System.getenv(COMMIT_LOCK_ACQUISITION_TIMEOUT);
+		final String commitInterval = System.getenv(COMMIT_INTERVAL);
+
+		this.properties.put(PARALLEL_CONSUMER_MAX_CONCURRENCY, maxConcurrency);
+		this.properties.put(PARALLEL_CONSUMER_ORDERING, ordering);
+		this.properties.put(ALLOW_EAGER_PROCESSING_DURING_TRANSACTION_COMMIT, allowEagerProcessingDuringTransactionCommit);
+		this.properties.put(COMMIT_LOCK_ACQUISITION_TIMEOUT, commitLockAcquisitionTimeout);
+		this.properties.put(COMMIT_INTERVAL, commitInterval);
+	}
+
+	private ProcessingOrder toOrder(String order) {
+		return switch (order) {
+			case "partition" -> ProcessingOrder.PARTITION;
+			case "unordered" -> ProcessingOrder.UNORDERED;
+			default -> ProcessingOrder.KEY; // Confluent Consumer Default Policy
+		};
+	}
+
+	public <K,V> ParallelConsumerOptions<K, V> toConsumerOptions(Consumer<K, V> consumer) {
+
+		ParallelConsumerOptions.ParallelConsumerOptionsBuilder<K, V> builder = ParallelConsumerOptions.builder();
+		builder.consumer(consumer);
+
+		final String maxConcurrencyString = this.properties.get(PARALLEL_CONSUMER_MAX_CONCURRENCY);
+		final String orderingString = this.properties.get(PARALLEL_CONSUMER_ORDERING);
+		final String allowEagerProcessingDuringTransactionCommitString = this.properties.get(ALLOW_EAGER_PROCESSING_DURING_TRANSACTION_COMMIT);
+		final String commitLockAcquisitionTimeoutString = this.properties.get(COMMIT_LOCK_ACQUISITION_TIMEOUT);
+		final String commitIntervalString = this.properties.get(COMMIT_INTERVAL);
+
+		if (StringUtils.hasText(maxConcurrencyString)) {
+			final Integer maxConcurrency = Integer.valueOf(maxConcurrencyString);
+			builder.maxConcurrency(maxConcurrency);
+		}
+
+		if (StringUtils.hasText(orderingString)) {
+			final ProcessingOrder processingOrder = toOrder(orderingString);
+			builder.ordering(processingOrder);
+		}
+
+		if (StringUtils.hasText(allowEagerProcessingDuringTransactionCommitString)) {
+			final Boolean allowEagerProcessingDuringTransactionCommit = Boolean.valueOf(allowEagerProcessingDuringTransactionCommitString);
+			builder.allowEagerProcessingDuringTransactionCommit(allowEagerProcessingDuringTransactionCommit);
+		}
+
+		if (StringUtils.hasText(commitLockAcquisitionTimeoutString)) {
+			final Long commitLockAcquisitionTimeout = Long.valueOf(commitLockAcquisitionTimeoutString);
+			builder.commitLockAcquisitionTimeout(Duration.ofSeconds(commitLockAcquisitionTimeout));
+		}
+
+		if (StringUtils.hasText(commitIntervalString)) {
+			final Long commitInterval = Long.valueOf(commitIntervalString);
+			builder.commitInterval(Duration.ofMillis(commitInterval));
+		}
+
+		return builder.build();
+	}
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/ParallelConsumerConfiguration.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/ParallelConsumerConfiguration.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.ParallelConsumerCallback;
+import org.springframework.kafka.core.ParallelConsumerFactory;
+import org.springframework.kafka.annotation.EnableParallelConsumer;
+
+/**
+ * If User decide to use parallelConsumer on SpringKafka, User should import this class to their ComponentScan scopes.
+ * If so, this class will register both {@link ParallelConsumerContext} and {@link ParallelConsumerFactory} as Spring Bean.
+ * User has responsibility
+ *   1. annotated {@link EnableParallelConsumer} on their spring application
+ *   2. register ConcreteClass of {@link ParallelConsumerCallback}.
+ * @author ...
+ * @since 3.2.0
+ */
+
+public class ParallelConsumerConfiguration<K, V> {
+
+	@Bean(name = ParallelConsumerContext.DEFAULT_BEAN_NAME)
+	public ParallelConsumerContext<K,V> parallelConsumerContext(ParallelConsumerCallback<K, V> parallelConsumerCallback) {
+		return new ParallelConsumerContext(parallelConsumerCallback);
+	}
+
+	@Bean(name = ParallelConsumerFactory.DEFAULT_BEAN_NAME)
+	public ParallelConsumerFactory<K,V> parallelConsumerFactory(DefaultKafkaConsumerFactory<K,V> consumerFactory,
+																ParallelConsumerContext<K,V> parallelConsumerContext) {
+		return new ParallelConsumerFactory(parallelConsumerContext, consumerFactory);
+	}
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/ParallelConsumerContext.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/ParallelConsumerContext.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2014-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.config;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.springframework.kafka.core.ParallelConsumerCallback;
+
+import io.confluent.parallelconsumer.ParallelConsumerOptions;
+import io.confluent.parallelconsumer.ParallelStreamProcessor;
+
+/**
+ * This class is for aggregating all related with ParallelConsumer.
+ * @author ...
+ * @since 3.2.0
+ */
+
+
+public class ParallelConsumerContext<K,V> {
+
+	public static final String DEFAULT_BEAN_NAME = "parallelConsumerContext";
+	private final ParallelConsumerConfig parallelConsumerConfig;
+	private final ParallelConsumerCallback<K,V> parallelConsumerCallback;
+	private ParallelStreamProcessor<K, V> processor;
+
+	public ParallelConsumerContext(ParallelConsumerCallback<K, V> callback) {
+		this.parallelConsumerConfig = new ParallelConsumerConfig();
+		this.parallelConsumerCallback = callback;
+	}
+
+
+	public ParallelConsumerCallback<K,V> parallelConsumerCallback() {
+		return this.parallelConsumerCallback;
+	}
+
+
+	public ParallelStreamProcessor<K, V> createConsumer(Consumer<K,V> consumer) {
+		final ParallelConsumerOptions<K, V> options = parallelConsumerConfig.toConsumerOptions(consumer);
+		this.processor = ParallelStreamProcessor.createEosStreamProcessor(options);
+		return this.processor;
+	}
+
+	public void stopParallelConsumer() {
+		this.processor.close();
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/ParallelConsumerImportSelector.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/ParallelConsumerImportSelector.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.config;
+
+import org.springframework.context.annotation.ImportSelector;
+import org.springframework.core.type.AnnotationMetadata;
+import org.springframework.kafka.annotation.EnableParallelConsumer;
+/**
+ * ParallelConsumerImportSelector is to register {@link ParallelConsumerConfiguration}.
+ * If you want to import {@link ParallelConsumerConfiguration} to your application,
+ * you just annotated {@link EnableParallelConsumer} to your spring application.
+ * @author ...
+ * @since 3.2.0
+ */
+
+public class ParallelConsumerImportSelector implements ImportSelector {
+	@Override
+	public String[] selectImports(AnnotationMetadata importingClassMetadata) {
+		return new String[]{ParallelConsumerConfiguration.class.getName()};
+	}
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/ParallelConsumerCallback.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/ParallelConsumerCallback.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.core;
+
+import java.util.List;
+
+import io.confluent.parallelconsumer.PollContext;
+import org.springframework.kafka.config.ParallelConsumerContext;
+
+/**
+ * User should create ConcreteClass of this and register it as Spring Bean.
+ * Concrete class of ParallelConsumerCallback will be registered {@link ParallelConsumerContext},
+ * and then it will be used in {@link ParallelConsumerFactory} when ParallelConsumerFactory start.
+ * @author ...
+ * @since 3.2.0
+ */
+
+public interface ParallelConsumerCallback<K, V> {
+
+	/**
+	 * This is for {@link ParallelConsumerFactory} and {@link ParallelConsumerContext}.
+	 * ParallelConsumer will process the consumed messages using this callback.
+	 * @param context context which Parallel Consumer produce
+	 * @return void.
+	 */
+	void accept(PollContext<K, V> context);
+	List<String> getTopics();
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/ParallelConsumerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/ParallelConsumerFactory.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2014-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.core;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.springframework.context.SmartLifecycle;
+import org.springframework.kafka.config.ParallelConsumerContext;
+
+import io.confluent.parallelconsumer.ParallelStreamProcessor;
+
+/**
+ * ParallelConsumerFactory will be started and closed by Spring LifeCycle.
+ * This class is quite simple, because ParallelConsumer requires delegating the situation to itself.
+ * @author ...
+ * @since 3.2.0
+ */
+
+public class ParallelConsumerFactory<K, V> implements SmartLifecycle {
+
+	public static final String DEFAULT_BEAN_NAME = "parallelConsumerFactory";
+	private final ParallelConsumerContext<K, V> parallelConsumerContext;
+	private final DefaultKafkaConsumerFactory<K, V> defaultKafkaConsumerFactory;
+	private boolean running;
+
+	public ParallelConsumerFactory(ParallelConsumerContext<K, V> parallelConsumerContext,
+								   DefaultKafkaConsumerFactory<K, V> defaultKafkaConsumerFactory) {
+		this.parallelConsumerContext = parallelConsumerContext;
+		this.defaultKafkaConsumerFactory = defaultKafkaConsumerFactory;
+	}
+
+
+	@Override
+	public void start() {
+		final Consumer<K, V> consumer = defaultKafkaConsumerFactory.createConsumer();
+		final ParallelStreamProcessor<K, V> parallelConsumer = parallelConsumerContext.createConsumer(consumer);
+		parallelConsumer.subscribe(parallelConsumerContext.parallelConsumerCallback().getTopics());
+		parallelConsumer.poll(recordContexts -> parallelConsumerContext.parallelConsumerCallback().accept(recordContexts));
+		this.running = true;
+	}
+
+	@Override
+	public void stop() {
+		this.parallelConsumerContext.stopParallelConsumer();
+		this.running = false;
+	}
+
+	@Override
+	public boolean isRunning() {
+		return this.running;
+	}
+}


### PR DESCRIPTION
### Introduction
Hi, Spring Team. 
This is chickenchickenlove, huge fan of you guys.
I saw this issue ([Support kafka parallel-consumer](https://github.com/spring-projects/spring-kafka/issues/2381)), and this comment as well! 
> No plans currently; but contributions are welcome!

So, i'd like to implement that integrate `Parallel Consumer` to `spring-kafka`
This is skeleton code.

Please take a look when you have some free time. 🙇‍♂️ 
Thank you for your time!

### Background
- Sometimes, Confluent `Parallel consumer` will be more helpful than kafka consumer, because parallel consumer have good parallel processing (If you want to know more, See [this](https://github.com/confluentinc/parallel-consumer?tab=readme-ov-file#51-illustrative-performance-example)).
- Thus, i think it will be good option to `spring-kafka` as well. 



### How To use
```java
@EnableKafka
@EnableParallelConsumer
@SpringBootApplication
public class SpringkafkasampleApplication {

	public static void main(String[] args) {
		SpringApplication.run(SpringkafkasampleApplication.class, args);
	}
}
```
- Annotated `@EnableParallelConsumer` to your Spring application. then, some spring bean related with `parallel consumer`, will be registered to `ApplicationContext`

```java
@Component
public class MyTestClass implements ParallelConsumerCallback<String, String> {

    private final List<String> topics;
    public MyTestClass(List<String> topics) {
        this.topics = topics;
    }

    @Override
    public void accept(PollContext<String, String> context) {
        context.getConsumerRecordsFlattened().forEach(kvConsumerRecord -> System.out.println(kvConsumerRecord));
    }

    @Override
    public List<String> getTopics() {
        return this.topics;
    }
}
```
- and then, you should implement interface `ParallelConsumerCallback` and register their concrete class as spring bean by annotating `@Component` or `@Configuration`.
- then, `ParallelConsumerFactory` will start `ParallelConsumer` and `ParallelConsumer` process records with `ParallelConsumerCallback` concrete class. 


### ETC
- How about follow the way like `@KafkaListener`? 
  - IMHO, it is unnecessary. because i think `ParallelConsumer` can allow only one callback. thus, it is not suitable for `ParallelConsumer`.
- Can we remove `ParallelConsumerImportSelector`? 
  - Yes. if `org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration.java` class support to register spring bean, `ParallelConsumerImportSelector` can be removed.


Thank you for your time, Again.
