### PR TITLE
Add `checkstyle` rule on `empty-line-separater`

### DIFF
--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaKraftBroker.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaKraftBroker.java
@@ -204,7 +204,6 @@ public class EmbeddedKafkaKraftBroker implements EmbeddedKafkaBroker {
 		}
 	}
 
-
 	private void start() {
 		if (this.cluster != null) {
 			return;

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/assertj/KafkaConditions.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/assertj/KafkaConditions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2019 the original author or authors.
+ * Copyright 2016-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,7 +89,6 @@ public final class KafkaConditions {
 	public static Condition<ConsumerRecord<?, ?>> partition(int partition) {
 		return new ConsumerRecordPartitionCondition(partition);
 	}
-
 
 	public static class ConsumerRecordKeyCondition<K> extends Condition<ConsumerRecord<K, ?>> {
 

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/condition/EmbeddedKafkaCondition.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/condition/EmbeddedKafkaCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -210,7 +210,6 @@ public class EmbeddedKafkaCondition implements ExecutionCondition, AfterAllCallb
 		ExtensionContext parent = context.getParent().get();
 		return parent.getStore(Namespace.create(getClass(), parent));
 	}
-
 
 	public static EmbeddedKafkaBroker getBroker() {
 		return BROKERS.get();

--- a/spring-kafka-test/src/test/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizerTests.java
+++ b/spring-kafka-test/src/test/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 the original author or authors.
+ * Copyright 2017-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -48,14 +48,12 @@ public class EmbeddedKafkaContextCustomizerTests {
 				AnnotationUtils.findAnnotation(SecondTestWithEmbeddedKafka.class, EmbeddedKafka.class);
 	}
 
-
 	@Test
 	void testHashCode() {
 		assertThat(new EmbeddedKafkaContextCustomizer(annotationFromFirstClass).hashCode()).isNotEqualTo(0);
 		assertThat(new EmbeddedKafkaContextCustomizer(annotationFromFirstClass).hashCode())
 				.isEqualTo(new EmbeddedKafkaContextCustomizer(annotationFromSecondClass).hashCode());
 	}
-
 
 	@Test
 	void testEquals() {
@@ -92,7 +90,6 @@ public class EmbeddedKafkaContextCustomizerTests {
 		assertThat(context.getBean(EmbeddedKafkaBroker.class).getBrokersAsString())
 				.matches("127.0.0.1:[0-9]+,127.0.0.1:[0-9]+");
 	}
-
 
 	@EmbeddedKafka(kraft = false)
 	private static final class TestWithEmbeddedKafka {

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
@@ -1190,7 +1190,6 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 
 	private record BytesToStringConverter(Charset charset) implements Converter<byte[], String> {
 
-
 		@Override
 		public String convert(byte[] source) {
 			return new String(source, this.charset);

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryTopicConfigurationProvider.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryTopicConfigurationProvider.java
@@ -37,7 +37,6 @@ import org.springframework.core.log.LogAccessor;
 import org.springframework.kafka.retrytopic.RetryTopicConfiguration;
 import org.springframework.lang.Nullable;
 
-
 /**
  *
  * Attempts to provide an instance of

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistry.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistry.java
@@ -317,7 +317,6 @@ public class KafkaListenerEndpointRegistry implements ListenerContainerRegistry,
 		return listenerContainer;
 	}
 
-
 	@Override
 	public void destroy() {
 		for (MessageListenerContainer listenerContainer : getListenerContainers()) {
@@ -375,7 +374,6 @@ public class KafkaListenerEndpointRegistry implements ListenerContainerRegistry,
 		return this.running;
 	}
 
-
 	@Override
 	public void onApplicationEvent(ContextRefreshedEvent event) {
 		if (event.getApplicationContext().equals(this.applicationContext)) {
@@ -394,7 +392,6 @@ public class KafkaListenerEndpointRegistry implements ListenerContainerRegistry,
 			listenerContainer.start();
 		}
 	}
-
 
 	private static final class AggregatingCallback implements Runnable {
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/MultiMethodKafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/MultiMethodKafkaListenerEndpoint.java
@@ -61,7 +61,6 @@ public class MultiMethodKafkaListenerEndpoint<K, V> extends MethodKafkaListenerE
 		setBean(bean);
 	}
 
-
 	/**
 	 * Get a method list.
 	 * @return the method list.

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
@@ -252,7 +252,6 @@ public class DefaultKafkaConsumerFactory<K, V> extends KafkaResourceFactory
 		this.valueDeserializerSupplier = valueDeserializerSupplier(valueDeserializerSupplier);
 	}
 
-
 	/**
 	 * Set to false (default true) to prevent programmatically provided deserializers (via
 	 * constructor or setters) from being configured using the producer configuration,

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaProducerFactory.java
@@ -68,8 +68,6 @@ import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
-
-
 /**
  * The {@link ProducerFactory} implementation for a {@code singleton} shared {@link Producer} instance.
  * <p>
@@ -566,7 +564,6 @@ public class DefaultKafkaProducerFactory<K, V> extends KafkaResourceFactory
 		}
 		return newFactory;
 	}
-
 
 	/**
 	 * Ensures that the returned properties map contains a transaction id prefix.

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
@@ -308,7 +308,6 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 		((MessagingMessageConverter) this.messageConverter).setMessagingConverter(messageConverter);
 	}
 
-
 	@Override
 	public boolean isTransactional() {
 		return this.transactional;
@@ -589,7 +588,6 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 		}
 		return observeSend((ProducerRecord<K, V>) producerRecord);
 	}
-
 
 	@Override
 	public List<PartitionInfo> partitionsFor(String topic) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/MicrometerProducerListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/MicrometerProducerListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 the original author or authors.
+ * Copyright 2020-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -64,7 +64,6 @@ public class MicrometerProducerListener<K, V> implements ProducerFactory.Listene
 		this.meterRegistry = meterRegistry;
 		this.tags = tags;
 	}
-
 
 	@Override
 	public synchronized void producerAdded(String id, Producer<K, V> producer) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/event/KafkaEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/KafkaEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 the original author or authors.
+ * Copyright 2015-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,6 @@ package org.springframework.kafka.event;
 
 import org.springframework.context.ApplicationEvent;
 import org.springframework.util.Assert;
-
 
 /**
  * Base class for events.

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/BatchMessageListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/BatchMessageListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 the original author or authors.
+ * Copyright 2015-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,6 @@ import org.springframework.lang.Nullable;
  */
 @FunctionalInterface
 public interface BatchMessageListener<K, V> extends GenericMessageListener<List<ConsumerRecord<K, V>>> {
-
 
 	/**
 	 * Listener receives the original {@link ConsumerRecords} object instead of a

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonContainerStoppingErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonContainerStoppingErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,7 +82,6 @@ public class CommonContainerStoppingErrorHandler extends KafkaExceptionLogLevelA
 
 		stopContainer(container, thrownException);
 	}
-
 
 	@Override
 	public void handleRemaining(Exception thrownException, List<ConsumerRecord<?, ?>> records, Consumer<?, ?> consumer,

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonLoggingErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonLoggingErrorHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,6 @@ public class CommonLoggingErrorHandler implements CommonErrorHandler {
 	public void setAckAfterHandle(boolean ackAfterHandle) {
 		this.ackAfterHandle = ackAfterHandle;
 	}
-
 
 	@Override
 	public boolean handleOne(Exception thrownException, ConsumerRecord<?, ?> record, Consumer<?, ?> consumer,

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerAwareRebalanceListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerAwareRebalanceListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 the original author or authors.
+ * Copyright 2017-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,6 @@ import org.apache.kafka.common.TopicPartition;
  *
  */
 public interface ConsumerAwareRebalanceListener extends ConsumerRebalanceListener {
-
 
 	/**
 	 * The same as {@link #onPartitionsRevoked(Collection)} with the additional consumer

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerAwareRecordRecoverer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerAwareRecordRecoverer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,7 +31,6 @@ import org.springframework.lang.Nullable;
  */
 @FunctionalInterface
 public interface ConsumerAwareRecordRecoverer extends ConsumerRecordRecoverer {
-
 
 	@Override
 	default void accept(ConsumerRecord<?, ?> record, Exception exception) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 the original author or authors.
+ * Copyright 2018-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1364,6 +1364,7 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 					this.exceptionCauseFqcn = exceptionCauseFqcn;
 					return this;
 				}
+
 				/**
 				 * Sets the name of the header that will be used to store the keyExceptionMessage
 				 * of the original record.

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -137,7 +137,6 @@ import org.springframework.util.StringUtils;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 
-
 /**
  * Single-threaded Message listener container using the Java {@link Consumer} supporting
  * auto-partition assignment or user-configured assignment.
@@ -592,7 +591,6 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 				+ (getAssignedPartitions() == null ? "none assigned" : getAssignedPartitions())
 				+ "]";
 	}
-
 
 	private final class ListenerConsumer implements SchedulingAwareRunnable, ConsumerSeekCallback {
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/BatchMessagingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/BatchMessagingMessageListenerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 the original author or authors.
+ * Copyright 2016-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,6 @@ import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.util.Assert;
-
 
 /**
  * A {@link org.springframework.kafka.listener.MessageListener MessageListener}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/DelegatingInvocableHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/DelegatingInvocableHandler.java
@@ -47,7 +47,6 @@ import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
 import org.springframework.util.Assert;
 import org.springframework.validation.Validator;
 
-
 /**
  * Delegates to an {@link InvocableHandlerMethod} based on the message payload type.
  * Matches a single, non-annotated parameter or one that is annotated with

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/RecordMessagingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/RecordMessagingMessageListenerAdapter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2023 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,6 @@ import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.kafka.support.converter.ProjectingMessageConverter;
 import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
-
 
 /**
  * A {@link org.springframework.kafka.listener.MessageListener MessageListener}

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DefaultDestinationTopicResolver.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DefaultDestinationTopicResolver.java
@@ -39,7 +39,6 @@ import org.springframework.kafka.retrytopic.DestinationTopic.Type;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
-
 /**
  *
  * Default implementation of the {@link DestinationTopicResolver} interface.

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DestinationTopic.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DestinationTopic.java
@@ -148,6 +148,7 @@ public class DestinationTopic {
 
 		@Nullable
 		private final Boolean autoStartDltHandler;
+
 		/**
 		 * Create an instance with the provided properties with the DLT container starting
 		 * automatically (if the container factory is so configured).

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfiguration.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfiguration.java
@@ -91,7 +91,9 @@ public class RetryTopicConfiguration {
 	static class TopicCreation {
 
 		private final boolean shouldCreateTopics;
+
 		private final int numPartitions;
+
 		private final short replicationFactor;
 
 		TopicCreation(@Nullable Boolean shouldCreate, @Nullable Integer numPartitions, @Nullable Short replicationFactor) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationBuilder.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationBuilder.java
@@ -72,7 +72,6 @@ public class RetryTopicConfigurationBuilder {
 
 	private RetryTopicConfiguration.TopicCreation topicCreationConfiguration = new RetryTopicConfiguration.TopicCreation();
 
-
 	private ConcurrentKafkaListenerContainerFactory<?, ?> listenerContainerFactory;
 
 	@Nullable

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationBuilder.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationBuilder.java
@@ -401,7 +401,6 @@ public class RetryTopicConfigurationBuilder {
 		return this;
 	}
 
-
 	/**
 	 * Configure a {@link FixedBackOffPolicy}.
 	 * @param interval the interval.

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
@@ -43,7 +43,6 @@ import org.springframework.kafka.support.TopicForRetryable;
 import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
 
-
 /**
  *
  * <p>Configures main, retry and DLT topics based on a main endpoint and provided

--- a/spring-kafka/src/main/java/org/springframework/kafka/streams/KafkaStreamsMicrometerListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/streams/KafkaStreamsMicrometerListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2022 the original author or authors.
+ * Copyright 2020-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -63,7 +63,6 @@ public class KafkaStreamsMicrometerListener implements StreamsBuilderFactoryBean
 		this.meterRegistry = meterRegistry;
 		this.tags = tags;
 	}
-
 
 	@Override
 	public synchronized void streamsAdded(String id, KafkaStreams kafkaStreams) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/AbstractKafkaHeaderMapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/AbstractKafkaHeaderMapper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 the original author or authors.
+ * Copyright 2018-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -270,7 +270,6 @@ public abstract class AbstractKafkaHeaderMapper implements KafkaHeaderMapper {
 		}
 		return null;
 	}
-
 
 	/**
 	 * A matcher for headers.

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/DefaultKafkaHeaderMapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/DefaultKafkaHeaderMapper.java
@@ -439,7 +439,6 @@ public class DefaultKafkaHeaderMapper extends AbstractKafkaHeaderMapper {
 			this.untrustedType = untrustedType;
 		}
 
-
 		public void setHeaderValue(byte[] headerValue) { // NOSONAR
 			this.headerValue = headerValue; // NOSONAR array reference
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/KafkaUtils.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/KafkaUtils.java
@@ -63,7 +63,6 @@ public final class KafkaUtils {
 	 */
 	public static final String VALUE_DESERIALIZER_EXCEPTION_HEADER = DESERIALIZER_EXCEPTION_HEADER_PREFIX + "Value";
 
-
 	private static Function<ProducerRecord<?, ?>, String> prFormatter = ProducerRecord::toString;
 
 	private static Function<ConsumerRecord<?, ?>, String> crFormatter =

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/Suffixer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/Suffixer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@ import java.util.stream.Collectors;
 
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
-
 
 /**
  * Utility class that suffixes strings.

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/converter/BatchMessagingMessageConverter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/converter/BatchMessagingMessageConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2022 the original author or authors.
+ * Copyright 2016-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -237,7 +237,6 @@ public class BatchMessagingMessageConverter implements BatchMessageConverter {
 	protected Object extractAndConvertValue(ConsumerRecord<?, ?> record, Type type) {
 		return record.value() == null ? KafkaNull.INSTANCE : record.value();
 	}
-
 
 	/**
 	 * Convert the record value.

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/converter/MessagingMessageConverter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/converter/MessagingMessageConverter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 the original author or authors.
+ * Copyright 2016-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -135,7 +135,6 @@ public class MessagingMessageConverter implements RecordMessageConverter {
 	public void setRawRecordHeader(boolean rawRecordHeader) {
 		this.rawRecordHeader = rawRecordHeader;
 	}
-
 
 	protected org.springframework.messaging.converter.MessageConverter getMessagingConverter() {
 		return this.messagingConverter;

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/micrometer/KafkaListenerObservation.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/micrometer/KafkaListenerObservation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,6 @@ public enum KafkaListenerObservation implements ObservationDocumentation {
 	 * Observation for Apache Kafka listeners.
 	 */
 	LISTENER_OBSERVATION {
-
 
 		@Override
 		public Class<? extends ObservationConvention<? extends Context>> getDefaultConvention() {

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2022 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -186,7 +186,6 @@ public class DelegatingSerializer implements Serializer<Object> {
 	public byte[] serialize(String topic, Object data) {
 		throw new UnsupportedOperationException();
 	}
-
 
 	@Override
 	public byte[] serialize(String topic, Headers headers, Object data) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2023 the original author or authors.
+ * Copyright 2015-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -177,7 +177,6 @@ public class JsonDeserializer<T> implements Deserializer<T> {
 	public JsonDeserializer(@Nullable TypeReference<? super T> targetType) {
 		this(targetType, true);
 	}
-
 
 	/**
 	 * Construct an instance with the provided target type, and a default {@link ObjectMapper}.

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/SerializationUtils.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/SerializationUtils.java
@@ -241,7 +241,6 @@ public final class SerializationUtils {
 					return super.resolveClass(desc);
 				}
 
-
 			};
 			return (DeserializationException) ois.readObject();
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ToStringSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ToStringSerializer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2020 the original author or authors.
+ * Copyright 2016-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,7 +42,6 @@ public class ToStringSerializer<T> implements Serializer<T> {
 	 * Kafka config property for enabling/disabling adding type headers.
 	 */
 	public static final String ADD_TYPE_INFO_HEADERS = "spring.message.add.type.headers";
-
 
 	/**
 	 * Header for the type of key.

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -1440,6 +1440,7 @@ public class EnableKafkaIntegrationTests {
 		public SeekToOffsetFromComputeFunction seekToOffsetFromComputeFunction() {
 			return new SeekToOffsetFromComputeFunction();
 		}
+
 		@Bean
 		public IfaceListener<String> ifaceListener() {
 			return new IfaceListenerImpl();
@@ -2650,7 +2651,6 @@ public class EnableKafkaIntegrationTests {
 	public static class Foo implements Bar {
 
 		private String bar;
-
 
 		public Foo() {
 		}

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -2352,6 +2352,7 @@ public class EnableKafkaIntegrationTests {
 	public static class SeekToOffsetFromComputeFunction extends AbstractConsumerSeekAware {
 
 		CountDownLatch latch1 = new CountDownLatch(10);
+
 		CountDownLatch latch2 = new CountDownLatch(1);
 
 		@KafkaListener(id = "seekToComputeFn", topics = "seekToComputeFn")

--- a/spring-kafka/src/test/java/org/springframework/kafka/config/KafkaListenerEndpointRegistryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/config/KafkaListenerEndpointRegistryTests.java
@@ -71,7 +71,6 @@ public class KafkaListenerEndpointRegistryTests {
 			.withMessage("'idMatcher' cannot be null");
 	}
 
-
 	@DisplayName("getListenerContainersMatching with BiPredicate throws on null biPredicate")
 	@Test
 	void getListenerContainersMatchingBiPredicateThrowsOnNullBiPredicate() {

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
@@ -119,7 +119,6 @@ public class DefaultKafkaConsumerFactoryTests {
 		DefaultKafkaConsumerFactory<String, String> target =
 				new DefaultKafkaConsumerFactory<String, String>(originalConfig) {
 
-
 					@Override
 					protected Consumer<String, String> createRawConsumer(Map<String, Object> configProps) {
 						configPassedToKafkaConsumer.putAll(configProps);

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaProducerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaProducerFactoryTests.java
@@ -706,7 +706,6 @@ public class DefaultKafkaProducerFactoryTests {
 		assertThat(configPassedToKafkaConsumer.get(ProducerConfig.TRANSACTIONAL_ID_CONFIG)).isEqualTo("tx.1");
 	}
 
-
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
 	void configUpdates() {

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultTransactionIdSuffixStrategyTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultTransactionIdSuffixStrategyTests.java
@@ -50,7 +50,6 @@ class DefaultTransactionIdSuffixStrategyTests {
 		assertThat(suffix).isNotNull();
 	}
 
-
 	@Test
 	void acquireSuffixWithCacheExhausted() {
 		String txIdPrefix = "txIdPrefix";

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaTemplateTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2023 the original author or authors.
+ * Copyright 2016-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -131,7 +131,6 @@ public class KafkaTemplateTests {
 	};
 
 	private static final ProducerPostProcessor<String, String> noopProducerPostProcessor = processor -> processor;
-
 
 	@BeforeAll
 	public static void setUp() {
@@ -349,6 +348,7 @@ public class KafkaTemplateTests {
 			}
 
 		}
+
 		PL pl1 = new PL();
 		PL pl2 = new PL();
 		CompositeProducerListener<Integer, String> cpl = new CompositeProducerListener<>(new PL[]{ pl1, pl2 });
@@ -637,6 +637,5 @@ public class KafkaTemplateTests {
 				.isThrownBy(() -> template.receive(Collections.singleton(tpoWithNullOffset)))
 				.withMessage("Offset supplied in TopicPartitionOffset is invalid: " + tpoWithNullOffset);
 	}
-
 
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerMockTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerMockTests.java
@@ -1413,7 +1413,6 @@ public class ConcurrentMessageListenerContainerMockTests {
 			this.latch.countDown();
 		}
 
-
 		@Override
 		public void onIdleContainer(Map<TopicPartition, Long> assignments, ConsumerSeekCallback callback) {
 			if (latch.getCount() > 0) {

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
@@ -652,7 +652,6 @@ public class ConcurrentMessageListenerContainerTests {
 
 	}
 
-
 	@Test
 	public void testAckOnErrorRecord() throws Exception {
 		logger.info("Start ack on error");

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ConsumerAwareRebalanceListenerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ConsumerAwareRebalanceListenerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,7 +46,6 @@ public class ConsumerAwareRebalanceListenerTests {
 		assertThat(called.get()).isTrue();
 	}
 
-
 	@Test
 	void nonConsumerAwareTestRevoked() {
 		AtomicBoolean called = new AtomicBoolean();
@@ -60,7 +59,6 @@ public class ConsumerAwareRebalanceListenerTests {
 		}.onPartitionsRevokedBeforeCommit(null, null);
 		assertThat(called.get()).isTrue();
 	}
-
 
 	@Test
 	void nonConsumerAwareTestLost() {

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ConsumerSeekAwareTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ConsumerSeekAwareTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2023 the original author or authors.
+ * Copyright 2020-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ public class ConsumerSeekAwareTests {
 	void beginningEndAndBulkSeekToTimestamp() throws Exception {
 		class CSA extends AbstractConsumerSeekAware {
 		}
+
 		AbstractConsumerSeekAware csa = new CSA();
 		var exec1 = Executors.newSingleThreadExecutor();
 		var exec2 = Executors.newSingleThreadExecutor();

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ContainerGroupSequencerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ContainerGroupSequencerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -99,7 +99,6 @@ public class ContainerGroupSequencerTests {
 		final List<String> order = Collections.synchronizedList(new ArrayList<>());
 
 		final List<Long> receivedAt = Collections.synchronizedList(new ArrayList<>());
-
 
 		@KafkaListener(id = "one", topics = "ContainerGroupSequencerTests", containerGroup = "g1", concurrency = "2")
 		public void listen1(String in) {

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ErrorHandlingDeserializerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ErrorHandlingDeserializerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 the original author or authors.
+ * Copyright 2018-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -130,6 +130,7 @@ public class ErrorHandlingDeserializerTests {
 			}
 
 		}
+
 		ErrorHandlingDeserializer<String> ehd = new ErrorHandlingDeserializer<>(new MyDes());
 		Headers headers = new RecordHeaders();
 		ehd.deserialize("foo", headers, new byte[1]);

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ErrorHandlingUtilsTest.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ErrorHandlingUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 the original author or authors.
+ * Copyright 2017-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,15 +53,24 @@ import org.springframework.util.backoff.FixedBackOff;
 class ErrorHandlingUtilsTest {
 
 	private final Exception thrownException = new RuntimeException("initial cause");
+
 	private final Consumer<?, ?> consumer = mock(Consumer.class);
+
 	private final MessageListenerContainer container = mock(MessageListenerContainer.class);
+
 	private final Runnable listener = mock(Runnable.class);
+
 	private final BackOff backOff = new FixedBackOff(1000, 3);
+
 	private final CommonErrorHandler seeker = mock(CommonErrorHandler.class);
+
 	@SuppressWarnings("unchecked")
 	private final BiConsumer<ConsumerRecords<?, ?>, Exception> recoverer = mock(BiConsumer.class);
+
 	private final LogAccessor logger = new LogAccessor(LogFactory.getLog(ErrorHandlingUtilsTest.class));
+
 	private final List<RetryListener> retryListeners = new ArrayList<>();
+
 	private final BinaryExceptionClassifier classifier = BinaryExceptionClassifier.defaultClassifier();
 
 	private final ConsumerRecords<?, ?> consumerRecords = recordsOf(

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
@@ -1448,7 +1448,6 @@ public class KafkaMessageListenerContainerTests {
 						throw new IllegalStateException();
 					}
 
-
 				});
 
 		final CountDownLatch commitLatch = new CountDownLatch(1);
@@ -1520,6 +1519,7 @@ public class KafkaMessageListenerContainerTests {
 			}
 
 		}
+
 		Listener messageListener = new Listener();
 		containerProps.setMessageListener(messageListener);
 		containerProps.setSyncCommits(true);
@@ -1599,6 +1599,7 @@ public class KafkaMessageListenerContainerTests {
 			}
 
 		}
+
 		Listener messageListener = new Listener();
 		containerProps.setMessageListener(messageListener);
 		containerProps.setSyncCommits(true);
@@ -2607,6 +2608,7 @@ public class KafkaMessageListenerContainerTests {
 			}
 
 		}
+
 		Listener messageListener = new Listener();
 		containerProps.setMessageListener(messageListener);
 		containerProps.setMissingTopicsFatal(false);
@@ -2935,6 +2937,7 @@ public class KafkaMessageListenerContainerTests {
 			}
 
 		}
+
 		containerProps.setMessageListener(new Listener());
 		containerProps.setMissingTopicsFatal(false);
 		KafkaMessageListenerContainer<Integer, String> container =

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ManualNackPauseResumeTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ManualNackPauseResumeTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 the original author or authors.
+ * Copyright 2017-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,6 +77,7 @@ public class ManualNackPauseResumeTests {
 	@SuppressWarnings("rawtypes")
 	@Autowired
 	private Consumer consumer;
+
 	@Autowired
 	private Config config;
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ManualNackRecordTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ManualNackRecordTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2022 the original author or authors.
+ * Copyright 2017-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,6 +77,7 @@ public class ManualNackRecordTests {
 	@SuppressWarnings("rawtypes")
 	@Autowired
 	private Consumer consumer;
+
 	@Autowired
 	private Config config;
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ManualNackRecordZeroSleepTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ManualNackRecordZeroSleepTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,6 +76,7 @@ public class ManualNackRecordZeroSleepTests {
 	@SuppressWarnings("rawtypes")
 	@Autowired
 	private Consumer consumer;
+
 	@Autowired
 	private Config config;
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/PauseContainerWhileErrorHandlerIsRetryingTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/PauseContainerWhileErrorHandlerIsRetryingTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2023 the original author or authors.
+ * Copyright 2023-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -152,7 +152,6 @@ public class PauseContainerWhileErrorHandlerIsRetryingTests {
 				producer.flush();
 			}
 		}
-
 
 		@KafkaListener(id = "id", groupId = "grp", topics = "foo")
 		public void process(List<String> batch, Acknowledgment acknowledgment) {

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/TransactionalContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/TransactionalContainerTests.java
@@ -1086,7 +1086,6 @@ public class TransactionalContainerTests {
 		assertThatIllegalStateException().isThrownBy(container::start);
 	}
 
-
 	@Test
 	void testArbpWithoutRecovery() throws InterruptedException {
 		// init producer

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapterTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapterTests.java
@@ -62,6 +62,7 @@ public class MessagingMessageListenerAdapterTests {
 			}
 
 		}
+
 		MyAdapter adapter = new MyAdapter();
 		adapter.setFallbackType(String.class);
 		RecordMessageConverter converter = mock(RecordMessageConverter.class);

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DestinationTopicTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DestinationTopicTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 the original author or authors.
+ * Copyright 2018-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -303,7 +303,9 @@ public class DestinationTopicTests {
 	}
 
 	class PropsHolder {
+
 		final String topicName;
+
 		final DestinationTopic.Properties props;
 
 		PropsHolder(String topicName, DestinationTopic.Properties props) {

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/ExistingRetryTopicClassLevelIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/ExistingRetryTopicClassLevelIntegrationTests.java
@@ -203,13 +203,17 @@ class ExistingRetryTopicClassLevelIntegrationTests {
 	static class CountDownLatchContainer {
 
 		CountDownLatch countDownLatch1 = new CountDownLatch(12);
+
 		CountDownLatch countDownLatch2 = new CountDownLatch(12);
+
 	}
 
 	static class CountByPartitionContainer {
 
 		Map<String, Integer> mainTopicMessageCountByPartition = new HashMap<>();
+
 		Map<String, Integer> retryTopicMessageCountByPartition = new HashMap<>();
+
 	}
 
 	@Configuration

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/ExistingRetryTopicIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/ExistingRetryTopicIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2023 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -200,13 +200,17 @@ public class ExistingRetryTopicIntegrationTests {
 	static class CountDownLatchContainer {
 
 		CountDownLatch countDownLatch1 = new CountDownLatch(40);
+
 		CountDownLatch countDownLatch2 = new CountDownLatch(40);
+
 	}
 
 	static class CountByPartitionContainer {
 
 		Map<String, Integer> mainTopicMessageCountByPartition = new HashMap<>();
+
 		Map<String, Integer> retryTopicMessageCountByPartition = new HashMap<>();
+
 	}
 
 	@Configuration

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/ListenerContainerFactoryConfigurerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/ListenerContainerFactoryConfigurerTests.java
@@ -139,7 +139,6 @@ class ListenerContainerFactoryConfigurerTests {
 	@Mock
 	private KafkaListenerEndpoint endpoint;
 
-
 	@Test
 	void shouldSetupErrorHandling() {
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/ListenerContainerFactoryResolverTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/ListenerContainerFactoryResolverTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 the original author or authors.
+ * Copyright 2018-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,9 @@ class ListenerContainerFactoryResolverTests {
 	private ConcurrentKafkaListenerContainerFactory<?, ?> factoryFromDefaultBeanName;
 
 	private final static String factoryName = "testListenerContainerFactory";
+
 	private final static String otherFactoryName = "otherTestListenerContainerFactory";
+
 	private final static String defaultFactoryBeanName = "defaultTestListenerContainerFactory";
 
 	@Test

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicClassLevelExceptionRoutingIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicClassLevelExceptionRoutingIntegrationTests.java
@@ -238,7 +238,6 @@ class RetryTopicClassLevelExceptionRoutingIntegrationTests {
 		@Autowired
 		CountDownLatchContainer container;
 
-
 		@KafkaHandler
 		public void listenWithAnnotation(String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic) {
 			container.fatalFrameworkLatch.countDown();

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicClassLevelExceptionRoutingIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicClassLevelExceptionRoutingIntegrationTests.java
@@ -75,9 +75,13 @@ import org.springframework.util.backoff.FixedBackOff;
 class RetryTopicClassLevelExceptionRoutingIntegrationTests {
 
 	final static String BLOCKING_AND_TOPIC_RETRY = "blocking-and-topic-retry";
+
 	final static String ONLY_RETRY_VIA_BLOCKING = "only-retry-blocking-topic";
+
 	final static String ONLY_RETRY_VIA_TOPIC = "only-retry-topic";
+
 	final static String USER_FATAL_EXCEPTION_TOPIC = "user-fatal-topic";
+
 	final static String FRAMEWORK_FATAL_EXCEPTION_TOPIC = "framework-fatal-topic";
 
 	@Autowired
@@ -256,20 +260,33 @@ class RetryTopicClassLevelExceptionRoutingIntegrationTests {
 	static class CountDownLatchContainer {
 
 		CountDownLatch blockingAndTopicsLatch = new CountDownLatch(12);
+
 		CountDownLatch onlyRetryViaBlockingLatch = new CountDownLatch(4);
+
 		CountDownLatch onlyRetryViaTopicLatch = new CountDownLatch(3);
+
 		CountDownLatch fatalUserLatch = new CountDownLatch(1);
+
 		CountDownLatch fatalFrameworkLatch = new CountDownLatch(1);
+
 		CountDownLatch annotatedDltOnlyBlockingLatch = new CountDownLatch(1);
+
 		CountDownLatch annotatedDltUserFatalLatch = new CountDownLatch(1);
+
 		CountDownLatch annotatedDltFrameworkFatalLatch = new CountDownLatch(1);
+
 		CountDownLatch dltProcessorLatch = new CountDownLatch(1);
+
 		CountDownLatch dltProcessorWithErrorLatch = new CountDownLatch(1);
 
 		AtomicInteger blockingAndTopicsListenerInvocations = new AtomicInteger();
+
 		AtomicInteger onlyRetryViaTopicListenerInvocations = new AtomicInteger();
+
 		AtomicInteger onlyRetryViaBlockingListenerInvocations = new AtomicInteger();
+
 		AtomicInteger userFatalListenerInvocations = new AtomicInteger();
+
 		AtomicInteger fatalFrameworkListenerInvocations = new AtomicInteger();
 
 	}

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicClassLevelIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicClassLevelIntegrationTests.java
@@ -480,7 +480,6 @@ class RetryTopicClassLevelIntegrationTests {
 		@Autowired
 		CountDownLatchContainer container;
 
-
 		@KafkaHandler
 		public void listenWithAnnotation2(String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic) {
 			container.countDownIfNotKnown(receivedTopic, container.countDownLatchNoRetry);

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicClassLevelIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicClassLevelIntegrationTests.java
@@ -556,22 +556,39 @@ class RetryTopicClassLevelIntegrationTests {
 	static class CountDownLatchContainer {
 
 		CountDownLatch countDownLatch1 = new CountDownLatch(5);
+
 		CountDownLatch countDownLatch2 = new CountDownLatch(3);
+
 		CountDownLatch countDownLatch3 = new CountDownLatch(3);
+
 		CountDownLatch countDownLatch4 = new CountDownLatch(4);
+
 		CountDownLatch countDownLatch51 = new CountDownLatch(4);
+
 		CountDownLatch countDownLatch52 = new CountDownLatch(4);
+
 		CountDownLatch countDownLatch6 = new CountDownLatch(4);
+
 		CountDownLatch countDownLatchNoRetry = new CountDownLatch(1);
+
 		CountDownLatch countDownLatchDltOne = new CountDownLatch(1);
+
 		CountDownLatch countDownLatchDltTwo = new CountDownLatch(1);
+
 		CountDownLatch countDownLatchDltThree = new CountDownLatch(1);
+
 		CountDownLatch countDownLatchDltFour = new CountDownLatch(1);
+
 		CountDownLatch countDownLatchReuseOne = new CountDownLatch(2);
+
 		CountDownLatch countDownLatchReuseTwo = new CountDownLatch(5);
+
 		CountDownLatch countDownLatchReuseThree = new CountDownLatch(5);
+
 		CountDownLatch customDltCountdownLatch = new CountDownLatch(1);
+
 		CountDownLatch customErrorHandlerCountdownLatch = new CountDownLatch(6);
+
 		CountDownLatch customMessageConverterCountdownLatch = new CountDownLatch(6);
 
 		final List<String> knownTopics = new ArrayList<>();

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurerTests.java
@@ -357,6 +357,7 @@ class RetryTopicConfigurerTests {
 	}
 
 	static class NoOpsClass {
-		void noOpsMethod() { };
+		void noOpsMethod() { }
 	}
+
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicExceptionRoutingIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicExceptionRoutingIntegrationTests.java
@@ -77,9 +77,13 @@ public class RetryTopicExceptionRoutingIntegrationTests {
 	private static final Logger logger = LoggerFactory.getLogger(RetryTopicExceptionRoutingIntegrationTests.class);
 
 	public final static String BLOCKING_AND_TOPIC_RETRY = "blocking-and-topic-retry";
+
 	public final static String ONLY_RETRY_VIA_BLOCKING = "only-retry-blocking-topic";
+
 	public final static String ONLY_RETRY_VIA_TOPIC = "only-retry-topic";
+
 	public final static String USER_FATAL_EXCEPTION_TOPIC = "user-fatal-topic";
+
 	public final static String FRAMEWORK_FATAL_EXCEPTION_TOPIC = "framework-fatal-topic";
 
 	@Autowired
@@ -270,20 +274,33 @@ public class RetryTopicExceptionRoutingIntegrationTests {
 	static class CountDownLatchContainer {
 
 		CountDownLatch blockingAndTopicsLatch = new CountDownLatch(12);
+
 		CountDownLatch onlyRetryViaBlockingLatch = new CountDownLatch(4);
+
 		CountDownLatch onlyRetryViaTopicLatch = new CountDownLatch(3);
+
 		CountDownLatch fatalUserLatch = new CountDownLatch(1);
+
 		CountDownLatch fatalFrameworkLatch = new CountDownLatch(1);
+
 		CountDownLatch annotatedDltOnlyBlockingLatch = new CountDownLatch(1);
+
 		CountDownLatch annotatedDltUserFatalLatch = new CountDownLatch(1);
+
 		CountDownLatch annotatedDltFrameworkFatalLatch = new CountDownLatch(1);
+
 		CountDownLatch dltProcessorLatch = new CountDownLatch(1);
+
 		CountDownLatch dltProcessorWithErrorLatch = new CountDownLatch(1);
 
 		AtomicInteger blockingAndTopicsListenerInvocations = new AtomicInteger();
+
 		AtomicInteger onlyRetryViaTopicListenerInvocations = new AtomicInteger();
+
 		AtomicInteger onlyRetryViaBlockingListenerInvocations = new AtomicInteger();
+
 		AtomicInteger userFatalListenerInvocations = new AtomicInteger();
+
 		AtomicInteger fatalFrameworkListenerInvocations = new AtomicInteger();
 
 	}

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicIntegrationTests.java
@@ -571,22 +571,39 @@ public class RetryTopicIntegrationTests {
 	static class CountDownLatchContainer {
 
 		CountDownLatch countDownLatch1 = new CountDownLatch(5);
+
 		CountDownLatch countDownLatch2 = new CountDownLatch(3);
+
 		CountDownLatch countDownLatch3 = new CountDownLatch(3);
+
 		CountDownLatch countDownLatch4 = new CountDownLatch(4);
+
 		CountDownLatch countDownLatch51 = new CountDownLatch(4);
+
 		CountDownLatch countDownLatch52 = new CountDownLatch(4);
+
 		CountDownLatch countDownLatch6 = new CountDownLatch(4);
+
 		CountDownLatch countDownLatchNoRetry = new CountDownLatch(1);
+
 		CountDownLatch countDownLatchDltOne = new CountDownLatch(1);
+
 		CountDownLatch countDownLatchDltTwo = new CountDownLatch(1);
+
 		CountDownLatch countDownLatchDltThree = new CountDownLatch(1);
+
 		CountDownLatch countDownLatchDltFour = new CountDownLatch(1);
+
 		CountDownLatch countDownLatchReuseOne = new CountDownLatch(2);
+
 		CountDownLatch countDownLatchReuseTwo = new CountDownLatch(5);
+
 		CountDownLatch countDownLatchReuseThree = new CountDownLatch(5);
+
 		CountDownLatch customDltCountdownLatch = new CountDownLatch(1);
+
 		CountDownLatch customErrorHandlerCountdownLatch = new CountDownLatch(6);
+
 		CountDownLatch customMessageConverterCountdownLatch = new CountDownLatch(6);
 
 		final List<String> knownTopics = new ArrayList<>();

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicSameContainerFactoryIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicSameContainerFactoryIntegrationTests.java
@@ -246,20 +246,29 @@ public class RetryTopicSameContainerFactoryIntegrationTests {
 	static class CountDownLatchContainer {
 
 		CountDownLatch countDownLatchFirstRetryable = new CountDownLatch(4);
+
 		CountDownLatch countDownLatchSecondRetryable = new CountDownLatch(3);
+
 		CountDownLatch countDownLatchDltOne = new CountDownLatch(1);
+
 		CountDownLatch countDownLatchDltSecond = new CountDownLatch(1);
 
 		CountDownLatch countDownLatchBasic = new CountDownLatch(1);
+
 		CountDownLatch customizerLatch = new CountDownLatch(10);
 
 		CountDownLatch countDownLatchClassLevelFirstRetryable = new CountDownLatch(4);
+
 		CountDownLatch countDownLatchClassLevelSecondRetryable = new CountDownLatch(3);
+
 		CountDownLatch countDownLatchClassLevelDltOne = new CountDownLatch(1);
+
 		CountDownLatch countDownLatchClassLevelDltSecond = new CountDownLatch(1);
 
 		CountDownLatch countDownLatchClassLevelBasic = new CountDownLatch(1);
+
 		CountDownLatch customizerClassLevelLatch = new CountDownLatch(10);
+
 	}
 
 	@EnableKafka

--- a/spring-kafka/src/test/java/org/springframework/kafka/streams/KafkaStreamsInteractiveQueryServiceTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/streams/KafkaStreamsInteractiveQueryServiceTests.java
@@ -200,7 +200,6 @@ class KafkaStreamsInteractiveQueryServiceTests {
 				serializer);
 	}
 
-
 	@Configuration
 	@EnableKafka
 	@EnableKafkaStreams

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/micrometer/ObservationIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/micrometer/ObservationIntegrationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 the original author or authors.
+ * Copyright 2022-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,7 +114,6 @@ public class ObservationIntegrationTests extends SampleTestRunner {
 							KeyValues.of("spring.kafka.listener.id", "obs2-0"));
 		};
 	}
-
 
 	@Configuration
 	@EnableKafka

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/JsonSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/JsonSerializationTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 the original author or authors.
+ * Copyright 2016-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -516,7 +516,7 @@ public class JsonSerializationTests {
 		Child(int number) {
 			super(number);
 		}
-	}
 
+	}
 
 }

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -191,6 +191,12 @@
 		<module name="TypecastParenPad"/>
 		<module name="WhitespaceAfter"/>
 		<module name="WhitespaceAround"/>
+		<!-- Add the EmptyLineSeparator module -->
+		<module name="EmptyLineSeparator">
+			<property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, STATIC_INIT, INSTANCE_INIT, METHOD_DEF, CTOR_DEF"/>
+			<property name="allowNoEmptyLineBetweenFields" value="false"/>
+			<property name="allowMultipleEmptyLines" value="false"/>
+		</module>
 
 	</module>
 </module>

--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -193,7 +193,7 @@
 		<module name="WhitespaceAround"/>
 		<!-- Add the EmptyLineSeparator module -->
 		<module name="EmptyLineSeparator">
-			<property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, STATIC_INIT, INSTANCE_INIT, METHOD_DEF, CTOR_DEF"/>
+			<property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, STATIC_INIT, INSTANCE_INIT, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
 			<property name="allowNoEmptyLineBetweenFields" value="false"/>
 			<property name="allowMultipleEmptyLines" value="false"/>
 		</module>


### PR DESCRIPTION
### Motivation

This PR adds `checkstyle` rule to enforce blank lines around things like class, methods, and constructors, etc..., except `field` making our codebase cleaner and more consistent.

### Key settings:

- Mandatory blank lines between class members, "excluding" fields.
- Only single blank lines are allowed for separation.

### Additional Note

Idea from recent [PR comment](https://github.com/spring-projects/spring-kafka/pull/3137#discussion_r1531001776). Figured why not have it checked during build?
