### PR TITLE
[Suggestion] Refactor KafkaListenerConfigUtils to Use Enum for Constants Management

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaBootstrapConfiguration.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaBootstrapConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2002-2019 the original author or authors.
+ * Copyright 2002-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import org.springframework.beans.factory.support.BeanDefinitionRegistry;
 import org.springframework.beans.factory.support.RootBeanDefinition;
 import org.springframework.context.annotation.ImportBeanDefinitionRegistrar;
 import org.springframework.core.type.AnnotationMetadata;
-import org.springframework.kafka.config.KafkaListenerConfigUtils;
+import org.springframework.kafka.config.KafkaListenerConfigTypes;
 import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
 
 /**
@@ -44,14 +44,14 @@ public class KafkaBootstrapConfiguration implements ImportBeanDefinitionRegistra
 	@Override
 	public void registerBeanDefinitions(AnnotationMetadata importingClassMetadata, BeanDefinitionRegistry registry) {
 		if (!registry.containsBeanDefinition(
-				KafkaListenerConfigUtils.KAFKA_LISTENER_ANNOTATION_PROCESSOR_BEAN_NAME)) {
+				KafkaListenerConfigTypes.KAFKA_LISTENER_ANNOTATION_PROCESSOR_BEAN_NAME.getBeanName())) {
 
-			registry.registerBeanDefinition(KafkaListenerConfigUtils.KAFKA_LISTENER_ANNOTATION_PROCESSOR_BEAN_NAME,
+			registry.registerBeanDefinition(KafkaListenerConfigTypes.KAFKA_LISTENER_ANNOTATION_PROCESSOR_BEAN_NAME.getBeanName(),
 					new RootBeanDefinition(KafkaListenerAnnotationBeanPostProcessor.class));
 		}
 
-		if (!registry.containsBeanDefinition(KafkaListenerConfigUtils.KAFKA_LISTENER_ENDPOINT_REGISTRY_BEAN_NAME)) {
-			registry.registerBeanDefinition(KafkaListenerConfigUtils.KAFKA_LISTENER_ENDPOINT_REGISTRY_BEAN_NAME,
+		if (!registry.containsBeanDefinition(KafkaListenerConfigTypes.KAFKA_LISTENER_ENDPOINT_REGISTRY_BEAN_NAME.getBeanName())) {
+			registry.registerBeanDefinition(KafkaListenerConfigTypes.KAFKA_LISTENER_ENDPOINT_REGISTRY_BEAN_NAME.getBeanName(),
 					new RootBeanDefinition(KafkaListenerEndpointRegistry.class));
 		}
 	}

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
@@ -78,7 +78,7 @@ import org.springframework.format.Formatter;
 import org.springframework.format.FormatterRegistry;
 import org.springframework.format.support.DefaultFormattingConversionService;
 import org.springframework.kafka.config.ContainerPostProcessor;
-import org.springframework.kafka.config.KafkaListenerConfigUtils;
+import org.springframework.kafka.config.KafkaListenerConfigTypes;
 import org.springframework.kafka.config.KafkaListenerContainerFactory;
 import org.springframework.kafka.config.KafkaListenerEndpointRegistrar;
 import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
@@ -316,7 +316,7 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 				Assert.state(this.beanFactory != null,
 						"BeanFactory must be set to find endpoint registry by bean name");
 				this.endpointRegistry = this.beanFactory.getBean(
-						KafkaListenerConfigUtils.KAFKA_LISTENER_ENDPOINT_REGISTRY_BEAN_NAME,
+						KafkaListenerConfigTypes.KAFKA_LISTENER_ENDPOINT_REGISTRY_BEAN_NAME.getBeanName(),
 						KafkaListenerEndpointRegistry.class);
 			}
 			this.registrar.setEndpointRegistry(this.endpointRegistry);
@@ -572,7 +572,7 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 
 			gac.registerBean(RetryTopicBeanNames.DESTINATION_TOPIC_RESOLVER_BEAN_NAME, DestinationTopicResolver.class,
 					() -> destResolver);
-			gac.registerBean(KafkaListenerConfigUtils.KAFKA_CONSUMER_BACK_OFF_MANAGER_BEAN_NAME,
+			gac.registerBean(KafkaListenerConfigTypes.KAFKA_CONSUMER_BACK_OFF_MANAGER_BEAN_NAME.getBeanName(),
 					KafkaConsumerBackoffManager.class, () -> bom);
 			gac.registerBean(RetryTopicBeanNames.RETRY_TOPIC_CONFIGURER_BEAN_NAME, RetryTopicConfigurer.class,
 					() -> rtc);

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerConfigTypes.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerConfigTypes.java
@@ -1,0 +1,47 @@
+package org.springframework.kafka.config;
+
+/**
+ * Configuration constants for internal sharing across subpackages.
+ *
+ * @author Juergen Hoeller
+ * @author Gary Russell
+ * @author Tomaz Fernandes
+ * @author Joe Kim
+ */
+public enum KafkaListenerConfigTypes {
+
+	KAFKA_LISTENER_ANNOTATION_PROCESSOR_BEAN_NAME(KAFKA_CONFIG_PATH.KAFKA_LISTENER_ANNOTATION_PROCESSOR_BEAN_NAME),
+	KAFKA_LISTENER_ENDPOINT_REGISTRY_BEAN_NAME(KAFKA_CONFIG_PATH.KAFKA_LISTENER_ENDPOINT_REGISTRY_BEAN_NAME),
+	KAFKA_CONSUMER_BACK_OFF_MANAGER_BEAN_NAME(KAFKA_CONFIG_PATH.KAFKA_CONSUMER_BACK_OFF_MANAGER_BEAN_NAME);
+
+	private final String beanName;
+
+	KafkaListenerConfigTypes(final String beanName) {
+		this.beanName = beanName;
+	}
+
+	public String getBeanName() {
+		return this.beanName;
+	}
+
+	public static class KAFKA_CONFIG_PATH {
+		/**
+		 * The bean name of the internally managed Kafka listener annotation processor.
+		 */
+		public static final String KAFKA_LISTENER_ANNOTATION_PROCESSOR_BEAN_NAME =
+				"org.springframework.kafka.config.internalKafkaListenerAnnotationProcessor";
+
+		/**
+		 * The bean name of the internally managed Kafka listener endpoint registry.
+		 */
+		public static final String KAFKA_LISTENER_ENDPOINT_REGISTRY_BEAN_NAME =
+				"org.springframework.kafka.config.internalKafkaListenerEndpointRegistry";
+
+		/**
+		 * The bean name of the internally managed Kafka consumer back off manager.
+		 */
+		public static final String KAFKA_CONSUMER_BACK_OFF_MANAGER_BEAN_NAME =
+				"org.springframework.kafka.config.internalKafkaConsumerBackOffManager";
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractKafkaBackOffManagerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractKafkaBackOffManagerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 the original author or authors.
+ * Copyright 2018-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package org.springframework.kafka.listener;
 
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
-import org.springframework.kafka.config.KafkaListenerConfigUtils;
+import org.springframework.kafka.config.KafkaListenerConfigTypes;
 import org.springframework.util.Assert;
 
 /**
@@ -78,7 +78,7 @@ public abstract class AbstractKafkaBackOffManagerFactory
 
 	private ListenerContainerRegistry getListenerContainerFromContext() {
 		Assert.notNull(this.applicationContext, "ApplicationContext not set.");
-		return this.applicationContext.getBean(KafkaListenerConfigUtils.KAFKA_LISTENER_ENDPOINT_REGISTRY_BEAN_NAME,
+		return this.applicationContext.getBean(KafkaListenerConfigTypes.KAFKA_LISTENER_ENDPOINT_REGISTRY_BEAN_NAME.getBeanName(),
 				ListenerContainerRegistry.class);
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationSupport.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 the original author or authors.
+ * Copyright 2022-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,7 +38,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.core.log.LogAccessor;
 import org.springframework.kafka.annotation.EnableKafkaRetryTopic;
 import org.springframework.kafka.annotation.KafkaListenerAnnotationBeanPostProcessor;
-import org.springframework.kafka.config.KafkaListenerConfigUtils;
+import org.springframework.kafka.config.KafkaListenerConfigTypes;
 import org.springframework.kafka.config.KafkaListenerEndpoint;
 import org.springframework.kafka.listener.CommonErrorHandler;
 import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
@@ -111,7 +111,7 @@ public class RetryTopicConfigurationSupport implements ApplicationContextAware, 
 	 * @see KafkaListenerAnnotationBeanPostProcessor
 	 */
 	@Bean(name = RetryTopicBeanNames.RETRY_TOPIC_CONFIGURER_BEAN_NAME)
-	public RetryTopicConfigurer retryTopicConfigurer(@Qualifier(KafkaListenerConfigUtils.KAFKA_CONSUMER_BACK_OFF_MANAGER_BEAN_NAME)
+	public RetryTopicConfigurer retryTopicConfigurer(@Qualifier(KafkaListenerConfigTypes.KAFKA_CONFIG_PATH.KAFKA_CONSUMER_BACK_OFF_MANAGER_BEAN_NAME)
 			KafkaConsumerBackoffManager kafkaConsumerBackoffManager,
 			@Qualifier(RetryTopicBeanNames.DESTINATION_TOPIC_RESOLVER_BEAN_NAME)
 			DestinationTopicResolver destinationTopicResolver,
@@ -307,9 +307,9 @@ public class RetryTopicConfigurationSupport implements ApplicationContextAware, 
 	 * @param taskScheduler a {@link TaskScheduler}.
 	 * @return the instance.
 	 */
-	@Bean(name = KafkaListenerConfigUtils.KAFKA_CONSUMER_BACK_OFF_MANAGER_BEAN_NAME)
+	@Bean(name = KafkaListenerConfigTypes.KAFKA_CONFIG_PATH.KAFKA_CONSUMER_BACK_OFF_MANAGER_BEAN_NAME)
 	public KafkaConsumerBackoffManager kafkaConsumerBackoffManager(ApplicationContext applicationContext,
-			@Qualifier(KafkaListenerConfigUtils.KAFKA_LISTENER_ENDPOINT_REGISTRY_BEAN_NAME)
+			@Qualifier(KafkaListenerConfigTypes.KAFKA_CONFIG_PATH.KAFKA_LISTENER_ENDPOINT_REGISTRY_BEAN_NAME)
 					@Nullable ListenerContainerRegistry registry,
 					ObjectProvider<RetryTopicComponentFactory> componentFactoryProvider,
 					@Nullable RetryTopicSchedulerWrapper wrapper,

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/AliasPropertiesTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/AliasPropertiesTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 the original author or authors.
+ * Copyright 2018-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,7 +39,7 @@ import org.springframework.core.annotation.AliasFor;
 import org.springframework.kafka.annotation.AliasPropertiesTests.Config.ClassAndMethodLevelListener;
 import org.springframework.kafka.annotation.KafkaListenerAnnotationBeanPostProcessor.AnnotationEnhancer;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
-import org.springframework.kafka.config.KafkaListenerConfigUtils;
+import org.springframework.kafka.config.KafkaListenerConfigTypes;
 import org.springframework.kafka.config.KafkaListenerContainerFactory;
 import org.springframework.kafka.config.KafkaListenerEndpointRegistry;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
@@ -128,7 +128,7 @@ public class AliasPropertiesTests {
 			return new OrderedEnhancer(orderedCalledFirst);
 		}
 
-		@Bean(KafkaListenerConfigUtils.KAFKA_LISTENER_ENDPOINT_REGISTRY_BEAN_NAME)
+		@Bean(KafkaListenerConfigTypes.KAFKA_CONFIG_PATH.KAFKA_LISTENER_ENDPOINT_REGISTRY_BEAN_NAME)
 		public KafkaListenerEndpointRegistry kafkaListenerEndpointRegistry() {
 			return new KafkaListenerEndpointRegistry();
 		}


### PR DESCRIPTION
This pull request introduces a significant refactor to the KafkaListenerConfigUtils class, transitioning it from an abstract class to an enum named KafkaListenerConfigTypes. 

This change aims to enhance the management of configuration constants within our project, leveraging the strengths of enum in Java for a more efficient and type-safe way to handle constants.

## Key Changes
KafkaListenerConfigUtils is now an enum KafkaListenerConfigTypes, encapsulating the bean names as enum constants.

Introduced a nested `KAFKA_CONFIG_PATH` class within `KafkaListenerConfigTypes` to maintain the original constants'values.

## Rationale
The primary motivation behind this change is to utilize enums for constant management, which offers several advantages

### Type Safety
Enums provide compile-time type checking, reducing the risk of assigning incorrect values to constants.

### Singleton Pattern 
By their nature, enums in Java implement the singleton pattern, ensuring that constant values are instantiated only once throughout the JVM lifecycle.

### Impact
This change does not introduce any breaking changes to existing functionality.
All references to KafkaListenerConfigUtils constants have been updated to use KafkaListenerConfigTypes accordingly.
