### PR TITLE
Create topology before kafka streams start.

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/config/StreamsBuilderFactoryBean.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/StreamsBuilderFactoryBean.java
@@ -339,7 +339,8 @@ public class StreamsBuilderFactoryBean extends AbstractFactoryBean<StreamsBuilde
 	public boolean isAutoStartup() {
 		try {
 			this.topology = getObject().build(this.properties);
-		} catch (Exception e) {
+		}
+		catch (Exception e) {
 			throw new RuntimeException(e);
 		}
 		return this.autoStartup;

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/StreamsBuilderFactoryBean.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/StreamsBuilderFactoryBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 the original author or authors.
+ * Copyright 2017-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -337,6 +337,11 @@ public class StreamsBuilderFactoryBean extends AbstractFactoryBean<StreamsBuilde
 
 	@Override
 	public boolean isAutoStartup() {
+		try {
+			this.topology = getObject().build(this.properties);
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		}
 		return this.autoStartup;
 	}
 
@@ -356,11 +361,9 @@ public class StreamsBuilderFactoryBean extends AbstractFactoryBean<StreamsBuilde
 				try {
 					Assert.state(this.properties != null,
 							"streams configuration properties must not be null");
-					Topology topol = getObject().build(this.properties); // NOSONAR: getObject() cannot return null
-					this.infrastructureCustomizer.configureTopology(topol);
-					this.topology = topol;
-					LOGGER.debug(() -> topol.describe().toString());
-					this.kafkaStreams = new KafkaStreams(topol, this.properties, this.clientSupplier);
+					this.infrastructureCustomizer.configureTopology(this.topology);
+					LOGGER.debug(() -> this.topology.describe().toString());
+					this.kafkaStreams = new KafkaStreams(this.topology, this.properties, this.clientSupplier);
 					this.kafkaStreams.setStateListener(this.stateListener);
 					this.kafkaStreams.setGlobalStateRestoreListener(this.stateRestoreListener);
 					if (this.streamsUncaughtExceptionHandler != null) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/StreamsBuilderFactoryBean.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/StreamsBuilderFactoryBean.java
@@ -56,6 +56,7 @@ import org.springframework.util.Assert;
  * @author Denis Washington
  * @author Gary Russell
  * @author Julien Wittouck
+ * @author Sanghyeok An
  *
  * @since 1.1.4
  */

--- a/spring-kafka/src/test/java/org/springframework/kafka/config/StreamsBuilderFactoryBeanTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/config/StreamsBuilderFactoryBeanTests.java
@@ -121,7 +121,7 @@ public class StreamsBuilderFactoryBeanTests {
 		};
 		streamsBuilderFactoryBean.afterPropertiesSet();
 		StreamsBuilder builder = streamsBuilderFactoryBean.getObject();
-		builder.stream(Pattern.compile("foo"));
+		builder.stream(Pattern.compile("test-topic"));
 
 		// When
 		streamsBuilderFactoryBean.afterSingletonsInstantiated();
@@ -130,7 +130,6 @@ public class StreamsBuilderFactoryBeanTests {
 		assertThat(streamsBuilderFactoryBean.getTopology()).isNotNull();
 		assertThat(streamsBuilderFactoryBean.isRunning()).isFalse();
 	}
-
 
 	@Configuration
 	@EnableKafkaStreams

--- a/spring-kafka/src/test/java/org/springframework/kafka/config/StreamsBuilderFactoryBeanTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/config/StreamsBuilderFactoryBeanTests.java
@@ -56,6 +56,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
  * @author Gary Russell
  * @author Denis Washington
  * @author Soby Chacko
+ * @author Sanghyeok An
  */
 @SpringJUnitConfig
 @DirtiesContext

--- a/spring-kafka/src/test/java/org/springframework/kafka/config/StreamsBuilderFactoryBeanTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/config/StreamsBuilderFactoryBeanTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 the original author or authors.
+ * Copyright 2018-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -92,20 +92,56 @@ public class StreamsBuilderFactoryBeanTests {
 	}
 
 	@Test
-	public void testBuildWithProperties() throws Exception {
+	public void testBuildWithPropertiesAndAutoStartUp() throws Exception {
+		boolean autoStartUp = true;
 		streamsBuilderFactoryBean = new StreamsBuilderFactoryBean(kafkaStreamsConfiguration) {
 			@Override
 			protected StreamsBuilder createInstance() {
 				return spy(super.createInstance());
 			}
 		};
+		streamsBuilderFactoryBean.setAutoStartup(autoStartUp);
 		streamsBuilderFactoryBean.afterPropertiesSet();
 		StreamsBuilder builder = streamsBuilderFactoryBean.getObject();
 		builder.stream(Pattern.compile("foo"));
-		streamsBuilderFactoryBean.start();
+
+
+		boolean isAutoStartUp = streamsBuilderFactoryBean.isAutoStartup();
+		if (isAutoStartUp) {
+			streamsBuilderFactoryBean.start();
+		}
+
 		StreamsBuilder streamsBuilder = streamsBuilderFactoryBean.getObject();
 		verify(streamsBuilder).build(kafkaStreamsConfiguration.asProperties());
 		assertThat(streamsBuilderFactoryBean.getTopology()).isNotNull();
+		assertThat(isAutoStartUp).isTrue();
+		assertThat(streamsBuilderFactoryBean.isRunning()).isTrue();
+	}
+
+	@Test
+	public void testBuildWithPropertiesAndNoAutoStartUp() throws Exception {
+		boolean autoStartUp = false;
+		streamsBuilderFactoryBean = new StreamsBuilderFactoryBean(kafkaStreamsConfiguration) {
+			@Override
+			protected StreamsBuilder createInstance() {
+				return spy(super.createInstance());
+			}
+		};
+		streamsBuilderFactoryBean.setAutoStartup(autoStartUp);
+		streamsBuilderFactoryBean.afterPropertiesSet();
+		StreamsBuilder builder = streamsBuilderFactoryBean.getObject();
+		builder.stream(Pattern.compile("foo"));
+
+		boolean isAutoStartUp = streamsBuilderFactoryBean.isAutoStartup();
+		if (isAutoStartUp) {
+			streamsBuilderFactoryBean.start();
+		}
+
+		StreamsBuilder streamsBuilder = streamsBuilderFactoryBean.getObject();
+		verify(streamsBuilder).build(kafkaStreamsConfiguration.asProperties());
+		assertThat(streamsBuilderFactoryBean.getTopology()).isNotNull();
+		assertThat(isAutoStartUp).isFalse();
+		assertThat(streamsBuilderFactoryBean.isRunning()).isFalse();
 	}
 
 	@Configuration

--- a/spring-kafka/src/test/java/org/springframework/kafka/config/StreamsBuilderFactoryBeanTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/config/StreamsBuilderFactoryBeanTests.java
@@ -93,57 +93,44 @@ public class StreamsBuilderFactoryBeanTests {
 	}
 
 	@Test
-	public void testBuildWithPropertiesAndAutoStartUp() throws Exception {
-		boolean autoStartUp = true;
+	public void testBuildWithProperties() throws Exception {
 		streamsBuilderFactoryBean = new StreamsBuilderFactoryBean(kafkaStreamsConfiguration) {
 			@Override
 			protected StreamsBuilder createInstance() {
 				return spy(super.createInstance());
 			}
 		};
-		streamsBuilderFactoryBean.setAutoStartup(autoStartUp);
 		streamsBuilderFactoryBean.afterPropertiesSet();
 		StreamsBuilder builder = streamsBuilderFactoryBean.getObject();
 		builder.stream(Pattern.compile("foo"));
-
-
-		boolean isAutoStartUp = streamsBuilderFactoryBean.isAutoStartup();
-		if (isAutoStartUp) {
-			streamsBuilderFactoryBean.start();
-		}
-
+		streamsBuilderFactoryBean.afterSingletonsInstantiated();
+		streamsBuilderFactoryBean.start();
 		StreamsBuilder streamsBuilder = streamsBuilderFactoryBean.getObject();
 		verify(streamsBuilder).build(kafkaStreamsConfiguration.asProperties());
 		assertThat(streamsBuilderFactoryBean.getTopology()).isNotNull();
-		assertThat(isAutoStartUp).isTrue();
-		assertThat(streamsBuilderFactoryBean.isRunning()).isTrue();
 	}
 
 	@Test
-	public void testBuildWithPropertiesAndNoAutoStartUp() throws Exception {
-		boolean autoStartUp = false;
+	public void testGetTopologyBeforeKafkaStreamsStart() throws Exception {
+		// Given
 		streamsBuilderFactoryBean = new StreamsBuilderFactoryBean(kafkaStreamsConfiguration) {
 			@Override
 			protected StreamsBuilder createInstance() {
 				return spy(super.createInstance());
 			}
 		};
-		streamsBuilderFactoryBean.setAutoStartup(autoStartUp);
 		streamsBuilderFactoryBean.afterPropertiesSet();
 		StreamsBuilder builder = streamsBuilderFactoryBean.getObject();
 		builder.stream(Pattern.compile("foo"));
 
-		boolean isAutoStartUp = streamsBuilderFactoryBean.isAutoStartup();
-		if (isAutoStartUp) {
-			streamsBuilderFactoryBean.start();
-		}
+		// When
+		streamsBuilderFactoryBean.afterSingletonsInstantiated();
 
-		StreamsBuilder streamsBuilder = streamsBuilderFactoryBean.getObject();
-		verify(streamsBuilder).build(kafkaStreamsConfiguration.asProperties());
+		// Then
 		assertThat(streamsBuilderFactoryBean.getTopology()).isNotNull();
-		assertThat(isAutoStartUp).isFalse();
 		assertThat(streamsBuilderFactoryBean.isRunning()).isFalse();
 	}
+
 
 	@Configuration
 	@EnableKafkaStreams

--- a/spring-kafka/src/test/java/org/springframework/kafka/config/StreamsBuilderFactoryLateConfigTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/config/StreamsBuilderFactoryLateConfigTests.java
@@ -43,6 +43,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
  * @author Soby Chacko
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Sanghyeok An
  */
 @SpringJUnitConfig
 @DirtiesContext

--- a/spring-kafka/src/test/java/org/springframework/kafka/config/StreamsBuilderFactoryLateConfigTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/config/StreamsBuilderFactoryLateConfigTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2020 the original author or authors.
+ * Copyright 2018-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,15 +72,19 @@ public class StreamsBuilderFactoryLateConfigTests {
 
 	@Test
 	public void testStreamsBuilderFactoryWithConfigProvidedLater() throws Exception {
+		boolean isAutoStartUp = true;
 		Properties props = new Properties();
 		props.put(StreamsConfig.APPLICATION_ID_CONFIG, APPLICATION_ID);
 		props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, this.brokerAddresses);
 		streamsBuilderFactoryBean.setStreamsConfiguration(props);
+		streamsBuilderFactoryBean.setAutoStartup(isAutoStartUp);
 		streamsBuilderFactoryBean.getObject().stream(Pattern.compile("foo"));
 
 		assertThat(streamsBuilderFactoryBean.isRunning()).isFalse();
+		boolean shouldAutoStartUp = streamsBuilderFactoryBean.isAutoStartup();
 		streamsBuilderFactoryBean.start();
 		assertThat(streamsBuilderFactoryBean.isRunning()).isTrue();
+		assertThat(shouldAutoStartUp).isEqualTo(isAutoStartUp);
 	}
 
 	@Configuration

--- a/spring-kafka/src/test/java/org/springframework/kafka/config/StreamsBuilderFactoryLateConfigTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/config/StreamsBuilderFactoryLateConfigTests.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import java.util.Properties;
 import java.util.regex.Pattern;
 
+import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.junit.jupiter.api.Test;
 
@@ -79,13 +80,10 @@ public class StreamsBuilderFactoryLateConfigTests {
 		props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, this.brokerAddresses);
 		streamsBuilderFactoryBean.setStreamsConfiguration(props);
 		streamsBuilderFactoryBean.setAutoStartup(isAutoStartUp);
-		streamsBuilderFactoryBean.getObject().stream(Pattern.compile("foo"));
 
 		assertThat(streamsBuilderFactoryBean.isRunning()).isFalse();
-		boolean shouldAutoStartUp = streamsBuilderFactoryBean.isAutoStartup();
 		streamsBuilderFactoryBean.start();
 		assertThat(streamsBuilderFactoryBean.isRunning()).isTrue();
-		assertThat(shouldAutoStartUp).isEqualTo(isAutoStartUp);
 	}
 
 	@Configuration
@@ -100,6 +98,23 @@ public class StreamsBuilderFactoryLateConfigTests {
 			return streamsBuilderFactoryBean;
 		}
 
+		@Bean
+		public KafkaStreamsService kafkaStreamsService(StreamsBuilder streamsBuilder) {
+			return new KafkaStreamsService(streamsBuilder);
+		}
+
 	}
 
+	static class KafkaStreamsService {
+		private final StreamsBuilder streamsBuilder;
+
+		public KafkaStreamsService(StreamsBuilder streamsBuilder) {
+			this.streamsBuilder = streamsBuilder;
+			buildPipeline();
+		}
+
+		public void buildPipeline() {
+			this.streamsBuilder.stream("foo");
+		}
+	}
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/config/StreamsBuilderFactoryLateConfigTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/config/StreamsBuilderFactoryLateConfigTests.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 import java.util.Properties;
-import java.util.regex.Pattern;
 
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
@@ -108,13 +107,13 @@ public class StreamsBuilderFactoryLateConfigTests {
 	static class KafkaStreamsService {
 		private final StreamsBuilder streamsBuilder;
 
-		public KafkaStreamsService(StreamsBuilder streamsBuilder) {
+		KafkaStreamsService(StreamsBuilder streamsBuilder) {
 			this.streamsBuilder = streamsBuilder;
 			buildPipeline();
 		}
 
-		public void buildPipeline() {
-			this.streamsBuilder.stream("foo");
+		void buildPipeline() {
+			this.streamsBuilder.stream("test-topic");
 		}
 	}
 }


### PR DESCRIPTION
### Introduction
Hi, Spring kafka Team.
This is chickenchickenlove, huge fan of you guys.
I saw this issue (https://github.com/spring-projects/spring-kafka/issues/3020). i want to resolve this problem by myself!

### Background
- https://github.com/spring-projects/spring-kafka/issues/3020
- If `Topology` of `kafka streams` are initialized before `StreamsBuilderFactoryBean#start()`, it will be very helpful to Test code for `spring kafka-streams`. `TopologyTestDriver` is very efficient to test comparing to `TestContainers`. 

### To reviewer
- I have tiny PR to solve Issue(https://github.com/spring-projects/spring-kafka/issues/3020).
- It might be a fairly simple fix, but it could look bad. IMHO, it's a better idea to register `StreamsBuilder` as a `Bean` in a different scope, however, it will introduce many changes to `StreamsBuilderFactoryBean`, `AbstractBuilderFactoryBean` as well. I have made modifications to minimize the changes. 
- When you have some free time, Please take a look 🙇‍♂️.


</br>

### Changes
- Point of initializing `kafka-streams topology` move to `StreamsBuilderFactoryBean#isAutoStartup()`.
</br>


### `@PostConstruct` or `StreamsBuilderFactoryBean#afterPropertiesSet()` Does not work well in this case. Why? 
- Because they are called just before bean is initialized. however, codes to make topology will be injected after `StreamsBuilderFactoryBean#afterPropertiesSet()` are called.
1. `StreamBuilder` is initialized in that time by this [code](https://github.com/spring-projects/spring-kafka/blob/c26f26e4598f40c0bf32b5294b110de438b3faf6/spring-kafka/src/main/java/org/springframework/kafka/config/StreamsBuilderFactoryBean.java#L322-L336).  (`StreamsBuilderFactoryBean#afterPropertiesSet()` -> `StreamsBuilderFactoryBean#createInstance()` -> finally, `StreamsBuilder` are intialized!)
2. However, codes to make topology, are not injected `StreamsBuilder` in this time. you can refer to this topology code below.
```java
@Component
public class MyComponent {

    private static final Serde<String> STRING_SERDE = Serdes.String();
    private final StreamsBuilder streamsBuilder;

    public MyComponent(StreamsBuilder streamsBuilder) {
        this.streamsBuilder = streamsBuilder;
        buildPipeline();
    }

    public void buildPipeline() {
        KStream<String, String> messageStream = streamsBuilder
                .stream("input-topic", Consumed.with(STRING_SERDE, STRING_SERDE));
        ...
        wordCounts.toStream().to("output-topic");
    }
}
```
3. MyComponent#buildPipeline()` is executed after `StreamsBuilderFactoryBean#afterPropertiesSet()` called. After this step, `StreamsBuilder` can return valid `topology`. Before this step, `StreamsBuilder` will return invalid `topology` always.

~~### Why am i used to `isAutoStart()`?~~
~~- AFAIK, There is no hooking point for this. even, `ContextRefreshedEvent` will be called after `SmartLifeCycle#isAutoStart()`~~
~~- IMHO, this is best simple modification. In common use case, Spring will call `SmartLifeCycle#isAutoStart()` only once.  I did send request to spring team whether if they can implement new hooking point such like it. ([link](https://github.com/spring-projects/spring-framework/issues/32554))~~
</br>

### Any Other workaround? 
~~- IMHO, `StreamsBuilder` should be registered as bean other scope (not in `StreamsBuilderFactoryBean scope`). But it will involves a lot of changes to the `StreamsBuilderFactoryBean`.~~
~~- I was wrong. IMHO, there is no workaround, i guess 😢 .~~
- Finally, i used `SmartInitializingSingleton.afterSingletonsInstantiated()` to resolve this issue.


</br>
