### PR TITLE
GH-3210: KafkaTemplate currentSpan tagging issue

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
@@ -768,7 +768,9 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 				this.observationRegistry);
 		try {
 			observation.start();
-			return doSend(producerRecord, observation);
+			try (Observation.Scope ignored = observation.openScope()) {
+				return doSend(producerRecord, observation);
+			}
 		}
 		catch (RuntimeException ex) {
 			// The error is added from org.apache.kafka.clients.producer.Callback


### PR DESCRIPTION
Fixes: #3210

* When adding a tag to the current span during the sending of a kafka message using KafkaTemplate, the tag gets added to another span because KafkaTemplate doesn't open the scope for the started observation. Fixing this issue by wrapping the doSend method call in a proper observation scope.

**Auto-cherry-pick to `3.1.x` & `3.0.x`**
