### PR TITLE
Fix ackDiscarded.

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
@@ -703,14 +703,12 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 		Object filter = resolveExpression(kafkaListener.filter());
 		if (filter instanceof RecordFilterStrategy rfs) {
 			endpoint.setRecordFilterStrategy(rfs);
-			endpoint.setAckDiscarded(true);
 		}
 		else {
 			String filterBeanName = resolveExpressionAsString(kafkaListener.filter(), "filter");
 			if (StringUtils.hasText(filterBeanName)) {
 				endpoint.setRecordFilterStrategy(
 						this.beanFactory.getBean(filterBeanName, RecordFilterStrategy.class));
-				endpoint.setAckDiscarded(true);
 			}
 		}
 	}

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
@@ -702,12 +702,12 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 	private void resolveFilter(MethodKafkaListenerEndpoint<?, ?> endpoint, KafkaListener kafkaListener) {
 		Object filter = resolveExpression(kafkaListener.filter());
 		if (filter instanceof RecordFilterStrategy rfs) {
-			endpoint.setRecordFilterStrategy(rfs);
+			endpoint.useRecordFilterStrategy(rfs);
 		}
 		else {
 			String filterBeanName = resolveExpressionAsString(kafkaListener.filter(), "filter");
 			if (StringUtils.hasText(filterBeanName)) {
-				endpoint.setRecordFilterStrategy(
+				endpoint.useRecordFilterStrategy(
 						this.beanFactory.getBean(filterBeanName, RecordFilterStrategy.class));
 			}
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
@@ -702,13 +702,15 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 	private void resolveFilter(MethodKafkaListenerEndpoint<?, ?> endpoint, KafkaListener kafkaListener) {
 		Object filter = resolveExpression(kafkaListener.filter());
 		if (filter instanceof RecordFilterStrategy rfs) {
-			endpoint.useRecordFilterStrategy(rfs);
+			endpoint.setRecordFilterStrategy(rfs);
+			endpoint.setAckDiscarded(true);
 		}
 		else {
 			String filterBeanName = resolveExpressionAsString(kafkaListener.filter(), "filter");
 			if (StringUtils.hasText(filterBeanName)) {
-				endpoint.useRecordFilterStrategy(
+				endpoint.setRecordFilterStrategy(
 						this.beanFactory.getBean(filterBeanName, RecordFilterStrategy.class));
+				endpoint.setAckDiscarded(true);
 			}
 		}
 	}

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2023 the original author or authors.
+ * Copyright 2014-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -373,7 +373,7 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 	private void configureEndpoint(AbstractKafkaListenerEndpoint<K, V> aklEndpoint) {
 		if (aklEndpoint.getRecordFilterStrategy() == null) {
 			JavaUtils.INSTANCE
-					.acceptIfNotNull(this.recordFilterStrategy, aklEndpoint::setRecordFilterStrategy);
+					.acceptIfNotNull(this.recordFilterStrategy, aklEndpoint::useRecordFilterStrategy);
 		}
 		JavaUtils.INSTANCE
 				.acceptIfNotNull(this.ackDiscarded, aklEndpoint::setAckDiscarded)

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
@@ -373,7 +373,7 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 	private void configureEndpoint(AbstractKafkaListenerEndpoint<K, V> aklEndpoint) {
 		if (aklEndpoint.getRecordFilterStrategy() == null) {
 			JavaUtils.INSTANCE
-					.acceptIfNotNull(this.recordFilterStrategy, aklEndpoint::useRecordFilterStrategy);
+					.acceptIfNotNull(this.recordFilterStrategy, aklEndpoint::setRecordFilterStrategy);
 		}
 		JavaUtils.INSTANCE
 				.acceptIfNotNull(this.ackDiscarded, aklEndpoint::setAckDiscarded)

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
@@ -340,6 +340,11 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 		this.ackDiscarded = ackDiscarded;
 	}
 
+	public void useRecordFilterStrategy(RecordFilterStrategy<? super K, ? super V> recordFilterStrategy) {
+		setRecordFilterStrategy(recordFilterStrategy);
+		setAckDiscarded(true);
+	}
+
 	@Nullable
 	@Override
 	public String getClientIdPrefix() {

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
@@ -62,6 +62,7 @@ import org.springframework.util.ObjectUtils;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Wang Zhiyang
+ * @author Sanghyeok An
  *
  * @see MethodKafkaListenerEndpoint
  */

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
@@ -340,11 +340,6 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 		this.ackDiscarded = ackDiscarded;
 	}
 
-	public void useRecordFilterStrategy(RecordFilterStrategy<? super K, ? super V> recordFilterStrategy) {
-		setRecordFilterStrategy(recordFilterStrategy);
-		setAckDiscarded(true);
-	}
-
 	@Nullable
 	@Override
 	public String getClientIdPrefix() {

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
@@ -327,7 +327,6 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 	@SuppressWarnings("unchecked")
 	public void setRecordFilterStrategy(RecordFilterStrategy<? super K, ? super V> recordFilterStrategy) {
 		this.recordFilterStrategy = (RecordFilterStrategy<K, V>) recordFilterStrategy;
-		setAckDiscarded(true);
 	}
 
 	protected boolean isAckDiscarded() {
@@ -335,7 +334,7 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 	}
 
 	/**
-	 * Set to true if the {@link #setRecordFilterStrategy(RecordFilterStrategy)} is in use.
+	 * Set to true if the {@link #setRecordFilterStrategy(RecordFilterStrategy)} should ack discarded messages.
 	 * @param ackDiscarded the ackDiscarded.
 	 */
 	public void setAckDiscarded(boolean ackDiscarded) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
@@ -326,6 +326,7 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 	@SuppressWarnings("unchecked")
 	public void setRecordFilterStrategy(RecordFilterStrategy<? super K, ? super V> recordFilterStrategy) {
 		this.recordFilterStrategy = (RecordFilterStrategy<K, V>) recordFilterStrategy;
+		setAckDiscarded(true);
 	}
 
 	protected boolean isAckDiscarded() {


### PR DESCRIPTION
### Background
- I found that the `descriptions` and `methods` related to `ackDiscarded` behave differently during investigating [issue](https://github.com/spring-projects/spring-kafka/issues/2806). 
https://github.com/spring-projects/spring-kafka/blob/1d0a7d305aec6e0976027267e80c3effd80e870c/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java#L335-L341
- From java docs, when `setRecordFilterStrategy()` in use, `ackDiscarded` should be `true`. however, `ackDiscarded` is always `false` even if some `BeanPostProcessor` call `setRecordFilterStrategy()` to use `RecordFilter`. 


### Changes
- create new method `useRecordFilterStrategy()` to bind `setRecordFilterStrategy()` and `setAckDiscarded()` to follow java docs.

