### PR TITLE
DRAFT : Add checkstyle: max line length 119.

### DIFF
--- a/src/checkstyle/checkstyle.xml
+++ b/src/checkstyle/checkstyle.xml
@@ -8,6 +8,11 @@
 		<property name="file" value="${config_loc}/checkstyle-suppressions.xml"/>
 	</module>
 
+	<module name="LineLength">
+		<property name="max" value="119"/>
+		<property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
+	</module>
+
 	<!-- Root Checks -->
 	<module name="RegexpHeader">
 		<property name="headerFile" value="${config_loc}/checkstyle-header.txt"/>


### PR DESCRIPTION
### Background
- Recently, i have learned that `spring-kafka` project has a line length convention. It would be better to include that rules to `checkStyle`.  (The code line length ! > 120 symbols.)

### To Reviewer
After adding new rule to `checkStyle`, `checkStyle` throw a lot of `style error`.  If you guys want to introduce this rule to `checkStyle`, i'm willing to fix all of `style error`. 
However, you guys don't want it, i will close this PR. 

<img width="1074" alt="image" src="https://github.com/spring-projects/spring-kafka/assets/90125071/b1fc2fc9-f6af-41db-8c99-a8c73b1f9845">


