### PR TITLE
GH-3227: Implement handleOne() in CommonDelegatingErrorHandler

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonDelegatingErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonDelegatingErrorHandler.java
@@ -39,6 +39,7 @@ import org.springframework.util.Assert;
  * @author Gary Russell
  * @author Adrian Chlebosz
  * @author Antonin Arquey
+ * @author Dan Blackney
  * @since 2.8
  *
  */
@@ -180,6 +181,19 @@ public class CommonDelegatingErrorHandler implements CommonErrorHandler {
 			this.defaultErrorHandler.handleOtherException(thrownException, consumer, container, batchListener);
 		}
 	}
+
+	@Override
+  	public boolean handleOne(Exception thrownException, ConsumerRecord<?, ?> record, Consumer<?, ?> consumer,
+			MessageListenerContainer container) {
+		
+    	CommonErrorHandler handler = findDelegate(thrownException);
+	    if (handler != null) {
+	      	return handler.handleOne(thrownException, record, consumer, container);
+	    }
+	    else {
+	      	return this.defaultErrorHandler.handleOne(thrownException, record, consumer, container);
+	    }
+  	}
 
 	@Nullable
 	private CommonErrorHandler findDelegate(Throwable thrownException) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonDelegatingErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonDelegatingErrorHandler.java
@@ -183,17 +183,17 @@ public class CommonDelegatingErrorHandler implements CommonErrorHandler {
 	}
 
 	@Override
-  	public boolean handleOne(Exception thrownException, ConsumerRecord<?, ?> record, Consumer<?, ?> consumer,
+	public boolean handleOne(Exception thrownException, ConsumerRecord<?, ?> record, Consumer<?, ?> consumer,
 			MessageListenerContainer container) {
-		
-    	CommonErrorHandler handler = findDelegate(thrownException);
-	    if (handler != null) {
-	      	return handler.handleOne(thrownException, record, consumer, container);
-	    }
-	    else {
-	      	return this.defaultErrorHandler.handleOne(thrownException, record, consumer, container);
-	    }
-  	}
+
+		CommonErrorHandler handler = findDelegate(thrownException);
+		if (handler != null) {
+			return handler.handleOne(thrownException, record, consumer, container);
+		}
+		else {
+			return this.defaultErrorHandler.handleOne(thrownException, record, consumer, container);
+		}
+	}
 
 	@Nullable
 	private CommonErrorHandler findDelegate(Throwable thrownException) {


### PR DESCRIPTION
Implement CommonErrorHandler.handleOne() in CommonDelegatingErrorHandler #3227
https://github.com/spring-projects/spring-kafka/issues/3227

Adds an implementation of `CommonErrorHandler.handleOne()` in `CommonDelegatingErrorHandler`.

Implementation functions the same as the other `handle` methods - Finds a delegate to call `handleOne()` on, or uses the `defaultErrorHandler`
