### PR TITLE
Fix deprecated Kafka Streams API in example code

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/streams.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/streams.adoc
@@ -473,7 +473,7 @@ public class KafkaStreamsConfig {
         stream
                 .mapValues((ValueMapper<String, String>) String::toUpperCase)
                 .groupByKey()
-                .windowedBy(TimeWindows.of(Duration.ofMillis(1_000)))
+                .windowedBy(TimeWindows.ofSizeWithNoGrace(Duration.ofMillis(1_000)))
                 .reduce((String value1, String value2) -> value1 + value2,
                 		Named.as("windowStore"))
                 .toStream()


### PR DESCRIPTION
Hi Team,

This PR the use of deprecated Kafka Streams API methods in the example code provided in the documentation.

### Changes
+ Replace deprecated `TimeWindows.of` method with `TimeWindows.ofSizeWithNoGrace`.

