### PR TITLE
GH-3277 : Fix coroutine detection login on MessagingMessageListenerAdapter

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/AdapterUtils.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/AdapterUtils.java
@@ -35,6 +35,7 @@ import reactor.core.publisher.Mono;
  *
  * @author Gary Russell
  * @author Wang Zhiyang
+ * @author Huijin Hong
  * @since 2.5
  *
  */
@@ -124,4 +125,13 @@ public final class AdapterUtils {
 		return CompletableFuture.class.isAssignableFrom(resultType);
 	}
 
+	/**
+	 * Return the true when type is {@code Continuation}.
+	 * @param  parameterType {@code MethodParameter} parameter type.
+	 * @return type is {@code Continuation}.
+	 * @since 3.2
+	 */
+	public static boolean isKotlinContinuation(Class<?> parameterType) {
+		return "kotlin.coroutines.Continuation".equals(parameterType.getName());
+	}
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/AdapterUtils.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/AdapterUtils.java
@@ -129,7 +129,7 @@ public final class AdapterUtils {
 	 * Return the true when type is {@code Continuation}.
 	 * @param  parameterType {@code MethodParameter} parameter type.
 	 * @return type is {@code Continuation}.
-	 * @since 3.2
+	 * @since 3.2.1
 	 */
 	public static boolean isKotlinContinuation(Class<?> parameterType) {
 		return "kotlin.coroutines.Continuation".equals(parameterType.getName());

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/ContinuationHandlerMethodArgumentResolver.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/ContinuationHandlerMethodArgumentResolver.java
@@ -30,6 +30,7 @@ import reactor.core.publisher.Mono;
  * but for regular {@link HandlerMethodArgumentResolver} contract.
  *
  * @author Wang Zhiyang
+ * @author Huijin Hong
  *
  * @since 3.2
  *
@@ -39,7 +40,7 @@ public class ContinuationHandlerMethodArgumentResolver implements HandlerMethodA
 
 	@Override
 	public boolean supportsParameter(MethodParameter parameter) {
-		return "kotlin.coroutines.Continuation".equals(parameter.getParameterType().getName());
+		return AdapterUtils.isKotlinContinuation(parameter.getParameterType());
 	}
 
 	@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
@@ -37,7 +37,6 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.common.TopicPartition;
 
 import org.springframework.context.expression.MapAccessor;
-import org.springframework.core.KotlinDetector;
 import org.springframework.core.MethodParameter;
 import org.springframework.core.log.LogAccessor;
 import org.springframework.expression.BeanResolver;
@@ -90,6 +89,7 @@ import reactor.core.publisher.Mono;
  * @author Venil Noronha
  * @author Nathan Xu
  * @author Wang ZhiYang
+ * @author Huijin Hong
  */
 public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerSeekAware, AsyncRepliesAware {
 
@@ -763,8 +763,8 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 			isNotConvertible |= isAck;
 			boolean isConsumer = parameterIsType(parameterType, Consumer.class);
 			isNotConvertible |= isConsumer;
-			boolean isCoroutines = KotlinDetector.isKotlinType(methodParameter.getParameterType());
-			isNotConvertible |= isCoroutines;
+			boolean isKotlinContinuation = AdapterUtils.isKotlinContinuation(methodParameter.getParameterType());
+			isNotConvertible |= isKotlinContinuation;
 			boolean isMeta = parameterIsType(parameterType, ConsumerRecordMetadata.class);
 			this.hasMetadataParameter |= isMeta;
 			isNotConvertible |= isMeta;
@@ -783,7 +783,7 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 					break;
 				}
 			}
-			else if (isAck || isCoroutines || isConsumer || annotationHeaderIsGroupId(methodParameter)) {
+			else if (isAck || isKotlinContinuation || isConsumer || annotationHeaderIsGroupId(methodParameter)) {
 				allowedBatchParameters++;
 			}
 		}


### PR DESCRIPTION
## Motivation:

* https://github.com/spring-projects/spring-kafka/issues/3277
* `isCoroutines` is a method unit, but on the determineInferredType method it determine by each parameter type. So I think that determine by parameter type is more nice way to improve it

## Modifications:

* Change variable naming `isCoroutines` to `isKotlinContinuation` variable 
* Change the coroutine detection logic 

## DIscussion

* Feel free to discuss about the test code improvement way
