### PR TITLE
Update misleading contents in ConsumerPartitionPausedEvent and features.adoc

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/retrytopic/features.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/retrytopic/features.adoc
@@ -221,7 +221,7 @@ This is to avoid creation of excessively large messages (due to the stack trace 
 
 See xref:kafka/annotation-error-handling.adoc#dlpr-headers[Managing Dead Letter Record Headers] for more information.
 
-To reconfigure the framework to use different settings for these properties, configure a `DeadLetterPublishingRecovererer` customizer by overriding the `configureCustomizers` method in a `@Configuration` class that extends `RetryTopicConfigurationSupport`.
+To reconfigure the framework to use different settings for these properties, configure a `DeadLetterPublishingRecoverer` customizer by overriding the `configureCustomizers` method in a `@Configuration` class that extends `RetryTopicConfigurationSupport`.
 See xref:retrytopic/retry-config.adoc#retry-topic-global-settings[Configuring Global Settings and Features] for more details.
 
 [source, java]

--- a/spring-kafka/src/main/java/org/springframework/kafka/event/ConsumerPartitionPausedEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/ConsumerPartitionPausedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2021 the original author or authors.
+ * Copyright 2018-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import org.apache.kafka.common.TopicPartition;
  * An event published when a consumer partition is paused.
  *
  * @author Tomaz Fernandes
+ * @author Borahm Lee
  * @since 2.7
  *
  */
@@ -47,13 +48,13 @@ public class ConsumerPartitionPausedEvent extends KafkaEvent {
 	 * Return the paused partition.
 	 * @return the partition.
 	 */
-	public TopicPartition getPartitions() {
+	public TopicPartition getPartition() {
 		return this.partition;
 	}
 
 	@Override
 	public String toString() {
-		return "ConsumerPausedEvent [partitions=" + this.partition + "]";
+		return "ConsumerPartitionPausedEvent [partition=" + this.partition + "]";
 	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/event/ConsumerPartitionPausedEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/ConsumerPartitionPausedEvent.java
@@ -47,6 +47,16 @@ public class ConsumerPartitionPausedEvent extends KafkaEvent {
 	/**
 	 * Return the paused partition.
 	 * @return the partition.
+	 * @deprecated replaced by {@link #getPartition()}
+	 */
+	@Deprecated(since = "3.3", forRemoval = true)
+	public TopicPartition getPartitions() {
+		return this.partition;
+	}
+
+	/**
+	 * Return the paused partition.
+	 * @return the partition.
 	 */
 	public TopicPartition getPartition() {
 		return this.partition;

--- a/spring-kafka/src/main/java/org/springframework/kafka/event/ConsumerPartitionPausedEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/ConsumerPartitionPausedEvent.java
@@ -57,6 +57,7 @@ public class ConsumerPartitionPausedEvent extends KafkaEvent {
 	/**
 	 * Return the paused partition.
 	 * @return the partition.
+	 * @since 3.3
 	 */
 	public TopicPartition getPartition() {
 		return this.partition;


### PR DESCRIPTION
<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->

## Changes
- **ConsumerPartitionPausedEvent**
  - Correct misleading method name and content.
    - `ConsumerPausedEvent` -> `ConsumerPartitionPausedEvent` (This prevents confusion with the existing event `ConsumerPausedEvent`).
    - `getPartitions()` -> `getPartition()` (Since the event is specific to a single partition, use the singular form)
- **features.adoc**
  - `DeadLetterPublishingRecovererer` -> `DeadLetterPublishingRecoverer` 
  - This reverts the incorrect change made in [PR #3226](https://github.com/spring-projects/spring-kafka/pull/3226). 
