### PR TITLE
GH-3319: Fix NPE in the `KafkaListenerEndpointRegistry`

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistry.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistry.java
@@ -168,7 +168,7 @@ public class KafkaListenerEndpointRegistry implements ListenerContainerRegistry,
 			refreshContextContainers();
 			return this.unregisteredContainers.get(id);
 		}
-		return null;
+		return container;
 	}
 
 	/**


### PR DESCRIPTION
The `KafkaListenerEndpointRegistry.getUnregisteredListenerContainer()` returns `null` when container is already present in the internal `unregisteredContainers` cache

* Fix `KafkaListenerEndpointRegistry.getUnregisteredListenerContainer()` to return a container instance from the `unregisteredContainers` cache

**Auto-cherry-pick to `3.2.x` & `3.1.x`**

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
