### PR TITLE
GH-3328: Enhance AbstractConsumerSeekAware with Extended callback for Multi-Group Listeners

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/seek.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/seek.adoc
@@ -187,16 +187,17 @@ public class SeekToLastOnIdleListener extends AbstractConsumerSeekAware {
     */
     public void rewindAllOneRecord() {
         getSeekCallbacks()
-            .forEach((tp, callback) ->
-                callback.seekRelative(tp.topic(), tp.partition(), -1, true));
+            .forEach((tp, callbacks) ->
+                    callbacks.forEach(callback -> callback.seekRelative(tp.topic(), tp.partition(), -1, true))
+            );
     }
 
     /**
     * Rewind one partition one record.
     */
     public void rewindOnePartitionOneRecord(String topic, int partition) {
-        getSeekCallbackFor(new TopicPartition(topic, partition))
-            .seekRelative(topic, partition, -1, true);
+        getSeekCallbacksFor(new TopicPartition(topic, partition))
+            .forEach(callback -> callback.seekRelative(topic, partition, -1, true));
     }
 
 }

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/seek.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/seek.adoc
@@ -184,25 +184,20 @@ public class SeekToLastOnIdleListener extends AbstractConsumerSeekAware {
 
     /**
     * Rewind all partitions one record.
-    * As of version 3.3, for multi-group listeners, it's recommended to use `getTopicsAndCallbacks()`
-    * in {@link org.springframework.kafka.listener.AbstractConsumerSeekAware}
-    * to handle seeks more accurately across different consumer groups.
     */
     public void rewindAllOneRecord() {
-        getSeekCallbacks()
-            .forEach((tp, callback) ->
-                callback.seekRelative(tp.topic(), tp.partition(), -1, true));
+        getTopicsAndCallbacks()
+            .forEach((tp, callbacks) ->
+                    callbacks.forEach(callback -> callback.seekRelative(tp.topic(), tp.partition(), -1, true))
+            );
     }
 
     /**
     * Rewind one partition one record.
-    * As of version 3.3, for multi-group listeners, it's recommended to use `getSeekCallbacksFor(TopicPartition)`
-    * in {@link org.springframework.kafka.listener.AbstractConsumerSeekAware}
-    * to handle seeks more accurately across different consumer groups.
     */
     public void rewindOnePartitionOneRecord(String topic, int partition) {
-        getSeekCallbackFor(new TopicPartition(topic, partition))
-            .seekRelative(topic, partition, -1, true);
+        getSeekCallbacksFor(new TopicPartition(topic, partition))
+            .forEach(callback -> callback.seekRelative(topic, partition, -1, true));
     }
 
 }

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/seek.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/seek.adoc
@@ -184,20 +184,25 @@ public class SeekToLastOnIdleListener extends AbstractConsumerSeekAware {
 
     /**
     * Rewind all partitions one record.
+    * As of version 3.3, for multi-group listeners, it's recommended to use `getTopicsAndCallbacks()`
+    * in {@link org.springframework.kafka.listener.AbstractConsumerSeekAware}
+    * to handle seeks more accurately across different consumer groups.
     */
     public void rewindAllOneRecord() {
         getSeekCallbacks()
-            .forEach((tp, callbacks) ->
-                    callbacks.forEach(callback -> callback.seekRelative(tp.topic(), tp.partition(), -1, true))
-            );
+            .forEach((tp, callback) ->
+                callback.seekRelative(tp.topic(), tp.partition(), -1, true));
     }
 
     /**
     * Rewind one partition one record.
+    * As of version 3.3, for multi-group listeners, it's recommended to use `getSeekCallbacksFor(TopicPartition)`
+    * in {@link org.springframework.kafka.listener.AbstractConsumerSeekAware}
+    * to handle seeks more accurately across different consumer groups.
     */
     public void rewindOnePartitionOneRecord(String topic, int partition) {
-        getSeekCallbacksFor(new TopicPartition(topic, partition))
-            .forEach(callback -> callback.seekRelative(topic, partition, -1, true));
+        getSeekCallbackFor(new TopicPartition(topic, partition))
+            .seekRelative(topic, partition, -1, true);
     }
 
 }

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -19,4 +19,8 @@ A new method, `getGroupId()`, has been added to the `ConsumerSeekCallback` inter
 This method allows for more selective seek operations by targeting only the desired consumer group.
 For more details, see xref:kafka/seek.adoc#seek[Seek API Docs].
 
+[[x33-enhanced-seek-callback-management]]
+=== Enhanced Callback Management in AbstractConsumerSeekAware
 
+`AbstractConsumerSeekAware` can now register, retrieve, and remove all callbacks for each topic partition in a multi-group listener scenario without missing any.
+See the new APIs (`getSeekCallbacksFor(TopicPartition topicPartition)`, `getTopicsAndCallbacks()`) for more details.

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractConsumerSeekAware.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractConsumerSeekAware.java
@@ -87,7 +87,6 @@ public abstract class AbstractConsumerSeekAware implements ConsumerSeekAware {
 
 	/**
 	 * Return the callbacks for the specified topic/partition.
-	 *
 	 * @param topicPartition the topic/partition.
 	 * @return the callbacks (or null if there is no assignment).
 	 */
@@ -98,7 +97,6 @@ public abstract class AbstractConsumerSeekAware implements ConsumerSeekAware {
 
 	/**
 	 * The map of callbacks for all currently assigned partitions.
-	 *
 	 * @return the map.
 	 */
 	protected Map<TopicPartition, List<ConsumerSeekCallback>> getSeekCallbacks() {
@@ -107,7 +105,6 @@ public abstract class AbstractConsumerSeekAware implements ConsumerSeekAware {
 
 	/**
 	 * Return the currently registered callbacks and their associated {@link TopicPartition}(s).
-	 *
 	 * @return the map of callbacks and partitions.
 	 * @since 2.6
 	 */
@@ -117,7 +114,6 @@ public abstract class AbstractConsumerSeekAware implements ConsumerSeekAware {
 
 	/**
 	 * Seek all assigned partitions to the beginning.
-	 *
 	 * @since 2.6
 	 */
 	public void seekToBeginning() {
@@ -126,7 +122,6 @@ public abstract class AbstractConsumerSeekAware implements ConsumerSeekAware {
 
 	/**
 	 * Seek all assigned partitions to the end.
-	 *
 	 * @since 2.6
 	 */
 	public void seekToEnd() {
@@ -135,7 +130,6 @@ public abstract class AbstractConsumerSeekAware implements ConsumerSeekAware {
 
 	/**
 	 * Seek all assigned partitions to the offset represented by the timestamp.
-	 *
 	 * @param time the time to seek to.
 	 * @since 2.6
 	 */

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractConsumerSeekAware.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractConsumerSeekAware.java
@@ -45,7 +45,7 @@ public abstract class AbstractConsumerSeekAware implements ConsumerSeekAware {
 
 	private final Map<TopicPartition, List<ConsumerSeekCallback>> topicToCallbacks = new ConcurrentHashMap<>();
 
-	private final Map<ConsumerSeekCallback, List<TopicPartition>> callbacksToTopic = new ConcurrentHashMap<>();
+	private final Map<ConsumerSeekCallback, List<TopicPartition>> callbackToTopics = new ConcurrentHashMap<>();
 
 	@Override
 	public void registerSeekCallback(ConsumerSeekCallback callback) {
@@ -58,7 +58,7 @@ public abstract class AbstractConsumerSeekAware implements ConsumerSeekAware {
 		if (threadCallback != null) {
 			assignments.keySet().forEach(tp -> {
 				this.topicToCallbacks.computeIfAbsent(tp, key -> new ArrayList<>()).add(threadCallback);
-				this.callbacksToTopic.computeIfAbsent(threadCallback, key -> new LinkedList<>()).add(tp);
+				this.callbackToTopics.computeIfAbsent(threadCallback, key -> new LinkedList<>()).add(tp);
 			});
 		}
 	}
@@ -69,11 +69,11 @@ public abstract class AbstractConsumerSeekAware implements ConsumerSeekAware {
 			List<ConsumerSeekCallback> removedCallbacks = this.topicToCallbacks.remove(tp);
 			if (removedCallbacks != null && !removedCallbacks.isEmpty()) {
 				removedCallbacks.forEach(cb -> {
-					List<TopicPartition> topics = this.callbacksToTopic.get(cb);
+					List<TopicPartition> topics = this.callbackToTopics.get(cb);
 					if (topics != null) {
 						topics.remove(tp);
 						if (topics.isEmpty()) {
-							this.callbacksToTopic.remove(cb);
+							this.callbackToTopics.remove(cb);
 						}
 					}
 				});
@@ -144,7 +144,7 @@ public abstract class AbstractConsumerSeekAware implements ConsumerSeekAware {
 	 * @since 2.6
 	 */
 	protected Map<ConsumerSeekCallback, List<TopicPartition>> getCallbacksAndTopics() {
-		return Collections.unmodifiableMap(this.callbacksToTopic);
+		return Collections.unmodifiableMap(this.callbackToTopics);
 	}
 
 	/**

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -1082,7 +1082,7 @@ public class EnableKafkaIntegrationTests {
 		assertThat(this.seekOnIdleListener.latch3.await(10, TimeUnit.SECONDS)).isTrue();
 		this.registry.getListenerContainer("seekOnIdle").stop();
 		assertThat(this.seekOnIdleListener.latch4.await(10, TimeUnit.SECONDS)).isTrue();
-		assertThat(KafkaTestUtils.getPropertyValue(this.seekOnIdleListener, "callbacks", Map.class)).hasSize(0);
+		assertThat(KafkaTestUtils.getPropertyValue(this.seekOnIdleListener, "topicToCallbacks", Map.class)).hasSize(0);
 	}
 
 	@SuppressWarnings({"unchecked", "rawtypes"})
@@ -2524,13 +2524,6 @@ public class EnableKafkaIntegrationTests {
 				if (latch1.getCount() > 0) {
 					latch1.countDown();
 					if (latch1.getCount() == 0) {
-						// TODO: This should be removed when the existing `getSeekCallbackFor()` disappears.
-						ConsumerSeekCallback seekToComputeFn = getSeekCallbackFor(
-								new org.apache.kafka.common.TopicPartition("seekToComputeFn", 0));
-						assertThat(seekToComputeFn).isNotNull();
-						seekToComputeFn.
-								seek("seekToComputeFn", 0, current -> 0L);
-
 						List<ConsumerSeekCallback> seekToComputeFunctions = getSeekCallbacksFor(
 								new org.apache.kafka.common.TopicPartition("seekToComputeFn", 0));
 						assertThat(seekToComputeFunctions).isNotEmpty();
@@ -2583,11 +2576,6 @@ public class EnableKafkaIntegrationTests {
 		}
 
 		public void rewindAllOneRecord() {
-			// TODO: This should be removed when the existing `getSeekCallbacks()` disappears.
-			getSeekCallbacks()
-					.forEach((tp, callback) ->
-							callback.seekRelative(tp.topic(), tp.partition(), -1, true));
-
 			getTopicsAndCallbacks()
 					.forEach((tp, callbacks) ->
 							callbacks.forEach(callback -> callback.seekRelative(tp.topic(), tp.partition(), -1, true))
@@ -2595,10 +2583,6 @@ public class EnableKafkaIntegrationTests {
 		}
 
 		public void rewindOnePartitionOneRecord(String topic, int partition) {
-			// TODO: This should be removed when the existing `getSeekCallbackFor()` disappears.
-			getSeekCallbackFor(new org.apache.kafka.common.TopicPartition(topic, partition))
-					.seekRelative(topic, partition, -1, true);
-
 			getSeekCallbacksFor(new org.apache.kafka.common.TopicPartition(topic, partition))
 					.forEach(callback -> callback.seekRelative(topic, partition, -1, true));
 		}

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -2213,7 +2213,7 @@ public class EnableKafkaIntegrationTests {
 
 		@KafkaListener(id = LISTENER_ID_SEEK_POSITION_TIMESTAMP_0, autoStartup = "false", topicPartitions = {
 				@TopicPartition(topic = TOPIC_SEEK_POSITION_TIMESTAMP, partitionOffsets =
-				@PartitionOffset(partition = "0", initialOffset = "9999999999000", seekPosition = "TIMESTAMP")
+						@PartitionOffset(partition = "0", initialOffset = "9999999999000", seekPosition = "TIMESTAMP")
 				)
 		})
 		void annotationPartitionOffsetSeekPositionTimestampNoMatch(ConsumerRecord<?, ?> record) {

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -2524,9 +2524,16 @@ public class EnableKafkaIntegrationTests {
 				if (latch1.getCount() > 0) {
 					latch1.countDown();
 					if (latch1.getCount() == 0) {
+						// TODO: This should be removed when the existing `getSeekCallbackFor()` disappears.
+						ConsumerSeekCallback seekToComputeFn = getSeekCallbackFor(
+								new org.apache.kafka.common.TopicPartition("seekToComputeFn", 0));
+						assertThat(seekToComputeFn).isNotNull();
+						seekToComputeFn.
+								seek("seekToComputeFn", 0, current -> 0L);
+
 						List<ConsumerSeekCallback> seekToComputeFunctions = getSeekCallbacksFor(
 								new org.apache.kafka.common.TopicPartition("seekToComputeFn", 0));
-						assertThat(seekToComputeFunctions).isNotNull().isNotEmpty();
+						assertThat(seekToComputeFunctions).isNotEmpty();
 						seekToComputeFunctions.forEach(callback -> callback.seek("seekToComputeFn", 0, current -> 0L));
 					}
 				}
@@ -2576,13 +2583,22 @@ public class EnableKafkaIntegrationTests {
 		}
 
 		public void rewindAllOneRecord() {
+			// TODO: This should be removed when the existing `getSeekCallbacks()` disappears.
 			getSeekCallbacks()
+					.forEach((tp, callback) ->
+							callback.seekRelative(tp.topic(), tp.partition(), -1, true));
+
+			getTopicsAndCallbacks()
 					.forEach((tp, callbacks) ->
 							callbacks.forEach(callback -> callback.seekRelative(tp.topic(), tp.partition(), -1, true))
 					);
 		}
 
 		public void rewindOnePartitionOneRecord(String topic, int partition) {
+			// TODO: This should be removed when the existing `getSeekCallbackFor()` disappears.
+			getSeekCallbackFor(new org.apache.kafka.common.TopicPartition(topic, partition))
+					.seekRelative(topic, partition, -1, true);
+
 			getSeekCallbacksFor(new org.apache.kafka.common.TopicPartition(topic, partition))
 					.forEach(callback -> callback.seekRelative(topic, partition, -1, true));
 		}

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -2526,7 +2526,7 @@ public class EnableKafkaIntegrationTests {
 					if (latch1.getCount() == 0) {
 						List<ConsumerSeekCallback> seekToComputeFunctions = getSeekCallbacksFor(
 								new org.apache.kafka.common.TopicPartition("seekToComputeFn", 0));
-						assertThat(seekToComputeFunctions).isNotNull();
+						assertThat(seekToComputeFunctions).isNotNull().isNotEmpty();
 						seekToComputeFunctions.forEach(callback -> callback.seek("seekToComputeFn", 0, current -> 0L));
 					}
 				}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/AbstractConsumerSeekAwareTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/AbstractConsumerSeekAwareTests.java
@@ -82,7 +82,7 @@ class AbstractConsumerSeekAwareTests {
 				Set<TopicPartition> getTopicPartitions = topicsAndCallbacks.keySet();
 				Set<ConsumerSeekCallback> getCallbacks = topicsAndCallbacks.values().stream().flatMap(Collection::stream).collect(Collectors.toSet());
 
-				assertThat(registeredCallbacks).containsExactlyInAnyOrderElementsOf(getCallbacks).hasSize(4);
+				assertThat(registeredCallbacks).containsExactlyInAnyOrderElementsOf(getCallbacks).isNotEmpty();
 				assertThat(registeredTopicPartitions).containsExactlyInAnyOrderElementsOf(getTopicPartitions).hasSize(3);
 		});
 	}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/AbstractConsumerSeekAwareTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/AbstractConsumerSeekAwareTests.java
@@ -75,15 +75,15 @@ class AbstractConsumerSeekAwareTests {
 	public void checkCallbacksAndTopicPartitions() {
 		await().timeout(Duration.ofSeconds(10)).untilAsserted(() -> {
 			Map<ConsumerSeekCallback, List<TopicPartition>> callbacksAndTopics = multiGroupListener.getCallbacksAndTopics();
-				Set<ConsumerSeekCallback> registeredCallbacks = callbacksAndTopics.keySet();
-				Set<TopicPartition> registeredTopicPartitions = callbacksAndTopics.values().stream().flatMap(Collection::stream).collect(Collectors.toSet());
+			Set<ConsumerSeekCallback> registeredCallbacks = callbacksAndTopics.keySet();
+			Set<TopicPartition> registeredTopicPartitions = callbacksAndTopics.values().stream().flatMap(Collection::stream).collect(Collectors.toSet());
 
-				Map<TopicPartition, List<ConsumerSeekCallback>> topicsAndCallbacks = multiGroupListener.getSeekCallbacks();
-				Set<TopicPartition> getTopicPartitions = topicsAndCallbacks.keySet();
-				Set<ConsumerSeekCallback> getCallbacks = topicsAndCallbacks.values().stream().flatMap(Collection::stream).collect(Collectors.toSet());
+			Map<TopicPartition, List<ConsumerSeekCallback>> topicsAndCallbacks = multiGroupListener.getSeekCallbacks();
+			Set<TopicPartition> getTopicPartitions = topicsAndCallbacks.keySet();
+			Set<ConsumerSeekCallback> getCallbacks = topicsAndCallbacks.values().stream().flatMap(Collection::stream).collect(Collectors.toSet());
 
-				assertThat(registeredCallbacks).containsExactlyInAnyOrderElementsOf(getCallbacks).isNotEmpty();
-				assertThat(registeredTopicPartitions).containsExactlyInAnyOrderElementsOf(getTopicPartitions).hasSize(3);
+			assertThat(registeredCallbacks).containsExactlyInAnyOrderElementsOf(getCallbacks).isNotEmpty();
+			assertThat(registeredTopicPartitions).containsExactlyInAnyOrderElementsOf(getTopicPartitions).hasSize(3);
 		});
 	}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/AbstractConsumerSeekAwareTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/AbstractConsumerSeekAwareTests.java
@@ -153,12 +153,12 @@ class AbstractConsumerSeekAwareTests {
 
 			static CountDownLatch latch2 = new CountDownLatch(2);
 
-			@KafkaListener(id = "group1", groupId = "group1", topics = TOPIC, concurrency = "2")
+			@KafkaListener(groupId = "group1", topics = TOPIC, concurrency = "2")
 			void listenForGroup1(String in) {
 				latch1.countDown();
 			}
 
-			@KafkaListener(id = "group2", groupId = "group2", topics = TOPIC, concurrency = "2")
+			@KafkaListener(groupId = "group2", topics = TOPIC, concurrency = "2")
 			void listenForGroup2(String in) {
 				latch2.countDown();
 			}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/AbstractConsumerSeekAwareTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/AbstractConsumerSeekAwareTests.java
@@ -78,7 +78,7 @@ class AbstractConsumerSeekAwareTests {
 			Set<ConsumerSeekCallback> registeredCallbacks = callbacksAndTopics.keySet();
 			Set<TopicPartition> registeredTopicPartitions = callbacksAndTopics.values().stream().flatMap(Collection::stream).collect(Collectors.toSet());
 
-			Map<TopicPartition, List<ConsumerSeekCallback>> topicsAndCallbacks = multiGroupListener.getSeekCallbacks();
+			Map<TopicPartition, List<ConsumerSeekCallback>> topicsAndCallbacks = multiGroupListener.getTopicsAndCallbacks();
 			Set<TopicPartition> getTopicPartitions = topicsAndCallbacks.keySet();
 			Set<ConsumerSeekCallback> getCallbacks = topicsAndCallbacks.values().stream().flatMap(Collection::stream).collect(Collectors.toSet());
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/AbstractConsumerSeekAwareTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/AbstractConsumerSeekAwareTests.java
@@ -73,7 +73,7 @@ class AbstractConsumerSeekAwareTests {
 
 	@Test
 	public void checkCallbacksAndTopicPartitions() {
-		await().timeout(Duration.ofSeconds(10)).untilAsserted(() -> {
+		await().timeout(Duration.ofSeconds(5)).untilAsserted(() -> {
 			Map<ConsumerSeekCallback, List<TopicPartition>> callbacksAndTopics = multiGroupListener.getCallbacksAndTopics();
 			Set<ConsumerSeekCallback> registeredCallbacks = callbacksAndTopics.keySet();
 			Set<TopicPartition> registeredTopicPartitions = callbacksAndTopics.values().stream().flatMap(Collection::stream).collect(Collectors.toSet());

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ConsumerSeekAwareTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ConsumerSeekAwareTests.java
@@ -36,6 +36,7 @@ import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 /**
  * @author Gary Russell
+ * @author Borahm Lee
  * @since 2.6
  *
  */
@@ -104,7 +105,7 @@ public class ConsumerSeekAwareTests {
 		};
 		exec1.submit(revoke2).get();
 		exec2.submit(revoke2).get();
-		assertThat(KafkaTestUtils.getPropertyValue(csa, "callbacks", Map.class)).isEmpty();
+		assertThat(KafkaTestUtils.getPropertyValue(csa, "topicToCallbacks", Map.class)).isEmpty();
 		assertThat(KafkaTestUtils.getPropertyValue(csa, "callbacksToTopic", Map.class)).isEmpty();
 		var checkTL = (Callable<Void>) () -> {
 			csa.unregisterSeekCallback();

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ConsumerSeekAwareTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ConsumerSeekAwareTests.java
@@ -106,7 +106,7 @@ public class ConsumerSeekAwareTests {
 		exec1.submit(revoke2).get();
 		exec2.submit(revoke2).get();
 		assertThat(KafkaTestUtils.getPropertyValue(csa, "topicToCallbacks", Map.class)).isEmpty();
-		assertThat(KafkaTestUtils.getPropertyValue(csa, "callbacksToTopic", Map.class)).isEmpty();
+		assertThat(KafkaTestUtils.getPropertyValue(csa, "callbackToTopics", Map.class)).isEmpty();
 		var checkTL = (Callable<Void>) () -> {
 			csa.unregisterSeekCallback();
 			assertThat(KafkaTestUtils.getPropertyValue(csa, "callbackForThread", Map.class).get(Thread.currentThread()))

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
@@ -144,6 +144,7 @@ import org.springframework.util.backoff.FixedBackOff;
  * @author Soby Chacko
  * @author Wang Zhiyang
  * @author Mikael Carlstedt
+ * @author Borahm Lee
  */
 @EmbeddedKafka(topics = { KafkaMessageListenerContainerTests.topic1, KafkaMessageListenerContainerTests.topic2,
 		KafkaMessageListenerContainerTests.topic3, KafkaMessageListenerContainerTests.topic4,
@@ -2595,16 +2596,18 @@ public class KafkaMessageListenerContainerTests {
 			public void onMessage(ConsumerRecord<String, String> data) {
 				if (data.partition() == 0 && data.offset() == 0) {
 					TopicPartition topicPartition = new TopicPartition(data.topic(), data.partition());
-					final ConsumerSeekCallback seekCallbackFor = getSeekCallbackFor(topicPartition);
-					assertThat(seekCallbackFor).isNotNull();
-					seekCallbackFor.seekToBeginning(records.keySet());
-					Iterator<TopicPartition> iterator = records.keySet().iterator();
-					seekCallbackFor.seekToBeginning(Collections.singletonList(iterator.next()));
-					seekCallbackFor.seekToBeginning(Collections.singletonList(iterator.next()));
-					seekCallbackFor.seekToEnd(records.keySet());
-					iterator = records.keySet().iterator();
-					seekCallbackFor.seekToEnd(Collections.singletonList(iterator.next()));
-					seekCallbackFor.seekToEnd(Collections.singletonList(iterator.next()));
+					final List<ConsumerSeekCallback> seekCallbacksFor = getSeekCallbacksFor(topicPartition);
+					assertThat(seekCallbacksFor).isNotNull().isNotEmpty();
+					seekCallbacksFor.forEach(callback -> {
+						callback.seekToBeginning(records.keySet());
+						Iterator<TopicPartition> iterator = records.keySet().iterator();
+						callback.seekToBeginning(Collections.singletonList(iterator.next()));
+						callback.seekToBeginning(Collections.singletonList(iterator.next()));
+						callback.seekToEnd(records.keySet());
+						iterator = records.keySet().iterator();
+						callback.seekToEnd(Collections.singletonList(iterator.next()));
+						callback.seekToEnd(Collections.singletonList(iterator.next()));
+					});
 				}
 			}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
@@ -2597,7 +2597,7 @@ public class KafkaMessageListenerContainerTests {
 				if (data.partition() == 0 && data.offset() == 0) {
 					TopicPartition topicPartition = new TopicPartition(data.topic(), data.partition());
 					final List<ConsumerSeekCallback> seekCallbacksFor = getSeekCallbacksFor(topicPartition);
-					assertThat(seekCallbacksFor).isNotNull().isNotEmpty();
+					assertThat(seekCallbacksFor).isNotEmpty();
 					seekCallbacksFor.forEach(callback -> {
 						callback.seekToBeginning(records.keySet());
 						Iterator<TopicPartition> iterator = records.keySet().iterator();


### PR DESCRIPTION
<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->

## Background
> Resolves #3328 
- When using `AbstractConsumerSeekAware` in a multi-group listeners scenario, there are cases where the number of registered callbacks differs from the number of discovered callbacks.
- This is due to the value type of `callbacks` Map in `AbstractConsumerSeekAware` class being simply `ConsumerSeekCallback`. This causes some callbacks looking at the same partition to be missing.

## Changes
- Change the value type of `callbacks` Map in `AbstractConsumerSeekAware` class from `ConsumerSeekCallback` to `List<ConsumerSeekCallback>`. Also modify some methods, test codes and docs that are affected by this change.
- Add test codes to verify that the callbacks registered via `registeredSeekCallback()` and the ones you can get via `getSeekCallbacks()` match completely.

