### PR TITLE
GH-3349: Polish

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistry.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistry.java
@@ -396,7 +396,7 @@ public class KafkaListenerEndpointRegistry implements ListenerContainerRegistry,
 	public void stop(Runnable callback) {
 		this.running = false;
 		Collection<MessageListenerContainer> listenerContainersToStop = getListenerContainers();
-		if (listenerContainersToStop.size() > 0) {
+		if (!listenerContainersToStop.isEmpty()) {
 			AggregatingCallback aggregatingCallback = new AggregatingCallback(listenerContainersToStop.size(),
 					callback);
 			for (MessageListenerContainer listenerContainer : listenerContainersToStop) {


### PR DESCRIPTION
Fixes: #3349

* The KafkaListenerEndpointRegistry refactoring for List.isEmpty() instead of List.size() > 0
