### PR TITLE
Reset Error reason after ConcurrentContainer is stopped

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
@@ -390,11 +390,11 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 		int startedContainersCount = this.startedContainers.decrementAndGet();
 		if (startedContainersCount == 0) {
 			publishConcurrentContainerStoppedEvent(this.reason);
-			if (Reason.AUTH.equals(this.reason)
-					&& getContainerProperties().isRestartAfterAuthExceptions()) {
+			boolean restartContainer = Reason.AUTH.equals(this.reason)
+					&& getContainerProperties().isRestartAfterAuthExceptions();
+			this.reason = null;
 
-				this.reason = null;
-
+			if (restartContainer) {
 				// This has to run on another thread to avoid a deadlock on lifecycleMonitor
 				AsyncTaskExecutor exec = getContainerProperties().getListenerTaskExecutor();
 				if (exec == null) {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
Error reason  is not cleared after the ConcurrentContainer is stopped. It is cleared only when the Reason is Auth