### PR TITLE
GH-3375: ExtendedKafkaConsumer now overrides close()

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
@@ -72,6 +72,7 @@ import org.springframework.util.StringUtils;
  * @author Artem Bilan
  * @author Chris Gilbert
  * @author Adrian Gygax
+ * @author Yaniv Nahoum
  */
 public class DefaultKafkaConsumerFactory<K, V> extends KafkaResourceFactory
 		implements ConsumerFactory<K, V>, BeanNameAware, ApplicationContextAware {
@@ -520,9 +521,18 @@ public class DefaultKafkaConsumerFactory<K, V> extends KafkaResourceFactory
 		}
 
 		@Override
+		public void close() {
+			super.close();
+			notifyConsumerRemoved();
+		}
+
+		@Override
 		public void close(Duration timeout) {
 			super.close(timeout);
+			notifyConsumerRemoved();
+		}
 
+		private void notifyConsumerRemoved() {
 			for (Listener<K, V> listener : DefaultKafkaConsumerFactory.this.listeners) {
 				listener.consumerRemoved(this.idForListeners, this);
 			}


### PR DESCRIPTION
Fixes  #3375: ExtendedKafkaConsumer now overrides close() in order to make sure listener.consumerRemoved() is called when the consumer is closed

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
