### PR TITLE
GH-3396 : Fix retry topic documentation for class-level configuration

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/retrytopic/how-the-pattern-works.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/retrytopic/how-the-pattern-works.adoc
@@ -13,22 +13,6 @@ IMPORTANT: By using this strategy you lose Kafka's ordering guarantees for that 
 
 IMPORTANT: You can set the `AckMode` mode you prefer, but `RECORD` is suggested.
 
-IMPORTANT: This functionality now supports class level `@KafkaListener` annotations since version 3.2.
-
-[source, java]
-----
-@RetryableTopic(listenerContainerFactory = "my-retry-topic-factory")
-@KafkaListener(topics = "my-annotated-topic")
-public class ClassLevelRetryListener {
-
-    @KafkaHandler
-    public void processMessage(MyPojo message) {
-        // message processing logic
-    }
-
-}
-----
-
 When using a manual `AckMode` with `asyncAcks` set to true, the `DefaultErrorHandler` must be configured with `seekAfterError` set to `false`.
 Starting with versions 2.9.10, 3.0.8, this will be set to `false` unconditionally for such configurations.
 With earlier versions, it was necessary to override the `RetryConfigurationSupport.configureCustomizers()` method to set the property to `false`.

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/retrytopic/how-the-pattern-works.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/retrytopic/how-the-pattern-works.adoc
@@ -13,7 +13,21 @@ IMPORTANT: By using this strategy you lose Kafka's ordering guarantees for that 
 
 IMPORTANT: You can set the `AckMode` mode you prefer, but `RECORD` is suggested.
 
-IMPORTANT: At this time this functionality doesn't support class level `@KafkaListener` annotations.
+IMPORTANT: This functionality now supports class level `@KafkaListener` annotations since version 3.2.
+
+[source, java]
+----
+@RetryableTopic(listenerContainerFactory = "my-retry-topic-factory")
+@KafkaListener(topics = "my-annotated-topic")
+public class ClassLevelRetryListener {
+
+    @KafkaHandler
+    public void processMessage(MyPojo message) {
+        // message processing logic
+    }
+
+}
+----
 
 When using a manual `AckMode` with `asyncAcks` set to true, the `DefaultErrorHandler` must be configured with `seekAfterError` set to `false`.
 Starting with versions 2.9.10, 3.0.8, this will be set to `false` unconditionally for such configurations.
@@ -28,4 +42,3 @@ protected void configureCustomizers(CustomizersConfigurer customizersConfigurer)
 ----
 
 In addition, before those versions, using the default (logging) DLT handler was not compatible with any kind of manual `AckMode`, regardless of the `asyncAcks` property.
-


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-kafka/issues/3396

This pull request updates the documentation to reflect the support for class-level @KafkaListener annotations in the retry topic configuration, available since version 3.2. It corrects the outdated statement and adds a relevant code example.