### PR TITLE
GH-3402: kafkaAdmin clusterId configuration is ignored if observability is enabled and bootstrap supplier is not set

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaAdmin.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaAdmin.java
@@ -213,6 +213,14 @@ public class KafkaAdmin extends KafkaResourceFactory
 		this.clusterId = clusterId;
 	}
 
+	/**
+	 * Get the clusterId property.
+	 * @since 3.3.0
+	 */
+	public String getClusterId() {
+		return clusterId;
+	}
+
 	@Override
 	public Map<String, Object> getConfigurationProperties() {
 		Map<String, Object> configs2 = new HashMap<>(this.configs);


### PR DESCRIPTION

fixes GH-3402 (https://github.com/spring-projects/spring-kafka/issues/3402)

* Re-set clusterId after creating new KafkaAdmin


