### PR TITLE
GH-3395: Use Original Key in Reply Record

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/sending-messages.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/sending-messages.adoc
@@ -650,8 +650,7 @@ public Message<?> messageReturn(String in) {
 }
 ----
 
-[[record-key-in-reply]]
-== Preserving Request Record Key in Reply
+=== Original Record Key in Reply
 
 Starting with version 3.3, the Kafka record key from the incoming request (if it exists) will be preserved in the reply record.
 This is only applicable for single record request/reply scenario.

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/sending-messages.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/sending-messages.adoc
@@ -650,6 +650,13 @@ public Message<?> messageReturn(String in) {
 }
 ----
 
+[[record-key-in-reply]]
+== Preserving Request Record Key in Reply
+
+Starting with version 3.3, the Kafka record key from the incoming request (if it exists) will be preserved in the reply record.
+This is only applicable for single record request/reply scenario.
+When the listener is batch or when the return type is a collection, it is up to the application to specify which keys to use by wrapping the reply record in a `Message` type.
+
 [[aggregating-request-reply]]
 == Aggregating Multiple Replies
 

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -35,8 +35,8 @@ For more details, see xref:kafka/receiving-messages/filtering.adoc[Message recei
 The `ConcurentContainerMessageListenerContainer` emits now a `ConcurrentContainerStoppedEvent` when all of its child containers are stopped.
 For more details, see xref:kafka/events.adoc[Application Events] and `ConcurrentContainerStoppedEvent` Javadocs.
 
-[[x33-record-key-in-reply]]
-=== Preserving Request Record Key in Reply
+[[x33-original-record-key-in-reply]]
+=== Original Record Key in Reply
 
 When using `ReplyingKafkaTemplate`, if the original record from the request contains a key, then that same key will be part of the reply as well.
-For more details, see xref:kafka/sending-messages.adoc#record-key-in-reply[Record Key in Reply] section of the reference docs.
+For more details, see xref:kafka/sending-messages.adoc[Sending Messages] section of the reference docs.

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -34,3 +34,9 @@ For more details, see xref:kafka/receiving-messages/filtering.adoc[Message recei
 
 The `ConcurentContainerMessageListenerContainer` emits now a `ConcurrentContainerStoppedEvent` when all of its child containers are stopped.
 For more details, see xref:kafka/events.adoc[Application Events] and `ConcurrentContainerStoppedEvent` Javadocs.
+
+[[x33-record-key-in-reply]]
+=== Preserving Request Record Key in Reply
+
+When using `ReplyingKafkaTemplate`, if the original record from the request contains a key, then that same key will be part of the reply as well.
+For more details, see xref:kafka/sending-messages.adoc#record-key-in-reply[Record Key in Reply] section of the reference docs.

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
@@ -644,6 +644,7 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 
 	protected void asyncSuccess(@Nullable Object result, String replyTopic, Message<?> source,
 			boolean returnTypeMessage) {
+
 		if (result == null) {
 			if (this.logger.isDebugEnabled()) {
 				this.logger.debug("Async result is null, ignoring");
@@ -718,7 +719,7 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 	}
 
 	private void setKey(MessageBuilder<?> builder, Message<?> source) {
-		Object key = getReplyKeyFromRequest(source);
+		Object key = source.getHeaders().get(KafkaHeaders.RECEIVED_KEY);
 		// Set the reply record key only for non-batch requests
 		if (key != null && !(key instanceof List)) {
 			builder.setHeader(KafkaHeaders.KEY, key);
@@ -728,11 +729,6 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 	@Nullable
 	private byte[] getReplyPartition(Message<?> source) {
 		return source.getHeaders().get(KafkaHeaders.REPLY_PARTITION, byte[].class);
-	}
-
-	@Nullable
-	private Object getReplyKeyFromRequest(Message<?> source) {
-		return source.getHeaders().get(KafkaHeaders.RECEIVED_KEY);
 	}
 
 	protected final String createMessagingErrorMessage(String description, Object payload) {

--- a/spring-kafka/src/test/java/org/springframework/kafka/requestreply/ReplyingKafkaTemplateTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/requestreply/ReplyingKafkaTemplateTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 the original author or authors.
+ * Copyright 2018-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,6 +101,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 /**
  * @author Gary Russell
  * @author Nathan Xu
+ * @author Soby Chacko
  * @since 2.1.3
  *
  */
@@ -196,11 +197,12 @@ public class ReplyingKafkaTemplateTests {
 			template.setDefaultReplyTimeout(Duration.ofSeconds(30));
 			Headers headers = new RecordHeaders();
 			headers.add("baz", "buz".getBytes());
-			ProducerRecord<Integer, String> record = new ProducerRecord<>(A_REQUEST, null, null, null, "foo", headers);
+			ProducerRecord<Integer, String> record = new ProducerRecord<>(A_REQUEST, null, null, 1, "foo", headers);
 			RequestReplyFuture<Integer, String, String> future = template.sendAndReceive(record);
 			future.getSendFuture().get(10, TimeUnit.SECONDS); // send ok
 			ConsumerRecord<Integer, String> consumerRecord = future.get(30, TimeUnit.SECONDS);
 			assertThat(consumerRecord.value()).isEqualTo("FOO");
+			assertThat(consumerRecord.key()).isEqualTo(1);
 			Map<String, Object> receivedHeaders = new HashMap<>();
 			new DefaultKafkaHeaderMapper().toHeaders(consumerRecord.headers(), receivedHeaders);
 			assertThat(receivedHeaders).containsKey("baz");


### PR DESCRIPTION
Fixes: #3395

When using `ReplyingKafkaTemplate,` include the original key from the request record if such a key exists.

