### PR TITLE
Fix ConcurrentContainer lifecycle issues

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
@@ -71,6 +71,7 @@ import org.springframework.util.StringUtils;
  * @author Wang Zhiyang
  * @author Soby Chacko
  * @author Sanghyeok An
+ * @author Lokesh Alamuri
  */
 public abstract class AbstractMessageListenerContainer<K, V>
 		implements GenericMessageListenerContainer<K, V>, BeanNameAware, ApplicationEventPublisherAware,
@@ -275,10 +276,6 @@ public abstract class AbstractMessageListenerContainer<K, V>
 
 	@Override
 	public boolean isRunning() {
-		return this.running;
-	}
-
-	protected boolean canStop() {
 		return this.running;
 	}
 
@@ -614,7 +611,7 @@ public abstract class AbstractMessageListenerContainer<K, V>
 	public final void stop(boolean wait) {
 		this.lifecycleLock.lock();
 		try {
-			if (canStop()) {
+			if (isRunning()) {
 				if (wait) {
 					final CountDownLatch latch = new CountDownLatch(1);
 					doStop(latch::countDown);
@@ -650,7 +647,7 @@ public abstract class AbstractMessageListenerContainer<K, V>
 	public void stop(Runnable callback) {
 		this.lifecycleLock.lock();
 		try {
-			if (canStop()) {
+			if (isRunning()) {
 				doStop(callback);
 			}
 			else {

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
@@ -380,6 +380,10 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 				}
 			}
 			setStoppedNormally(normal);
+			// All the containers are stopped before calling stop API
+			if (this.startedContainers.get() == 0) {
+				publishConcurrentContainerStoppedEvent(this.reason);
+			}
 		}
 	}
 
@@ -408,7 +412,10 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 			}
 			int startedContainersCount = this.startedContainers.decrementAndGet();
 			if (startedContainersCount == 0) {
-				publishConcurrentContainerStoppedEvent(this.reason);
+				if (!isRunning()) {
+					this.containers.clear();
+					publishConcurrentContainerStoppedEvent(this.reason);
+				}
 				boolean restartContainer = Reason.AUTH.equals(this.reason)
 						&& getContainerProperties().isRestartAfterAuthExceptions();
 				this.reason = null;

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerGroupSequencer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerGroupSequencer.java
@@ -153,22 +153,24 @@ public class ContainerGroupSequencer implements ApplicationContextAware,
 	}
 
 	private synchronized void stopParentAndCheckGroup(MessageListenerContainer parent) {
-		LOGGER.debug(() -> "Stopping: " + parent);
-		parent.stop(() -> {
-			if (this.currentGroup != null) {
-				LOGGER.debug(() -> "Checking group: " + this.currentGroup.toString());
-				if (this.currentGroup.allStopped()) {
-					if (this.iterator.hasNext()) {
-						this.currentGroup = this.iterator.next();
-						LOGGER.debug(() -> "Starting next group: " + this.currentGroup);
-						this.currentGroup.start();
-					}
-					else {
-						this.currentGroup = null;
+		if (parent.isRunning()) {
+			LOGGER.debug(() -> "Stopping: " + parent);
+			parent.stop(() -> {
+				if (this.currentGroup != null) {
+					LOGGER.debug(() -> "Checking group: " + this.currentGroup.toString());
+					if (this.currentGroup.allStopped()) {
+						if (this.iterator.hasNext()) {
+							this.currentGroup = this.iterator.next();
+							LOGGER.debug(() -> "Starting next group: " + this.currentGroup);
+							this.currentGroup.start();
+						}
+						else {
+							this.currentGroup = null;
+						}
 					}
 				}
-			}
-		});
+			});
+		}
 	}
 
 	@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerGroupSequencer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerGroupSequencer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 the original author or authors.
+ * Copyright 2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerGroupSequencer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerGroupSequencer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -153,24 +153,22 @@ public class ContainerGroupSequencer implements ApplicationContextAware,
 	}
 
 	private synchronized void stopParentAndCheckGroup(MessageListenerContainer parent) {
-		if (parent.isRunning()) {
-			LOGGER.debug(() -> "Stopping: " + parent);
-			parent.stop(() -> {
-				if (this.currentGroup != null) {
-					LOGGER.debug(() -> "Checking group: " + this.currentGroup.toString());
-					if (this.currentGroup.allStopped()) {
-						if (this.iterator.hasNext()) {
-							this.currentGroup = this.iterator.next();
-							LOGGER.debug(() -> "Starting next group: " + this.currentGroup);
-							this.currentGroup.start();
-						}
-						else {
-							this.currentGroup = null;
-						}
+		LOGGER.debug(() -> "Stopping: " + parent);
+		parent.stop(() -> {
+			if (this.currentGroup != null) {
+				LOGGER.debug(() -> "Checking group: " + this.currentGroup.toString());
+				if (this.currentGroup.allStopped()) {
+					if (this.iterator.hasNext()) {
+						this.currentGroup = this.iterator.next();
+						LOGGER.debug(() -> "Starting next group: " + this.currentGroup);
+						this.currentGroup.start();
+					}
+					else {
+						this.currentGroup = null;
 					}
 				}
-			});
-		}
+			}
+		});
 	}
 
 	@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -378,7 +378,6 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			}
 		}
 		this.listenerConsumer = new ListenerConsumer(listener, listenerType, observationRegistry);
-		this.thisOrParentContainer.childStarted(this);
 		setRunning(true);
 		this.startLatch = new CountDownLatch(1);
 		this.listenerConsumerFuture = consumerExecutor.submitCompletable(this.listenerConsumer);
@@ -1369,6 +1368,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			this.count = 0;
 			this.last = System.currentTimeMillis();
 			initAssignedPartitions();
+			KafkaMessageListenerContainer.this.thisOrParentContainer.childStarted(KafkaMessageListenerContainer.this);
 			publishConsumerStartedEvent();
 		}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -166,6 +166,7 @@ import io.micrometer.observation.ObservationRegistry;
  * @author Christian Mergenthaler
  * @author Mikael Carlstedt
  * @author Borahm Lee
+ * @author Lokesh Alamuri
  */
 public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		extends AbstractMessageListenerContainer<K, V> implements ConsumerPauseResumeEventPublisher {

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
@@ -819,18 +819,16 @@ public class ConcurrentMessageListenerContainerTests {
 	@Test
 	public void testIsChildRunning() throws Exception {
 		this.logger.info("Start isChildRunning");
-		Map<String, Object> props = KafkaTestUtils.consumerProps("test1", "true", embeddedKafka);
+		Map<String, Object> props = KafkaTestUtils.consumerProps("test1", "true",
+				embeddedKafka);
 		AtomicReference<Properties> overrides = new AtomicReference<>();
 		DefaultKafkaConsumerFactory<Integer, String> cf = new DefaultKafkaConsumerFactory<Integer, String>(props) {
-
 			@Override
 			protected Consumer<Integer, String> createKafkaConsumer(String groupId, String clientIdPrefix,
-																	String clientIdSuffixArg, Properties properties) {
-
+				String clientIdSuffixArg, Properties properties) {
 				overrides.set(properties);
 				return super.createKafkaConsumer(groupId, clientIdPrefix, clientIdSuffixArg, properties);
 			}
-
 		};
 		ContainerProperties containerProps = new ContainerProperties(topic1);
 		containerProps.setLogContainerConfig(true);
@@ -942,7 +940,8 @@ public class ConcurrentMessageListenerContainerTests {
 				assertThat(concurrentContainerStoppedEvent.getSource()).isSameAs(container);
 				assertThat(concurrentContainerStoppedEvent.getContainer(MessageListenerContainer.class))
 						.isSameAs(container);
-				assertThat(concurrentContainerStoppedEvent.getReason()).isEqualTo(ConsumerStoppedEvent.Reason.NORMAL);
+				assertThat(concurrentContainerStoppedEvent.getReason()).
+						isEqualTo(ConsumerStoppedEvent.Reason.NORMAL);
 			}
 		});
 		assertThat(container.isChildRunning()).isFalse();
@@ -969,18 +968,16 @@ public class ConcurrentMessageListenerContainerTests {
 	@Test
 	public void testContainerStartStop() throws Exception {
 		this.logger.info("Start containerStartStop");
-		Map<String, Object> props = KafkaTestUtils.consumerProps("test1", "true", embeddedKafka);
+		Map<String, Object> props = KafkaTestUtils.consumerProps("test1", "true",
+				embeddedKafka);
 		AtomicReference<Properties> overrides = new AtomicReference<>();
 		DefaultKafkaConsumerFactory<Integer, String> cf = new DefaultKafkaConsumerFactory<Integer, String>(props) {
-
 			@Override
 			protected Consumer<Integer, String> createKafkaConsumer(String groupId, String clientIdPrefix,
 																	String clientIdSuffixArg, Properties properties) {
-
 				overrides.set(properties);
 				return super.createKafkaConsumer(groupId, clientIdPrefix, clientIdSuffixArg, properties);
 			}
-
 		};
 		ContainerProperties containerProps = new ContainerProperties(topic1);
 		containerProps.setLogContainerConfig(true);
@@ -1060,8 +1057,10 @@ public class ConcurrentMessageListenerContainerTests {
 		assertThat(container.isChildRunning()).isTrue();
 		assertThat(childContainer1.isRunning()).isTrue();
 		assertThat(childContainer0.isRunning()).isFalse();
-		assertThat(container.getContainers()).contains((KafkaMessageListenerContainer<Integer, String>) childContainer0);
-		assertThat(container.getContainers()).contains((KafkaMessageListenerContainer<Integer, String>) childContainer1);
+		assertThat(container.getContainers()).
+				contains((KafkaMessageListenerContainer<Integer, String>) childContainer0);
+		assertThat(container.getContainers()).
+				contains((KafkaMessageListenerContainer<Integer, String>) childContainer1);
 
 		container.stop();
 
@@ -1074,8 +1073,10 @@ public class ConcurrentMessageListenerContainerTests {
 
 		// Accept this start
 		container.start();
-		assertThat(container.getContainers()).doesNotContain((KafkaMessageListenerContainer<Integer, String>) childContainer0);
-		assertThat(container.getContainers()).doesNotContain((KafkaMessageListenerContainer<Integer, String>) childContainer1);
+		assertThat(container.getContainers()).
+				doesNotContain((KafkaMessageListenerContainer<Integer, String>) childContainer0);
+		assertThat(container.getContainers()).
+				doesNotContain((KafkaMessageListenerContainer<Integer, String>) childContainer1);
 		container.stop();
 		assertThat(concurrentContainerSecondStopLatch.await(30, TimeUnit.SECONDS)).isTrue();
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
@@ -974,7 +974,7 @@ public class ConcurrentMessageListenerContainerTests {
 		DefaultKafkaConsumerFactory<Integer, String> cf = new DefaultKafkaConsumerFactory<Integer, String>(props) {
 			@Override
 			protected Consumer<Integer, String> createKafkaConsumer(String groupId, String clientIdPrefix,
-																	String clientIdSuffixArg, Properties properties) {
+						String clientIdSuffixArg, Properties properties) {
 				overrides.set(properties);
 				return super.createKafkaConsumer(groupId, clientIdPrefix, clientIdSuffixArg, properties);
 			}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
@@ -932,7 +932,7 @@ public class ConcurrentMessageListenerContainerTests {
 
 		firstLatch.countDown();
 
-		assertThat(listenerThreadNames).contains("testAuto-0", "testAuto-1");
+		assertThat(listenerThreadNames).containsAnyOf("testAuto-0", "testAuto-1");
 
 		assertThat(concurrentContainerStopLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(container.isInExpectedState()).isTrue();

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
@@ -816,4 +816,270 @@ public class ConcurrentMessageListenerContainerTests {
 		logger.info("Stop ack on error with ManualImmediate ack mode");
 	}
 
+	@Test
+	public void testIsChildRunning() throws Exception {
+		this.logger.info("Start isChildRunning");
+		Map<String, Object> props = KafkaTestUtils.consumerProps("test1", "true", embeddedKafka);
+		AtomicReference<Properties> overrides = new AtomicReference<>();
+		DefaultKafkaConsumerFactory<Integer, String> cf = new DefaultKafkaConsumerFactory<Integer, String>(props) {
+
+			@Override
+			protected Consumer<Integer, String> createKafkaConsumer(String groupId, String clientIdPrefix,
+																	String clientIdSuffixArg, Properties properties) {
+
+				overrides.set(properties);
+				return super.createKafkaConsumer(groupId, clientIdPrefix, clientIdSuffixArg, properties);
+			}
+
+		};
+		ContainerProperties containerProps = new ContainerProperties(topic1);
+		containerProps.setLogContainerConfig(true);
+		containerProps.setClientId("client");
+		containerProps.setAckMode(ContainerProperties.AckMode.RECORD);
+
+		final CountDownLatch secondRunLatch = new CountDownLatch(5);
+		final Set<String> listenerThreadNames = new ConcurrentSkipListSet<>();
+		final List<String> payloads = new ArrayList<>();
+		final CountDownLatch processingLatch = new CountDownLatch(1);
+		final CountDownLatch firstLatch = new CountDownLatch(1);
+
+		AtomicBoolean first = new AtomicBoolean(true);
+
+		containerProps.setMessageListener((MessageListener<Integer, String>) message -> {
+			if (first.getAndSet(false)) {
+				try {
+					firstLatch.await(100, TimeUnit.SECONDS);
+				}
+				catch (InterruptedException e) {
+					throw new RuntimeException(e);
+				}
+			}
+			ConcurrentMessageListenerContainerTests.this.logger.info("auto: " + message);
+			listenerThreadNames.add(Thread.currentThread().getName());
+			payloads.add(message.value());
+			secondRunLatch.countDown();
+			processingLatch.countDown();
+		});
+
+		ConcurrentMessageListenerContainer<Integer, String> container =
+				new ConcurrentMessageListenerContainer<>(cf, containerProps);
+		container.setConcurrency(2);
+		container.setBeanName("testAuto");
+		container.setChangeConsumerThreadName(true);
+		BlockingQueue<KafkaEvent> events = new LinkedBlockingQueue<>();
+		CountDownLatch concurrentContainerStopLatch = new CountDownLatch(1);
+		CountDownLatch concurrentContainerSecondStopLatch = new CountDownLatch(1);
+		CountDownLatch consumerStoppedEventLatch = new CountDownLatch(1);
+
+		container.setApplicationEventPublisher(e -> {
+			events.add((KafkaEvent) e);
+			if (e instanceof ConcurrentContainerStoppedEvent) {
+				concurrentContainerStopLatch.countDown();
+				concurrentContainerSecondStopLatch.countDown();
+			}
+			if (e instanceof ConsumerStoppedEvent) {
+				consumerStoppedEventLatch.countDown();
+			}
+		});
+
+		CountDownLatch interceptedSecondRun = new CountDownLatch(5);
+		container.setRecordInterceptor((record, consumer) -> {
+			interceptedSecondRun.countDown();
+			return record;
+		});
+
+		container.start();
+
+		MessageListenerContainer childContainer0 = container.getContainers().get(0);
+		MessageListenerContainer childContainer1 = container.getContainers().get(1);
+
+		ContainerTestUtils.waitForAssignment(container, embeddedKafka.getPartitionsPerTopic());
+		assertThat(container.getAssignedPartitions()).hasSize(2);
+		Map<String, Collection<TopicPartition>> assignments = container.getAssignmentsByClientId();
+		assertThat(assignments).hasSize(2);
+		assertThat(assignments.get("client-0")).isNotNull();
+		assertThat(assignments.get("client-1")).isNotNull();
+
+		Map<String, Object> senderProps = KafkaTestUtils.producerProps(embeddedKafka);
+		ProducerFactory<Integer, String> pf = new DefaultKafkaProducerFactory<>(senderProps);
+		KafkaTemplate<Integer, String> template = new KafkaTemplate<>(pf);
+		template.setDefaultTopic(topic1);
+		template.sendDefault(0, 0, "foo");
+		template.sendDefault(1, 2, "bar");
+		template.sendDefault(0, 0, "baz");
+		template.sendDefault(1, 2, "qux");
+		template.flush();
+
+		assertThat(container.metrics()).isNotNull();
+		assertThat(container.isInExpectedState()).isTrue();
+		assertThat(childContainer0.isRunning()).isTrue();
+		assertThat(childContainer1.isRunning()).isTrue();
+		assertThat(container.isChildRunning()).isTrue();
+
+		assertThat(processingLatch.await(60, TimeUnit.SECONDS)).isTrue();
+
+		container.stop();
+
+		assertThat(container.isChildRunning()).isTrue();
+		assertThat(container.isRunning()).isFalse();
+		assertThat(childContainer0.isRunning()).isFalse();
+		assertThat(childContainer1.isRunning()).isFalse();
+
+		assertThat(consumerStoppedEventLatch.await(30, TimeUnit.SECONDS)).isTrue();
+
+		// This returns true since one container is still processing message. Key validation for this test case.
+		assertThat(container.isChildRunning()).isTrue();
+
+		firstLatch.countDown();
+
+		assertThat(listenerThreadNames).contains("testAuto-0", "testAuto-1");
+
+		assertThat(concurrentContainerStopLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(container.isInExpectedState()).isTrue();
+		events.forEach(e -> {
+			assertThat(e.getContainer(MessageListenerContainer.class)).isSameAs(container);
+			if (e instanceof ConcurrentContainerStoppedEvent concurrentContainerStoppedEvent) {
+				assertThat(concurrentContainerStoppedEvent.getSource()).isSameAs(container);
+				assertThat(concurrentContainerStoppedEvent.getContainer(MessageListenerContainer.class))
+						.isSameAs(container);
+				assertThat(concurrentContainerStoppedEvent.getReason()).isEqualTo(ConsumerStoppedEvent.Reason.NORMAL);
+			}
+		});
+		assertThat(container.isChildRunning()).isFalse();
+		assertThat(payloads).containsAnyOf("foo", "bar", "qux", "baz");
+
+		template.sendDefault(0, 0, "FOO");
+		template.sendDefault(1, 2, "BAR");
+		template.sendDefault(0, 0, "BAZ");
+		template.sendDefault(1, 2, "QUX");
+		template.flush();
+
+		container.start();
+
+		assertThat(secondRunLatch.await(60, TimeUnit.SECONDS)).isTrue();
+		assertThat(interceptedSecondRun.await(10, TimeUnit.SECONDS)).isTrue();
+
+		container.stop();
+		assertThat(concurrentContainerSecondStopLatch.await(30, TimeUnit.SECONDS)).isTrue();
+		assertThat(payloads).containsAnyOf("FOO", "BAR", "QUX", "BAZ");
+
+		this.logger.info("Stop isChildRunning");
+	}
+
+	@Test
+	public void testContainerStartStop() throws Exception {
+		this.logger.info("Start containerStartStop");
+		Map<String, Object> props = KafkaTestUtils.consumerProps("test1", "true", embeddedKafka);
+		AtomicReference<Properties> overrides = new AtomicReference<>();
+		DefaultKafkaConsumerFactory<Integer, String> cf = new DefaultKafkaConsumerFactory<Integer, String>(props) {
+
+			@Override
+			protected Consumer<Integer, String> createKafkaConsumer(String groupId, String clientIdPrefix,
+																	String clientIdSuffixArg, Properties properties) {
+
+				overrides.set(properties);
+				return super.createKafkaConsumer(groupId, clientIdPrefix, clientIdSuffixArg, properties);
+			}
+
+		};
+		ContainerProperties containerProps = new ContainerProperties(topic1);
+		containerProps.setLogContainerConfig(true);
+		containerProps.setClientId("client");
+		containerProps.setAckMode(ContainerProperties.AckMode.RECORD);
+
+		final List<String> payloads = new ArrayList<>();
+
+		containerProps.setMessageListener((MessageListener<Integer, String>) message -> {
+			payloads.add(message.value());
+		});
+
+		ConcurrentMessageListenerContainer<Integer, String> container =
+				new ConcurrentMessageListenerContainer<>(cf, containerProps);
+		container.setConcurrency(2);
+		container.setBeanName("testAuto");
+		container.setChangeConsumerThreadName(true);
+		BlockingQueue<KafkaEvent> events = new LinkedBlockingQueue<>();
+		CountDownLatch concurrentContainerStopLatch = new CountDownLatch(1);
+		CountDownLatch concurrentContainerSecondStopLatch = new CountDownLatch(1);
+		CountDownLatch consumerStoppedEventLatch = new CountDownLatch(1);
+
+		container.setApplicationEventPublisher(e -> {
+			events.add((KafkaEvent) e);
+			if (e instanceof ConcurrentContainerStoppedEvent) {
+				concurrentContainerStopLatch.countDown();
+				concurrentContainerSecondStopLatch.countDown();
+			}
+			if (e instanceof ConsumerStoppedEvent) {
+				consumerStoppedEventLatch.countDown();
+			}
+		});
+
+		container.setCommonErrorHandler(null);
+
+		container.start();
+
+		MessageListenerContainer childContainer0 = container.getContainers().get(0);
+		MessageListenerContainer childContainer1 = container.getContainers().get(1);
+
+		ContainerTestUtils.waitForAssignment(container, embeddedKafka.getPartitionsPerTopic());
+		assertThat(container.getAssignedPartitions()).hasSize(2);
+		Map<String, Collection<TopicPartition>> assignments = container.getAssignmentsByClientId();
+		assertThat(assignments).hasSize(2);
+		assertThat(assignments.get("client-0")).isNotNull();
+		assertThat(assignments.get("client-1")).isNotNull();
+
+		Map<String, Object> senderProps = KafkaTestUtils.producerProps(embeddedKafka);
+		ProducerFactory<Integer, String> pf = new DefaultKafkaProducerFactory<>(senderProps);
+
+		KafkaTemplate<Integer, String> template = new KafkaTemplate<>(pf);
+		template.setDefaultTopic(topic1);
+		template.sendDefault(0, 0, "foo");
+		template.sendDefault(1, 2, "bar");
+		template.sendDefault(0, 0, "baz");
+		template.sendDefault(1, 2, "qux");
+		template.flush();
+
+		assertThat(container.metrics()).isNotNull();
+		assertThat(container.isInExpectedState()).isTrue();
+		assertThat(childContainer0.isRunning()).isTrue();
+		assertThat(childContainer1.isRunning()).isTrue();
+		assertThat(container.isChildRunning()).isTrue();
+
+		childContainer0.stop();
+
+		assertThat(consumerStoppedEventLatch.await(30, TimeUnit.SECONDS)).isTrue();
+
+		assertThat(container.isChildRunning()).isTrue();
+		assertThat(childContainer1.isRunning()).isTrue();
+		assertThat(childContainer0.isRunning()).isFalse();
+		assertThat(container.isRunning()).isFalse();
+
+		//Ignore this start
+		container.start();
+
+		assertThat(container.isChildRunning()).isTrue();
+		assertThat(childContainer1.isRunning()).isTrue();
+		assertThat(childContainer0.isRunning()).isFalse();
+		assertThat(container.getContainers()).contains((KafkaMessageListenerContainer<Integer, String>) childContainer0);
+		assertThat(container.getContainers()).contains((KafkaMessageListenerContainer<Integer, String>) childContainer1);
+
+		container.stop();
+
+		assertThat(container.isRunning()).isFalse();
+		// child container1 is stopped.
+		assertThat(childContainer1.isRunning()).isFalse();
+		assertThat(childContainer0.isRunning()).isFalse();
+
+		assertThat(concurrentContainerStopLatch.await(30, TimeUnit.SECONDS)).isTrue();
+
+		// Accept this start
+		container.start();
+		assertThat(container.getContainers()).doesNotContain((KafkaMessageListenerContainer<Integer, String>) childContainer0);
+		assertThat(container.getContainers()).doesNotContain((KafkaMessageListenerContainer<Integer, String>) childContainer1);
+		container.stop();
+		assertThat(concurrentContainerSecondStopLatch.await(30, TimeUnit.SECONDS)).isTrue();
+
+		this.logger.info("Stop containerStartStop");
+	}
+
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
@@ -1049,7 +1049,7 @@ public class ConcurrentMessageListenerContainerTests {
 		assertThat(container.isChildRunning()).isTrue();
 		assertThat(childContainer1.isRunning()).isTrue();
 		assertThat(childContainer0.isRunning()).isFalse();
-		assertThat(container.isRunning()).isFalse();
+		assertThat(container.isRunning()).isTrue();
 
 		//Ignore this start
 		container.start();


### PR DESCRIPTION
This commit would fix the [issue](https://github.com/spring-projects/spring-kafka/issues/3338).

1) 'isChildRunning' API would return true only after all the containers are actually stopped. 
2) Add 'stopAbnormally' in a Lock.
3) Call `childStarted` in ConcurrentContainer from KafkaMessageListenerContainer right before publishing ConsumerStartedEvent.

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
