### PR TITLE
Clean up `processSeeks()` duplicate code

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -3011,8 +3011,14 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			while (offset != null) {
 				traceSeek(offset);
 				try {
-					SeekPosition position = offset.getPosition();
 					TopicPartition topicPartition = offset.getTopicPartition();
+					if (assigned == null || !assigned.contains(topicPartition)) {
+						this.logger.warn("No current assignment for partition " + topicPartition +
+								" due to partition reassignment prior to seeking.");
+						offset = this.seeks.poll();
+						continue;
+					}
+					SeekPosition position = offset.getPosition();
 					Long whereTo = offset.getOffset();
 					Function<Long, Long> offsetComputeFunction = offset.getOffsetComputeFunction();
 					if (position == null) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -3004,6 +3004,10 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			}
 		}
 
+		private boolean isPartitionAssigned(@Nullable Collection<TopicPartition> assigned, TopicPartition topicPartition) {
+			return assigned != null && assigned.contains(topicPartition);
+		}
+
 		private void processSeeks() {
 			Collection<TopicPartition> assigned = getAssignedPartitions();
 			processTimestampSeeks(assigned);
@@ -3012,9 +3016,9 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 				traceSeek(offset);
 				try {
 					TopicPartition topicPartition = offset.getTopicPartition();
-					if (assigned == null || !assigned.contains(topicPartition)) {
-						this.logger.warn("No current assignment for partition " + topicPartition +
-								" due to partition reassignment prior to seeking.");
+					if (!isPartitionAssigned(assigned, topicPartition)) {
+						this.logger.warn("No current assignment for partition '" + topicPartition +
+								"' due to partition reassignment prior to seeking.");
 						offset = this.seeks.poll();
 						continue;
 					}
@@ -3068,7 +3072,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			Map<TopicPartition, Long> timestampSeeks = null;
 			while (seekIterator.hasNext()) {
 				TopicPartitionOffset tpo = seekIterator.next();
-				if (assigned == null || !assigned.contains(tpo.getTopicPartition())) {
+				if (!isPartitionAssigned(assigned, tpo.getTopicPartition())) {
 					this.logger.warn("No current assignment for partition " + tpo.getTopicPartition() +
 							" due to partition reassignment prior to seeking.");
 					seekIterator.remove();

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -3011,14 +3011,8 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			while (offset != null) {
 				traceSeek(offset);
 				try {
-					TopicPartition topicPartition = offset.getTopicPartition();
-					if (assigned == null || !assigned.contains(topicPartition)) {
-						this.logger.warn("No current assignment for partition " + topicPartition +
-								" due to partition reassignment prior to seeking.");
-						offset = this.seeks.poll();
-						continue;
-					}
 					SeekPosition position = offset.getPosition();
+					TopicPartition topicPartition = offset.getTopicPartition();
 					Long whereTo = offset.getOffset();
 					Function<Long, Long> offsetComputeFunction = offset.getOffsetComputeFunction();
 					if (position == null) {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->

In `processTimestampSeeks()`, we use `seekIterator` to pre-remove unassigned partitions, thus eliminating duplicate code running in the following loop. 
