### PR TITLE
DOC: JavaDoc for KafkaMessageHeaderAccessor.getBlockingRetryDeliveryAttempt()

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/KafkaMessageHeaderAccessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/KafkaMessageHeaderAccessor.java
@@ -44,7 +44,7 @@ public class KafkaMessageHeaderAccessor extends MessageHeaderAccessor {
 
 	/**
 	 * Access the header value when the blocking delivery attempt header is present.
-	 * @return 1 if there is no header present; the decoded header value otherwise.
+	 * @return The decoded header value if the header is present.
 	 * @throws IllegalStateException if the header is not present.
 	 * @see org.springframework.kafka.listener.ContainerProperties#setDeliveryAttemptHeader(boolean)
 	 */


### PR DESCRIPTION
#3408 

Updated JavaDoc to show the return of the method is the the decoded header if header is present. Throws IllegalStateException if otherwise
