### PR TITLE
GH-3409: Improve exceptions during retry

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -2213,7 +2213,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 					commitOffsetsIfNeededAfterHandlingError(records);
 				}
 				catch (RecordInRetryException rire) {
-					rire.selfLog(this.logger);
+					this.logger.info("Record in retry and not yet recovered");
 					return rire;
 				}
 				catch (KafkaException ke) {
@@ -2720,7 +2720,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 						commitOffsetsIfNeededAfterHandlingError(cRecord);
 					}
 					catch (RecordInRetryException rire) {
-						rire.selfLog(this.logger);
+						this.logger.info("Record in retry and not yet recovered");
 						return rire;
 					}
 					catch (KafkaException ke) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -2212,6 +2212,10 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 					invokeBatchErrorHandler(records, recordList, e);
 					commitOffsetsIfNeededAfterHandlingError(records);
 				}
+				catch (RecordInRetryException rire) {
+					rire.selfLog(this.logger);
+					return rire;
+				}
 				catch (KafkaException ke) {
 					ke.selfLog(ERROR_HANDLER_THREW_AN_EXCEPTION, this.logger);
 					return ke;
@@ -2714,6 +2718,10 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 					try {
 						invokeErrorHandler(cRecord, iterator, e);
 						commitOffsetsIfNeededAfterHandlingError(cRecord);
+					}
+					catch (RecordInRetryException rire) {
+						rire.selfLog(this.logger);
+						return rire;
 					}
 					catch (KafkaException ke) {
 						ke.selfLog(ERROR_HANDLER_THREW_AN_EXCEPTION, this.logger);

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/RecordInRetryException.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/RecordInRetryException.java
@@ -19,7 +19,6 @@ package org.springframework.kafka.listener;
 import javax.annotation.Nullable;
 
 import org.springframework.core.NestedRuntimeException;
-import org.springframework.core.log.LogAccessor;
 
 /**
  * Internal {@link NestedRuntimeException} that is used as an exception thrown
@@ -31,9 +30,8 @@ import org.springframework.core.log.LogAccessor;
  * @author Soby Chacko
  * @since 3.3.0
  */
+@SuppressWarnings("serial")
 class RecordInRetryException extends NestedRuntimeException {
-
-	private final String message;
 
 	/**
 	 * Package protected constructor to create an instance with the provided properties.
@@ -43,10 +41,6 @@ class RecordInRetryException extends NestedRuntimeException {
 	 */
 	RecordInRetryException(String message, @Nullable Throwable cause) {
 		super(message, cause);
-		this.message = message;
 	}
 
-	void selfLog(LogAccessor logger) {
-		logger.info(this.message);
-	}
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/RecordInRetryException.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/RecordInRetryException.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import javax.annotation.Nullable;
+
+import org.springframework.core.NestedRuntimeException;
+import org.springframework.core.log.LogAccessor;
+
+/**
+ * Internal {@link NestedRuntimeException} that is used as an exception thrown
+ * when the record is in retry and not yet recovered during error handling.
+ * This is to prevent the record from being prematurely committed in the middle of a retry.
+ *
+ * Intended only for framework use and thus the package-protected access.
+ *
+ * @author Soby Chacko
+ * @since 3.3.0
+ */
+class RecordInRetryException extends NestedRuntimeException {
+
+	private final String message;
+
+	/**
+	 * Package protected constructor to create an instance with the provided properties.
+	 *
+	 * @param message logging message
+	 * @param cause {@link Throwable}
+	 */
+	RecordInRetryException(String message, @Nullable Throwable cause) {
+		super(message, cause);
+		this.message = message;
+	}
+
+	void selfLog(LogAccessor logger) {
+		logger.info(this.message);
+	}
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/SeekUtils.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/SeekUtils.java
@@ -32,7 +32,6 @@ import org.apache.kafka.common.errors.SerializationException;
 
 import org.springframework.core.NestedRuntimeException;
 import org.springframework.core.log.LogAccessor;
-import org.springframework.kafka.KafkaException;
 import org.springframework.kafka.KafkaException.Level;
 import org.springframework.kafka.listener.ContainerProperties.AckMode;
 import org.springframework.kafka.support.KafkaUtils;
@@ -46,6 +45,7 @@ import org.springframework.util.backoff.FixedBackOff;
  * @author Gary Russell
  * @author Francois Rosiere
  * @author Wang Zhiyang
+ * @author Soby Chacko
  * @since 2.2
  *
  */
@@ -224,7 +224,7 @@ public final class SeekUtils {
 		}
 
 		if (!doSeeks(records, consumer, thrownException, true, recovery, container, logger)) { // NOSONAR
-			throw new KafkaException("Seek to current after exception", level, thrownException);
+			throw new RecordInRetryException("Record in retry and not yet recovered", thrownException);
 		}
 		if (commitRecovered) {
 			if (container.getContainerProperties().getAckMode().equals(AckMode.MANUAL_IMMEDIATE)) {

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/DefaultErrorHandlerRecordTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/DefaultErrorHandlerRecordTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019-2023 the original author or authors.
+ * Copyright 2019-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -45,7 +45,6 @@ import org.apache.kafka.common.errors.SerializationException;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 
-import org.springframework.kafka.KafkaException;
 import org.springframework.kafka.support.converter.ConversionException;
 import org.springframework.kafka.support.serializer.DeserializationException;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
@@ -55,6 +54,7 @@ import org.springframework.util.backoff.FixedBackOff;
  * {@link DefaultErrorHandler} tests for record listeners.
  *
  * @author Gary Russell
+ * @author Soby Chacko
  * @since 2.8
  *
  */
@@ -155,7 +155,7 @@ public class DefaultErrorHandlerRecordTests {
 		List<ConsumerRecord<?, ?>> records = Arrays.asList(record1, record2);
 		IllegalStateException illegalState = new IllegalStateException();
 		Consumer<?, ?> consumer = mock(Consumer.class);
-		assertThatExceptionOfType(KafkaException.class).isThrownBy(() -> handler.handleRemaining(illegalState, records,
+		assertThatExceptionOfType(RecordInRetryException.class).isThrownBy(() -> handler.handleRemaining(illegalState, records,
 					consumer, mock(MessageListenerContainer.class)))
 				.withCause(illegalState);
 		handler.handleRemaining(new DeserializationException("intended", null, false, illegalState), records,
@@ -214,7 +214,7 @@ public class DefaultErrorHandlerRecordTests {
 		MessageListenerContainer container = mock(MessageListenerContainer.class);
 		given(container.isRunning()).willReturn(false);
 		long t1 = System.currentTimeMillis();
-		assertThatExceptionOfType(KafkaException.class).isThrownBy(() -> handler.handleRemaining(illegalState,
+		assertThatExceptionOfType(RecordInRetryException.class).isThrownBy(() -> handler.handleRemaining(illegalState,
 						records, consumer, container));
 		assertThat(System.currentTimeMillis() < t1 + 5_000);
 	}
@@ -230,7 +230,7 @@ public class DefaultErrorHandlerRecordTests {
 		MessageListenerContainer container = mock(MessageListenerContainer.class);
 		given(container.isRunning()).willReturn(true);
 		long t1 = System.currentTimeMillis();
-		assertThatExceptionOfType(KafkaException.class).isThrownBy(() -> handler.handleRemaining(illegalState,
+		assertThatExceptionOfType(RecordInRetryException.class).isThrownBy(() -> handler.handleRemaining(illegalState,
 						records, consumer, container));
 		assertThat(System.currentTimeMillis() >= t1 + 200);
 	}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/FailedBatchProcessorTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/FailedBatchProcessorTests.java
@@ -43,13 +43,13 @@ import org.mockito.ArgumentCaptor;
 
 import org.springframework.core.log.LogAccessor;
 import org.springframework.data.util.DirectFieldAccessFallbackBeanWrapper;
-import org.springframework.kafka.KafkaException;
 import org.springframework.util.backoff.BackOff;
 import org.springframework.util.backoff.FixedBackOff;
 
 /**
  * @author Gary Russell
  * @author Francois Rosiere
+ * @author Soby Chacko
  * @since 3.0.3
  *
  */
@@ -118,10 +118,10 @@ public class FailedBatchProcessorTests {
 		willThrow(new RebalanceInProgressException("rebalance in progress")).given(consumer).commitSync(anyMap(), any());
 		final MessageListenerContainer mockMLC = mock(MessageListenerContainer.class);
 		willReturn(new ContainerProperties("topic")).given(mockMLC).getContainerProperties();
-		assertThatExceptionOfType(KafkaException.class).isThrownBy(() ->
+		assertThatExceptionOfType(RecordInRetryException.class).isThrownBy(() ->
 				testFBP.handle(new BatchListenerFailedException("topic", rec2),
 						records, consumer, mockMLC, mock(Runnable.class))
-		).withMessage("Seek to current after exception");
+		).withMessage("Record in retry and not yet recovered");
 	}
 
 	static class TestFBP extends FailedBatchProcessor {


### PR DESCRIPTION
Fixes: #3409

- During error handling, records in retry are throwing `KafkaException` after seeking that causes the exception to get logged which maybe misleading. It seems to indicate that the error handling process itself thew the exception, while the exception was thrown in order to prevent accidental committing of a not-yet recovered record. Change this exception during seeks in retry while handling error from `KafkaException` to a new framework-only used exception - `RecordInRetryException` that simply logs the message at INFO level.
