### PR TITLE
No Issue : Internal Refactoring to improve code readability.

### DIFF
--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaKraftBroker.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaKraftBroker.java
@@ -71,6 +71,7 @@ import kafka.testkit.TestKitNodes;
  * @author Pawel Lozinski
  * @author Adrian Chlebosz
  * @author Soby Chacko
+ * @author Sanghyeok An
  *
  * @since 3.1
  */

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaKraftBroker.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaKraftBroker.java
@@ -532,7 +532,7 @@ public class EmbeddedKafkaKraftBroker implements EmbeddedKafkaBroker {
 		List<String> notEmbedded = Arrays.stream(topicsToConsume)
 				.filter(topic -> !this.topics.contains(topic))
 				.collect(Collectors.toList());
-		if (notEmbedded.size() > 0) {
+		if (!notEmbedded.isEmpty()) {
 			throw new IllegalStateException("topic(s):'" + notEmbedded + "' are not in embedded topic list");
 		}
 		final AtomicReference<Collection<TopicPartition>> assigned = new AtomicReference<>();

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaZKBroker.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaZKBroker.java
@@ -734,7 +734,7 @@ public class EmbeddedKafkaZKBroker implements EmbeddedKafkaBroker {
 		List<String> notEmbedded = Arrays.stream(topicsToConsume)
 				.filter(topic -> !this.topics.contains(topic))
 				.collect(Collectors.toList());
-		if (notEmbedded.size() > 0) {
+		if (!notEmbedded.isEmpty()) {
 			throw new IllegalStateException("topic(s):'" + notEmbedded + "' are not in embedded topic list");
 		}
 		final AtomicReference<Collection<TopicPartition>> assigned = new AtomicReference<>();

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaZKBroker.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaZKBroker.java
@@ -88,6 +88,7 @@ import kafka.zookeeper.ZooKeeperClient;
  * @author Pawel Lozinski
  * @author Adrian Chlebosz
  * @author Soby Chacko
+ * @author Sanghyeok An
  *
  * @since 2.2
  */

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
@@ -141,6 +141,7 @@ import org.springframework.validation.Validator;
  * @author Filip Halemba
  * @author Tomaz Fernandes
  * @author Wang Zhiyang
+ * @author Sanghyeok An
  *
  * @see KafkaListener
  * @see KafkaListenerErrorHandler

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
@@ -349,7 +349,7 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 		if (this.applicationContext != null) {
 			Map<String, AnnotationEnhancer> enhancersMap =
 					this.applicationContext.getBeansOfType(AnnotationEnhancer.class, false, false);
-			if (enhancersMap.size() > 0) {
+			if (!enhancersMap.isEmpty()) {
 				List<AnnotationEnhancer> enhancers = enhancersMap.values()
 						.stream()
 						.sorted(new OrderComparator())

--- a/spring-kafka/src/main/java/org/springframework/kafka/aot/KafkaAvroBeanRegistrationAotProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/aot/KafkaAvroBeanRegistrationAotProcessor.java
@@ -41,6 +41,7 @@ import org.springframework.util.ReflectionUtils;
  * Detect and register Avro types for Apache Kafka listeners.
  *
  * @author Gary Russell
+ * @author Sagnhyeok An
  * @since 3.0
  *
  */

--- a/spring-kafka/src/main/java/org/springframework/kafka/aot/KafkaAvroBeanRegistrationAotProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/aot/KafkaAvroBeanRegistrationAotProcessor.java
@@ -80,7 +80,7 @@ public class KafkaAvroBeanRegistrationAotProcessor implements BeanRegistrationAo
 				}
 			}, method -> method.getName().equals("onMessage"));
 		}
-		if (avroTypes.size() > 0) {
+		if (!avroTypes.isEmpty()) {
 			return (generationContext, beanRegistrationCode) -> {
 				ReflectionHints reflectionHints = generationContext.getRuntimeHints().reflection();
 				avroTypes.forEach(type -> reflectionHints.registerType(type,

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/TopicBuilder.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/TopicBuilder.java
@@ -132,7 +132,7 @@ public final class TopicBuilder {
 		NewTopic topic = this.replicasAssignments == null
 				? new NewTopic(this.name, this.partitions, this.replicas)
 				: new NewTopic(this.name, this.replicasAssignments);
-		if (this.configs.size() > 0) {
+		if (!this.configs.isEmpty()) {
 			topic.configs(this.configs);
 		}
 		return topic;

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/TopicBuilder.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/TopicBuilder.java
@@ -30,6 +30,7 @@ import org.apache.kafka.common.config.TopicConfig;
  * {@link Optional#empty()} indicating the broker defaults will be applied.
  *
  * @author Gary Russell
+ * @author Sanghyeok An
  * @since 2.3
  *
  */

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
@@ -73,6 +73,7 @@ import org.springframework.util.StringUtils;
  * @author Chris Gilbert
  * @author Adrian Gygax
  * @author Yaniv Nahoum
+ * @author Sanghyeok An
  */
 public class DefaultKafkaConsumerFactory<K, V> extends KafkaResourceFactory
 		implements ConsumerFactory<K, V>, BeanNameAware, ApplicationContextAware {

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
@@ -398,7 +398,7 @@ public class DefaultKafkaConsumerFactory<K, V> extends KafkaResourceFactory
 		boolean shouldModifyClientId = (this.configs.containsKey(ConsumerConfig.CLIENT_ID_CONFIG)
 				&& StringUtils.hasText(clientIdSuffix)) || overrideClientIdPrefix;
 		if (groupId == null
-				&& (properties == null || properties.stringPropertyNames().size() == 0)
+				&& (properties == null || properties.stringPropertyNames().isEmpty())
 				&& !shouldModifyClientId) {
 			return createKafkaConsumer(new HashMap<>(this.configs));
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaAdmin.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaAdmin.java
@@ -74,6 +74,7 @@ import org.springframework.util.Assert;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Adrian Gygax
+ * @author Sanghyeok An
  *
  * @since 1.3
  */

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaAdmin.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaAdmin.java
@@ -239,7 +239,7 @@ public class KafkaAdmin extends KafkaResourceFactory
 	 */
 	public final boolean initialize() {
 		Collection<NewTopic> newTopics = newTopics();
-		if (newTopics.size() > 0) {
+		if (!newTopics.isEmpty()) {
 			AdminClient adminClient = null;
 			try {
 				adminClient = createAdmin();
@@ -399,7 +399,7 @@ public class KafkaAdmin extends KafkaResourceFactory
 	}
 
 	private void addOrModifyTopicsIfNeeded(AdminClient adminClient, Collection<NewTopic> topics) {
-		if (topics.size() > 0) {
+		if (!topics.isEmpty()) {
 			Map<String, NewTopic> topicNameToTopic = new HashMap<>();
 			topics.forEach(t -> topicNameToTopic.compute(t.name(), (k, v) -> t));
 			DescribeTopicsResult topicInfo = adminClient
@@ -409,10 +409,10 @@ public class KafkaAdmin extends KafkaResourceFactory
 			List<NewTopic> topicsToAdd = new ArrayList<>();
 			Map<String, NewPartitions> topicsWithPartitionMismatches =
 					checkPartitions(topicNameToTopic, topicInfo, topicsToAdd);
-			if (topicsToAdd.size() > 0) {
+			if (!topicsToAdd.isEmpty()) {
 				addTopics(adminClient, topicsToAdd);
 			}
-			if (topicsWithPartitionMismatches.size() > 0) {
+			if (!topicsWithPartitionMismatches.isEmpty()) {
 				createMissingPartitions(adminClient, topicsWithPartitionMismatches);
 			}
 			if (this.modifyTopicConfigs) {
@@ -457,7 +457,7 @@ public class KafkaAdmin extends KafkaResourceFactory
 							configMismatchesEntries.add(actualConfigParameter);
 						}
 					}
-					if (configMismatchesEntries.size() > 0) {
+					if (!configMismatchesEntries.isEmpty()) {
 						configMismatches.put(topicConfig.getKey(), configMismatchesEntries);
 					}
 				}
@@ -491,7 +491,7 @@ public class KafkaAdmin extends KafkaResourceFactory
 												desiredConfigs.get(mismatchConfigEntry.name())),
 										OpType.SET));
 					}
-					if (alterConfigOperations.size() > 0) {
+					if (!alterConfigOperations.isEmpty()) {
 						try {
 							AlterConfigsResult alterConfigsResult = adminClient
 									.incrementalAlterConfigs(Map.of(topicConfigResource, alterConfigOperations));

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
@@ -70,6 +70,7 @@ import org.springframework.util.StringUtils;
  * @author Tomaz Fernandes
  * @author Wang Zhiyang
  * @author Soby Chacko
+ * @author Sanghyeok An
  */
 public abstract class AbstractMessageListenerContainer<K, V>
 		implements GenericMessageListenerContainer<K, V>, BeanNameAware, ApplicationEventPublisherAware,

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
@@ -570,7 +570,7 @@ public abstract class AbstractMessageListenerContainer<K, V>
 			catch (Exception e) {
 				this.logger.error(e, "Failed to check topic existence");
 			}
-			if (missing != null && missing.size() > 0) {
+			if (missing != null && !missing.isEmpty()) {
 				throw new IllegalStateException(
 						"Topic(s) " + missing.toString()
 								+ " is/are not present and missingTopicsFatal is true");

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerProperties.java
@@ -520,7 +520,7 @@ public class ConsumerProperties {
 				+ (this.offsetAndMetadataProvider != null ? "\n offsetAndMetadataProvider=" + this.offsetAndMetadataProvider : "")
 				+ "\n syncCommits=" + this.syncCommits
 				+ (this.syncCommitTimeout != null ? "\n syncCommitTimeout=" + this.syncCommitTimeout : "")
-				+ (this.kafkaConsumerProperties.size() > 0 ? "\n properties=" + this.kafkaConsumerProperties : "")
+				+ (!this.kafkaConsumerProperties.isEmpty() ? "\n properties=" + this.kafkaConsumerProperties : "")
 				+ "\n authExceptionRetryInterval=" + this.authExceptionRetryInterval
 				+ "\n commitRetries=" + this.commitRetries
 				+ "\n fixTxOffsets" + this.fixTxOffsets;

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerProperties.java
@@ -35,6 +35,7 @@ import org.springframework.util.StringUtils;
  * Common consumer properties.
  *
  * @author Gary Russell
+ * @author Sagnhyeok An
  * @since 2.3
  *
  */

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerGroupSequencer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerGroupSequencer.java
@@ -186,7 +186,7 @@ public class ContainerGroupSequencer implements ApplicationContextAware,
 		for (String group : this.groupNames) {
 			this.groups.add(this.applicationContext.getBean(group + ".group", ContainerGroup.class));
 		}
-		if (this.groups.size() > 0) {
+		if (!this.groups.isEmpty()) {
 			this.iterator = this.groups.iterator();
 			this.currentGroup = this.iterator.next();
 			this.groups.forEach(grp -> {

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerGroupSequencer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerGroupSequencer.java
@@ -37,6 +37,7 @@ import org.springframework.kafka.event.ListenerContainerIdleEvent;
  * idle.
  *
  * @author Gary Russell
+ * @author Sanghyeok An
  * @since 2.7.3
  *
  */

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/DefaultAfterRollbackProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/DefaultAfterRollbackProcessor.java
@@ -210,7 +210,7 @@ public class DefaultAfterRollbackProcessor<K, V> extends FailedRecordProcessor
 				Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
 				records.forEach(rec -> offsets.put(new TopicPartition(rec.topic(), rec.partition()),
 						ListenerUtils.createOffsetAndMetadata(container, rec.offset() + 1)));
-				if (offsets.size() > 0 && this.kafkaTemplate != null && this.kafkaTemplate.isTransactional()) {
+				if (!offsets.isEmpty() && this.kafkaTemplate != null && this.kafkaTemplate.isTransactional()) {
 					this.kafkaTemplate.sendOffsetsToTransaction(offsets, consumer.groupMetadata());
 				}
 				clearThreadState();

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/DefaultAfterRollbackProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/DefaultAfterRollbackProcessor.java
@@ -51,6 +51,7 @@ import org.springframework.util.backoff.BackOffExecution;
  * @author Gary Russell
  * @author Francois Rosiere
  * @author Wang Zhiyang
+ * @author Sanghyeok An
  *
  * @since 1.3.5
  *

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/BatchMessagingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/BatchMessagingMessageListenerAdapter.java
@@ -54,6 +54,7 @@ import org.springframework.util.Assert;
  * @author Artem Bilan
  * @author Venil Noronha
  * @author Wang ZhiYang
+ * @author Sanghyeok An
  * @since 1.1
  */
 public class BatchMessagingMessageListenerAdapter<K, V> extends MessagingMessageListenerAdapter<K, V>

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/BatchMessagingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/BatchMessagingMessageListenerAdapter.java
@@ -95,6 +95,9 @@ public class BatchMessagingMessageListenerAdapter<K, V> extends MessagingMessage
 		if (recordMessageConverter != null) {
 			setMessageConverter(recordMessageConverter);
 		}
+		else {
+			logger.warn("No batch message converter is set. because record message converter is null.");
+		}
 	}
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/requestreply/AggregatingReplyingKafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/requestreply/AggregatingReplyingKafkaTemplate.java
@@ -50,6 +50,7 @@ import org.springframework.util.Assert;
  * @param <R> the reply data type.
  *
  * @author Gary Russell
+ * @author Sanghyeok An
  * @since 2.3
  *
  */

--- a/spring-kafka/src/main/java/org/springframework/kafka/requestreply/AggregatingReplyingKafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/requestreply/AggregatingReplyingKafkaTemplate.java
@@ -162,7 +162,7 @@ public class AggregatingReplyingKafkaTemplate<K, V, R>
 				}
 			}
 		});
-		if (completed.size() > 0) {
+		if (!completed.isEmpty()) {
 			super.onMessage(completed);
 		}
 	}

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DestinationTopic.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DestinationTopic.java
@@ -31,6 +31,7 @@ import org.springframework.lang.Nullable;
  * @author Tomaz Fernandes
  * @author Gary Russell
  * @author Adrian Chlebosz
+ * @author Sanghyeok An
  * @since 2.7
  *
  */

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DestinationTopic.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DestinationTopic.java
@@ -46,8 +46,7 @@ public class DestinationTopic {
 	}
 
 	public DestinationTopic(String destinationName, DestinationTopic sourceDestinationtopic, String suffix, Type type) {
-		this.destinationName = destinationName;
-		this.properties = new Properties(sourceDestinationtopic.properties, suffix, type);
+		this(destinationName, new Properties(sourceDestinationtopic.properties, suffix, type));
 	}
 
 	public Long getDestinationDelay() {

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/AbstractKafkaHeaderMapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/AbstractKafkaHeaderMapper.java
@@ -43,6 +43,7 @@ import org.springframework.util.PatternMatchUtils;
  *
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Sanghyeok An
  *
  * @since 2.1.3
  *

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/AbstractKafkaHeaderMapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/AbstractKafkaHeaderMapper.java
@@ -216,7 +216,7 @@ public abstract class AbstractKafkaHeaderMapper implements KafkaHeaderMapper {
 		if (this.outbound) {
 			return true;
 		}
-		if (this.matchers.size() == 0) {
+		if (this.matchers.isEmpty()) {
 			return true;
 		}
 		return doesMatch(header);

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/converter/BatchMessagingMessageConverter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/converter/BatchMessagingMessageConverter.java
@@ -60,6 +60,7 @@ import org.springframework.messaging.support.MessageBuilder;
  * @author Gary Russell
  * @author Dariusz Szablinski
  * @author Biju Kunjummen
+ * @author Sanghyeok An
  * @since 1.1
  */
 public class BatchMessagingMessageConverter implements BatchMessageConverter {

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/converter/BatchMessagingMessageConverter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/converter/BatchMessagingMessageConverter.java
@@ -66,6 +66,7 @@ public class BatchMessagingMessageConverter implements BatchMessageConverter {
 
 	protected final LogAccessor logger = new LogAccessor(LogFactory.getLog(getClass())); // NOSONAR
 
+	@Nullable
 	private final RecordMessageConverter recordConverter;
 
 	private boolean generateMessageId = false;
@@ -123,6 +124,7 @@ public class BatchMessagingMessageConverter implements BatchMessageConverter {
 		this.headerMapper = headerMapper;
 	}
 
+	@Nullable
 	@Override
 	public RecordMessageConverter getRecordMessageConverter() {
 		return this.recordConverter;

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingByTopicSerialization.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingByTopicSerialization.java
@@ -39,6 +39,7 @@ import org.springframework.util.StringUtils;
  *
  * @author Gary Russell
  * @author Wang Zhiyang
+ * @author Sanghyeok An
  *
  * @since 2.8
  *

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingByTopicSerialization.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingByTopicSerialization.java
@@ -108,7 +108,7 @@ public abstract class DelegatingByTopicSerialization<T extends Closeable> implem
 
 	@SuppressWarnings(UNCHECKED)
 	protected void configure(Map<String, ?> configs, boolean isKey) {
-		if (this.delegates.size() > 0) {
+		if (!this.delegates.isEmpty()) {
 			this.delegates.values().forEach(delegate -> configureDelegate(configs, isKey, delegate));
 		}
 		this.forKeys = isKey;

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
@@ -815,7 +815,7 @@ public class KafkaMessageListenerContainerTests {
 				latch1.countDown();
 				latch2.countDown();
 				acks.add(ack);
-				if (latch1.getCount() == 0 && records1.values().size() > 0
+				if (latch1.getCount() == 0 && !records1.isEmpty()
 						&& records1.values().iterator().next().size() == 4) {
 					acks.get(3).acknowledge();
 					acks.get(2).acknowledge();

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
@@ -145,6 +145,7 @@ import org.springframework.util.backoff.FixedBackOff;
  * @author Wang Zhiyang
  * @author Mikael Carlstedt
  * @author Borahm Lee
+ * @author Sanghyeok An
  */
 @EmbeddedKafka(topics = { KafkaMessageListenerContainerTests.topic1, KafkaMessageListenerContainerTests.topic2,
 		KafkaMessageListenerContainerTests.topic3, KafkaMessageListenerContainerTests.topic4,


### PR DESCRIPTION
### Motivation:
- There are some codes using `*.size() > 0` or `*.size() == 0` in `spring-kafka`.
- There is code where the constructor could be reused, but it was not. 
- There is code where a `null` value can occur, but it does not indicate that `null` is possible.

### Modifications:
- Replace `a.size() > 0` with `!a.isEmpty()`.
- Replace `a.size() == 0` with `a.isEmpty()`.
- Reuse constructor already existed to remove duplicate constructor logic. 
- Add @Nullable annotations to field, and method. Also, add warning log. 

### Result:
- There is only one side effect which developer can observe.
  -  when `BatchMessagingMessageListenerAdapter#setBatchMessageConverter()` is executed, new warning log can be occur. 