### PR TITLE
GH-3424: Customizing DeadLetterPublishingRecovererFactory logging

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -40,3 +40,8 @@ For more details, see xref:kafka/events.adoc[Application Events] and `Concurrent
 
 When using `ReplyingKafkaTemplate`, if the original record from the request contains a key, then that same key will be part of the reply as well.
 For more details, see xref:kafka/sending-messages.adoc[Sending Messages] section of the reference docs.
+
+[[x33-customize-logging-in-DeadLetterPublishingRecovererFactory]]
+=== Customizing Logging in DeadLetterPublishingRecovererFactory
+
+When using `DeadLetterPublishingRecovererFactory`, the user applications can override the `maybeLogListenerException` method to customize the logging behavior.

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DeadLetterPublishingRecovererFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DeadLetterPublishingRecovererFactory.java
@@ -246,7 +246,7 @@ public class DeadLetterPublishingRecovererFactory {
 	 * @param nextDestination the next topic where the record goes
 	 * @since 3.3.0
 	 */
-	public void maybeLogListenerException(Exception exception, ConsumerRecord<?, ?> consumerRecord, DestinationTopic nextDestination) {
+	protected void maybeLogListenerException(Exception exception, ConsumerRecord<?, ?> consumerRecord, DestinationTopic nextDestination) {
 		if (nextDestination.isDltTopic()
 				&& !ListenerExceptionLoggingStrategy.NEVER.equals(this.loggingStrategy)) {
 			LOGGER.error(exception, () -> getErrorMessage(consumerRecord) + " and won't be retried. "


### PR DESCRIPTION
Fixes: #3424

Provide the ability to customize logging in `DeadLetterPublishingRecovererFactory`.

