### PR TITLE
GH-3463: Allow `@DltHandler` on super class

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryableTopicAnnotationProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryableTopicAnnotationProcessor.java
@@ -34,6 +34,7 @@ import org.springframework.beans.factory.config.BeanExpressionResolver;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.expression.BeanFactoryResolver;
 import org.springframework.context.expression.StandardBeanExpressionResolver;
+import org.springframework.core.MethodIntrospector;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.kafka.core.KafkaOperations;
@@ -64,6 +65,7 @@ import org.springframework.util.StringUtils;
  * @author Gary Russell
  * @author Adrian Chlebosz
  * @author Wang Zhiyang
+ * @author Artem Bilan
  *
  * @since 2.7
  *
@@ -228,8 +230,10 @@ public class RetryableTopicAnnotationProcessor {
 	}
 
 	private EndpointHandlerMethod getDltProcessor(Class<?> clazz, Object bean) {
-		return Arrays.stream(ReflectionUtils.getDeclaredMethods(clazz))
-				.filter(method -> AnnotationUtils.findAnnotation(method, DltHandler.class) != null)
+		ReflectionUtils.MethodFilter selector =
+				(method) -> AnnotationUtils.findAnnotation(method, DltHandler.class) != null;
+		return MethodIntrospector.selectMethods(clazz, selector)
+				.stream()
 				.map(method -> RetryTopicConfigurer.createHandlerMethodWith(bean, method))
 				.findFirst()
 				.orElse(RetryTopicConfigurer.DEFAULT_DLT_HANDLER);


### PR DESCRIPTION
Fixes: #3463

Currently, a `@DltHandler`-annotated method must be in the same class as the corresponding `@KafkaListener` annotation. Some logic might be really the same for different `@KafkaListener` services.

* Use `MethodIntrospector` in the `RetryableTopicAnnotationProcessor` to be able to process methods from super classes as well

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
