### PR TITLE
GH-3466: Optimize KafkaAdmin creation in KafkaTemplate

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
@@ -80,6 +80,7 @@ import org.springframework.messaging.converter.SmartMessageConverter;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
 
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
@@ -484,8 +485,9 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 			if (this.kafkaAdmin == null) {
 				this.kafkaAdmin = this.applicationContext.getBeanProvider(KafkaAdmin.class).getIfUnique();
 				if (this.kafkaAdmin != null) {
-					Object producerServers = this.producerFactory.getConfigurationProperties()
-							.get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG);
+					String producerServers = this.producerFactory.getConfigurationProperties()
+							.get(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG).toString();
+					producerServers = removeLeadingAndTrailingBrackets(producerServers);
 					String adminServers = getAdminBootstrapAddress();
 					if (!producerServers.equals(adminServers)) {
 						Map<String, Object> props = new HashMap<>(this.kafkaAdmin.getConfigurationProperties());
@@ -506,10 +508,14 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 		}
 	}
 
+	private String removeLeadingAndTrailingBrackets(String str) {
+		return StringUtils.trimTrailingCharacter(StringUtils.trimLeadingCharacter(str, '['),
+				']');
+	}
+
 	private String getAdminBootstrapAddress() {
 		// Retrieve bootstrap servers from KafkaAdmin bootstrap supplier if available
 		String adminServers = this.kafkaAdmin.getBootstrapServers();
-
 		// Fallback to configuration properties if bootstrap servers are not set
 		if (adminServers == null) {
 			adminServers = this.kafkaAdmin.getConfigurationProperties().getOrDefault(
@@ -517,8 +523,7 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 					""
 			).toString();
 		}
-
-		return adminServers;
+		return removeLeadingAndTrailingBrackets(adminServers);
 	}
 
 	@Nullable

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
@@ -508,11 +508,6 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 		}
 	}
 
-	private String removeLeadingAndTrailingBrackets(String str) {
-		return StringUtils.trimTrailingCharacter(StringUtils.trimLeadingCharacter(str, '['),
-				']');
-	}
-
 	private String getAdminBootstrapAddress() {
 		// Retrieve bootstrap servers from KafkaAdmin bootstrap supplier if available
 		String adminServers = this.kafkaAdmin.getBootstrapServers();
@@ -1006,6 +1001,10 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 		if (this.producerInterceptor != null) {
 			this.producerInterceptor.close();
 		}
+	}
+
+	private static String removeLeadingAndTrailingBrackets(String str) {
+		return StringUtils.trimTrailingCharacter(StringUtils.trimLeadingCharacter(str, '['), ']');
 	}
 
 	@SuppressWarnings("serial")


### PR DESCRIPTION
Fixes: #3466

https://github.com/spring-projects/spring-kafka/issues/3466

Improve bootstrap-server config comparison to avoid unnecessary KafkaAdmin recreation. This addresses inconsistencies between List<String> and String configurations for bootstrap servers.

The change ensures that List versions of bootstrap-server configs are converted to regular Strings by removing brackets. This allows for consistent comparison between producer and admin configurations.

This optimization is particularly relevant for Spring Boot scenarios where configs may be provided in different formats but represent the same underlying values.

