### PR TITLE
Refactor code

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/BackOffValuesGenerator.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/BackOffValuesGenerator.java
@@ -28,7 +28,6 @@ import org.springframework.retry.backoff.FixedBackOffPolicy;
 import org.springframework.retry.backoff.NoBackOffPolicy;
 import org.springframework.retry.backoff.Sleeper;
 import org.springframework.retry.backoff.SleepingBackOffPolicy;
-import org.springframework.retry.backoff.UniformRandomBackOffPolicy;
 import org.springframework.retry.support.RetrySynchronizationManager;
 
 /**
@@ -82,12 +81,6 @@ public class BackOffValuesGenerator {
 		BackoffRetainerSleeper sleeper = new BackoffRetainerSleeper();
 		SleepingBackOffPolicy<?> retainingBackOffPolicy =
 				((SleepingBackOffPolicy<?>) providedBackOffPolicy).withSleeper(sleeper);
-
-		// UniformRandomBackOffPolicy loses the max value when a sleeper is set.
-		if (providedBackOffPolicy instanceof UniformRandomBackOffPolicy) {
-			((UniformRandomBackOffPolicy) retainingBackOffPolicy)
-					.setMaxBackOffPeriod(((UniformRandomBackOffPolicy) providedBackOffPolicy).getMaxBackOffPeriod());
-		}
 		BackOffContext backOffContext = retainingBackOffPolicy.start(RetrySynchronizationManager.getContext());
 		IntStream.range(0, maxAttempts)
 				.forEach(index -> retainingBackOffPolicy.backOff(backOffContext));

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/ListenerContainerFactoryResolver.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/ListenerContainerFactoryResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2022 the original author or authors.
+ * Copyright 2018-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -205,9 +205,7 @@ public class ListenerContainerFactoryResolver {
 																ConcurrentKafkaListenerContainerFactory<?, ?> resolvedFactory) {
 			synchronized (this.cacheMap) {
 				Key key = cacheKey(factoryFromKafkaListenerAnnotation, config);
-				if (!this.cacheMap.containsKey(key)) {
-					this.cacheMap.put(key, resolvedFactory);
-				}
+				this.cacheMap.putIfAbsent(key, resolvedFactory);
 				return resolvedFactory;
 			}
 		}


### PR DESCRIPTION
Following code is refactored.

1) `generateFromSleepingBackOffPolicy` method in `org.springframework.kafka.retrytopic.BackOffValuesGenerator`

Removed the code to set the `maxBackOffPeriod`, if the BackOffPolicy is `UniformRandomBackOffPolicy`. This is not required since, when sleeper is added to the `UniformRandomBackOffPolicy` `maxBackOffPeriod` is not modified. This could be an issue with the earlier versions of spring-retry. But, latest version of spring-kafka 3.3 and spring-retry 2.0.8, this is not an issue.

2) Modified `addIfAbsent` in `org.springframework.kafka.retrytopic.ListenerContainerFactoryResolver.Cache` to use `putIfAbsent`, rather than explictly checking for the key, if it is not there than adding it to the `HashMap`.

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
