### PR TITLE
Fix `toSting()` methods in `KafkaEvent` subclasses

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/event/ListenerContainerPartitionIdleEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/ListenerContainerPartitionIdleEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2021 the original author or authors.
+ * Copyright 2016-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import org.apache.kafka.common.TopicPartition;
  * is configured to do so.
  *
  * @author Tomaz Fernandes
+ * @author Borahm Lee
  * @since 2.7
  */
 public class ListenerContainerPartitionIdleEvent extends KafkaEvent {
@@ -108,7 +109,7 @@ public class ListenerContainerPartitionIdleEvent extends KafkaEvent {
 
 	@Override
 	public String toString() {
-		return "ListenerContainerIdleEvent [idleTime="
+		return "ListenerContainerPartitionIdleEvent [idleTime="
 				+ ((float) this.idleTime / 1000) + "s, listenerId=" + this.listenerId // NOSONAR magic #
 				+ ", container=" + getSource()
 				+ ", paused=" + this.paused

--- a/spring-kafka/src/main/java/org/springframework/kafka/event/ListenerContainerPartitionNoLongerIdleEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/ListenerContainerPartitionNoLongerIdleEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 the original author or authors.
+ * Copyright 2020-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import org.apache.kafka.common.TopicPartition;
  * idle events.
  *
  * @author Gary Russell
+ * @author Borahm Lee
  * @since 2.6.2
  */
 public class ListenerContainerPartitionNoLongerIdleEvent extends KafkaEvent {
@@ -92,9 +93,9 @@ public class ListenerContainerPartitionNoLongerIdleEvent extends KafkaEvent {
 
 	@Override
 	public String toString() {
-		return "ListenerContainerNoLongerIdleEvent [idleTime="
+		return "ListenerContainerPartitionNoLongerIdleEvent [idleTime="
 				+ ((float) this.idleTime / 1000) + "s, listenerId=" + this.listenerId // NOSONAR magic #
 				+ ", container=" + getSource()
-				+ ", topicPartitions=" + this.topicPartition + "]";
+				+ ", topicPartition=" + this.topicPartition + "]";
 	}
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
## Description
- This commit updates the toString() methods in two Kafka event classes: `ListenerContainerPartitionIdleEvent` and `ListenerContainerPartitionNoLongerIdleEvent`.
- The changes ensure that both methods accurately reflect their class names and properties.