### PR TITLE
Update `message-listener-container.adoc`

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/receiving-messages/message-listener-container.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/receiving-messages/message-listener-container.adoc
@@ -142,7 +142,7 @@ For example, if you have three topics with five partitions each and you want to 
 This is because the default Kafka `PartitionAssignor` is the `RangeAssignor` (see its Javadoc).
 For this scenario, you may want to consider using the `RoundRobinAssignor` instead, which distributes the partitions across all of the consumers.
 Then, each consumer is assigned one topic or partition.
-To change the `PartitionAssignor`, you can set the `partition.assignment.strategy` consumer property (`ConsumerConfigs.PARTITION_ASSIGNMENT_STRATEGY_CONFIG`) in the properties provided to the `DefaultKafkaConsumerFactory`.
+To change the `PartitionAssignor`, you can set the `partition.assignment.strategy` consumer property (`ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG`) in the properties provided to the `DefaultKafkaConsumerFactory`.
 
 When using Spring Boot, you can assign set the strategy as follows:
 

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/receiving-messages/message-listener-container.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/receiving-messages/message-listener-container.adoc
@@ -139,10 +139,10 @@ For the first constructor, Kafka distributes the partitions across the consumers
 ====
 When listening to multiple topics, the default partition distribution may not be what you expect.
 For example, if you have three topics with five partitions each and you want to use `concurrency=15`, you see only five active consumers, each assigned one partition from each topic, with the other 10 consumers being idle.
-This is because the default Kafka `PartitionAssignor` is the `RangeAssignor` (see its Javadoc).
+This is because the default Kafka `ConsumerPartitionAssignor` is the `RangeAssignor` (see its Javadoc).
 For this scenario, you may want to consider using the `RoundRobinAssignor` instead, which distributes the partitions across all of the consumers.
 Then, each consumer is assigned one topic or partition.
-To change the `PartitionAssignor`, you can set the `partition.assignment.strategy` consumer property (`ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG`) in the properties provided to the `DefaultKafkaConsumerFactory`.
+To change the `ConsumerPartitionAssignor`, you can set the `partition.assignment.strategy` consumer property (`ConsumerConfig.PARTITION_ASSIGNMENT_STRATEGY_CONFIG`) in the properties provided to the `DefaultKafkaConsumerFactory`.
 
 When using Spring Boot, you can assign set the strategy as follows:
 


### PR DESCRIPTION
## Description

* The class name `ConsumerConfigs` was incorrectly referenced in the documentation. Updated it to `ConsumerConfig` to match the correct class name.
* Kafka's `PartitionAssignor` has been deprecated. Updated the documentation to use the new `ConsumerPartitionAssignor` class for better clarity and to align with Kafka's latest API.