### PR TITLE
Support custom KafkaStreams implementations

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/streams.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/streams.adoc
@@ -82,7 +82,7 @@ A new `KafkaStreams` is created on each `start()`.
 You might also consider using different `StreamsBuilderFactoryBean` instances, if you would like to control the lifecycles for `KStream` instances separately.
 
 You also can specify `KafkaStreams.StateListener`, `Thread.UncaughtExceptionHandler`, and `StateRestoreListener` options on the `StreamsBuilderFactoryBean`, which are delegated to the internal `KafkaStreams` instance.
-Also, apart from setting those options indirectly on `StreamsBuilderFactoryBean`, starting with _version 2.1.5_, you can use a `KafkaStreamsCustomizer` callback interface to configure an inner `KafkaStreams` instance.
+Also, apart from setting those options indirectly on `StreamsBuilderFactoryBean`, starting with _version 2.1.5_, you can use a `KafkaStreamsCustomizer` callback interface to configure an inner `KafkaStreams` instance and (from _version 3.3.0_) instantiate a custom implementation of `KafkaStreams`.
 Note that `KafkaStreamsCustomizer` overrides the options provided by `StreamsBuilderFactoryBean`.
 If you need to perform some `KafkaStreams` operations directly, you can access that internal `KafkaStreams` instance by using `StreamsBuilderFactoryBean.getKafkaStreams()`.
 You can autowire `StreamsBuilderFactoryBean` bean by type, but you should be sure to use the full type in the bean definition, as the following example shows:

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/streams.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/streams.adoc
@@ -82,9 +82,14 @@ A new `KafkaStreams` is created on each `start()`.
 You might also consider using different `StreamsBuilderFactoryBean` instances, if you would like to control the lifecycles for `KStream` instances separately.
 
 You also can specify `KafkaStreams.StateListener`, `Thread.UncaughtExceptionHandler`, and `StateRestoreListener` options on the `StreamsBuilderFactoryBean`, which are delegated to the internal `KafkaStreams` instance.
-Also, apart from setting those options indirectly on `StreamsBuilderFactoryBean`, starting with _version 2.1.5_, you can use a `KafkaStreamsCustomizer` callback interface to configure an inner `KafkaStreams` instance and (from _version 3.3.0_) instantiate a custom implementation of `KafkaStreams`.
-Note that `KafkaStreamsCustomizer` overrides the options provided by `StreamsBuilderFactoryBean`.
-If you need to perform some `KafkaStreams` operations directly, you can access that internal `KafkaStreams` instance by using `StreamsBuilderFactoryBean.getKafkaStreams()`.
+
+Also, apart from setting those options indirectly on `StreamsBuilderFactoryBean`, you can use a `KafkaStreamsCustomizer` callback interface to configure:
+
+1. (from _version 2.1.5_) an inner `KafkaStreams` instance using `customize(KafkaStreams)`
+2. (from _version 3.3.0_) instantiate a custom implementation of `KafkaStreams` using `initKafkaStreams(Topology, Properties, KafkaClientSupplier)`
+
+Note that `KafkaStreamsCustomizer` overrides the options provided by `StreamsBuilderFactoryBean`. If you need to perform some `KafkaStreams` operations directly, you can access that internal `KafkaStreams` instance by using `StreamsBuilderFactoryBean.getKafkaStreams()`.
+
 You can autowire `StreamsBuilderFactoryBean` bean by type, but you should be sure to use the full type in the bean definition, as the following example shows:
 
 [source,java]

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/streams.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/streams.adoc
@@ -83,12 +83,14 @@ You might also consider using different `StreamsBuilderFactoryBean` instances, i
 
 You also can specify `KafkaStreams.StateListener`, `Thread.UncaughtExceptionHandler`, and `StateRestoreListener` options on the `StreamsBuilderFactoryBean`, which are delegated to the internal `KafkaStreams` instance.
 
-Also, apart from setting those options indirectly on `StreamsBuilderFactoryBean`, you can use a `KafkaStreamsCustomizer` callback interface to configure:
+Also, apart from setting those options indirectly on `StreamsBuilderFactoryBean`, you can use a `KafkaStreamsCustomizer` callback interface to:
 
-1. (from _version 2.1.5_) an inner `KafkaStreams` instance using `customize(KafkaStreams)`
+1. (from _version 2.1.5_) configure an inner `KafkaStreams` instance using `customize(KafkaStreams)`
 2. (from _version 3.3.0_) instantiate a custom implementation of `KafkaStreams` using `initKafkaStreams(Topology, Properties, KafkaClientSupplier)`
 
-Note that `KafkaStreamsCustomizer` overrides the options provided by `StreamsBuilderFactoryBean`. If you need to perform some `KafkaStreams` operations directly, you can access that internal `KafkaStreams` instance by using `StreamsBuilderFactoryBean.getKafkaStreams()`.
+Note that `KafkaStreamsCustomizer` overrides the options provided by `StreamsBuilderFactoryBean`.
+
+If you need to perform some `KafkaStreams` operations directly, you can access that internal `KafkaStreams` instance by using `StreamsBuilderFactoryBean.getKafkaStreams()`.
 
 You can autowire `StreamsBuilderFactoryBean` bean by type, but you should be sure to use the full type in the bean definition, as the following example shows:
 

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -45,3 +45,8 @@ For more details, see xref:kafka/sending-messages.adoc[Sending Messages] section
 === Customizing Logging in DeadLetterPublishingRecovererFactory
 
 When using `DeadLetterPublishingRecovererFactory`, the user applications can override the `maybeLogListenerException` method to customize the logging behavior.
+
+[[x33-customize-kafka-streams-implementation]]
+=== Customizing The Implementation of Kafka Streams
+
+When using `KafkaStreamsCustomizer` it is now possible to return a custom implementation of the `KafkaStreams` object by overriding the `initKafkaStreams` method.

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaStreamsCustomizer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaStreamsCustomizer.java
@@ -36,6 +36,15 @@ import org.apache.kafka.streams.Topology;
 public interface KafkaStreamsCustomizer {
 
 	/**
+	 * Customize the instantiation of the {@code KafkaStreams} instance. This
+	 * happens before the modifications made by {@link StreamsBuilderFactoryBean}.
+	 *
+	 * @param topology the full topology
+	 * @param properties the configuration properties
+	 * @param clientSupplier the client supplier
+	 *
+	 * @return a new instance of {@link KafkaStreams}
+	 *
 	 * @since 3.3.0
 	 */
 	default KafkaStreams initKafkaStreams(
@@ -46,6 +55,12 @@ public interface KafkaStreamsCustomizer {
 		return new KafkaStreams(topology, properties, clientSupplier);
 	}
 
+	/**
+	 * Customize the instance of {@code KafkaStreams} after {@link StreamsBuilderFactoryBean}
+	 * has applied its default configurations.
+	 *
+	 * @param kafkaStreams the instantiated Kafka Streams instance
+	 */
 	void customize(KafkaStreams kafkaStreams);
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaStreamsCustomizer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaStreamsCustomizer.java
@@ -26,6 +26,7 @@ import org.apache.kafka.streams.Topology;
  * Callback interface that can be used to configure {@link KafkaStreams} directly.
  *
  * @author Nurettin Yilmaz
+ * @author Almog Gavra
  *
  * @since 2.1.5
  *
@@ -34,6 +35,9 @@ import org.apache.kafka.streams.Topology;
 @FunctionalInterface
 public interface KafkaStreamsCustomizer {
 
+	/**
+	 * @since 3.3.0
+	 */
 	default KafkaStreams initKafkaStreams(
 			Topology topology,
 			Properties properties,

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaStreamsCustomizer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaStreamsCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 the original author or authors.
+ * Copyright 2018-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,11 @@
 
 package org.springframework.kafka.config;
 
+import java.util.Properties;
+
+import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.Topology;
 
 /**
  * Callback interface that can be used to configure {@link KafkaStreams} directly.
@@ -29,6 +33,14 @@ import org.apache.kafka.streams.KafkaStreams;
  */
 @FunctionalInterface
 public interface KafkaStreamsCustomizer {
+
+	default KafkaStreams initKafkaStreams(
+			Topology topology,
+			Properties properties,
+			KafkaClientSupplier clientSupplier
+	) {
+		return new KafkaStreams(topology, properties, clientSupplier);
+	}
 
 	void customize(KafkaStreams kafkaStreams);
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/StreamsBuilderFactoryBean.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/StreamsBuilderFactoryBean.java
@@ -92,7 +92,7 @@ public class StreamsBuilderFactoryBean extends AbstractFactoryBean<StreamsBuilde
 	private KafkaStreamsInfrastructureCustomizer infrastructureCustomizer = new KafkaStreamsInfrastructureCustomizer() {
 	};
 
-	private KafkaStreamsCustomizer kafkaStreamsCustomizer;
+	private KafkaStreamsCustomizer kafkaStreamsCustomizer = kafkaStreams -> { };
 
 	private KafkaStreams.StateListener stateListener;
 
@@ -361,15 +361,15 @@ public class StreamsBuilderFactoryBean extends AbstractFactoryBean<StreamsBuilde
 				try {
 					Assert.state(this.properties != null,
 							"streams configuration properties must not be null");
-					this.kafkaStreams = new KafkaStreams(this.topology, this.properties, this.clientSupplier);
+					this.kafkaStreams = this.kafkaStreamsCustomizer.initKafkaStreams(
+							this.topology, this.properties, this.clientSupplier
+					);
 					this.kafkaStreams.setStateListener(this.stateListener);
 					this.kafkaStreams.setGlobalStateRestoreListener(this.stateRestoreListener);
 					if (this.streamsUncaughtExceptionHandler != null) {
 						this.kafkaStreams.setUncaughtExceptionHandler(this.streamsUncaughtExceptionHandler);
 					}
-					if (this.kafkaStreamsCustomizer != null) {
-						this.kafkaStreamsCustomizer.customize(this.kafkaStreams);
-					}
+					this.kafkaStreamsCustomizer.customize(this.kafkaStreams);
 					if (this.cleanupConfig.cleanupOnStart()) {
 						this.kafkaStreams.cleanUp();
 					}

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/StreamsBuilderFactoryBean.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/StreamsBuilderFactoryBean.java
@@ -61,6 +61,7 @@ import org.springframework.util.Assert;
  * @author Julien Wittouck
  * @author Sanghyeok An
  * @author Cédric Schaller
+ * @author Almog Gavra
  *
  * @since 1.1.4
  */

--- a/spring-kafka/src/test/java/org/springframework/kafka/config/KafkaStreamsCustomizerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/config/KafkaStreamsCustomizerTests.java
@@ -59,6 +59,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 /**
  * @author Nurettin Yilmaz
  * @author Artem Bilan
+ * @author Almog Gavra
  *
  * @since 2.1.5
  */


### PR DESCRIPTION
Fixes #3515. This PR introduces the ability to customize the instantiation of `KafkaStreams` using the `KafkaStreamsCustomizer` interface.