### PR TITLE
GH-3524: Replace KafkaTemplate with KafkaOperations for ReplyTemplate

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
@@ -32,7 +32,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.core.log.LogAccessor;
 import org.springframework.kafka.core.ConsumerFactory;
-import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.KafkaOperations;
 import org.springframework.kafka.listener.AbstractMessageListenerContainer;
 import org.springframework.kafka.listener.AfterRollbackProcessor;
 import org.springframework.kafka.listener.BatchInterceptor;
@@ -90,7 +90,7 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 
 	private ApplicationEventPublisher applicationEventPublisher;
 
-	private KafkaTemplate<?, ?> replyTemplate;
+	private KafkaOperations<?, ?> replyTemplate;
 
 	private AfterRollbackProcessor<? super K, ? super V> afterRollbackProcessor;
 
@@ -209,11 +209,11 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 	}
 
 	/**
-	 * Set the {@link KafkaTemplate} to use to send replies.
+	 * Set the {@link KafkaOperations} to use to send replies.
 	 * @param replyTemplate the template.
 	 * @since 2.0
 	 */
-	public void setReplyTemplate(KafkaTemplate<?, ?> replyTemplate) {
+	public void setReplyTemplate(KafkaOperations<?, ?> replyTemplate) {
 		if (replyTemplate instanceof ReplyingKafkaOperations) {
 			this.logger.warn(
 					"The 'replyTemplate' should not be an implementation of 'ReplyingKafkaOperations'; "
@@ -401,7 +401,6 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 	 * @param instance the container instance to configure.
 	 * @param endpoint the endpoint.
 	 */
-	@SuppressWarnings("deprecation")
 	protected void initializeContainer(C instance, KafkaListenerEndpoint endpoint) {
 		ContainerProperties properties = instance.getContainerProperties();
 		BeanUtils.copyProperties(this.containerProperties, properties, "topics", "topicPartitions", "topicPattern",

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
@@ -35,7 +35,7 @@ import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.context.expression.BeanFactoryResolver;
 import org.springframework.core.log.LogAccessor;
 import org.springframework.expression.BeanResolver;
-import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.KafkaOperations;
 import org.springframework.kafka.listener.BatchMessageListener;
 import org.springframework.kafka.listener.MessageListener;
 import org.springframework.kafka.listener.MessageListenerContainer;
@@ -97,7 +97,7 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 
 	private Boolean batchListener;
 
-	private KafkaTemplate<?, ?> replyTemplate;
+	private KafkaOperations<?, ?> replyTemplate;
 
 	private String clientIdPrefix;
 
@@ -302,16 +302,16 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 	}
 
 	/**
-	 * Set the {@link KafkaTemplate} to use to send replies.
+	 * Set the {@link KafkaOperations} to use to send replies.
 	 * @param replyTemplate the template.
 	 * @since 2.0
 	 */
-	public void setReplyTemplate(KafkaTemplate<?, ?> replyTemplate) {
+	public void setReplyTemplate(KafkaOperations<?, ?> replyTemplate) {
 		this.replyTemplate = replyTemplate;
 	}
 
 	@Nullable
-	protected KafkaTemplate<?, ?> getReplyTemplate() {
+	protected KafkaOperations<?, ?> getReplyTemplate() {
 		return this.replyTemplate;
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
@@ -45,7 +45,7 @@ import org.springframework.expression.common.LiteralExpression;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.expression.spel.support.StandardTypeConverter;
-import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.KafkaOperations;
 import org.springframework.kafka.listener.ConsumerSeekAware;
 import org.springframework.kafka.listener.KafkaListenerErrorHandler;
 import org.springframework.kafka.listener.ListenerExecutionFailedException;
@@ -136,7 +136,7 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 	private Expression replyTopicExpression;
 
 	@SuppressWarnings("rawtypes")
-	private KafkaTemplate replyTemplate;
+	private KafkaOperations replyTemplate;
 
 	private boolean hasAckParameter;
 
@@ -287,7 +287,7 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 	 * @param replyTemplate the template.
 	 * @since 2.0
 	 */
-	public void setReplyTemplate(KafkaTemplate<?, ?> replyTemplate) {
+	public void setReplyTemplate(KafkaOperations<?, ?> replyTemplate) {
 		this.replyTemplate = replyTemplate;
 	}
 


### PR DESCRIPTION
Fixes: #3524

https://github.com/spring-projects/spring-kafka/issues/3524

Replacing `KafkaTemplate` with `KafkaOperations` for Container Factories opens more opportunities for developers to configure replying kafka templates since extending `KafkaTemplate` might not always be possible.

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
