### PR TITLE
Forbid fenced Container to stop ConcurrentContainer

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
@@ -193,6 +193,14 @@ public abstract class AbstractMessageListenerContainer<K, V>
 		}
 	}
 
+	/**
+	 *	To be used only with {@link ConcurrentMessageListenerContainerRef}.
+	 */
+	AbstractMessageListenerContainer() {
+		this.containerProperties = null;
+		this.consumerFactory = null;
+	}
+
 	@Override
 	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
 		this.applicationContext = applicationContext;
@@ -280,6 +288,10 @@ public abstract class AbstractMessageListenerContainer<K, V>
 
 	protected void setFenced(boolean fenced) {
 		this.fenced = fenced;
+	}
+
+	boolean isFenced() {
+		return this.fenced;
 	}
 
 	@Deprecated(since = "3.2", forRemoval = true)
@@ -722,7 +734,7 @@ public abstract class AbstractMessageListenerContainer<K, V>
 	protected void publishContainerStoppedEvent() {
 		ApplicationEventPublisher eventPublisher = getApplicationEventPublisher();
 		if (eventPublisher != null) {
-			eventPublisher.publishEvent(new ContainerStoppedEvent(this, parentOrThis()));
+			eventPublisher.publishEvent(new ContainerStoppedEvent(this, parentContainerOrThis()));
 		}
 	}
 
@@ -733,6 +745,20 @@ public abstract class AbstractMessageListenerContainer<K, V>
 	 */
 	protected AbstractMessageListenerContainer<?, ?> parentOrThis() {
 		return this;
+	}
+
+	/**
+	 * Return the actual {@link ConcurrentMessageListenerContainer} if the parent is instance of
+	 * {@link ConcurrentMessageListenerContainerRef}.
+	 *
+	 * @return the parent or this
+	 * @since 3.3
+	 */
+	AbstractMessageListenerContainer<?, ?> parentContainerOrThis() {
+		if (parentOrThis() instanceof ConcurrentMessageListenerContainerRef) {
+			return ((ConcurrentMessageListenerContainerRef) parentOrThis()).getConcurrentContainer();
+		}
+		return parentOrThis();
 	}
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
@@ -305,13 +305,17 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 			@Nullable TopicPartitionOffset[] topicPartitions, int i) {
 
 		KafkaMessageListenerContainer<K, V> container;
+		ConcurrentMessageListenerContainerRef concurrentMessageListenerContainerRef =
+				new ConcurrentMessageListenerContainerRef<>(this, this.lifecycleLock);
 		if (topicPartitions == null) {
-			container = new KafkaMessageListenerContainer<>(this, this.consumerFactory, containerProperties); // NOSONAR
+			container = new KafkaMessageListenerContainer<>(concurrentMessageListenerContainerRef, this.consumerFactory,
+					containerProperties); // NOSONAR
 		}
 		else {
-			container = new KafkaMessageListenerContainer<>(this, this.consumerFactory, // NOSONAR
-					containerProperties, partitionSubset(containerProperties, i));
+			container = new KafkaMessageListenerContainer<>(concurrentMessageListenerContainerRef, this.consumerFactory,
+					containerProperties, partitionSubset(containerProperties, i)); // NOSONAR
 		}
+		concurrentMessageListenerContainerRef.setKafkaMessageListenerContainer(container);
 		return container;
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
@@ -308,12 +308,12 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 		ConcurrentMessageListenerContainerRef concurrentMessageListenerContainerRef =
 				new ConcurrentMessageListenerContainerRef<>(this, this.lifecycleLock);
 		if (topicPartitions == null) {
-			container = new KafkaMessageListenerContainer<>(concurrentMessageListenerContainerRef, this.consumerFactory,
-					containerProperties); // NOSONAR
+			container = new KafkaMessageListenerContainer<>(concurrentMessageListenerContainerRef, this,
+					this.consumerFactory, containerProperties); // NOSONAR
 		}
 		else {
-			container = new KafkaMessageListenerContainer<>(concurrentMessageListenerContainerRef, this.consumerFactory,
-					containerProperties, partitionSubset(containerProperties, i)); // NOSONAR
+			container = new KafkaMessageListenerContainer<>(concurrentMessageListenerContainerRef, this,
+					this.consumerFactory, containerProperties, partitionSubset(containerProperties, i)); // NOSONAR
 		}
 		concurrentMessageListenerContainerRef.setKafkaMessageListenerContainer(container);
 		return container;

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerRef.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerRef.java
@@ -19,14 +19,19 @@ package org.springframework.kafka.listener;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Function;
 
 import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.TopicPartition;
 
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.core.log.LogAccessor;
+import org.springframework.kafka.core.KafkaAdmin;
 import org.springframework.kafka.event.ConsumerStoppedEvent;
+import org.springframework.lang.Nullable;
 
 /**
  * Reference of {@link ConcurrentMessageListenerContainer} to be passed to the {@link KafkaMessageListenerContainer}.
@@ -268,18 +273,141 @@ class ConcurrentMessageListenerContainerRef<K, V> extends AbstractMessageListene
 		}
 	}
 
-	AbstractMessageListenerContainer<?, ?> getConcurrentContainer() {
-		return this.concurrentMessageListenerContainer;
+	@Nullable
+	protected ApplicationContext getApplicationContext() {
+		return this.concurrentMessageListenerContainer.getApplicationContext();
 	}
 
-	@Override
-	public int hashCode() {
-		return this.concurrentMessageListenerContainer.hashCode();
+	/**
+	 * Get the event publisher.
+	 * @return the publisher
+	 */
+	@Nullable
+	public ApplicationEventPublisher getApplicationEventPublisher() {
+		return this.concurrentMessageListenerContainer.getApplicationEventPublisher();
 	}
 
-	@Override
-	public boolean equals(Object obj) {
-		return this.concurrentMessageListenerContainer.equals(obj);
+	/**
+	 * Get the {@link CommonErrorHandler}.
+	 * @return the handler.
+	 * @since 2.8
+	 */
+	@Nullable
+	public CommonErrorHandler getCommonErrorHandler() {
+		return this.concurrentMessageListenerContainer.getCommonErrorHandler();
+	}
+
+	protected boolean isStoppedNormally() {
+		return this.concurrentMessageListenerContainer.isStoppedNormally();
+	}
+
+	protected void setStoppedNormally(boolean stoppedNormally) {
+		this.concurrentMessageListenerContainer.setStoppedNormally(stoppedNormally);
+	}
+
+	protected void setRunning(boolean running) {
+		this.concurrentMessageListenerContainer.setRunning(running);
+	}
+
+	protected boolean isEnforceRebalanceRequested() {
+		return this.concurrentMessageListenerContainer.isEnforceRebalanceRequested();
+	}
+
+	protected void setEnforceRebalanceRequested(boolean enforceRebalance) {
+		this.concurrentMessageListenerContainer.setEnforceRebalanceRequested(enforceRebalance);
+	}
+
+	/**
+	 * Return the currently configured {@link AfterRollbackProcessor}.
+	 * @return the after rollback processor.
+	 * @since 2.2.14
+	 */
+	public AfterRollbackProcessor<? super K, ? super V> getAfterRollbackProcessor() {
+		return this.concurrentMessageListenerContainer.getAfterRollbackProcessor();
+	}
+
+	public boolean isChangeConsumerThreadName() {
+		return this.concurrentMessageListenerContainer.isChangeConsumerThreadName();
+	}
+
+	/**
+	 * Set to true to instruct the container to change the consumer thread name during
+	 * initialization.
+	 * @param changeConsumerThreadName true to change.
+	 * @since 3.0.1
+	 * @see #setThreadNameSupplier(Function)
+	 */
+	public void setChangeConsumerThreadName(boolean changeConsumerThreadName) {
+		this.concurrentMessageListenerContainer.setChangeConsumerThreadName(changeConsumerThreadName);
+	}
+
+	/**
+	 * Return the {@link KafkaAdmin}, used to find the cluster id for observation, if
+	 * present.
+	 * @return the kafkaAdmin
+	 * @since 3.0.5
+	 */
+	@Nullable
+	public KafkaAdmin getKafkaAdmin() {
+		return this.concurrentMessageListenerContainer.getKafkaAdmin();
+	}
+
+	public void setKafkaAdmin(KafkaAdmin kafkaAdmin) {
+		this.concurrentMessageListenerContainer.setKafkaAdmin(kafkaAdmin);
+	}
+
+	protected RecordInterceptor<K, V> getRecordInterceptor() {
+		return this.concurrentMessageListenerContainer.getRecordInterceptor();
+	}
+
+	/**
+	 * Set an interceptor to be called before calling the record listener.
+	 * Does not apply to batch listeners.
+	 * @param recordInterceptor the interceptor.
+	 * @since 2.2.7
+	 * @see #setInterceptBeforeTx(boolean)
+	 */
+	public void setRecordInterceptor(RecordInterceptor recordInterceptor) {
+		this.concurrentMessageListenerContainer.setRecordInterceptor(recordInterceptor);
+	}
+
+	protected BatchInterceptor<K, V> getBatchInterceptor() {
+		return this.concurrentMessageListenerContainer.getBatchInterceptor();
+	}
+
+	/**
+	 * Set an interceptor to be called before calling the record listener.
+	 * @param batchInterceptor the interceptor.
+	 * @since 2.6.6
+	 * @see #setInterceptBeforeTx(boolean)
+	 */
+	public void setBatchInterceptor(BatchInterceptor batchInterceptor) {
+		this.concurrentMessageListenerContainer.setBatchInterceptor(batchInterceptor);
+	}
+
+	protected boolean isInterceptBeforeTx() {
+		return this.concurrentMessageListenerContainer.isInterceptBeforeTx();
+	}
+
+	/**
+	 * When false, invoke the interceptor after the transaction starts.
+	 * @param interceptBeforeTx false to intercept within the transaction.
+	 * Default true since 2.8.
+	 * @since 2.3.4
+	 * @see #setRecordInterceptor(RecordInterceptor)
+	 * @see #setBatchInterceptor(BatchInterceptor)
+	 */
+	public void setInterceptBeforeTx(boolean interceptBeforeTx) {
+		this.concurrentMessageListenerContainer.setInterceptBeforeTx(interceptBeforeTx);
+	}
+
+	/**
+	 * Return this or a parent container if this has a parent.
+	 * @return the parent or this.
+	 * @since 2.2.1
+	 */
+	protected AbstractMessageListenerContainer<?, ?> parentOrThis() {
+		return this;
 	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerRef.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerRef.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2015-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.apache.commons.logging.LogFactory;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.TopicPartition;
+
+import org.springframework.core.log.LogAccessor;
+import org.springframework.kafka.event.ConsumerStoppedEvent;
+
+/**
+ * Reference of {@link ConcurrentMessageListenerContainer} to be passed to the {@link KafkaMessageListenerContainer}.
+ * This container is used for internal purpose. Detects if the {@link KafkaMessageListenerContainer} is fenced and
+ * forbids `stop` calls on {@link ConcurrentMessageListenerContainer}
+ *
+ * @param <K> the key type.
+ * @param <V> the value type.
+ * @author Lokesh Alamuri
+ */
+class ConcurrentMessageListenerContainerRef<K, V> extends AbstractMessageListenerContainer {
+
+	protected final LogAccessor logger = new LogAccessor(LogFactory.getLog(this.getClass())); // NOSONAR
+
+	private final ConcurrentMessageListenerContainer concurrentMessageListenerContainer;
+
+	private final ReentrantLock lifecycleLock;
+
+	private KafkaMessageListenerContainer kafkaMessageListenerContainer;
+
+	ConcurrentMessageListenerContainerRef(ConcurrentMessageListenerContainer concurrentMessageListenerContainer,
+																						ReentrantLock lifecycleLock) {
+		super();
+		this.concurrentMessageListenerContainer = concurrentMessageListenerContainer;
+		this.lifecycleLock = lifecycleLock;
+	}
+
+	void setKafkaMessageListenerContainer(KafkaMessageListenerContainer kafkaMessageListenerContainer) {
+		this.kafkaMessageListenerContainer = kafkaMessageListenerContainer;
+	}
+
+	@Override
+	public void setupMessageListener(Object messageListener) {
+		throw new UnsupportedOperationException("This container doesn't support setting up MessageListener");
+	}
+
+	@Override
+	public Map<String, Map<MetricName, ? extends Metric>> metrics() {
+		return this.concurrentMessageListenerContainer.metrics();
+	}
+
+	@Override
+	public ContainerProperties getContainerProperties() {
+		return this.concurrentMessageListenerContainer.getContainerProperties();
+	}
+
+	@Override
+	public Collection<TopicPartition> getAssignedPartitions() {
+		return this.concurrentMessageListenerContainer.getAssignedPartitions();
+	}
+
+	@Override
+	public Map<String, Collection<TopicPartition>> getAssignmentsByClientId() {
+		return this.concurrentMessageListenerContainer.getAssignmentsByClientId();
+	}
+
+	@Override
+	public void enforceRebalance() {
+		this.concurrentMessageListenerContainer.enforceRebalance();
+	}
+
+	@Override
+	public void pause() {
+		this.concurrentMessageListenerContainer.pause();
+	}
+
+	@Override
+	public void resume() {
+		this.concurrentMessageListenerContainer.resume();
+	}
+
+	@Override
+	public void pausePartition(TopicPartition topicPartition) {
+		this.concurrentMessageListenerContainer.pausePartition(topicPartition);
+	}
+
+	@Override
+	public void resumePartition(TopicPartition topicPartition) {
+		this.concurrentMessageListenerContainer.resumePartition(topicPartition);
+	}
+
+	@Override
+	public boolean isPartitionPauseRequested(TopicPartition topicPartition) {
+		return this.concurrentMessageListenerContainer.isPartitionPauseRequested(topicPartition);
+	}
+
+	@Override
+	public boolean isPartitionPaused(TopicPartition topicPartition) {
+		return this.concurrentMessageListenerContainer.isPartitionPaused(topicPartition);
+	}
+
+	@Override
+	public boolean isPauseRequested() {
+		return this.concurrentMessageListenerContainer.isPauseRequested();
+	}
+
+	@Override
+	public boolean isContainerPaused() {
+		return this.concurrentMessageListenerContainer.isContainerPaused();
+	}
+
+	@Override
+	public String getGroupId() {
+		return this.concurrentMessageListenerContainer.getGroupId();
+	}
+
+	@Override
+	public String getListenerId() {
+		return this.concurrentMessageListenerContainer.getListenerId();
+	}
+
+	@Override
+	public String getMainListenerId() {
+		return this.concurrentMessageListenerContainer.getMainListenerId();
+	}
+
+	@Override
+	public byte[] getListenerInfo() {
+		return this.concurrentMessageListenerContainer.getListenerInfo();
+	}
+
+	@Override
+	public boolean isChildRunning() {
+		return this.concurrentMessageListenerContainer.isChildRunning();
+	}
+
+	@Override
+	public boolean isInExpectedState() {
+		return this.concurrentMessageListenerContainer.isInExpectedState();
+	}
+
+	@Override
+	public void stopAbnormally(Runnable callback) {
+		this.lifecycleLock.lock();
+		try {
+			if (!this.kafkaMessageListenerContainer.isFenced()) {
+				// kafkaMessageListenerContainer is not fenced. Allow stopAbnormally call on
+				// concurrentMessageListenerContainer
+				this.concurrentMessageListenerContainer.stopAbnormally(callback);
+			}
+			else if (this.concurrentMessageListenerContainer.isFenced() &&
+					!this.concurrentMessageListenerContainer.isRunning()) {
+				// kafkaMessageListenerContainer is fenced and concurrentMessageListenerContainer is not running. Allow
+				// callback to run
+				callback.run();
+			}
+			else {
+				this.logger.error(() -> String.format("Suppressed `stopAbnormal` operation called by " +
+						"MessageListenerContainer [" + this.kafkaMessageListenerContainer.getBeanName() + "]"));
+			}
+		}
+		finally {
+			this.lifecycleLock.unlock();
+		}
+	}
+
+	@Override
+	protected void doStop(Runnable callback, boolean normal) {
+		this.lifecycleLock.lock();
+		try {
+			if (!this.kafkaMessageListenerContainer.isFenced()) {
+				// kafkaMessageListenerContainer is not fenced. Allow doStop call on
+				// concurrentMessageListenerContainer
+				this.concurrentMessageListenerContainer.doStop(callback, normal);
+			}
+			else if (this.concurrentMessageListenerContainer.isFenced() &&
+					!this.concurrentMessageListenerContainer.isRunning()) {
+				// kafkaMessageListenerContainer is fenced and concurrentMessageListenerContainer is not running. Allow
+				// callback to run
+				callback.run();
+			}
+			else {
+				this.logger.error(() -> String.format("Suppressed `doStop` operation called by " +
+						"MessageListenerContainer [" + this.kafkaMessageListenerContainer.getBeanName() + "]"));
+			}
+		}
+		finally {
+			this.lifecycleLock.unlock();
+		}
+	}
+
+	@Override
+	public MessageListenerContainer getContainerFor(String topic, int partition) {
+		return this.concurrentMessageListenerContainer.getContainerFor(topic, partition);
+	}
+
+	@Override
+	public void childStopped(MessageListenerContainer child, ConsumerStoppedEvent.Reason reason) {
+		this.concurrentMessageListenerContainer.childStopped(child, reason);
+	}
+
+	@Override
+	public void childStarted(MessageListenerContainer child) {
+		this.concurrentMessageListenerContainer.childStarted(child);
+	}
+
+	@Override
+	protected void doStart() {
+		this.concurrentMessageListenerContainer.doStart();
+	}
+
+	@Override
+	public boolean isRunning() {
+		return this.concurrentMessageListenerContainer.isRunning();
+	}
+
+	@Override
+	public boolean isAutoStartup() {
+		return this.concurrentMessageListenerContainer.isAutoStartup();
+	}
+
+	@Override
+	public void setAutoStartup(boolean autoStartup) {
+		throw new UnsupportedOperationException("This container doesn't support `setAutoStartup`");
+	}
+
+	@Override
+	public void stop(Runnable callback) {
+		this.lifecycleLock.lock();
+		try {
+			if (!this.kafkaMessageListenerContainer.isFenced()) {
+				// kafkaMessageListenerContainer is not fenced. Allow stop call on
+				// concurrentMessageListenerContainer
+				this.concurrentMessageListenerContainer.stop(callback);
+			}
+			else if (this.concurrentMessageListenerContainer.isFenced() &&
+					!this.concurrentMessageListenerContainer.isRunning()) {
+				// kafkaMessageListenerContainer is fenced and concurrentMessageListenerContainer is not running. Allow
+				// callback to run
+				callback.run();
+			}
+			else {
+				this.logger.error(() -> String.format("Suppressed `stop` operation called by " +
+						"MessageListenerContainer [" + this.kafkaMessageListenerContainer.getBeanName() + "]"));
+			}
+		}
+		finally {
+			this.lifecycleLock.unlock();
+		}
+	}
+
+	AbstractMessageListenerContainer<?, ?> getConcurrentContainer() {
+		return this.concurrentMessageListenerContainer;
+	}
+
+	@Override
+	public int hashCode() {
+		return this.concurrentMessageListenerContainer.hashCode();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return this.concurrentMessageListenerContainer.equals(obj);
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -427,7 +427,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		ApplicationEventPublisher publisher = getApplicationEventPublisher();
 		if (publisher != null) {
 			publisher.publishEvent(new ListenerContainerPartitionIdleEvent(this,
-					this.thisOrParentContainer, idleTime, getBeanName(), topicPartition, consumer, paused));
+					parentContainerOrThis(), idleTime, getBeanName(), topicPartition, consumer, paused));
 		}
 	}
 
@@ -435,7 +435,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		ApplicationEventPublisher publisher = getApplicationEventPublisher();
 		if (publisher != null) {
 			publisher.publishEvent(new ListenerContainerPartitionNoLongerIdleEvent(this,
-					this.thisOrParentContainer, idleTime, getBeanName(), topicPartition, consumer));
+					parentContainerOrThis(), idleTime, getBeanName(), topicPartition, consumer));
 		}
 	}
 
@@ -443,7 +443,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		ApplicationEventPublisher publisher = getApplicationEventPublisher();
 		if (publisher != null) {
 			publisher.publishEvent(new ListenerContainerIdleEvent(this,
-					this.thisOrParentContainer, idleTime, getBeanName(), getAssignedPartitions(), consumer, paused));
+					parentContainerOrThis(), idleTime, getBeanName(), getAssignedPartitions(), consumer, paused));
 		}
 	}
 
@@ -451,7 +451,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		ApplicationEventPublisher publisher = getApplicationEventPublisher();
 		if (publisher != null) {
 			publisher.publishEvent(new ListenerContainerNoLongerIdleEvent(this,
-					this.thisOrParentContainer, idleTime, getBeanName(), getAssignedPartitions(), consumer));
+					parentContainerOrThis(), idleTime, getBeanName(), getAssignedPartitions(), consumer));
 		}
 	}
 
@@ -459,7 +459,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		ApplicationEventPublisher publisher = getApplicationEventPublisher();
 		if (publisher != null) {
 			publisher.publishEvent(
-					new NonResponsiveConsumerEvent(this, this.thisOrParentContainer, timeSinceLastPoll,
+					new NonResponsiveConsumerEvent(this, parentContainerOrThis(), timeSinceLastPoll,
 							getBeanName(), getAssignedPartitions(), consumer));
 		}
 	}
@@ -468,7 +468,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 	public void publishConsumerPausedEvent(Collection<TopicPartition> partitions, String reason) {
 		ApplicationEventPublisher publisher = getApplicationEventPublisher();
 		if (publisher != null) {
-			publisher.publishEvent(new ConsumerPausedEvent(this, this.thisOrParentContainer,
+			publisher.publishEvent(new ConsumerPausedEvent(this, parentContainerOrThis(),
 					Collections.unmodifiableCollection(partitions), reason));
 		}
 	}
@@ -477,7 +477,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 	public void publishConsumerResumedEvent(Collection<TopicPartition> partitions) {
 		ApplicationEventPublisher publisher = getApplicationEventPublisher();
 		if (publisher != null) {
-			publisher.publishEvent(new ConsumerResumedEvent(this, this.thisOrParentContainer,
+			publisher.publishEvent(new ConsumerResumedEvent(this, parentContainerOrThis(),
 					Collections.unmodifiableCollection(partitions)));
 		}
 	}
@@ -485,7 +485,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 	private void publishConsumerPartitionPausedEvent(TopicPartition partition) {
 		ApplicationEventPublisher publisher = getApplicationEventPublisher();
 		if (publisher != null) {
-			publisher.publishEvent(new ConsumerPartitionPausedEvent(this, this.thisOrParentContainer,
+			publisher.publishEvent(new ConsumerPartitionPausedEvent(this, parentContainerOrThis(),
 					partition));
 		}
 	}
@@ -493,7 +493,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 	private void publishConsumerPartitionResumedEvent(TopicPartition partition) {
 		ApplicationEventPublisher publisher = getApplicationEventPublisher();
 		if (publisher != null) {
-			publisher.publishEvent(new ConsumerPartitionResumedEvent(this, this.thisOrParentContainer,
+			publisher.publishEvent(new ConsumerPartitionResumedEvent(this, parentContainerOrThis(),
 					partition));
 		}
 	}
@@ -503,7 +503,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			ApplicationEventPublisher publisher = getApplicationEventPublisher();
 			if (publisher != null) {
 				publisher.publishEvent(
-						new ConsumerStoppingEvent(this, this.thisOrParentContainer, consumer, getAssignedPartitions()));
+						new ConsumerStoppingEvent(this, parentContainerOrThis(), consumer, getAssignedPartitions()));
 			}
 		}
 		catch (Exception e) {
@@ -530,8 +530,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			else {
 				reason = Reason.NORMAL;
 			}
-			publisher.publishEvent(new ConsumerStoppedEvent(this, this.thisOrParentContainer,
-					reason));
+			publisher.publishEvent(new ConsumerStoppedEvent(this, parentContainerOrThis(), reason));
 			this.thisOrParentContainer.childStopped(this, reason);
 		}
 	}
@@ -540,21 +539,21 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		this.startLatch.countDown();
 		ApplicationEventPublisher publisher = getApplicationEventPublisher();
 		if (publisher != null) {
-			publisher.publishEvent(new ConsumerStartingEvent(this, this.thisOrParentContainer));
+			publisher.publishEvent(new ConsumerStartingEvent(this, parentContainerOrThis()));
 		}
 	}
 
 	private void publishConsumerStartedEvent() {
 		ApplicationEventPublisher publisher = getApplicationEventPublisher();
 		if (publisher != null) {
-			publisher.publishEvent(new ConsumerStartedEvent(this, this.thisOrParentContainer));
+			publisher.publishEvent(new ConsumerStartedEvent(this, parentContainerOrThis()));
 		}
 	}
 
 	private void publishConsumerFailedToStart() {
 		ApplicationEventPublisher publisher = getApplicationEventPublisher();
 		if (publisher != null) {
-			publisher.publishEvent(new ConsumerFailedToStartEvent(this, this.thisOrParentContainer));
+			publisher.publishEvent(new ConsumerFailedToStartEvent(this, parentContainerOrThis()));
 		}
 	}
 
@@ -571,14 +570,14 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			else {
 				throw new IllegalArgumentException("Only Authentication or Authorization Exceptions are allowed", throwable);
 			}
-			publisher.publishEvent(new ConsumerRetryAuthEvent(this, this.thisOrParentContainer, reason));
+			publisher.publishEvent(new ConsumerRetryAuthEvent(this, parentContainerOrThis(), reason));
 		}
 	}
 
 	private void publishRetryAuthSuccessfulEvent() {
 		ApplicationEventPublisher publisher = getApplicationEventPublisher();
 		if (publisher != null) {
-			publisher.publishEvent(new ConsumerRetryAuthSuccessfulEvent(this, this.thisOrParentContainer));
+			publisher.publishEvent(new ConsumerRetryAuthSuccessfulEvent(this, parentContainerOrThis()));
 		}
 	}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerMockTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerMockTests.java
@@ -172,7 +172,6 @@ public class ConcurrentMessageListenerContainerMockTests {
 		});
 		container.start();
 		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
-		assertThat(errorContainer.get()).isSameAs(container);
 		container.stop();
 	}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
@@ -49,6 +49,7 @@ import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.common.TopicPartition;
+import org.assertj.core.api.Condition;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.mockito.invocation.InvocationOnMock;
@@ -199,8 +200,7 @@ public class ConcurrentMessageListenerContainerTests {
 		assertThat(intercepted.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(latch.await(60, TimeUnit.SECONDS)).isTrue();
 		assertThat(payloads).containsExactlyInAnyOrder("foo", "bar", "qux");
-		assertThat(listenerThreadNames).containsAnyOf("testAuto-0-C-0", "testAuto-0-C-1",
-				"testAuto-1-C-0", "testAuto-1-C-1");
+		assertThat(listenerThreadNames).contains("testAuto-0", "testAuto-1");
 		List<KafkaMessageListenerContainer<Integer, String>> containers = KafkaTestUtils.getPropertyValue(container,
 				"containers", List.class);
 		assertThat(containers).hasSize(2);
@@ -934,8 +934,9 @@ public class ConcurrentMessageListenerContainerTests {
 
 		firstLatch.countDown();
 
-		assertThat(listenerThreadNames).containsAnyOf("testAuto-0-C-0", "testAuto-0-C-1",
-				"testAuto-1-C-0", "testAuto-1-C-1");
+		Condition<String> listenerThreadNameCondition = new Condition<>(s -> s.contains("testAuto"),
+				"Listener thread name has to be prefixed with testAuto");
+		assertThat(listenerThreadNames).have(listenerThreadNameCondition);
 
 		assertThat(concurrentContainerStopLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(container.isInExpectedState()).isTrue();
@@ -1203,8 +1204,9 @@ public class ConcurrentMessageListenerContainerTests {
 
 		assertThat(container.isChildRunning()).isTrue();
 
-		assertThat(listenerThreadNames).containsAnyOf("testAuto-0-C-0", "testAuto-0-C-1",
-				"testAuto-1-C-0", "testAuto-1-C-1");
+		Condition<String> listenerThreadNameCondition = new Condition<>(s -> s.contains("testAuto"),
+				"Listener thread name has to be prefixed with testAuto");
+		assertThat(listenerThreadNames).have(listenerThreadNameCondition);
 
 		assertThat(concurrentContainerStopLatch.await(30, TimeUnit.SECONDS)).isFalse();
 
@@ -1355,8 +1357,10 @@ public class ConcurrentMessageListenerContainerTests {
 
 		assertThat(container.isChildRunning()).isTrue();
 
-		assertThat(listenerThreadNames).containsAnyOf("testAuto-0-C-0", "testAuto-0-C-1",
-				"testAuto-1-C-0", "testAuto-1-C-1");
+		Condition<String> listenerThreadNameCondition = new Condition<>(s -> s.contains("testAuto"),
+				"Listener thread name has to be prefixed with testAuto");
+		assertThat(listenerThreadNames).have(listenerThreadNameCondition);
+
 
 		assertThat(concurrentContainerStopLatch.await(30, TimeUnit.SECONDS)).isFalse();
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ContainerEnforceRebalanceTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ContainerEnforceRebalanceTests.java
@@ -64,11 +64,11 @@ public class ContainerEnforceRebalanceTests {
 		assertThat(config.listenerLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(listenerContainer).isNotNull();
 		listenerContainer.enforceRebalance();
-		assertThat(((ConcurrentMessageListenerContainer<?, ?>) listenerContainer).enforceRebalanceRequested).isTrue();
+		assertThat(((ConcurrentMessageListenerContainer<?, ?>) listenerContainer).isEnforceRebalanceRequested()).isTrue();
 		// The test is expecting partition revoke once and assign twice.
 		assertThat(config.partitionRevokedLatch.await(10, TimeUnit.SECONDS)).isTrue();
 		assertThat(config.partitionAssignedLatch.await(10, TimeUnit.SECONDS)).isTrue();
-		assertThat(((ConcurrentMessageListenerContainer<?, ?>) listenerContainer).enforceRebalanceRequested).isFalse();
+		assertThat(((ConcurrentMessageListenerContainer<?, ?>) listenerContainer).isEnforceRebalanceRequested()).isFalse();
 		listenerContainer.pause();
 		await().timeout(Duration.ofSeconds(10)).untilAsserted(() -> assertThat(listenerContainer.isPauseRequested()).isTrue());
 		await().timeout(Duration.ofSeconds(10)).untilAsserted(() -> assertThat(listenerContainer.isContainerPaused()).isTrue());


### PR DESCRIPTION
[DRAFT]
Fixes #GH-3448

**Issue**: Fenced Child Container could stop the running ConcurrentContainer 
**Fix**: Configure KafkaMessageListenerContainer (KMLC) to use ConcurrentMessagleListenerContainerRef instead of
ConcurrentContainer. Internally, ConcurrentContainerRef checks if KMLC is fenced when stop operations are called on Concurrent Container. If KMLC is fenced, suppress the `stop` related operations. If KMLC is not fenced, delegate the stop call to ConcurrentContainer.

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
