### PR TITLE
GH-3514: Change default template bean name from retryTopicDefaultKafkaTemplate to defaultRetryTopicKafkaTemplate.

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryableTopic.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryableTopic.java
@@ -81,7 +81,7 @@ public @interface RetryableTopic {
 	 *
 	 * The bean name of the {@link org.springframework.kafka.core.KafkaTemplate} bean that
 	 * will be used to forward the message to the retry and Dlt topics. If not specified,
-	 * a bean with name {@code retryTopicDefaultKafkaTemplate} or {@code kafkaTemplate}
+	 * a bean with name {@code defaultRetryTopicKafkaTemplate} or {@code kafkaTemplate}
 	 * will be looked up.
 	 *
 	 * @return the kafkaTemplate bean name.

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationProviderTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationProviderTests.java
@@ -89,7 +89,7 @@ class RetryTopicConfigurationProviderTests {
 	void shouldProvideFromAnnotation() {
 
 		// setup
-		willReturn(kafkaOperations).given(beanFactory).getBean("retryTopicDefaultKafkaTemplate", KafkaOperations.class);
+		willReturn(kafkaOperations).given(beanFactory).getBean(RetryTopicBeanNames.DEFAULT_KAFKA_TEMPLATE_BEAN_NAME, KafkaOperations.class);
 
 		// given
 		RetryTopicConfigurationProvider provider = new RetryTopicConfigurationProvider(beanFactory);
@@ -149,7 +149,7 @@ class RetryTopicConfigurationProviderTests {
 	void shouldProvideFromMetaAnnotation() {
 
 		// setup
-		willReturn(kafkaOperations).given(beanFactory).getBean("retryTopicDefaultKafkaTemplate", KafkaOperations.class);
+		willReturn(kafkaOperations).given(beanFactory).getBean(RetryTopicBeanNames.DEFAULT_KAFKA_TEMPLATE_BEAN_NAME, KafkaOperations.class);
 
 		// given
 		RetryTopicConfigurationProvider provider = new RetryTopicConfigurationProvider(beanFactory);


### PR DESCRIPTION
I have updated the documentation in `@RetryableTopic` to change the previously referenced `retryTopicDefaultKafkaTemplate` to `defaultRetryTopicKafkaTemplate`.

Additionally, I modified the test code to replace instances of `retryTopicDefaultKafkaTemplate` with `RetryTopicBeanNames.DEFAULT_KAFKA_TEMPLATE_BEAN_NAME` to ensure it uses the correct default bean name.

Thank you for considering my PR, and I would be grateful for the opportunity to become a contributor.

>>> Fixes: https://github.com/spring-projects/spring-kafka/issues/3514
