### PR TITLE
Refactor ProducerFactory to use constant for repeated exception message

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/ProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/ProducerFactory.java
@@ -35,6 +35,7 @@ import org.springframework.lang.Nullable;
  *
  * @author Gary Russell
  * @author Thomas Strauß
+ * @author  Kwon YongHyun
  */
 public interface ProducerFactory<K, V> {
 
@@ -42,6 +43,11 @@ public interface ProducerFactory<K, V> {
 	 * The default close timeout duration as 30 seconds.
 	 */
 	Duration DEFAULT_PHYSICAL_CLOSE_TIMEOUT = Duration.ofSeconds(30);
+
+	/**
+	 * Error message for unsupported factory methods.
+	 */
+	String FACTORY_DOES_NOT_SUPPORT_METHOD = "This factory does not support this method";
 
 	/**
 	 * Create a producer which will be transactional if the factory is so configured.
@@ -57,7 +63,7 @@ public interface ProducerFactory<K, V> {
 	 * @since 2.3
 	 */
 	default Producer<K, V> createProducer(@Nullable @SuppressWarnings("unused") String txIdPrefix) {
-		throw new UnsupportedOperationException("This factory does not support this method");
+		throw new UnsupportedOperationException(FACTORY_DOES_NOT_SUPPORT_METHOD);
 	}
 
 	/**
@@ -67,7 +73,7 @@ public interface ProducerFactory<K, V> {
 	 * @see #transactionCapable()
 	 */
 	default Producer<K, V> createNonTransactionalProducer() {
-		throw new UnsupportedOperationException("This factory does not support this method");
+		throw new UnsupportedOperationException(FACTORY_DOES_NOT_SUPPORT_METHOD);
 	}
 
 	/**


### PR DESCRIPTION
The error message "This factory does not support this method" was hardcoded twice in the production code of the ProducerFactory interface. By introducing the constant FACTORY_DOES_NOT_SUPPORT_METHOD, we eliminate this duplication, improve code maintainability, and ensure consistency. This change is particularly significant as it affects actual production code, not test code. Moreover, while currently used twice, this constant could potentially be reused in other parts of the codebase in the future, further justifying its creation and enhancing the overall code quality and future maintainability of the ProducerFactory and related classes.