### PR TITLE
Improve warning message for ConsumerRecords filter strategy

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
@@ -63,6 +63,7 @@ import org.springframework.util.ObjectUtils;
  * @author Artem Bilan
  * @author Wang Zhiyang
  * @author Sanghyeok An
+ * @author Borahm Lee
  *
  * @see MethodKafkaListenerEndpoint
  */
@@ -537,8 +538,8 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 		if (this.recordFilterStrategy != null) {
 			if (isBatchListener()) {
 				if (((MessagingMessageListenerAdapter<K, V>) messageListener).isConsumerRecords()) {
-					this.logger.warn(() -> "Filter strategy ignored when consuming 'ConsumerRecords' instead of a List"
-							+ (this.id != null ? " id: " + this.id : ""));
+					this.logger.warn(() -> "Filter strategy is ignored when consuming 'ConsumerRecords' directly instead of a List of records."
+							+ (this.id != null ? " listenerId: " + this.id : ""));
 				}
 				else {
 					messageListener = new FilteringBatchMessageListenerAdapter<>(


### PR DESCRIPTION
<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
## Description

I noticed that the warning message when using `ConsumerRecords` is somewhat unclear. In particular, the distinction between 'List' and 'id' could be more explicit. To enhance clarity, I made some adjustments to that part.

<img width="858" alt="image" src="https://github.com/user-attachments/assets/1913e0ab-f711-4cce-853a-43f39e601a50">
