### PR TITLE
GH-3528: Improving Observability in Asynchronous Processing 

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -106,6 +106,8 @@ import org.springframework.kafka.listener.ContainerProperties.AckMode;
 import org.springframework.kafka.listener.ContainerProperties.AssignmentCommitOption;
 import org.springframework.kafka.listener.ContainerProperties.EOSMode;
 import org.springframework.kafka.listener.adapter.AsyncRepliesAware;
+import org.springframework.kafka.listener.adapter.MessagingMessageListenerAdapter;
+import org.springframework.kafka.listener.adapter.RecordMessagingMessageListenerAdapter;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.support.KafkaUtils;
@@ -948,6 +950,10 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			this.lastAlertPartition = new HashMap<>();
 			this.wasIdlePartition = new HashMap<>();
 			this.kafkaAdmin = obtainAdmin();
+
+			if (this.listener instanceof RecordMessagingMessageListenerAdapter<?, ?> rmmla) {
+				rmmla.setObservationRegistry(observationRegistry);
+			}
 		}
 
 		private AckMode determineAckMode() {
@@ -2693,6 +2699,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		 * @throws Error an error.
 		 */
 		@Nullable
+		@SuppressWarnings("try")
 		private RuntimeException doInvokeRecordListener(final ConsumerRecord<K, V> cRecord, // NOSONAR
 				Iterator<ConsumerRecord<K, V>> iterator) {
 
@@ -2703,42 +2710,49 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 					() -> new KafkaRecordReceiverContext(cRecord, getListenerId(), getClientId(), this.consumerGroupId,
 							this::clusterId),
 					this.observationRegistry);
-			return observation.observe(() -> {
-				try {
-					invokeOnMessage(cRecord);
-					successTimer(sample, cRecord);
-					recordInterceptAfter(cRecord, null);
-				}
-				catch (RuntimeException e) {
-					failureTimer(sample, cRecord);
-					recordInterceptAfter(cRecord, e);
-					if (this.commonErrorHandler == null) {
-						throw e;
-					}
+
+			observation.start();
+			try (Observation.Scope ignored = observation.openScope()) {
+				invokeOnMessage(cRecord);
+				successTimer(sample, cRecord);
+				recordInterceptAfter(cRecord, null);
+			}
+			catch (RuntimeException e) {
+				failureTimer(sample, cRecord);
+				recordInterceptAfter(cRecord, e);
+				if (!(this.listener instanceof MessagingMessageListenerAdapter<?, ?>)) {
 					observation.error(e);
-					try {
-						invokeErrorHandler(cRecord, iterator, e);
-						commitOffsetsIfNeededAfterHandlingError(cRecord);
-					}
-					catch (RecordInRetryException rire) {
-						this.logger.info("Record in retry and not yet recovered");
-						return rire;
-					}
-					catch (KafkaException ke) {
-						ke.selfLog(ERROR_HANDLER_THREW_AN_EXCEPTION, this.logger);
-						return ke;
-					}
-					catch (RuntimeException ee) {
-						this.logger.error(ee, ERROR_HANDLER_THREW_AN_EXCEPTION);
-						return ee;
-					}
-					catch (Error er) { // NOSONAR
-						this.logger.error(er, "Error handler threw an error");
-						throw er;
-					}
 				}
-				return null;
-			});
+				if (this.commonErrorHandler == null) {
+					throw e;
+				}
+				try {
+					invokeErrorHandler(cRecord, iterator, e);
+					commitOffsetsIfNeededAfterHandlingError(cRecord);
+				}
+				catch (RecordInRetryException rire) {
+					this.logger.info("Record in retry and not yet recovered");
+					return rire;
+				}
+				catch (KafkaException ke) {
+					ke.selfLog(ERROR_HANDLER_THREW_AN_EXCEPTION, this.logger);
+					return ke;
+				}
+				catch (RuntimeException ee) {
+					this.logger.error(ee, ERROR_HANDLER_THREW_AN_EXCEPTION);
+					return ee;
+				}
+				catch (Error er) { // NOSONAR
+					this.logger.error(er, "Error handler threw an error");
+					throw er;
+				}
+			}
+			finally {
+				if (!(this.listener instanceof MessagingMessageListenerAdapter<?, ?>)) {
+					observation.stop();
+				}
+			}
+			return null;
 		}
 
 		private void commitOffsetsIfNeededAfterHandlingError(final ConsumerRecord<K, V> cRecord) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -106,7 +106,6 @@ import org.springframework.kafka.listener.ContainerProperties.AckMode;
 import org.springframework.kafka.listener.ContainerProperties.AssignmentCommitOption;
 import org.springframework.kafka.listener.ContainerProperties.EOSMode;
 import org.springframework.kafka.listener.adapter.AsyncRepliesAware;
-import org.springframework.kafka.listener.adapter.MessagingMessageListenerAdapter;
 import org.springframework.kafka.listener.adapter.RecordMessagingMessageListenerAdapter;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.kafka.support.KafkaHeaders;
@@ -2720,7 +2719,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			catch (RuntimeException e) {
 				failureTimer(sample, cRecord);
 				recordInterceptAfter(cRecord, e);
-				if (!(this.listener instanceof MessagingMessageListenerAdapter<?, ?>)) {
+				if (!(this.listener instanceof RecordMessagingMessageListenerAdapter<K, V>)) {
 					observation.error(e);
 				}
 				if (this.commonErrorHandler == null) {
@@ -2748,7 +2747,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 				}
 			}
 			finally {
-				if (!(this.listener instanceof MessagingMessageListenerAdapter<?, ?>)) {
+				if (!(this.listener instanceof RecordMessagingMessageListenerAdapter<K, V>)) {
 					observation.stop();
 				}
 			}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/HandlerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/HandlerAdapter.java
@@ -65,6 +65,7 @@ public class HandlerAdapter {
 		return this.asyncReplies;
 	}
 
+	@Nullable
 	public Object invoke(Message<?> message, Object... providedArgs) throws Exception { //NOSONAR
 		if (this.invokerHandlerMethod != null) {
 			return this.invokerHandlerMethod.invoke(message, providedArgs); // NOSONAR

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.stream.Collectors;
 
 import org.apache.commons.logging.LogFactory;
@@ -73,6 +74,8 @@ import org.springframework.util.ClassUtils;
 import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
 import reactor.core.publisher.Mono;
 
 /**
@@ -152,6 +155,8 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 	private boolean splitIterables = true;
 
 	private String correlationHeaderName = KafkaHeaders.CORRELATION_ID;
+
+	private ObservationRegistry observationRegistry = ObservationRegistry.NOOP;
 
 	/**
 	 * Create an instance with the provided bean and method.
@@ -382,15 +387,34 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 	protected void invoke(Object records, @Nullable Acknowledgment acknowledgment, Consumer<?, ?> consumer,
 			final Message<?> message) {
 
+		Throwable listenerError = null;
+		Object result = null;
+		Observation currentObservation = getCurrentObservation();
 		try {
-			Object result = invokeHandler(records, acknowledgment, message, consumer);
+			result = invokeHandler(records, acknowledgment, message, consumer);
 			if (result != null) {
 				handleResult(result, records, acknowledgment, consumer, message);
 			}
 		}
-		catch (ListenerExecutionFailedException e) { // NOSONAR ex flow control
+		catch (ListenerExecutionFailedException e) {
+			listenerError = e;
+			currentObservation.error(e);
 			handleException(records, acknowledgment, consumer, message, e);
 		}
+		catch (Error e) {
+			listenerError = e;
+			currentObservation.error(e);
+		}
+		finally {
+			if (listenerError != null || result == null) {
+				currentObservation.stop();
+			}
+		}
+	}
+
+	private Observation getCurrentObservation() {
+		Observation currentObservation = this.observationRegistry.getCurrentObservation();
+		return currentObservation == null ? Observation.NOOP : currentObservation;
 	}
 
 	/**
@@ -402,6 +426,7 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 	 * @param consumer the consumer.
 	 * @return the result of invocation.
 	 */
+	@Nullable
 	protected final Object invokeHandler(Object data, @Nullable Acknowledgment acknowledgment, Message<?> message,
 			Consumer<?, ?> consumer) {
 
@@ -460,7 +485,7 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 	 */
 	protected void handleResult(Object resultArg, Object request, @Nullable Acknowledgment acknowledgment,
 			Consumer<?, ?> consumer, @Nullable Message<?> source) {
-
+		final Observation observation = getCurrentObservation();
 		this.logger.debug(() -> "Listener method returned result [" + resultArg
 				+ "] - generating response message for it");
 		String replyTopic = evaluateReplyTopic(request, source, resultArg);
@@ -474,35 +499,39 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 				invocationResult.messageReturnType() :
 				this.messageReturnType;
 
-		if (result instanceof CompletableFuture<?> completable) {
+		if (monoPresent && result instanceof Mono<?> mono) {
+			if (acknowledgment == null || !acknowledgment.isOutOfOrderCommit()) {
+				this.logger.warn("Container 'Acknowledgment' must be async ack for Mono<?> return type " +
+						"(or Kotlin suspend function); otherwise the container will ack the message immediately");
+			}
+			result = mono.toFuture();
+		}
+		else if (!(result instanceof CompletableFuture<?>)) {
+			result = CompletableFuture.completedFuture(result);
+		}
+		else {
 			if (acknowledgment == null || !acknowledgment.isOutOfOrderCommit()) {
 				this.logger.warn("Container 'Acknowledgment' must be async ack for Future<?> return type; "
 						+ "otherwise the container will ack the message immediately");
 			}
-			completable.whenComplete((r, t) -> {
+		}
+
+		((CompletableFuture<?>) result).whenComplete((r, t) -> {
+			try {
 				if (t == null) {
 					asyncSuccess(r, replyTopic, source, messageReturnType);
 					acknowledge(acknowledgment);
 				}
 				else {
-					asyncFailure(request, acknowledgment, consumer, t, source);
+					Throwable cause = t instanceof CompletionException ? t.getCause() : t;
+					observation.error(cause);
+					asyncFailure(request, acknowledgment, consumer, cause, source);
 				}
-			});
-		}
-		else if (monoPresent && result instanceof Mono<?> mono) {
-			if (acknowledgment == null || !acknowledgment.isOutOfOrderCommit()) {
-				this.logger.warn("Container 'Acknowledgment' must be async ack for Mono<?> return type " +
-						"(or Kotlin suspend function); otherwise the container will ack the message immediately");
 			}
-			mono.subscribe(
-					r -> asyncSuccess(r, replyTopic, source, messageReturnType),
-					t -> asyncFailure(request, acknowledgment, consumer, t, source),
-					() -> acknowledge(acknowledgment)
-			);
-		}
-		else {
-			sendResponse(result, replyTopic, source, messageReturnType);
-		}
+			finally {
+				observation.stop();
+			}
+		});
 	}
 
 	@Nullable
@@ -868,6 +897,10 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 
 	private boolean rawByParameterIsType(Type parameterType, Type type) {
 		return parameterType instanceof ParameterizedType pType && pType.getRawType().equals(type);
+	}
+
+	public void setObservationRegistry(ObservationRegistry observationRegistry) {
+		this.observationRegistry = observationRegistry;
 	}
 
 	/**

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/micrometer/ObservationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/micrometer/ObservationTests.java
@@ -398,6 +398,7 @@ public class ObservationTests {
 			@Autowired @Qualifier("throwableTemplate") KafkaTemplate<Integer, String> errorTemplate,
 			@Autowired KafkaListenerEndpointRegistry endpointRegistry)
 			throws ExecutionException, InterruptedException, TimeoutException {
+
 		errorTemplate.send(OBSERVATION_ERROR_COMPLETABLE_FUTURE, "testError").get(10, TimeUnit.SECONDS);
 		Deque<SimpleSpan> spans = tracer.getSpans();
 		await().untilAsserted(() -> assertThat(spans).hasSize(2));


### PR DESCRIPTION
…bleFuture, Mono)

Fixes: #3528

https://github.com/spring-projects/spring-kafka/issues/3528

- Improve spring-kafka observability for failures in async consumer tasks when listener methods return CompletableFuture<?> or Mono<?> and throw errors during async execution
- Refactoring code in KafkaMessageListenerContainer and MessagingMessageListenerAdapter around observability
- Adding tests to verify
- Add @Nullable annotations to relevant methods for better null safety
