### PR TITLE
Improve the implementation of the toMessage() function in the BatchMessagingMessageConverter:

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/converter/BatchMessagingMessageConverter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/converter/BatchMessagingMessageConverter.java
@@ -19,11 +19,11 @@ package org.springframework.kafka.support.converter;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Optional;
 
 import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.clients.consumer.Consumer;
@@ -32,7 +32,6 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.utils.Bytes;
 
-import org.jetbrains.annotations.NotNull;
 import org.springframework.core.log.LogAccessor;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.kafka.support.DefaultKafkaHeaderMapper;
@@ -144,8 +143,7 @@ public class BatchMessagingMessageConverter implements BatchMessageConverter {
 	}
 
 	@Override // NOSONAR
-	public @NotNull Message<?> toMessage(List<ConsumerRecord<?, ?>> records, @Nullable Acknowledgment acknowledgment,
-										 Consumer<?, ?> consumer, Type type) {
+	public Message<?> toMessage(List<ConsumerRecord<?, ?>> records, @Nullable Acknowledgment acknowledgment, Consumer<?, ?> consumer, Type type) {
 
 		KafkaMessageHeaders kafkaMessageHeaders = new KafkaMessageHeaders(this.generateMessageId,
 				this.generateTimestamp);
@@ -172,10 +170,10 @@ public class BatchMessagingMessageConverter implements BatchMessageConverter {
 	}
 
 	private void processRecord(ConsumerRecord<?, ?> record, List<Object> payloads, List<Object> keys,
-							   List<String> topics, List<Integer> partitions, List<Long> offsets,
-							   List<String> timestampTypes, List<Long> timestamps, List<Map<String, Object>> convertedHeaders,
-							   List<Headers> natives, List<ConsumerRecord<?, ?>> raws, List<ConversionException> conversionFailures,
-							   Map<String, Object> rawHeaders, Type type) {
+			List<String> topics, List<Integer> partitions, List<Long> offsets,
+			List<String> timestampTypes, List<Long> timestamps, List<Map<String, Object>> convertedHeaders,
+			List<Headers> natives, List<ConsumerRecord<?, ?>> raws, List<ConversionException> conversionFailures,
+			Map<String, Object> rawHeaders, Type type) {
 		payloads.add(obtainPayload(type, record, conversionFailures));
 		keys.add(record.key());
 		topics.add(record.topic());

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/converter/BatchMessagingMessageConverter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/converter/BatchMessagingMessageConverter.java
@@ -19,10 +19,7 @@ package org.springframework.kafka.support.converter;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.clients.consumer.Consumer;
@@ -160,48 +157,65 @@ public class BatchMessagingMessageConverter implements BatchMessageConverter {
 		List<Headers> natives = new ArrayList<>();
 		List<ConsumerRecord<?, ?>> raws = new ArrayList<>();
 		List<ConversionException> conversionFailures = new ArrayList<>();
+
 		addToRawHeaders(rawHeaders, convertedHeaders, natives, raws, conversionFailures);
 		commonHeaders(acknowledgment, consumer, rawHeaders, keys, topics, partitions, offsets, timestampTypes,
 				timestamps);
+		records.forEach(record -> processRecord(record, payloads, keys, topics, partitions, offsets, timestampTypes, timestamps,
+				convertedHeaders, natives, raws, conversionFailures, rawHeaders, type));
+
+		return MessageBuilder.createMessage(payloads, kafkaMessageHeaders);
+	}
+
+	private void processRecord(ConsumerRecord<?, ?> record, List<Object> payloads, List<Object> keys,
+							   List<String> topics, List<Integer> partitions, List<Long> offsets,
+							   List<String> timestampTypes, List<Long> timestamps, List<Map<String, Object>> convertedHeaders,
+							   List<Headers> natives, List<ConsumerRecord<?, ?>> raws, List<ConversionException> conversionFailures,
+							   Map<String, Object> rawHeaders, Type type) {
+		payloads.add(obtainPayload(type, record, conversionFailures));
+		keys.add(record.key());
+		topics.add(record.topic());
+		partitions.add(record.partition());
+		offsets.add(record.offset());
+
+		if (record.timestampType() != null) {
+			timestampTypes.add(record.timestampType().name());
+		}
+		timestamps.add(record.timestamp());
+
 		boolean logged = false;
 		String info = null;
-		for (ConsumerRecord<?, ?> record : records) {
-			payloads.add(obtainPayload(type, record, conversionFailures));
-			keys.add(record.key());
-			topics.add(record.topic());
-			partitions.add(record.partition());
-			offsets.add(record.offset());
-			if (record.timestampType() != null) {
-				timestampTypes.add(record.timestampType().name());
+
+		if (this.headerMapper != null && record.headers() != null) {
+			Map<String, Object> converted = new HashMap<>();
+			this.headerMapper.toHeaders(record.headers(), converted);
+			convertedHeaders.add(converted);
+			Object object = converted.get(KafkaHeaders.LISTENER_INFO);
+			info = Optional.ofNullable(object)
+					.filter(String.class::isInstance)
+					.map(String.class::cast)
+					.orElse(null);
+		}
+		else {
+			if (!logged) {
+				logHeaderWarningOnce();
+				logged = true;
 			}
-			timestamps.add(record.timestamp());
-			if (this.headerMapper != null && record.headers() != null) {
-				Map<String, Object> converted = new HashMap<>();
-				this.headerMapper.toHeaders(record.headers(), converted);
-				convertedHeaders.add(converted);
-				Object object = converted.get(KafkaHeaders.LISTENER_INFO);
-				if (object instanceof String) {
-					info = (String) object;
-				}
-			}
-			else {
-				if (!logged) {
-					this.logger.debug(() ->
-						"No header mapper is available; Jackson is required for the default mapper; "
-						+ "headers (if present) are not mapped but provided raw in "
-						+ KafkaHeaders.NATIVE_HEADERS);
-					logged = true;
-				}
-				natives.add(record.headers());
-			}
-			if (this.rawRecordHeader) {
-				raws.add(record);
-			}
+			natives.add(record.headers());
+		}
+		if (this.rawRecordHeader) {
+			raws.add(record);
 		}
 		if (info != null) {
 			rawHeaders.put(KafkaHeaders.LISTENER_INFO, info);
 		}
-		return MessageBuilder.createMessage(payloads, kafkaMessageHeaders);
+	}
+
+	private void logHeaderWarningOnce() {
+		this.logger.debug(() ->
+				"No header mapper is available; Jackson is required for the default mapper; "
+						+ "headers (if present) are not mapped but provided raw in "
+						+ KafkaHeaders.NATIVE_HEADERS);
 	}
 
 	private void addToRawHeaders(Map<String, Object> rawHeaders, List<Map<String, Object>> convertedHeaders,

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/converter/BatchMessagingMessageConverter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/converter/BatchMessagingMessageConverter.java
@@ -19,7 +19,11 @@ package org.springframework.kafka.support.converter;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.HashMap;
 
 import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.clients.consumer.Consumer;
@@ -28,6 +32,7 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.utils.Bytes;
 
+import org.jetbrains.annotations.NotNull;
 import org.springframework.core.log.LogAccessor;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.kafka.support.DefaultKafkaHeaderMapper;
@@ -139,8 +144,8 @@ public class BatchMessagingMessageConverter implements BatchMessageConverter {
 	}
 
 	@Override // NOSONAR
-	public Message<?> toMessage(List<ConsumerRecord<?, ?>> records, @Nullable Acknowledgment acknowledgment,
-			Consumer<?, ?> consumer, Type type) {
+	public @NotNull Message<?> toMessage(List<ConsumerRecord<?, ?>> records, @Nullable Acknowledgment acknowledgment,
+										 Consumer<?, ?> consumer, Type type) {
 
 		KafkaMessageHeaders kafkaMessageHeaders = new KafkaMessageHeaders(this.generateMessageId,
 				this.generateTimestamp);
@@ -163,7 +168,6 @@ public class BatchMessagingMessageConverter implements BatchMessageConverter {
 				timestamps);
 		records.forEach(record -> processRecord(record, payloads, keys, topics, partitions, offsets, timestampTypes, timestamps,
 				convertedHeaders, natives, raws, conversionFailures, rawHeaders, type));
-
 		return MessageBuilder.createMessage(payloads, kafkaMessageHeaders);
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/converter/BatchMessagingMessageConverter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/converter/BatchMessagingMessageConverter.java
@@ -19,10 +19,10 @@ package org.springframework.kafka.support.converter;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
-import java.util.List;
-import java.util.Map;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import org.apache.commons.logging.LogFactory;


### PR DESCRIPTION
<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
### Improvement for BatchMessagingMessageConverter.toMessage()

**While analyzing the toMessage() function of BatchMessagingMessageConverter, improvements were made. We have worked on improving it accordingly.**

1. Replace traditional loops with **Java Stream API** for processing collections. This enhances code conciseness and readability, allowing for functional-style operations on data.
```java
private void processRecord(ConsumerRecord<?, ?> record, List<Object> payloads, List<Object> keys,
			List<String> topics, List<Integer> partitions, List<Long> offsets,
			List<String> timestampTypes, List<Long> timestamps, List<Map<String, Object>> convertedHeaders,
			List<Headers> natives, List<ConsumerRecord<?, ?>> raws, List<ConversionException> conversionFailures,
			Map<String, Object> rawHeaders, Type type) {
  // proceedRecord..
}
```
2. Utilize Optional to handle potential null values more gracefully.
3. Separate function that prints log once

I think The analysis of the toMessage() code is expected to become more convenient.