### PR TITLE
Add `TaskScheduler` option for Kafka metrics components

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/micrometer.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/micrometer.adoc
@@ -88,6 +88,11 @@ double count = this.meterRegistry.get("kafka.producer.node.incoming.byte.total")
 
 A similar listener is provided for the `StreamsBuilderFactoryBean` - see xref:streams.adoc#streams-micrometer[KafkaStreams Micrometer Support].
 
+Starting with version 3.3, a `KafkaMetricsSupport` abstract class is introduced to manage `io.micrometer.core.instrument.binder.kafka.KafkaMetrics` binding into a `MeterRegistry` for provided Kafka client.
+This class is a super for the mentioned above `MicrometerConsumerListener`, `MicrometerProducerListener` and `KafkaStreamsMicrometerListener`.
+However, it can be used for any Kafka client use-cases.
+The class needs to be extended and its `bindClient()` and `unbindClient()` API have to be called to connect Kafka client metrics with a Micrometer collector.
+
 [[observation]]
 == Micrometer Observation
 

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -58,6 +58,13 @@ When using `KafkaStreamsCustomizer` it is now possible to return a custom implem
 
 [[x33-kafka-headers-for-batch-listeners]]
 === KafkaHeaders.DELIVERY_ATTEMPT for batch listeners
+
 When using a `BatchListener`, the `ConsumerRecord` can have the `KafkaHeaders.DELIVERY_ATTMPT` header in its headers fields.
 If the `DeliveryAttemptAwareRetryListener` is set to error handler as retry listener, each `ConsumerRecord` has delivery attempt header.
-For more details, see xref:kafka/annotation-error-handling.adoc#delivery-attempts-header-for-batch-listener[kafka-headers-for-batch-listener].
+For more details, see xref:kafka/annotation-error-handling.adoc#delivery-attempts-header-for-batch-listener[Kafka Headers for Batch Listener].
+
+[[x33-task-scheduler-for-kafka-metrics]]
+=== Kafka Metrics Listeners and `TaskScheduler`
+
+The `MicrometerProducerListener`, `MicrometerConsumerListener` and `KafkaStreamsMicrometerListener` can now be configured with a `TaskScheduler`.
+See `KafkaMetrics` JavaDocs and xref:kafka/micrometer.adoc[Micrometer Support] for more information.

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -67,4 +67,4 @@ For more details, see xref:kafka/annotation-error-handling.adoc#delivery-attempt
 === Kafka Metrics Listeners and `TaskScheduler`
 
 The `MicrometerProducerListener`, `MicrometerConsumerListener` and `KafkaStreamsMicrometerListener` can now be configured with a `TaskScheduler`.
-See `KafkaMetrics` JavaDocs and xref:kafka/micrometer.adoc[Micrometer Support] for more information.
+See `KafkaMetricsSupport` JavaDocs and xref:kafka/micrometer.adoc[Micrometer Support] for more information.

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaMetricsSupport.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaMetricsSupport.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.core;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.producer.Producer;
+
+import org.springframework.lang.Nullable;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.util.Assert;
+import org.springframework.util.ReflectionUtils;
+
+
+import io.micrometer.core.instrument.ImmutableTag;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.instrument.binder.kafka.KafkaClientMetrics;
+
+/**
+ * An abstract class to manage {@link io.micrometer.core.instrument.binder.kafka.KafkaClientMetrics}.
+ *
+ * @param <C> the Kafka Client type.
+ *
+ * @author Artem Bilan
+ *
+ * @since 3.3
+ */
+public abstract class KafkaMetricsSupport<C> {
+
+	protected final MeterRegistry meterRegistry;
+
+	protected final List<Tag> tags;
+
+	@Nullable
+	protected final ScheduledExecutorService scheduler;
+
+	private final Map<String, MeterBinder> metrics = new HashMap<>();
+
+	/**
+	 * Construct an instance with the provided registry.
+	 *
+	 * @param meterRegistry the registry.
+	 */
+	protected KafkaMetricsSupport(MeterRegistry meterRegistry) {
+		this(meterRegistry, Collections.emptyList());
+	}
+
+	/**
+	 * Construct an instance with the provided {@link MeterRegistry} and {@link TaskScheduler}.
+	 *
+	 * @param meterRegistry the registry.
+	 * @param taskScheduler the task scheduler.
+	 */
+	protected KafkaMetricsSupport(MeterRegistry meterRegistry, TaskScheduler taskScheduler) {
+		this(meterRegistry, Collections.emptyList(), taskScheduler);
+	}
+
+	/**
+	 * Construct an instance with the provided {@link MeterRegistry} and tags.
+	 *
+	 * @param meterRegistry the registry.
+	 * @param tags          the tags.
+	 */
+	protected KafkaMetricsSupport(MeterRegistry meterRegistry, List<Tag> tags) {
+		Assert.notNull(meterRegistry, "The 'meterRegistry' cannot be null");
+		this.meterRegistry = meterRegistry;
+		this.tags = tags;
+		this.scheduler = null;
+	}
+
+	/**
+	 * Construct an instance with the provided {@link MeterRegistry}, tags and {@link TaskScheduler}.
+	 *
+	 * @param meterRegistry the registry.
+	 * @param tags          the tags.
+	 * @param taskScheduler the task scheduler.
+	 */
+	protected KafkaMetricsSupport(MeterRegistry meterRegistry, List<Tag> tags, TaskScheduler taskScheduler) {
+		Assert.notNull(meterRegistry, "The 'meterRegistry' cannot be null");
+		Assert.notNull(taskScheduler, "The 'taskScheduler' cannot be null");
+		this.meterRegistry = meterRegistry;
+		this.tags = tags;
+		this.scheduler = obtainScheduledExecutorService(taskScheduler);
+	}
+
+	protected void clientAdded(String id, C client) {
+		if (!this.metrics.containsKey(id)) {
+			List<Tag> clientTags = new ArrayList<>(this.tags);
+			clientTags.add(new ImmutableTag("spring.id", id));
+			this.metrics.put(id, createClientMetrics(client, clientTags));
+			this.metrics.get(id).bindTo(this.meterRegistry);
+		}
+	}
+
+	protected MeterBinder createClientMetrics(C client, List<Tag> tags) {
+		if (client instanceof Consumer<?, ?> consumer) {
+			return createConsumerMetrics(consumer, tags);
+		}
+		else if (client instanceof Producer<?, ?> producer) {
+			return createProducerMetrics(producer, tags);
+		}
+		else if (client instanceof AdminClient admin) {
+			return createAdminMetrics(admin, tags);
+		}
+
+		throw new IllegalArgumentException("Unsupported client type: " + client.getClass());
+	}
+
+	private KafkaClientMetrics createConsumerMetrics(Consumer<?, ?> consumer, List<Tag> tags) {
+		return this.scheduler != null
+				? new KafkaClientMetrics(consumer, tags, this.scheduler)
+				: new KafkaClientMetrics(consumer, tags);
+	}
+
+	private KafkaClientMetrics createProducerMetrics(Producer<?, ?> producer, List<Tag> tags) {
+		return this.scheduler != null
+				? new KafkaClientMetrics(producer, tags, this.scheduler)
+				: new KafkaClientMetrics(producer, tags);
+	}
+
+	private KafkaClientMetrics createAdminMetrics(AdminClient adminClient, List<Tag> tags) {
+		return this.scheduler != null
+				? new KafkaClientMetrics(adminClient, tags, this.scheduler)
+				: new KafkaClientMetrics(adminClient, tags);
+	}
+
+	protected void clientRemoved(String id, C client) {
+		AutoCloseable removed = (AutoCloseable) this.metrics.remove(id);
+		if (removed != null) {
+			try {
+				removed.close();
+			}
+			catch (Exception ex) {
+				ReflectionUtils.rethrowRuntimeException(ex);
+			}
+		}
+	}
+
+	private static ScheduledExecutorService obtainScheduledExecutorService(TaskScheduler taskScheduler) {
+		if (taskScheduler instanceof ThreadPoolTaskScheduler threadPoolTaskScheduler) {
+			return threadPoolTaskScheduler.getScheduledExecutor();
+		}
+
+		return new ScheduledExecutorServiceAdapter(taskScheduler);
+	}
+
+	private static final class ScheduledExecutorServiceAdapter extends ScheduledThreadPoolExecutor {
+
+		private final TaskScheduler delegate;
+
+		private ScheduledExecutorServiceAdapter(TaskScheduler delegate) {
+			super(0);
+			this.delegate = delegate;
+		}
+
+		@Override
+		public ScheduledFuture<?> scheduleAtFixedRate(Runnable command,
+				long initialDelay,
+				long period,
+				TimeUnit unit) {
+
+			return this.delegate.scheduleAtFixedRate(command,
+					Instant.now().plus(initialDelay, unit.toChronoUnit()),
+					Duration.of(period, unit.toChronoUnit()));
+		}
+
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/MicrometerConsumerListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/MicrometerConsumerListener.java
@@ -82,12 +82,12 @@ public class MicrometerConsumerListener<K, V> extends KafkaMetricsSupport<Consum
 
 	@Override
 	public synchronized void consumerAdded(String id, Consumer<K, V> consumer) {
-		clientAdded(id, consumer);
+		bindClient(id, consumer);
 	}
 
 	@Override
 	public synchronized void consumerRemoved(String id, Consumer<K, V> consumer) {
-		clientRemoved(id, consumer);
+		unbindClient(id, consumer);
 	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/MicrometerProducerListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/MicrometerProducerListener.java
@@ -81,12 +81,12 @@ public class MicrometerProducerListener<K, V> extends KafkaMetricsSupport<Produc
 
 	@Override
 	public synchronized void producerAdded(String id, Producer<K, V> producer) {
-		clientAdded(id, producer);
+		bindClient(id, producer);
 	}
 
 	@Override
 	public synchronized void producerRemoved(String id, Producer<K, V> producer) {
-		clientRemoved(id, producer);
+		unbindClient(id, producer);
 	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/streams/KafkaStreamsMicrometerListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/streams/KafkaStreamsMicrometerListener.java
@@ -82,7 +82,7 @@ public class KafkaStreamsMicrometerListener extends KafkaMetricsSupport<KafkaStr
 
 	@Override
 	public synchronized void streamsAdded(String id, KafkaStreams kafkaStreams) {
-		clientAdded(id, kafkaStreams);
+		bindClient(id, kafkaStreams);
 	}
 
 	@Override
@@ -94,7 +94,7 @@ public class KafkaStreamsMicrometerListener extends KafkaMetricsSupport<KafkaStr
 
 	@Override
 	public synchronized void streamsRemoved(String id, KafkaStreams streams) {
-		clientRemoved(id, streams);
+		unbindClient(id, streams);
 	}
 
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -152,6 +152,7 @@ import org.springframework.messaging.handler.annotation.support.MethodArgumentNo
 import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
 import org.springframework.messaging.support.GenericMessage;
 import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.scheduling.concurrent.SimpleAsyncTaskScheduler;
 import org.springframework.stereotype.Component;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestPropertySource;
@@ -1489,8 +1490,9 @@ public class EnableKafkaIntegrationTests {
 			Map<String, Object> configs = consumerConfigs();
 			configs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
 			DefaultKafkaConsumerFactory<byte[], String> cf = new DefaultKafkaConsumerFactory<>(configs);
-			cf.addListener(new MicrometerConsumerListener<byte[], String>(meterRegistry(),
-					Collections.singletonList(new ImmutableTag("consumerTag", "bytesString"))));
+			cf.addListener(new MicrometerConsumerListener<>(meterRegistry(),
+					Collections.singletonList(new ImmutableTag("consumerTag", "bytesString")),
+					new SimpleAsyncTaskScheduler()));
 			return cf;
 		}
 
@@ -1580,7 +1582,8 @@ public class EnableKafkaIntegrationTests {
 			configs.put(ProducerConfig.CLIENT_ID_CONFIG, "bsPF");
 			DefaultKafkaProducerFactory<byte[], String> pf = new DefaultKafkaProducerFactory<>(configs);
 			pf.addListener(new MicrometerProducerListener<>(meterRegistry(),
-					Collections.singletonList(new ImmutableTag("producerTag", "bytesString"))));
+					Collections.singletonList(new ImmutableTag("producerTag", "bytesString")),
+					new SimpleAsyncTaskScheduler()));
 			return pf;
 		}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/config/KafkaStreamsCustomizerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/config/KafkaStreamsCustomizerTests.java
@@ -49,6 +49,7 @@ import org.springframework.kafka.streams.KafkaStreamsMicrometerListener;
 import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.scheduling.concurrent.SimpleAsyncTaskScheduler;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
@@ -157,7 +158,8 @@ public class KafkaStreamsCustomizerTests {
 
 			});
 			streamsBuilderFactoryBean.addListener(new KafkaStreamsMicrometerListener(meterRegistry(),
-					Collections.singletonList(new ImmutableTag("customTag", "stream"))));
+					Collections.singletonList(new ImmutableTag("customTag", "stream")),
+					new SimpleAsyncTaskScheduler()));
 			return streamsBuilderFactoryBean;
 		}
 


### PR DESCRIPTION
Related to: https://github.com/micrometer-metrics/micrometer/issues/4976

* Introduce a `KafkaMetricsSupport` to have a common API for the `MeterBinder` registration
* Rework `MicrometerConsumerListener`, `MicrometerProducerListener` and `KafkaStreamsMicrometerListener` to extend the `KafkaMetricsSupport` which allows to minimize code duplication
* Expose ctors on those listeners based on the `TaskScheduler`
* Implement a simple `ScheduledExecutorServiceAdapter` to adapt a `TaskScheduler` to the expected by the `KafkaMetrics` `ScheduledExecutorService`

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
