### PR TITLE
GH-3581: Address NPE in `AbstractKafkaHeaderMapper`

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/AbstractKafkaHeaderMapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/AbstractKafkaHeaderMapper.java
@@ -44,6 +44,7 @@ import org.springframework.util.PatternMatchUtils;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Sanghyeok An
+ * @author Soby Chacko
  *
  * @since 2.1.3
  *
@@ -268,11 +269,11 @@ public abstract class AbstractKafkaHeaderMapper implements KafkaHeaderMapper {
 	 * @return the value to add.
 	 */
 	protected Object headerValueToAddIn(Header header) {
-		Object mapped = mapRawIn(header.key(), header.value());
-		if (mapped == null) {
-			mapped = header.value();
+		if (header == null || header.value() == null) {
+			return null;
 		}
-		return mapped;
+		String mapped = mapRawIn(header.key(), header.value());
+		return mapped != null ? mapped : header.value();
 	}
 
 	@Nullable

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/DefaultKafkaHeaderMapperTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/DefaultKafkaHeaderMapperTests.java
@@ -47,6 +47,10 @@ import org.springframework.util.MimeTypeUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 /**
  * @author Gary Russell
@@ -358,6 +362,20 @@ public class DefaultKafkaHeaderMapperTests {
 		mapper.fromHeaders(new MessageHeaders(springHeaders), headers);
 		assertThat(headers.lastHeader(SerializationUtils.KEY_DESERIALIZER_EXCEPTION_HEADER)).isNull();
 		assertThat(headers.lastHeader(SerializationUtils.VALUE_DESERIALIZER_EXCEPTION_HEADER)).isNull();
+	}
+
+	@Test
+	void ensureNullHeaderValueHandledGraciously() {
+		DefaultKafkaHeaderMapper mapper = new DefaultKafkaHeaderMapper();
+
+		Header mockHeader = mock(Header.class);
+		given(mockHeader.value()).willReturn(null);
+
+		Object result = mapper.headerValueToAddIn(mockHeader);
+
+		assertThat(result).isNull();
+		verify(mockHeader).value();
+		verify(mockHeader, never()).key();
 	}
 
 	public static final class Foo {


### PR DESCRIPTION
Fixes: #3581

https://github.com/spring-projects/spring-kafka/issues/3581

- Optimize `headerValueToAddIn` method by adding better null checks
- Add unit test to verify


