### PR TITLE
Refine docs for consistency and correctness

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/receiving-messages/message-listener-container.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/receiving-messages/message-listener-container.adoc
@@ -6,7 +6,7 @@ Two `MessageListenerContainer` implementations are provided:
 * `KafkaMessageListenerContainer`
 * `ConcurrentMessageListenerContainer`
 
-The `KafkaMessageListenerContainer` receives all message from all topics or partitions on a single thread.
+The `KafkaMessageListenerContainer` receives all messages from all topics or partitions on a single thread.
 The `ConcurrentMessageListenerContainer` delegates to one or more `KafkaMessageListenerContainer` instances to provide multi-threaded consumption.
 
 Starting with version 2.2.7, you can add a `RecordInterceptor` to the listener container; it will be invoked before calling the listener allowing inspection or modification of the record.

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/sending-messages.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/sending-messages.adoc
@@ -139,9 +139,9 @@ The following listing shows the definition of the `ProducerListener` interface:
 ----
 public interface ProducerListener<K, V> {
 
-    void onSuccess(ProducerRecord<K, V> producerRecord, RecordMetadata recordMetadata);
+    default void onSuccess(ProducerRecord<K, V> producerRecord, RecordMetadata recordMetadata);
 
-    void onError(ProducerRecord<K, V> producerRecord, RecordMetadata recordMetadata,
+    default void onError(ProducerRecord<K, V> producerRecord, RecordMetadata recordMetadata,
             Exception exception);
 
 }
@@ -307,6 +307,7 @@ public KafkaTemplate<Integer, CustomValue> kafkaTemplate() {
 Starting with version 2.5.10, you can now update the producer properties after the factory is created.
 This might be useful, for example, if you have to update SSL key/trust store locations after a credentials change.
 The changes will not affect existing producer instances; call `reset()` to close any existing  producers so that new producers will be created using the new properties.
+
 NOTE: You cannot change a transactional producer factory to non-transactional, and vice-versa.
 
 Two new methods are now provided:
@@ -447,7 +448,7 @@ catch (InterruptedException e) {
     ...
 }
 catch (ExecutionException e) {
-    if (e.getCause instanceof MyException) {
+    if (e.getCause() instanceof MyException) {
         ...
     }
 }

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/serdes.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/serdes.adoc
@@ -364,7 +364,7 @@ producerConfigs.put(DelegatingByTopicSerializer.VALUE_SERIALIZATION_TOPIC_CONFIG
             "topic[0-4]:" + ByteArraySerializer.class.getName()
         + ", topic[5-9]:" + StringSerializer.class.getName());
 ...
-ConsumerConfigs.put(DelegatingByTopicDeserializer.VALUE_SERIALIZATION_TOPIC_CONFIG,
+consumerConfigs.put(DelegatingByTopicDeserializer.VALUE_SERIALIZATION_TOPIC_CONFIG,
             "topic[0-4]:" + ByteArrayDeserializer.class.getName()
         + ", topic[5-9]:" + StringDeserializer.class.getName());
 ----

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
@@ -74,6 +74,7 @@ import org.springframework.util.StringUtils;
  * @author Adrian Gygax
  * @author Yaniv Nahoum
  * @author Sanghyeok An
+ * @author Borahm Lee
  */
 public class DefaultKafkaConsumerFactory<K, V> extends KafkaResourceFactory
 		implements ConsumerFactory<K, V>, BeanNameAware, ApplicationContextAware {
@@ -222,7 +223,7 @@ public class DefaultKafkaConsumerFactory<K, V> extends KafkaResourceFactory
 
 	/**
 	 * Set to false (default true) to prevent programmatically provided deserializers (via
-	 * constructor or setters) from being configured using the producer configuration,
+	 * constructor or setters) from being configured using the consumer configuration,
 	 * e.g. if the deserializers are already fully configured.
 	 * @param configureDeserializers false to not configure.
 	 * @since 2.8.7


### PR DESCRIPTION
<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
## Changes
- Corrected "producer configuration" to "consumer configuration" in `DefaultKafkaConsumerFactory` comments
- Added `default` keyword to methods in `ProducerListener` interface in `sending-messages.adoc`
- Updated casing from `ConsumerConfigs` to `consumerConfigs` for consistency in `serdes.adoc`
- Added other minor refinements.