### PR TITLE
GH-3589: Refactor `toMessage` batch method and fix logging/header issues

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/converter/BatchMessagingMessageConverter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/converter/BatchMessagingMessageConverter.java
@@ -185,7 +185,7 @@ public class BatchMessagingMessageConverter implements BatchMessageConverter {
 			}
 		}
 		if (this.headerMapper == null) {
-			this.logger.warn(() ->
+			this.logger.debug(() ->
 					"No header mapper is available; Jackson is required for the default mapper; "
 							+ "headers (if present) are not mapped but provided raw in "
 							+ KafkaHeaders.NATIVE_HEADERS);

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/converter/BatchMessagingMessageConverter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/converter/BatchMessagingMessageConverter.java
@@ -184,7 +184,7 @@ public class BatchMessagingMessageConverter implements BatchMessageConverter {
 				raws.add(record);
 			}
 		}
-		if (this.headerMapper == null) {
+		if (this.headerMapper == null && !natives.isEmpty()) {
 			this.logger.debug(() ->
 					"No header mapper is available; Jackson is required for the default mapper; "
 							+ "headers (if present) are not mapped but provided raw in "

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/converter/BatchMessagingMessageConverter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/converter/BatchMessagingMessageConverter.java
@@ -176,7 +176,8 @@ public class BatchMessagingMessageConverter implements BatchMessageConverter {
 				if (obj instanceof String) {
 					listenerInfo = (String) obj;
 				}
-			} else {
+			}
+			else {
 				natives.add(record.headers());
 			}
 			if (this.rawRecordHeader) {
@@ -210,8 +211,8 @@ public class BatchMessagingMessageConverter implements BatchMessageConverter {
 	}
 
 	private void addRecordInfo(ConsumerRecord<?, ?> record, Type type, List<Object> payloads, List<Object> keys,
-	    List<String> topics, List<Integer> partitions, List<Long> offsets, List<String> timestampTypes,
-		   List<Long> timestamps, List<ConversionException> conversionFailures) {
+		List<String> topics, List<Integer> partitions, List<Long> offsets, List<String> timestampTypes,
+		List<Long> timestamps, List<ConversionException> conversionFailures) {
 		payloads.add(obtainPayload(type, record, conversionFailures));
 		keys.add(record.key());
 		topics.add(record.topic());

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/converter/BatchMessagingMessageConverter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/converter/BatchMessagingMessageConverter.java
@@ -171,8 +171,8 @@ public class BatchMessagingMessageConverter implements BatchMessageConverter {
 		for (ConsumerRecord<?, ?> record : records) {
 			addRecordInfo(record, type, payloads, keys, topics, partitions, offsets, timestampTypes, timestamps, conversionFailures);
 			if (this.headerMapper != null && record.headers() != null) {
-				addToConvertedHeaders(record.headers(), convertedHeaders);
-				Object obj = convertedHeaders.get(convertedHeaders.size() - 1).get(KafkaHeaders.LISTENER_INFO);
+				Map<String, Object> converted = convertHeaders(record.headers(), convertedHeaders);
+				Object obj = converted.get(KafkaHeaders.LISTENER_INFO);
 				if (obj instanceof String) {
 					listenerInfo = (String) obj;
 				}
@@ -230,10 +230,11 @@ public class BatchMessagingMessageConverter implements BatchMessageConverter {
 				: convert(record, type, conversionFailures);
 	}
 
-	private void addToConvertedHeaders(Headers headers, List<Map<String, Object>> convertedHeaders) {
+	private Map<String, Object> convertHeaders(Headers headers, List<Map<String, Object>> convertedHeaders) {
 		Map<String, Object> converted = new HashMap<>();
 		this.headerMapper.toHeaders(headers, converted);
 		convertedHeaders.add(converted);
+		return converted;
 	}
 
 	@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/converter/BatchMessagingMessageConverter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/converter/BatchMessagingMessageConverter.java
@@ -172,11 +172,9 @@ public class BatchMessagingMessageConverter implements BatchMessageConverter {
 			addRecordInfo(record, type, payloads, keys, topics, partitions, offsets, timestampTypes, timestamps, conversionFailures);
 			if (this.headerMapper != null && record.headers() != null) {
 				addToConvertedHeaders(record.headers(), convertedHeaders);
-				if (!convertedHeaders.isEmpty()) {
-					Object obj = convertedHeaders.get(convertedHeaders.size() - 1).get(KafkaHeaders.LISTENER_INFO);
-					if (obj != null && obj instanceof String) {
-						listenerInfo = (String) obj;
-					}
+				Object obj = convertedHeaders.get(convertedHeaders.size() - 1).get(KafkaHeaders.LISTENER_INFO);
+				if (obj instanceof String) {
+					listenerInfo = (String) obj;
 				}
 			} else {
 				natives.add(record.headers());


### PR DESCRIPTION
<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
## Description

- Fixes: #3589
- Remove duplicate logging and listenerInfo operation that occurs for each record in `processRecord()`.
- And refactor the tasks in `toMessage()` as follows:
    - `addRecordInfo()`: Adds information such as `type`, `payload`, `key`, etc. from the `record` to the given lists.
    - `addToConvertedHeaders()`: Adds the converted value of `record.headers()` to `convertedHeaders`.
    - Extract the value of the `KafkaHeaders.LISTENER_INFO` key from `convertedHeaders`, and put it to `rawHeaders` after the loop ends.
    - If there's no `headerMapper`, log a message so that users can refer to `KafkaHeaders.NATIVE_HEADERS`. As there's no need to check `boolean logged` every time in the loop, the `logged` variable has been removed, and the check for the existence of `headerMapper` and `natives` is now performed only once after the loop ends.

> [!NOTE]
> Also, I changed the logging level from `DEBUG` to `WARN` when there is no header mapper. `INFO` might be better, please let me know what you think. -> Sorry, I'll keep `DEBUG` because it's logged every time the listener poll.
