### PR TITLE
Lower the replication factor for transactions topic on @EmbeddedKafka Test

### DIFF
--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizer.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017-2023 the original author or authors.
+ * Copyright 2017-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -47,12 +47,13 @@ import org.springframework.util.StringUtils;
  * @author Oleg Artyomov
  * @author Sergio Lourenco
  * @author Pawel Lozinski
- *
+ * @author Dltmd202
  * @since 1.3
  */
 class EmbeddedKafkaContextCustomizer implements ContextCustomizer {
 
 	private final EmbeddedKafka embeddedKafka;
+	private final String TRANSACTION_STATE_LOG_REPLICATION_FACTOR = "transaction.state.log.replication.factor";
 
 	EmbeddedKafkaContextCustomizer(EmbeddedKafka embeddedKafka) {
 		this.embeddedKafka = embeddedKafka;
@@ -120,6 +121,8 @@ class EmbeddedKafkaContextCustomizer implements ContextCustomizer {
 				throw new IllegalStateException("Failed to load broker properties from [" + propertiesResource + "]", ex);
 			}
 		}
+
+		properties.putIfAbsent(TRANSACTION_STATE_LOG_REPLICATION_FACTOR, String.valueOf(Math.min(3, embeddedKafka.value())));
 
 		embeddedKafkaBroker.brokerProperties((Map<String, String>) (Map<?, ?>) properties);
 		if (StringUtils.hasText(this.embeddedKafka.bootstrapServersProperty())) {

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizer.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizer.java
@@ -47,12 +47,14 @@ import org.springframework.util.StringUtils;
  * @author Oleg Artyomov
  * @author Sergio Lourenco
  * @author Pawel Lozinski
- * @author Dltmd202
+ * @author Seonghwan Lee
+ *
  * @since 1.3
  */
 class EmbeddedKafkaContextCustomizer implements ContextCustomizer {
 
 	private final EmbeddedKafka embeddedKafka;
+
 	private final String TRANSACTION_STATE_LOG_REPLICATION_FACTOR = "transaction.state.log.replication.factor";
 
 	EmbeddedKafkaContextCustomizer(EmbeddedKafka embeddedKafka) {
@@ -122,7 +124,7 @@ class EmbeddedKafkaContextCustomizer implements ContextCustomizer {
 			}
 		}
 
-		properties.putIfAbsent(TRANSACTION_STATE_LOG_REPLICATION_FACTOR, String.valueOf(Math.min(3, embeddedKafka.value())));
+		properties.putIfAbsent(TRANSACTION_STATE_LOG_REPLICATION_FACTOR, String.valueOf(Math.min(3, embeddedKafka.count())));
 
 		embeddedKafkaBroker.brokerProperties((Map<String, String>) (Map<?, ?>) properties);
 		if (StringUtils.hasText(this.embeddedKafka.bootstrapServersProperty())) {

--- a/spring-kafka-test/src/test/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizerTests.java
+++ b/spring-kafka-test/src/test/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizerTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.kafka.test.context;
 
+import java.util.Map;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -25,7 +27,6 @@ import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 
-import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -34,6 +35,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Sergio Lourenco
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Seonghwan Lee
+ *
  * @since 1.3
  */
 public class EmbeddedKafkaContextCustomizerTests {
@@ -106,7 +109,6 @@ public class EmbeddedKafkaContextCustomizerTests {
 
 		assertThat(properties.get("transaction.state.log.replication.factor")).isEqualTo("2");
 	}
-
 
 	@EmbeddedKafka(kraft = false)
 	private static final class TestWithEmbeddedKafka {


### PR DESCRIPTION
Fixes: #3557 

Expected Behavior

It would be nice if the embedded broker started by @EmbeddedKafka (or the similar JUnit Rule) defaulted the replication factor for the transaction state topic to the number of brokers, or a min(<number-of-brokers>, 3).

Current Behavior
The embedded broker starts with the default configuration of transaction.state.log.replication.factor = 3 which doesn't make sense for a single-broker cluster, which is quite common in tests:

```
org.apache.kafka.common.errors.InvalidReplicationFactorException: Replication factor: 3 larger than available brokers: 1.
```

Fix

* When writing test code using EmbeddedKafka, adjust the number of brokers for the transaction topic to the minimum.
* The topic has been made constant