### PR TITLE
Remove duplicate producerProperties declaration in kafkaProducerFactory

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/interceptors.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/interceptors.adoc
@@ -30,11 +30,9 @@ public class Application {
         Map<String, Object> producerProperties = new HashMap<>();
         // producerProperties.put(..., ...)
         // ...
-        Map<String, Object> producerProperties = properties.buildProducerProperties();
         producerProperties.put(ProducerConfig.INTERCEPTOR_CLASSES_CONFIG, MyProducerInterceptor.class.getName());
         producerProperties.put("some.bean", someBean);
-        DefaultKafkaProducerFactory<?, ?> factory = new DefaultKafkaProducerFactory<>(producerProperties);
-        return factory;
+        return new DefaultKafkaProducerFactory<>(producerProperties);
     }
 
     @Bean


### PR DESCRIPTION
<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
- #3587

Modifications:

- Removed the duplicate producerProperties declaration from kafkaProducerFactory.
- Updated the code structure in kafkaProducerFactory to be consistent with the consumerFactory sample
