### PR TITLE
GH-3638: Fixes bug caused by race condition during handleAsyncFailure().

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -1469,13 +1469,10 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 
 			// If we use failedRecords.clear() to remove copied record from failed records,
 			// We may encounter race condition during this operation.
-			// Main Thread : copy 100 records from failed records.
-			// Thread A : Oops! I have an exception. Add record to failedRecords. (failedRecords size is 101)
-			// Main Thread : clear failedRecords!
-			// In this case, Main Thread misses one failed record.
-			int shouldRemoveCount = copyFailedRecords.size();
-			for (int i = 0; i < shouldRemoveCount; i++) {
-				failedRecords.pollFirst();
+			// Other, the thread which execute this block, may miss one failed record.
+			int capturedRecordsCount = copyFailedRecords.size();
+			for (int i = 0; i < capturedRecordsCount; i++) {
+				this.failedRecords.pollFirst();
 			}
 
 			// If any copied and failed record fails to complete due to an unexpected error,

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -1466,7 +1466,17 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 
 		protected void handleAsyncFailure() {
 			List<FailedRecordTuple<K, V>> copyFailedRecords = new ArrayList<>(this.failedRecords);
-			this.failedRecords.clear();
+
+			// If we use failedRecords.clear() to remove copied record from failed records,
+			// We may encounter race condition during this operation.
+			// Main Thread : copy 100 records from failed records.
+			// Thread A : Oops! I have an exception. Add record to failedRecords. (failedRecords size is 101)
+			// Main Thread : clear failedRecords!
+			// In this case, Main Thread misses one failed record.
+			int shouldRemoveCount = copyFailedRecords.size();
+			for (int i = 0; i < shouldRemoveCount; i++) {
+				failedRecords.pollFirst();
+			}
 
 			// If any copied and failed record fails to complete due to an unexpected error,
 			// We will give up on retrying with the remaining copied and failed Records.


### PR DESCRIPTION
### Motivation
- In the [previous PR](https://github.com/spring-projects/spring-kafka/pull/3523), `spring-kafka` has a potential bug during async retry because of race condition between thread for KafkaMessageListenerContainer and threads for `Mono` or `CompletableFuture`.

### Modification
- After capturing the size to remove from `failedRecords`, it is repeatedly removed.

### Result
- Fixes https://github.com/spring-projects/spring-kafka/issues/3638