### PR TITLE
Allow configuring observation registry directly

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
@@ -153,7 +153,7 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 
 	private KafkaTemplateObservationConvention observationConvention;
 
-	private ObservationRegistry observationRegistry = ObservationRegistry.NOOP;
+	private ObservationRegistry observationRegistry;
 
 	@Nullable
 	private Function<ProducerRecord<?, ?>, Map<String, String>> micrometerTagsProvider;
@@ -457,6 +457,15 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 	}
 
 	/**
+	 * Configure the {@link ObservationRegistry} to use for recording observations.
+	 * @param observationRegistry the observation registry to use.
+	 * @since 3.3
+	 */
+	public void setObservationRegistry(ObservationRegistry observationRegistry) {
+		this.observationRegistry = observationRegistry;
+	}
+
+	/**
 	 * Return the {@link KafkaAdmin}, used to find the cluster id for observation, if
 	 * present.
 	 * @return the kafkaAdmin
@@ -478,7 +487,7 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 
 	@Override
 	public void afterSingletonsInstantiated() {
-		if (this.observationEnabled && this.applicationContext != null) {
+		if (this.observationRegistry == null && this.observationEnabled && this.applicationContext != null) {
 			this.observationRegistry = this.applicationContext.getBeanProvider(ObservationRegistry.class)
 					.getIfUnique(() -> this.observationRegistry);
 			if (this.kafkaAdmin == null) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
@@ -42,6 +42,7 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
+import io.micrometer.observation.ObservationRegistry;
 
 /**
  * Contains runtime properties for a listener container.
@@ -280,6 +281,8 @@ public class ContainerProperties extends ConsumerProperties {
 	private boolean micrometerEnabled = true;
 
 	private boolean observationEnabled;
+
+	private ObservationRegistry observationRegistry;
 
 	private Duration consumerStartTimeout = DEFAULT_CONSUMER_START_TIMEOUT;
 
@@ -716,6 +719,19 @@ public class ContainerProperties extends ConsumerProperties {
 		this.observationEnabled = observationEnabled;
 	}
 
+	public ObservationRegistry getObservationRegistry() {
+		return this.observationRegistry;
+	}
+
+	/**
+	 * Configure the {@link ObservationRegistry} to use for recording observations.
+	 * @param observationRegistry the observation registry to use.
+	 * @since 3.3
+	 */
+	public void setObservationRegistry(ObservationRegistry observationRegistry) {
+		this.observationRegistry = observationRegistry;
+	}
+
 	/**
 	 * Set additional tags for the Micrometer listener timers.
 	 * @param tags the tags.
@@ -1117,6 +1133,9 @@ public class ContainerProperties extends ConsumerProperties {
 				+ "\n observationEnabled=" + this.observationEnabled
 				+ (this.observationConvention != null
 						? "\n observationConvention=" + this.observationConvention
+						: "")
+				+ (this.observationRegistry != null
+						? "\n observationRegistry=" + this.observationRegistry
 						: "")
 				+ "\n restartAfterAuthExceptions=" + this.restartAfterAuthExceptions
 				+ "\n]";

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -372,14 +372,16 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		}
 		GenericMessageListener<?> listener = (GenericMessageListener<?>) messageListener;
 		ListenerType listenerType = determineListenerType(listener);
-		ObservationRegistry observationRegistry = ObservationRegistry.NOOP;
-		ApplicationContext applicationContext = getApplicationContext();
-		if (applicationContext != null && containerProperties.isObservationEnabled()) {
-			ObjectProvider<ObservationRegistry> registry =
-					applicationContext.getBeanProvider(ObservationRegistry.class);
-			ObservationRegistry reg = registry.getIfUnique();
-			if (reg != null) {
-				observationRegistry = reg;
+		ObservationRegistry observationRegistry = containerProperties.getObservationRegistry();
+		if (observationRegistry == null) {
+			ApplicationContext applicationContext = getApplicationContext();
+			if (applicationContext != null && containerProperties.isObservationEnabled()) {
+				ObjectProvider<ObservationRegistry> registry =
+						applicationContext.getBeanProvider(ObservationRegistry.class);
+				ObservationRegistry reg = registry.getIfUnique();
+				if (reg != null) {
+					observationRegistry = reg;
+				}
 			}
 		}
 		this.listenerConsumer = new ListenerConsumer(listener, listenerType, observationRegistry);


### PR DESCRIPTION
This changes allows configuring the observation registry directly, instead of it being fetched from the application context. This is to allow observability when KafkaTemplate/KafkaMessageListenerContainer are used without an application context.