### PR TITLE
GH-3617 : Value parameters in ReactiveKafkaProducerTemplate should be nullable

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/reactive/ReactiveKafkaProducerTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/reactive/ReactiveKafkaProducerTemplate.java
@@ -33,6 +33,7 @@ import reactor.kafka.sender.SenderOptions;
 import reactor.kafka.sender.SenderRecord;
 import reactor.kafka.sender.SenderResult;
 import reactor.kafka.sender.TransactionManager;
+import reactor.util.annotation.Nullable;
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;
 
@@ -92,19 +93,19 @@ public class ReactiveKafkaProducerTemplate<K, V> implements AutoCloseable, Dispo
 		return sendTransactionally.single();
 	}
 
-	public Mono<SenderResult<Void>> send(String topic, V value) {
+	public Mono<SenderResult<Void>> send(String topic, @Nullable V value) {
 		return send(new ProducerRecord<>(topic, value));
 	}
 
-	public Mono<SenderResult<Void>> send(String topic, K key, V value) {
+	public Mono<SenderResult<Void>> send(String topic, K key, @Nullable V value) {
 		return send(new ProducerRecord<>(topic, key, value));
 	}
 
-	public Mono<SenderResult<Void>> send(String topic, int partition, K key, V value) {
+	public Mono<SenderResult<Void>> send(String topic, int partition, K key, @Nullable V value) {
 		return send(new ProducerRecord<>(topic, partition, key, value));
 	}
 
-	public Mono<SenderResult<Void>> send(String topic, int partition, long timestamp, K key, V value) {
+	public Mono<SenderResult<Void>> send(String topic, int partition, long timestamp, K key, @Nullable V value) {
 		return send(new ProducerRecord<>(topic, partition, timestamp, key, value));
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/reactive/ReactiveKafkaProducerTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/reactive/ReactiveKafkaProducerTemplate.java
@@ -26,7 +26,6 @@ import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
 import org.reactivestreams.Publisher;
-import org.springframework.lang.Nullable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.kafka.sender.KafkaSender;
@@ -41,6 +40,7 @@ import org.springframework.beans.factory.DisposableBean;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.support.converter.MessagingMessageConverter;
 import org.springframework.kafka.support.converter.RecordMessageConverter;
+import org.springframework.lang.Nullable;
 import org.springframework.messaging.Message;
 import org.springframework.util.Assert;
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/reactive/ReactiveKafkaProducerTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/reactive/ReactiveKafkaProducerTemplate.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
 import org.reactivestreams.Publisher;
+import org.springframework.lang.Nullable;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.kafka.sender.KafkaSender;
@@ -33,7 +34,6 @@ import reactor.kafka.sender.SenderOptions;
 import reactor.kafka.sender.SenderRecord;
 import reactor.kafka.sender.SenderResult;
 import reactor.kafka.sender.TransactionManager;
-import reactor.util.annotation.Nullable;
 import reactor.util.function.Tuple2;
 import reactor.util.function.Tuples;
 
@@ -52,6 +52,7 @@ import org.springframework.util.Assert;
  *
  * @author Mark Norkin
  * @author Adrian Chlebosz
+ * @author Juhyun Kim
  *
  * @since 2.3.0
  */


### PR DESCRIPTION
* Fixes : #3617 
* add @Nullable to parameter of send method
* Fix to allow tombstone records to be transferred.