### PR TITLE
Change "synchronized" to reentrant lock for virtual-threads

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
@@ -37,6 +37,8 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiFunction;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -144,6 +146,7 @@ import org.springframework.validation.Validator;
  * @author Wang Zhiyang
  * @author Sanghyeok An
  * @author Soby Chacko
+ * @author Omer Celik
  *
  * @see KafkaListener
  * @see KafkaListenerErrorHandler
@@ -206,6 +209,8 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 
 	@Nullable
 	private RetryTopicConfigurer retryTopicConfigurer;
+
+	private final Lock globalLock = new ReentrantLock();
 
 	@Override
 	public int getOrder() {
@@ -278,14 +283,20 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 	 * {@link #setEndpointRegistry endpoint registry} has to be explicitly configured.
 	 * @param beanFactory the {@link BeanFactory} to be used.
 	 */
-	public synchronized void setBeanFactory(BeanFactory beanFactory) {
-		this.beanFactory = beanFactory;
-		if (beanFactory instanceof ConfigurableListableBeanFactory clbf) {
-			BeanExpressionResolver beanExpressionResolver = clbf.getBeanExpressionResolver();
-			if (beanExpressionResolver != null) {
-				this.resolver = beanExpressionResolver;
+	public void setBeanFactory(BeanFactory beanFactory) {
+		try {
+			globalLock.lock();
+			this.beanFactory = beanFactory;
+			if (beanFactory instanceof ConfigurableListableBeanFactory clbf) {
+				BeanExpressionResolver beanExpressionResolver = clbf.getBeanExpressionResolver();
+				if (beanExpressionResolver != null) {
+					this.resolver = beanExpressionResolver;
+				}
+				this.expressionContext = new BeanExpressionContext(clbf, this.listenerScope);
 			}
-			this.expressionContext = new BeanExpressionContext(clbf, this.listenerScope);
+		}
+		finally {
+			globalLock.unlock();
 		}
 	}
 
@@ -451,36 +462,48 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 		}
 	}
 
-	private synchronized void processMultiMethodListeners(Collection<KafkaListener> classLevelListeners,
+	private void processMultiMethodListeners(Collection<KafkaListener> classLevelListeners,
 			List<Method> multiMethods, Class<?> clazz, Object bean, String beanName) {
 
-		List<Method> checkedMethods = new ArrayList<>();
-		Method defaultMethod = null;
-		for (Method method : multiMethods) {
-			Method checked = checkProxy(method, bean);
-			KafkaHandler annotation = AnnotationUtils.findAnnotation(method, KafkaHandler.class);
-			if (annotation != null && annotation.isDefault()) {
-				Method toAssert = defaultMethod;
-				Assert.state(toAssert == null, () -> "Only one @KafkaHandler can be marked 'isDefault', found: "
-						+ toAssert.toString() + " and " + method);
-				defaultMethod = checked;
+		try {
+			globalLock.lock();
+			List<Method> checkedMethods = new ArrayList<>();
+			Method defaultMethod = null;
+			for (Method method : multiMethods) {
+				Method checked = checkProxy(method, bean);
+				KafkaHandler annotation = AnnotationUtils.findAnnotation(method, KafkaHandler.class);
+				if (annotation != null && annotation.isDefault()) {
+					Method toAssert = defaultMethod;
+					Assert.state(toAssert == null, () -> "Only one @KafkaHandler can be marked 'isDefault', found: "
+							+ toAssert.toString() + " and " + method);
+					defaultMethod = checked;
+				}
+				checkedMethods.add(checked);
 			}
-			checkedMethods.add(checked);
+			for (KafkaListener classLevelListener : classLevelListeners) {
+				MultiMethodKafkaListenerEndpoint<K, V> endpoint =
+						new MultiMethodKafkaListenerEndpoint<>(checkedMethods, defaultMethod, bean);
+				processMainAndRetryListeners(classLevelListener, bean, beanName, endpoint, null, clazz);
+			}
 		}
-		for (KafkaListener classLevelListener : classLevelListeners) {
-			MultiMethodKafkaListenerEndpoint<K, V> endpoint =
-					new MultiMethodKafkaListenerEndpoint<>(checkedMethods, defaultMethod, bean);
-			processMainAndRetryListeners(classLevelListener, bean, beanName, endpoint, null, clazz);
+		finally {
+			globalLock.unlock();
 		}
 	}
 
-	protected synchronized void processKafkaListener(KafkaListener kafkaListener, Method method, Object bean,
+	protected void processKafkaListener(KafkaListener kafkaListener, Method method, Object bean,
 			String beanName) {
 
-		Method methodToUse = checkProxy(method, bean);
-		MethodKafkaListenerEndpoint<K, V> endpoint = new MethodKafkaListenerEndpoint<>();
-		endpoint.setMethod(methodToUse);
-		processMainAndRetryListeners(kafkaListener, bean, beanName, endpoint, methodToUse, null);
+		try {
+			globalLock.lock();
+			Method methodToUse = checkProxy(method, bean);
+			MethodKafkaListenerEndpoint<K, V> endpoint = new MethodKafkaListenerEndpoint<>();
+			endpoint.setMethod(methodToUse);
+			processMainAndRetryListeners(kafkaListener, bean, beanName, endpoint, methodToUse, null);
+		}
+		finally {
+			globalLock.unlock();
+		}
 	}
 
 	private void processMainAndRetryListeners(KafkaListener kafkaListener, Object bean, String beanName,

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
@@ -285,7 +285,7 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 	 */
 	public void setBeanFactory(BeanFactory beanFactory) {
 		try {
-			globalLock.lock();
+			this.globalLock.lock();
 			this.beanFactory = beanFactory;
 			if (beanFactory instanceof ConfigurableListableBeanFactory clbf) {
 				BeanExpressionResolver beanExpressionResolver = clbf.getBeanExpressionResolver();
@@ -296,7 +296,7 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 			}
 		}
 		finally {
-			globalLock.unlock();
+			this.globalLock.unlock();
 		}
 	}
 
@@ -466,7 +466,7 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 			List<Method> multiMethods, Class<?> clazz, Object bean, String beanName) {
 
 		try {
-			globalLock.lock();
+			this.globalLock.lock();
 			List<Method> checkedMethods = new ArrayList<>();
 			Method defaultMethod = null;
 			for (Method method : multiMethods) {
@@ -487,7 +487,7 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 			}
 		}
 		finally {
-			globalLock.unlock();
+			this.globalLock.unlock();
 		}
 	}
 
@@ -495,14 +495,14 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 			String beanName) {
 
 		try {
-			globalLock.lock();
+			this.globalLock.lock();
 			Method methodToUse = checkProxy(method, bean);
 			MethodKafkaListenerEndpoint<K, V> endpoint = new MethodKafkaListenerEndpoint<>();
 			endpoint.setMethod(methodToUse);
 			processMainAndRetryListeners(kafkaListener, bean, beanName, endpoint, methodToUse, null);
 		}
 		finally {
-			globalLock.unlock();
+			this.globalLock.unlock();
 		}
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistrar.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistrar.java
@@ -20,6 +20,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
@@ -40,6 +42,7 @@ import org.springframework.validation.Validator;
  * @author Gary Russell
  * @author Filip Halemba
  * @author Wang Zhiyang
+ * @author Omer Celik
  *
  * @see org.springframework.kafka.annotation.KafkaListenerConfigurer
  */
@@ -48,6 +51,8 @@ public class KafkaListenerEndpointRegistrar implements BeanFactoryAware, Initial
 	private final List<KafkaListenerEndpointDescriptor> endpointDescriptors = new ArrayList<>();
 
 	private List<HandlerMethodArgumentResolver> customMethodArgumentResolvers = new ArrayList<>();
+
+	private final Lock endpointsLock = new ReentrantLock();
 
 	private KafkaListenerEndpointRegistry endpointRegistry;
 
@@ -188,7 +193,8 @@ public class KafkaListenerEndpointRegistrar implements BeanFactoryAware, Initial
 	}
 
 	protected void registerAllEndpoints() {
-		synchronized (this.endpointDescriptors) {
+		try {
+			endpointsLock.lock();
 			for (KafkaListenerEndpointDescriptor descriptor : this.endpointDescriptors) {
 				if (descriptor.endpoint instanceof MultiMethodKafkaListenerEndpoint<?, ?> mmkle
 						&& this.validator != null) {
@@ -198,6 +204,9 @@ public class KafkaListenerEndpointRegistrar implements BeanFactoryAware, Initial
 						descriptor.endpoint, resolveContainerFactory(descriptor));
 			}
 			this.startImmediately = true;  // trigger immediate startup
+		}
+		finally {
+			endpointsLock.unlock();
 		}
 	}
 
@@ -234,7 +243,8 @@ public class KafkaListenerEndpointRegistrar implements BeanFactoryAware, Initial
 		Assert.hasText(endpoint.getId(), "Endpoint id must be set");
 		// Factory may be null, we defer the resolution right before actually creating the container
 		KafkaListenerEndpointDescriptor descriptor = new KafkaListenerEndpointDescriptor(endpoint, factory);
-		synchronized (this.endpointDescriptors) {
+		try {
+			endpointsLock.lock();
 			if (this.startImmediately) { // Register and start immediately
 				this.endpointRegistry.registerListenerContainer(descriptor.endpoint,
 						resolveContainerFactory(descriptor), true);
@@ -242,6 +252,9 @@ public class KafkaListenerEndpointRegistrar implements BeanFactoryAware, Initial
 			else {
 				this.endpointDescriptors.add(descriptor);
 			}
+		}
+		finally {
+			endpointsLock.unlock();
 		}
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistrar.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistrar.java
@@ -194,7 +194,7 @@ public class KafkaListenerEndpointRegistrar implements BeanFactoryAware, Initial
 
 	protected void registerAllEndpoints() {
 		try {
-			endpointsLock.lock();
+			this.endpointsLock.lock();
 			for (KafkaListenerEndpointDescriptor descriptor : this.endpointDescriptors) {
 				if (descriptor.endpoint instanceof MultiMethodKafkaListenerEndpoint<?, ?> mmkle
 						&& this.validator != null) {
@@ -206,7 +206,7 @@ public class KafkaListenerEndpointRegistrar implements BeanFactoryAware, Initial
 			this.startImmediately = true;  // trigger immediate startup
 		}
 		finally {
-			endpointsLock.unlock();
+			this.endpointsLock.unlock();
 		}
 	}
 
@@ -244,7 +244,7 @@ public class KafkaListenerEndpointRegistrar implements BeanFactoryAware, Initial
 		// Factory may be null, we defer the resolution right before actually creating the container
 		KafkaListenerEndpointDescriptor descriptor = new KafkaListenerEndpointDescriptor(endpoint, factory);
 		try {
-			endpointsLock.lock();
+			this.endpointsLock.lock();
 			if (this.startImmediately) { // Register and start immediately
 				this.endpointRegistry.registerListenerContainer(descriptor.endpoint,
 						resolveContainerFactory(descriptor), true);
@@ -254,7 +254,7 @@ public class KafkaListenerEndpointRegistrar implements BeanFactoryAware, Initial
 			}
 		}
 		finally {
-			endpointsLock.unlock();
+			this.endpointsLock.unlock();
 		}
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaAdmin.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaAdmin.java
@@ -32,6 +32,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -78,6 +80,7 @@ import org.springframework.util.Assert;
  * @author Sanghyeok An
  * @author Valentina Armenise
  * @author Anders Swanson
+ * @author Omer Celik
  *
  * @since 1.3
  */
@@ -94,6 +97,8 @@ public class KafkaAdmin extends KafkaResourceFactory
 	private static final LogAccessor LOGGER = new LogAccessor(LogFactory.getLog(KafkaAdmin.class));
 
 	private static final AtomicInteger CLIENT_ID_COUNTER = new AtomicInteger();
+
+	private final Lock clusterIdLock = new ReentrantLock();
 
 	private final Map<String, Object> configs;
 
@@ -267,11 +272,15 @@ public class KafkaAdmin extends KafkaResourceFactory
 			}
 			if (adminClient != null) {
 				try {
-					synchronized (this) {
+					try {
+						clusterIdLock.lock();
 						if (this.clusterId != null) {
 							this.clusterId = adminClient.describeCluster().clusterId().get(this.operationTimeout,
 									TimeUnit.SECONDS);
 						}
+					}
+					finally {
+						clusterIdLock.unlock();
 					}
 					addOrModifyTopicsIfNeeded(adminClient, newTopics);
 					return true;

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaAdmin.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaAdmin.java
@@ -272,16 +272,7 @@ public class KafkaAdmin extends KafkaResourceFactory
 			}
 			if (adminClient != null) {
 				try {
-					try {
-						this.clusterIdLock.lock();
-						if (this.clusterId != null) {
-							this.clusterId = adminClient.describeCluster().clusterId().get(this.operationTimeout,
-									TimeUnit.SECONDS);
-						}
-					}
-					finally {
-						this.clusterIdLock.unlock();
-					}
+					updateClusterId(adminClient);
 					addOrModifyTopicsIfNeeded(adminClient, newTopics);
 					return true;
 				}
@@ -304,6 +295,19 @@ public class KafkaAdmin extends KafkaResourceFactory
 		}
 		this.initializingContext = false;
 		return false;
+	}
+
+	private void updateClusterId(Admin adminClient) throws InterruptedException, ExecutionException, TimeoutException {
+		try {
+			this.clusterIdLock.lock();
+			if (this.clusterId != null) {
+				this.clusterId = adminClient.describeCluster().clusterId().get(this.operationTimeout,
+						TimeUnit.SECONDS);
+			}
+		}
+		finally {
+			this.clusterIdLock.unlock();
+		}
 	}
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaAdmin.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaAdmin.java
@@ -273,14 +273,14 @@ public class KafkaAdmin extends KafkaResourceFactory
 			if (adminClient != null) {
 				try {
 					try {
-						clusterIdLock.lock();
+						this.clusterIdLock.lock();
 						if (this.clusterId != null) {
 							this.clusterId = adminClient.describeCluster().clusterId().get(this.operationTimeout,
 									TimeUnit.SECONDS);
 						}
 					}
 					finally {
-						clusterIdLock.unlock();
+						this.clusterIdLock.unlock();
 					}
 					addOrModifyTopicsIfNeeded(adminClient, newTopics);
 					return true;

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DefaultDestinationTopicResolver.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DefaultDestinationTopicResolver.java
@@ -216,11 +216,11 @@ public class DefaultDestinationTopicResolver extends ExceptionClassifier
 
 	private DestinationTopicHolder getDestinationTopicSynchronized(String mainListenerId, String topic) {
 		try {
-			sourceDestinationsHolderLock.lock();
+			this.sourceDestinationsHolderLock.lock();
 			return doGetDestinationFor(mainListenerId, topic);
 		}
 		finally {
-			sourceDestinationsHolderLock.unlock();
+			this.sourceDestinationsHolderLock.unlock();
 		}
 	}
 
@@ -239,13 +239,13 @@ public class DefaultDestinationTopicResolver extends ExceptionClassifier
 		}
 		validateDestinations(destinationsToAdd);
 		try {
-			sourceDestinationsHolderLock.lock();
+			this.sourceDestinationsHolderLock.lock();
 			Map<String, DestinationTopicHolder> map = this.sourceDestinationsHolderMap.computeIfAbsent(mainListenerId,
 					id -> new HashMap<>());
 			map.putAll(correlatePairSourceAndDestinationValues(destinationsToAdd));
 		}
 		finally {
-			sourceDestinationsHolderLock.unlock();
+			this.sourceDestinationsHolderLock.unlock();
 		}
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonDeserializer.java
@@ -404,7 +404,7 @@ public class JsonDeserializer<T> implements Deserializer<T> {
 	@Override
 	public void configure(Map<String, ?> configs, boolean isKey) {
 		try {
-			trustedPackagesLock.lock();
+			this.trustedPackagesLock.lock();
 			if (this.configured) {
 				return;
 			}
@@ -429,7 +429,7 @@ public class JsonDeserializer<T> implements Deserializer<T> {
 			this.configured = true;
 		}
 		finally {
-			trustedPackagesLock.unlock();
+			this.trustedPackagesLock.unlock();
 		}
 	}
 
@@ -535,12 +535,12 @@ public class JsonDeserializer<T> implements Deserializer<T> {
 	 */
 	public void addTrustedPackages(String... packages) {
 		try {
-			trustedPackagesLock.lock();
+			this.trustedPackagesLock.lock();
 			doAddTrustedPackages(packages);
 			this.setterCalled = true;
 		}
 		finally {
-			trustedPackagesLock.unlock();
+			this.trustedPackagesLock.unlock();
 		}
 	}
 
@@ -723,13 +723,13 @@ public class JsonDeserializer<T> implements Deserializer<T> {
 	 */
 	public JsonDeserializer<T> trustedPackages(String... packages) {
 		try {
-			trustedPackagesLock.lock();
+			this.trustedPackagesLock.lock();
 			Assert.isTrue(!this.typeMapperExplicitlySet, "When using a custom type mapper, set the trusted packages there");
 			this.typeMapper.addTrustedPackages(packages);
 			return this;
 		}
 		finally {
-			trustedPackagesLock.unlock();
+			this.trustedPackagesLock.unlock();
 		}
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerializer.java
@@ -151,9 +151,9 @@ public class JsonSerializer<T> implements Serializer<T> {
 	}
 
 	@Override
-	public synchronized void configure(Map<String, ?> configs, boolean isKey) {
+	public void configure(Map<String, ?> configs, boolean isKey) {
 		try {
-			globalLock.lock();
+			this.globalLock.lock();
 			if (this.configured) {
 				return;
 			}
@@ -180,7 +180,7 @@ public class JsonSerializer<T> implements Serializer<T> {
 			this.configured = true;
 		}
 		finally {
-			globalLock.unlock();
+			this.globalLock.unlock();
 		}
 	}
 


### PR DESCRIPTION
This commit ensures that the method is friendly for virtual threads to avoid blocking and pinning. The lock is acquired at the beginning of the method and released in a finally block to ensure it is always released, even if an exception occurs.