### PR TITLE
Update DLT log message and docs

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/retrytopic/dlt-strategies.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/retrytopic/dlt-strategies.adoc
@@ -22,7 +22,7 @@ public void processMessage(MyPojo message) {
 }
 
 @DltHandler
-public void processMessage(MyPojo message) {
+public void processDltMessage(MyPojo message) {
     // ... message processing, persistence, etc
 }
 ----

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/retrytopic/features.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/retrytopic/features.adoc
@@ -291,7 +291,6 @@ public RetryTopicConfiguration myRetryTopic(KafkaTemplate<String, MyPojo> templa
     return RetryTopicConfigurationBuilder
             .newInstance()
             .dltRoutingRules(Map.of("-deserialization", Set.of(DeserializationException.class)))
-            .create(kafkaOperations)
             .create(template);
 }
 ----

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
@@ -65,6 +65,7 @@ import org.springframework.util.ObjectUtils;
  * @author Gary Russell
  * @author Tomaz Fernandes
  * @author Watlas R
+ * @author Borahm Lee
  * @since 2.2
  *
  */
@@ -571,7 +572,7 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 
 	private void maybeThrow(ConsumerRecord<?, ?> record, Exception exception) {
 		String message = String.format("No destination returned for record %s and exception %s. " +
-				"failIfNoDestinationReturned: %s", KafkaUtils.format(record), exception,
+				"throwIfNoDestinationReturned: %s", KafkaUtils.format(record), exception,
 				this.throwIfNoDestinationReturned);
 		this.logger.warn(message);
 		if (this.throwIfNoDestinationReturned) {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->

## Changes

- **DeadLetterPublishingRecoverer.java**
  - The field `failIfNoDestinationReturned` is non-existent. Moreover, in the context of DLT strategy here, `fail` means ending without performing any retry or throwing an error. However, `failIfNoDestinationReturned: true` actually throws an error, which is inconsistent with this meaning. Therefore, I changed it to `throwIfNoDestinationReturned` for clarity and consistency.
- **dlt-strategies.adoc**
  - Modified the method signature for the `@DltHandler` annotation because it cannot be identical to the method signature for the `@RetryableTopic` annotation.
- **features.adoc**
  - Removed the reference to `kafkaOperations` as it is a non-existent variable.