### PR TITLE
GH-3658: Fix `@EmbeddedKafka` for `adminTimeout` resolution

### DIFF
--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaBroker.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaBroker.java
@@ -90,6 +90,14 @@ public interface EmbeddedKafkaBroker extends InitializingBean, DisposableBean {
 	EmbeddedKafkaBroker brokerListProperty(String brokerListProperty);
 
 	/**
+	 * Set the timeout in seconds for admin operations (e.g. topic creation, close).
+	 * @param adminTimeout the timeout.
+	 * @return the {@link EmbeddedKafkaBroker}
+	 * @since 2.8.5
+	 */
+	EmbeddedKafkaBroker adminTimeout(int adminTimeout);
+
+	/**
 	 * Get the bootstrap server addresses as a String.
 	 * @return the bootstrap servers.
 	 */

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaBrokerFactory.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaBrokerFactory.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Properties;
+import java.util.function.Function;
+
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.util.StringUtils;
+
+/**
+ * The factory to encapsulate an {@link EmbeddedKafkaBroker} creation logic.
+ *
+ * @author Artem Bilan
+ *
+ * @since 3.2.6
+ */
+public final class EmbeddedKafkaBrokerFactory {
+
+	private static final String TRANSACTION_STATE_LOG_REPLICATION_FACTOR = "transaction.state.log.replication.factor";
+
+	/**
+	 * Create an {@link EmbeddedKafkaBroker} based on the {@code EmbeddedKafka} annotation.
+	 * @param embeddedKafka the {@code EmbeddedKafka} annotation.
+	 * @return a new {@link EmbeddedKafkaBroker} instance.
+	 */
+	public static EmbeddedKafkaBroker create(EmbeddedKafka embeddedKafka) {
+		return create(embeddedKafka, Function.identity());
+	}
+
+	/**
+	 * Create an {@link EmbeddedKafkaBroker} based on the {@code EmbeddedKafka} annotation.
+	 * @param embeddedKafka the {@code EmbeddedKafka} annotation.
+	 * @param propertyResolver the {@link Function} for placeholders in the annotation attributes.
+	 * @return a new {@link EmbeddedKafkaBroker} instance.
+	 */
+	@SuppressWarnings("unchecked")
+	public static EmbeddedKafkaBroker create(EmbeddedKafka embeddedKafka, Function<String, String> propertyResolver) {
+		String[] topics =
+				Arrays.stream(embeddedKafka.topics())
+						.map(propertyResolver)
+						.toArray(String[]::new);
+
+		EmbeddedKafkaBroker embeddedKafkaBroker;
+		if (embeddedKafka.kraft()) {
+			embeddedKafkaBroker = kraftBroker(embeddedKafka, topics);
+		}
+		else {
+			embeddedKafkaBroker = zkBroker(embeddedKafka, topics);
+		}
+		int[] ports = setupPorts(embeddedKafka);
+
+		embeddedKafkaBroker.kafkaPorts(ports)
+				.adminTimeout(embeddedKafka.adminTimeout());
+
+		Properties properties = new Properties();
+
+		for (String pair : embeddedKafka.brokerProperties()) {
+			if (!StringUtils.hasText(pair)) {
+				continue;
+			}
+			try {
+				properties.load(new StringReader(propertyResolver.apply(pair)));
+			}
+			catch (Exception ex) {
+				throw new IllegalStateException("Failed to load broker property from [" + pair + "]", ex);
+			}
+		}
+
+		String brokerPropertiesLocation = embeddedKafka.brokerPropertiesLocation();
+		if (StringUtils.hasText(brokerPropertiesLocation)) {
+			String propertiesLocation = propertyResolver.apply(brokerPropertiesLocation);
+			Resource propertiesResource = new PathMatchingResourcePatternResolver().getResource(propertiesLocation);
+			if (!propertiesResource.exists()) {
+				throw new IllegalStateException(
+						"Failed to load broker properties from [" + propertiesResource + "]: resource does not exist.");
+			}
+			try (InputStream in = propertiesResource.getInputStream()) {
+				Properties p = new Properties();
+				p.load(in);
+				p.forEach((key, value) -> properties.putIfAbsent(key, propertyResolver.apply((String) value)));
+			}
+			catch (IOException ex) {
+				throw new IllegalStateException("Failed to load broker properties from [" + propertiesResource + "]", ex);
+			}
+		}
+
+		properties.putIfAbsent(TRANSACTION_STATE_LOG_REPLICATION_FACTOR,
+				String.valueOf(Math.min(3, embeddedKafka.count())));
+
+		embeddedKafkaBroker.brokerProperties((Map<String, String>) (Map<?, ?>) properties);
+		String bootstrapServersProperty = embeddedKafka.bootstrapServersProperty();
+		if (StringUtils.hasText(bootstrapServersProperty)) {
+			embeddedKafkaBroker.brokerListProperty(bootstrapServersProperty);
+		}
+
+		// Safe to start an embedded broker eagerly before context refresh
+		embeddedKafkaBroker.afterPropertiesSet();
+
+		return embeddedKafkaBroker;
+	}
+
+	private static int[] setupPorts(EmbeddedKafka embedded) {
+		int[] ports = embedded.ports();
+		if (embedded.count() > 1 && ports.length == 1 && ports[0] == 0) {
+			ports = new int[embedded.count()];
+		}
+		return ports;
+	}
+
+	private static EmbeddedKafkaBroker kraftBroker(EmbeddedKafka embedded, String[] topics) {
+		return new EmbeddedKafkaKraftBroker(embedded.count(), embedded.partitions(), topics);
+	}
+
+	private static EmbeddedKafkaBroker zkBroker(EmbeddedKafka embedded, String[] topics) {
+		return new EmbeddedKafkaZKBroker(embedded.count(), embedded.controlledShutdown(), embedded.partitions(), topics)
+				.zkPort(embedded.zookeeperPort())
+				.zkConnectionTimeout(embedded.zkConnectionTimeout())
+				.zkSessionTimeout(embedded.zkSessionTimeout());
+	}
+
+	private EmbeddedKafkaBrokerFactory() {
+	}
+
+}

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaKraftBroker.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaKraftBroker.java
@@ -176,12 +176,7 @@ public class EmbeddedKafkaKraftBroker implements EmbeddedKafkaBroker {
 		return this;
 	}
 
-	/**
-	 * Set the timeout in seconds for admin operations (e.g. topic creation, close).
-	 * @param adminTimeout the timeout.
-	 * @return the {@link EmbeddedKafkaKraftBroker}
-	 * @since 2.8.5
-	 */
+	@Override
 	public EmbeddedKafkaBroker adminTimeout(int adminTimeout) {
 		this.adminTimeout = Duration.ofSeconds(adminTimeout);
 		return this;

--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaZKBroker.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaZKBroker.java
@@ -250,12 +250,7 @@ public class EmbeddedKafkaZKBroker implements EmbeddedKafkaBroker {
 		this.zkPort = zkPort;
 	}
 
-	/**
-	 * Set the timeout in seconds for admin operations (e.g. topic creation, close).
-	 * @param adminTimeout the timeout.
-	 * @return the {@link EmbeddedKafkaBroker}
-	 * @since 2.8.5
-	 */
+	@Override
 	public EmbeddedKafkaBroker adminTimeout(int adminTimeout) {
 		this.adminTimeout = Duration.ofSeconds(adminTimeout);
 		return this;

--- a/spring-kafka-test/src/test/java/org/springframework/kafka/test/condition/EmbeddedKafkaConditionTests.java
+++ b/spring-kafka-test/src/test/java/org/springframework/kafka/test/condition/EmbeddedKafkaConditionTests.java
@@ -16,6 +16,8 @@
 
 package org.springframework.kafka.test.condition;
 
+import java.time.Duration;
+
 import org.junit.jupiter.api.Test;
 
 import org.springframework.kafka.test.EmbeddedKafkaBroker;
@@ -28,12 +30,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * @author Gary Russell
  * @author Michał Padula
+ * @author Artem Bilan
  *
  * @since 2.3
  *
  */
 @EmbeddedKafka(bootstrapServersProperty = "my.bss.property", count = 2, controlledShutdown = true, partitions = 3,
-		kraft = false)
+		adminTimeout = 67)
 public class EmbeddedKafkaConditionTests {
 
 	@Test
@@ -41,6 +44,7 @@ public class EmbeddedKafkaConditionTests {
 		assertThat(broker.getBrokersAsString()).isNotNull();
 		assertThat(KafkaTestUtils.getPropertyValue(broker, "brokerListProperty")).isEqualTo("my.bss.property");
 		assertThat(KafkaTestUtils.getPropertyValue(broker, "controlledShutdown")).isEqualTo(Boolean.TRUE);
+		assertThat(KafkaTestUtils.getPropertyValue(broker, "adminTimeout")).isEqualTo(Duration.ofSeconds(67));
 		assertThat(broker.getPartitionsPerTopic()).isEqualTo(3);
 	}
 

--- a/spring-kafka-test/src/test/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizerTests.java
+++ b/spring-kafka-test/src/test/java/org/springframework/kafka/test/context/EmbeddedKafkaContextCustomizerTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.kafka.test.context;
 
+import java.time.Duration;
 import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -80,6 +81,8 @@ public class EmbeddedKafkaContextCustomizerTests {
 				.isEqualTo("127.0.0.1:" + annotationWithPorts.ports()[0]);
 		assertThat(KafkaTestUtils.getPropertyValue(embeddedKafkaBroker, "brokerListProperty"))
 				.isEqualTo("my.bss.prop");
+		assertThat(KafkaTestUtils.getPropertyValue(embeddedKafkaBroker, "adminTimeout"))
+				.isEqualTo(Duration.ofSeconds(33));
 	}
 
 	@Test
@@ -121,7 +124,7 @@ public class EmbeddedKafkaContextCustomizerTests {
 
 	}
 
-	@EmbeddedKafka(kraft = false, ports = 8085, bootstrapServersProperty = "my.bss.prop")
+	@EmbeddedKafka(kraft = false, ports = 8085, bootstrapServersProperty = "my.bss.prop", adminTimeout = 33)
 	private static final class TestWithEmbeddedKafkaPorts {
 
 	}


### PR DESCRIPTION
Fixes: #3658
Issue link: https://github.com/spring-projects/spring-kafka/issues/3658

When `@EmbeddedKafka` is used with Spring context, the `adminTimeout` is not resolved. Apparently when `adminTimeout` was introduced, it was covered only by the `EmbeddedKafkaCondition`.

* Extract `EmbeddedKafkaBrokerFactory` to encapsulate an `EmbeddedKafkaBroker` creation logic (including the mentioned `adminTimeout`)
* Replace the logic in the `EmbeddedKafkaCondition` and `EmbeddedKafkaContextCustomizer` with that new `EmbeddedKafkaBrokerFactory`, essentially, introducing a single place of truth.
* Pull `adminTimeout(int)` property to the `EmbeddedKafkaBroker` interface, making the logic in the `EmbeddedKafkaBrokerFactory` simpler
* Add `adminTimeout` attribute verification into tests for condition, as well as Spring-based

**Auto-cherry-pick to `3.2.x`**

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
