### PR TITLE
GH-3662: Support Kafka 3.9.0+ in EmbeddedKafkaKraftBroker

### DIFF
--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaKraftBroker.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/EmbeddedKafkaKraftBroker.java
@@ -247,7 +247,7 @@ public class EmbeddedKafkaKraftBroker implements EmbeddedKafkaBroker {
 		System.setProperty(SPRING_EMBEDDED_KAFKA_BROKERS, getBrokersAsString());
 	}
 
-	private static void setConfigProperty(Object clusterBuilder, Object key, Object value) {
+	private static void setConfigProperty(KafkaClusterTestKit.Builder clusterBuilder, Object key, Object value) {
 		try {
 			boolean isKafka39OrLater = isClassicConsumerPresent();
 			Class<?> builderClass = clusterBuilder.getClass();
@@ -258,9 +258,8 @@ public class EmbeddedKafkaKraftBroker implements EmbeddedKafkaBroker {
 				setConfigMethod.invoke(clusterBuilder, (String) key, value);
 			}
 			else {
-				// For Kafka 3.8.0: setConfigProp(String, String)
-				Method setConfigMethod = builderClass.getMethod("setConfigProp", String.class, String.class);
-				setConfigMethod.invoke(clusterBuilder, (String) key, (String) value);
+				// For Kafka 3.8.0: direct call to setConfigProp(String, String)
+				clusterBuilder.setConfigProp((String) key, (String) value);
 			}
 		}
 		catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {


### PR DESCRIPTION
Fixes: #3662
Issue: https://github.com/spring-projects/spring-kafka/issues/3662

Add compatibility for both Kafka 3.8.0 and 3.9.0+ by handling different method signatures for setConfigProp:
- 3.9.0+: setConfigProp(String, Object)
- 3.8.0: setConfigProp(String, String)

The change uses reflection to detect Kafka version and call appropriate method.
