### PR TITLE
GH-3690: Fix observation leak in the `KafkaMessageListenerContainer`

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -966,8 +966,8 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			this.wasIdlePartition = new HashMap<>();
 			this.kafkaAdmin = obtainAdmin();
 
-			if (this.listener instanceof RecordMessagingMessageListenerAdapter<?, ?> rmmla) {
-				rmmla.setObservationRegistry(observationRegistry);
+			if (isListenerAdapterObservationAware()) {
+				((RecordMessagingMessageListenerAdapter<?, ?>) this.listener).setObservationRegistry(observationRegistry);
 			}
 		}
 
@@ -1226,6 +1226,10 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 							.ofMillis((int) CONSUMER_CONFIG_DEFAULTS.get(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG));
 				}
 			}
+		}
+
+		private boolean isListenerAdapterObservationAware() {
+			return this.listener != null && RecordMessagingMessageListenerAdapter.class.equals(this.listener.getClass());
 		}
 
 		private void subscribeOrAssignTopics(final Consumer<? super K, ? super V> subscribingConsumer) {
@@ -2772,7 +2776,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			catch (RuntimeException e) {
 				failureTimer(sample, cRecord);
 				recordInterceptAfter(cRecord, e);
-				if (!(this.listener instanceof RecordMessagingMessageListenerAdapter<K, V>)) {
+				if (!isListenerAdapterObservationAware()) {
 					observation.error(e);
 				}
 				if (this.commonErrorHandler == null) {
@@ -2800,7 +2804,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 				}
 			}
 			finally {
-				if (!(this.listener instanceof RecordMessagingMessageListenerAdapter<K, V>)) {
+				if (!isListenerAdapterObservationAware()) {
 					observation.stop();
 				}
 				observationScope.close();


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-kafka/issues/3690

When `this.listener` is an instance of `RecordMessagingMessageListenerAdapter`, we rely on its logic to call `invoke()` from super class to handle observation lifecycle this or other way.
However, Spring Integration's `KafkaMessageDrivenChannelAdapter` use its own `IntegrationRecordMessageListener` extension of the `RecordMessagingMessageListenerAdapter` without calling super `invoke()`.
The problem apparent from Spring Cloud Stream Kafka Binder, where an observation is enabled.

* Fix `KafkaMessageListenerContainer` to check for exact type of `this.listener` before making decision to close an observation here, or propagate it down to the `RecordMessagingMessageListenerAdapter`

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
