### PR TITLE
GH-3695: Fix `MessagingMessageListenerAdapter` to not ack when sync

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
@@ -80,9 +80,9 @@ import org.springframework.util.StringUtils;
 import org.springframework.util.TypeUtils;
 
 /**
- * An abstract {@link org.springframework.kafka.listener.MessageListener} adapter
+ * An abstract {@link MessageListener} adapter
  * providing the necessary infrastructure to extract the payload of a
- * {@link org.springframework.messaging.Message}.
+ * {@link Message}.
  *
  * @param <K> the key type.
  * @param <V> the value type.
@@ -205,9 +205,9 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 
 	/**
 	 * Return the {@link MessagingMessageConverter} for this listener,
-	 * being able to convert {@link org.springframework.messaging.Message}.
+	 * being able to convert {@link Message}.
 	 * @return the {@link MessagingMessageConverter} for this listener,
-	 * being able to convert {@link org.springframework.messaging.Message}.
+	 * being able to convert {@link Message}.
 	 */
 	protected final RecordMessageConverter getMessageConverter() {
 		return this.messageConverter;
@@ -550,7 +550,9 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 			try {
 				if (t == null) {
 					asyncSuccess(r, replyTopic, source, messageReturnType);
-					acknowledge(acknowledgment);
+					if (isAsyncReplies()) {
+						acknowledge(acknowledgment);
+					}
 				}
 				else {
 					Throwable cause = t instanceof CompletionException ? t.getCause() : t;


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-kafka/issues/3695

Even if th `@KafkaHandler` method is `void` the `DelegatingInvocableHandler` returns an empty `InvocationResult`. That triggers a `MessagingMessageListenerAdapter.handleResult()` logic. On the `completableFutureResult.whenComplete()` we call `acknowledge()` which is not expected for `void` POJO methods.

* Fix `MessagingMessageListenerAdapter` to check for `isAsyncReplies()` before calling `acknowledge()`

This is a regression after https://github.com/spring-projects/spring-kafka/issues/3528

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
