### PR TITLE
Fixing the class names in one of the documentation provided snippets.

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/testing.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/testing.adoc
@@ -275,7 +275,7 @@ public class KafkaStreamsTests {
 
     @Configuration
     @EnableKafkaStreams
-    public static class KafkaStreamsConfiguration {
+    public static class TestKafkaStreamsConfiguration {
 
         @Value("${" + EmbeddedKafkaBroker.SPRING_EMBEDDED_KAFKA_BROKERS + "}")
         private String brokerAddresses;


### PR DESCRIPTION
Fixing a typo in the documentation - see #3701.