### PR TITLE
Correct non-blocking retries docs

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/retrytopic/features.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/retrytopic/features.adoc
@@ -97,7 +97,7 @@ You can also set it to traverse the causes to lookup nested exceptions.
 
 [source, java]
 ----
-@RetryableTopic(include = {MyRetryException.class, MyOtherRetryException.class}, traversingCauses = true)
+@RetryableTopic(include = {MyRetryException.class, MyOtherRetryException.class}, traversingCauses = "true")
 @KafkaListener(topics = "my-annotated-topic")
 public void processMessage(MyPojo message) {
     throw new RuntimeException(new MyRetryException()); // will retry
@@ -175,13 +175,13 @@ IMPORTANT: Note that if you're not using Spring Boot you'll have to provide a Ka
 
 [source, java]
 ----
-@RetryableTopic(numPartitions = 2, replicationFactor = 3)
+@RetryableTopic(numPartitions = "2", replicationFactor = "3")
 @KafkaListener(topics = "my-annotated-topic")
 public void processMessage(MyPojo message) {
     // ... message processing
 }
 
-@RetryableTopic(autoCreateTopics = false)
+@RetryableTopic(autoCreateTopics = "false")
 @KafkaListener(topics = "my-annotated-topic")
 public void processMessage(MyPojo message) {
     // ... message processing
@@ -245,7 +245,7 @@ Starting with version 2.9.5, if the `Headers` returned by the function contains 
 
 As can be seen in xref:retrytopic/features.adoc#retry-headers[Failure Header Management] it is possible to customize the default `DeadLetterPublishingRecoverer` instances created by the framework.
 However, for some use cases, it is necessary to subclass the `DeadLetterPublishingRecoverer`, for example to override `createProducerRecord()` to modify the contents sent to the retry (or dead-letter) topics.
-Starting with version 3.0.9, you can override the `RetryConfigurationSupport.configureDeadLetterPublishingContainerFactory()` method to provide a `DeadLetterPublisherCreator` instance, for example:
+Starting with version 3.0.9, you can override the `RetryTopicConfigurationSupport.configureDeadLetterPublishingContainerFactory()` method to provide a `DeadLetterPublisherCreator` instance, for example:
 
 [source, java]
 ----

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/retrytopic/how-the-pattern-works.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/retrytopic/how-the-pattern-works.adoc
@@ -15,7 +15,7 @@ IMPORTANT: You can set the `AckMode` mode you prefer, but `RECORD` is suggested.
 
 When using a manual `AckMode` with `asyncAcks` set to true, the `DefaultErrorHandler` must be configured with `seekAfterError` set to `false`.
 Starting with versions 2.9.10, 3.0.8, this will be set to `false` unconditionally for such configurations.
-With earlier versions, it was necessary to override the `RetryConfigurationSupport.configureCustomizers()` method to set the property to `false`.
+With earlier versions, it was necessary to override the `RetryTopicConfigurationSupport.configureCustomizers()` method to set the property to `false`.
 
 [source, java]
 ----

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/retrytopic/retry-config.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/retrytopic/retry-config.adoc
@@ -10,7 +10,7 @@ Also, starting with that version, for more advanced configuration of the feature
 For more details refer to xref:retrytopic/retry-config.adoc#retry-topic-global-settings[Configuring Global Settings and Features].
 
 By default, the containers for the retry topics will have the same concurrency as the main container.
-Starting with version 3.0, you can set a different `concurrency` for the retry containers (either on the annotation, or in `RetryConfigurationBuilder`).
+Starting with version 3.0, you can set a different `concurrency` for the retry containers (either on the annotation, or in `RetryTopicConfigurationBuilder`).
 
 IMPORTANT: Only one of the above techniques can be used, and only one `@Configuration` class can extend `RetryTopicConfigurationSupport`.
 
@@ -100,7 +100,7 @@ public RetryTopicConfiguration myRetryTopic(KafkaTemplate<String, MyPojo> templa
             .fixedBackOff(3000)
             .maxAttempts(5)
             .concurrency(1)
-            .includeTopics("my-topic", "my-other-topic")
+            .includeTopics(List.of("my-topic", "my-other-topic"))
             .create(template);
 }
 
@@ -110,7 +110,7 @@ public RetryTopicConfiguration myOtherRetryTopic(KafkaTemplate<String, MyOtherPo
             .newInstance()
             .exponentialBackoff(1000, 2, 5000)
             .maxAttempts(4)
-            .excludeTopics("my-topic", "my-other-topic")
+            .excludeTopics(List.of("my-topic", "my-other-topic"))
             .retryOn(MyException.class)
             .create(template);
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 the original author or authors.
+ * Copyright 2018-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -118,7 +118,7 @@ import org.springframework.lang.Nullable;
  *                 .newInstance()
  *                 .fixedBackOff(3000)
  *                 .maxAttempts(5)
- *                 .includeTopics("my-topic", "my-other-topic")
+ *                 .includeTopics(List.of("my-topic", "my-other-topic"))
  *                 .create(template);
  *         }</code>
  * </pre>
@@ -129,7 +129,7 @@ import org.springframework.lang.Nullable;
  *                 .newInstance()
  *                 .exponentialBackoff(1000, 2, 5000)
  *                 .maxAttempts(4)
- *                 .excludeTopics("my-topic", "my-other-topic")
+ *                 .excludeTopics(List.of("my-topic", "my-other-topic"))
  *                 .retryOn(MyException.class)
  *                 .create(template);
  *         }</code>


### PR DESCRIPTION
<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->

## Description

- Corrected `RetryConfigurationSupport` to `RetryTopicConfigurationSupport` in `features.adoc`, `how-the-pattern-works.adoc` `retry-config.adoc`.
- Added quotes(`""`) for string-type attributes in `@RetryableTopic` (e.g., traversingCauses, numPartitions, autoCreateTopics).
- Updated `RetryTopicConfigurationBuilder` methods to use `List` for arguments (e.g., includeTopics(), excludeTopics()).