### PR TITLE
GH-3734: Configure Gradle toolchain auto-provisioning

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -7,6 +7,7 @@ pluginManagement {
 
 plugins {
 	id 'io.spring.develocity.conventions' version '0.0.22'
+	id 'org.gradle.toolchains.foojay-resolver-convention' version '0.9.0'
 }
 
 rootProject.name = 'spring-kafka-dist'


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-kafka/issues/3734

This commit configures the Foojay resolver plugin in the Gradle build to auto-provision a required JDK distribution if it's not present already on the host.

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
