### PR TITLE
Fix typo in `CONTRIBUTING` and `README`

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -113,10 +113,10 @@ From the command line you can check this using:
 log --graph --pretty=oneline
 ----
 
-As this may cause lots of typing, we recommend creating a global alias, e.g. `git log` for this:
+As this may cause lots of typing, we recommend creating a global alias, e.g. `git logg` for this:
 
 ----
-git config --global alias.log 'log --graph --pretty=oneline'
+git config --global alias.logg 'log --graph --pretty=oneline'
 ----
 
 This command, will provide the following output, which in this case shows a nice linear history:

--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -113,10 +113,10 @@ From the command line you can check this using:
 log --graph --pretty=oneline
 ----
 
-As this may cause lots of typing, we recommend creating a global alias, e.g. `git logg` for this:
+As this may cause lots of typing, we recommend creating a global alias, e.g. `git log` for this:
 
 ----
-git config --global alias.logg 'log --graph --pretty=oneline'
+git config --global alias.log 'log --graph --pretty=oneline'
 ----
 
 This command, will provide the following output, which in this case shows a nice linear history:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Spring for Apache Kafka
 
 # Code of Conduct
 
-Please see our [Code of conduct](https://github.com/spring-projects/.github/blob/master/CODE_OF_CONDUCT.md).
+Please see our [Code of conduct](https://github.com/spring-projects/.github/blob/main/CODE_OF_CONDUCT.md).
 
 # Reporting Security Vulnerabilities
 


### PR DESCRIPTION
<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
