### PR TITLE
GH-3740: Fix `HandlerAdapter` to detect Kotlin suspend functions

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/HandlerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/HandlerAdapter.java
@@ -16,8 +16,11 @@
 
 package org.springframework.kafka.listener.adapter;
 
+import java.lang.reflect.Method;
+
 import org.jspecify.annotations.Nullable;
 
+import org.springframework.core.KotlinDetector;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
 
@@ -27,6 +30,7 @@ import org.springframework.messaging.handler.invocation.InvocableHandlerMethod;
  * underlying handler.
  *
  * @author Gary Russell
+ * @author Artem Bilan
  *
  */
 public class HandlerAdapter {
@@ -44,7 +48,10 @@ public class HandlerAdapter {
 	public HandlerAdapter(InvocableHandlerMethod invokerHandlerMethod) {
 		this.invokerHandlerMethod = invokerHandlerMethod;
 		this.delegatingHandler = null;
-		this.asyncReplies = AdapterUtils.isAsyncReply(invokerHandlerMethod.getMethod().getReturnType());
+		Method handlerMethod = invokerHandlerMethod.getMethod();
+		this.asyncReplies =
+				AdapterUtils.isAsyncReply(handlerMethod.getReturnType())
+						|| KotlinDetector.isSuspendingFunction(handlerMethod);
 	}
 
 	/**


### PR DESCRIPTION
Fixes: #3740
Issue link: https://github.com/spring-projects/spring-kafka/issues/3740

Even if Kotlin `suspend` functions are called properly, the acknowledgement is not called because this kind of method is not treated as an `asyncReplies` mode

* Fix `HandlerAdapter` to check for `KotlinDetector.isSuspendingFunction()` in addition to `CompletableFuture` & `Mono`
* Adjust `EnableKafkaKotlinCoroutinesTests.kt` to verify that `acknowledgement` has been called by the Framework

**Auto-cherry-pick to `3.3.x` & `3.2.x`**

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
