### PR TITLE
GH-3741: Fix metric tag to show underlying exception type

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
@@ -425,7 +425,7 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 		}
 		catch (ListenerExecutionFailedException e) {
 			listenerError = e;
-			currentObservation.error(e);
+			currentObservation.error(e.getCause() != null ? e.getCause() : e);
 			handleException(records, acknowledgment, consumer, message, e);
 		}
 		catch (Error e) {

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/micrometer/MicrometerMetricsTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/micrometer/MicrometerMetricsTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.kafka.support.micrometer;
 
-import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -25,8 +24,6 @@ import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.observation.DefaultMeterObservationHandler;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import io.micrometer.observation.ObservationRegistry;
-import io.micrometer.tracing.test.simple.SimpleTracer;
-import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.jupiter.api.Test;
 
@@ -39,7 +36,6 @@ import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
-import org.springframework.kafka.core.KafkaAdmin;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.test.EmbeddedKafkaBroker;
@@ -52,7 +48,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Soby Chacko
- * @since 3.3.3
+ * @since 3.2.7
  */
 @SpringJUnitConfig
 @EmbeddedKafka(topics = { MicrometerMetricsTests.METRICS_TEST_TOPIC }, partitions = 1)
@@ -100,13 +96,6 @@ public class MicrometerMetricsTests {
 	@Configuration
 	@EnableKafka
 	static class Config {
-
-		@Bean
-		KafkaAdmin admin(EmbeddedKafkaBroker broker) {
-			return new KafkaAdmin(Map.of(
-					AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG,
-					broker.getBrokersAsString()));
-		}
 
 		@Bean
 		ProducerFactory<Integer, String> producerFactory(EmbeddedKafkaBroker broker) {
@@ -160,11 +149,6 @@ public class MicrometerMetricsTests {
 		@Bean
 		ObservationListener observationListener() {
 			return new ObservationListener();
-		}
-
-		@Bean
-		SimpleTracer simpleTracer() {
-			return new SimpleTracer();
 		}
 
 		@Bean

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/micrometer/MicrometerMetricsTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/micrometer/MicrometerMetricsTests.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support.micrometer;
+
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.observation.DefaultMeterObservationHandler;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.tracing.test.simple.SimpleTracer;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaAdmin;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Soby Chacko
+ * @since 3.3.3
+ */
+@SpringJUnitConfig
+@EmbeddedKafka(topics = { MicrometerMetricsTests.METRICS_TEST_TOPIC }, partitions = 1)
+@DirtiesContext
+public class MicrometerMetricsTests {
+
+	public final static String METRICS_TEST_TOPIC = "metrics.test.topic";
+
+	@Test
+	void verifyMetricsWithoutObservation(@Autowired MetricsListener listener,
+			@Autowired MeterRegistry meterRegistry,
+			@Autowired KafkaTemplate<Integer, String> template)
+			throws Exception {
+
+		template.send(METRICS_TEST_TOPIC, "test").get(10, TimeUnit.SECONDS);
+		assertThat(listener.latch.await(10, TimeUnit.SECONDS)).isTrue();
+
+		Timer timer = meterRegistry.find("spring.kafka.listener")
+				.tags("name", "metricsTest-0")
+				.tag("result", "failure")
+				.timer();
+
+		assertThat(timer).isNotNull();
+		assertThat(timer.getId().getTag("exception"))
+				.isEqualTo("IllegalStateException");
+	}
+
+	@Test
+	void verifyMetricsWithObservation(@Autowired ObservationListener observationListener,
+			@Autowired MeterRegistry meterRegistry,
+			@Autowired KafkaTemplate<Integer, String> template)
+			throws Exception {
+
+		template.send(METRICS_TEST_TOPIC, "test").get(10, TimeUnit.SECONDS);
+		assertThat(observationListener.latch.await(10, TimeUnit.SECONDS)).isTrue();
+
+		Timer timer = meterRegistry.find("spring.kafka.listener")
+				.tag("spring.kafka.listener.id", "observationTest-0")
+				.tag("error", "IllegalStateException")
+				.timer();
+
+		assertThat(timer).isNotNull();
+	}
+
+	@Configuration
+	@EnableKafka
+	static class Config {
+
+		@Bean
+		KafkaAdmin admin(EmbeddedKafkaBroker broker) {
+			return new KafkaAdmin(Map.of(
+					AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG,
+					broker.getBrokersAsString()));
+		}
+
+		@Bean
+		ProducerFactory<Integer, String> producerFactory(EmbeddedKafkaBroker broker) {
+			return new DefaultKafkaProducerFactory<>(
+					KafkaTestUtils.producerProps(broker));
+		}
+
+		@Bean
+		ConsumerFactory<Integer, String> consumerFactory(EmbeddedKafkaBroker broker) {
+			return new DefaultKafkaConsumerFactory<>(
+					KafkaTestUtils.consumerProps("metrics", "false", broker));
+		}
+
+		@Bean
+		KafkaTemplate<Integer, String> template(ProducerFactory<Integer, String> pf) {
+			return new KafkaTemplate<>(pf);
+		}
+
+		@Bean
+		ConcurrentKafkaListenerContainerFactory<Integer, String> kafkaListenerContainerFactory(
+				ConsumerFactory<Integer, String> cf) {
+			ConcurrentKafkaListenerContainerFactory<Integer, String> factory =
+					new ConcurrentKafkaListenerContainerFactory<>();
+			factory.setConsumerFactory(cf);
+			factory.getContainerProperties().setMicrometerEnabled(true);
+			factory.getContainerProperties().setObservationEnabled(false);
+			return factory;
+		}
+
+		@Bean
+		ConcurrentKafkaListenerContainerFactory<Integer, String> observationListenerContainerFactory(
+				ConsumerFactory<Integer, String> cf, ObservationRegistry observationRegistry) {
+			ConcurrentKafkaListenerContainerFactory<Integer, String> factory =
+					new ConcurrentKafkaListenerContainerFactory<>();
+			factory.setConsumerFactory(cf);
+			factory.getContainerProperties().setObservationEnabled(true);
+			factory.getContainerProperties().setObservationRegistry(observationRegistry);
+			return factory;
+		}
+
+		@Bean
+		MetricsListener metricsListener() {
+			return new MetricsListener();
+		}
+
+		@Bean
+		MeterRegistry meterRegistry() {
+			return new SimpleMeterRegistry();
+		}
+
+		@Bean
+		ObservationListener observationListener() {
+			return new ObservationListener();
+		}
+
+		@Bean
+		SimpleTracer simpleTracer() {
+			return new SimpleTracer();
+		}
+
+		@Bean
+		ObservationRegistry observationRegistry(MeterRegistry meterRegistry) {
+			ObservationRegistry observationRegistry = ObservationRegistry.create();
+			observationRegistry.observationConfig()
+					.observationHandler(new DefaultMeterObservationHandler(meterRegistry));
+			return observationRegistry;
+		}
+	}
+
+	static class MetricsListener {
+		final CountDownLatch latch = new CountDownLatch(1);
+
+		@KafkaListener(id = "metricsTest", topics = METRICS_TEST_TOPIC)
+		void listen(ConsumerRecord<Integer, String> in) {
+			try {
+				throw new IllegalStateException("metrics test exception");
+			}
+			finally {
+				latch.countDown();
+			}
+		}
+	}
+
+	static class ObservationListener {
+		final CountDownLatch latch = new CountDownLatch(1);
+
+		@KafkaListener(id = "observationTest",
+				topics = METRICS_TEST_TOPIC,
+				containerFactory = "observationListenerContainerFactory")
+		void listen(ConsumerRecord<Integer, String> in) {
+			try {
+				throw new IllegalStateException("observation test exception");
+			}
+			finally {
+				latch.countDown();
+			}
+		}
+	}
+
+}
+


### PR DESCRIPTION
Fixes: #3741
Issue: https://github.com/spring-projects/spring-kafka/issues/3741

When exceptions occur in Kafka listeners, the metrics currently show `ListenerExecutionFailedException` in both the `error` tag (when using observation) and `exception` tag (when using micrometer without observation), rather than the actual underlying exception.

* Modify ListenerContainer to pass actual exception to failure metrics
* Update MessagingMessageListenerAdapter to report cause to observation
* Add MicrometerMetricsTests to verify both observation and non-observation metrics
* Fix ObservationTests to verify correct error reporting in metrics

This ensures metrics show the actual underlying exception while maintaining existing span behavior.

Signed-off-by: Soby Chacko <soby.chacko@broadcom.com>

**Auto-cherry-pick to `3.3.x` & `3.2.x`**
