### PR TITLE
feat: Replace LinkedList with ArrayList

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -16,7 +16,6 @@
 
 package org.springframework.kafka.listener;
 
-import java.lang.reflect.Array;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.AbstractMap.SimpleEntry;
@@ -2239,15 +2238,9 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		}
 
 		private List<ConsumerRecord<K, V>> createRecordList(final ConsumerRecords<K, V> records) {
-			Iterator<ConsumerRecord<K, V>> iterator = records.iterator();
-			@SuppressWarnings("unchecked") ConsumerRecord<K, V>[] recordsArray =
-					(ConsumerRecord<K, V>[]) Array.newInstance(ConsumerRecord.class, records.count());
-			int index = 0;
-			while (iterator.hasNext()) {
-				recordsArray[index] = iterator.next();
-				index += 1;
-			}
-			return Arrays.asList(recordsArray);
+			List<ConsumerRecord<K, V>> recordList = new ArrayList<>(records.count());
+			records.forEach(recordList::add);
+			return recordList;
 		}
 
 		/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -173,6 +173,7 @@ import org.springframework.util.StringUtils;
  * @author Sanghyeok An
  * @author Christian Fredriksson
  * @author Timofey Barabanov
+ * @author Janek Lasocki-Biczysko
  */
 public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		extends AbstractMessageListenerContainer<K, V> implements ConsumerPauseResumeEventPublisher {

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -16,6 +16,7 @@
 
 package org.springframework.kafka.listener;
 
+import java.lang.reflect.Array;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.AbstractMap.SimpleEntry;
@@ -2238,11 +2239,14 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 
 		private List<ConsumerRecord<K, V>> createRecordList(final ConsumerRecords<K, V> records) {
 			Iterator<ConsumerRecord<K, V>> iterator = records.iterator();
-			List<ConsumerRecord<K, V>> list = new LinkedList<>();
+			@SuppressWarnings("unchecked") ConsumerRecord<K, V>[] recordsArray =
+					(ConsumerRecord<K, V>[]) Array.newInstance(ConsumerRecord.class, records.count());
+			int index = 0;
 			while (iterator.hasNext()) {
-				list.add(iterator.next());
+				recordsArray[index] = iterator.next();
+				index += 1;
 			}
-			return list;
+			return Arrays.asList(recordsArray);
 		}
 
 		/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/RecordFilterStrategy.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/RecordFilterStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2025 the original author or authors.
+ * Copyright 2016-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,7 +16,6 @@
 
 package org.springframework.kafka.listener.adapter;
 
-import java.util.Arrays;
 import java.util.List;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -33,7 +32,6 @@ import org.springframework.kafka.listener.BatchMessageListener;
  *
  * @author Gary Russell
  * @author Sanghyeok An
- * @author Janek Lasocki-Biczysko
  */
 public interface RecordFilterStrategy<K, V> {
 
@@ -51,10 +49,9 @@ public interface RecordFilterStrategy<K, V> {
 	 * @return the filtered records.
 	 * @since 2.8
 	 */
-	@SuppressWarnings("unchecked")
 	default List<ConsumerRecord<K, V>> filterBatch(List<ConsumerRecord<K, V>> records) {
-		var recordsArray = records.stream().filter(record -> !this.filter(record)).toArray(ConsumerRecord[]::new);
-		return Arrays.asList(recordsArray);
+		records.removeIf(this::filter);
+		return records;
 	}
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/RecordFilterStrategy.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/RecordFilterStrategy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016-2024 the original author or authors.
+ * Copyright 2016-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.springframework.kafka.listener.BatchMessageListener;
  *
  * @author Gary Russell
  * @author Sanghyeok An
+ * @author Janek Lasocki-Biczysko
  */
 public interface RecordFilterStrategy<K, V> {
 
@@ -50,8 +51,7 @@ public interface RecordFilterStrategy<K, V> {
 	 * @since 2.8
 	 */
 	default List<ConsumerRecord<K, V>> filterBatch(List<ConsumerRecord<K, V>> records) {
-		records.removeIf(this::filter);
-		return records;
+		return records.stream().filter(record -> !this.filter(record)).toList();
 	}
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/RecordFilterStrategy.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/RecordFilterStrategy.java
@@ -16,6 +16,7 @@
 
 package org.springframework.kafka.listener.adapter;
 
+import java.util.Arrays;
 import java.util.List;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -50,8 +51,10 @@ public interface RecordFilterStrategy<K, V> {
 	 * @return the filtered records.
 	 * @since 2.8
 	 */
+	@SuppressWarnings("unchecked")
 	default List<ConsumerRecord<K, V>> filterBatch(List<ConsumerRecord<K, V>> records) {
-		return records.stream().filter(record -> !this.filter(record)).toList();
+		var recordsArray = records.stream().filter(record -> !this.filter(record)).toArray(ConsumerRecord[]::new);
+		return Arrays.asList(recordsArray);
 	}
 
 	/**


### PR DESCRIPTION
Initialise the "batch of records" list container as an ArrayList rather than LinkedList. 

Using a LinkedList has an impact on performance as outlined here https://github.com/spring-projects/spring-kafka/issues/3764

(fixes #3764)