### PR TITLE
Handle null group id in listener observation

### DIFF
--- a/spring-kafka/src/test/java/org/springframework/kafka/support/micrometer/KafkaListenerObservationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/micrometer/KafkaListenerObservationTests.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support.micrometer;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.kafka.support.micrometer.KafkaListenerObservation.DefaultKafkaListenerObservationConvention;
+
+/**
+ * @author Christian Fredriksson
+ */
+public class KafkaListenerObservationTests {
+
+	@Test
+	void lowCardinalityKeyValues() {
+		ConsumerRecord<String, String> record = new ConsumerRecord<>("topic", 1, 2, "key", "value");
+		KafkaRecordReceiverContext context = new KafkaRecordReceiverContext(record, "listener", () -> null);
+		DefaultKafkaListenerObservationConvention.INSTANCE.getLowCardinalityKeyValues(context);
+	}
+
+	@Test
+	void highCardinalityKeyValues() {
+		ConsumerRecord<String, String> record = new ConsumerRecord<>("topic", 1, 2, "key", "value");
+		KafkaRecordReceiverContext context = new KafkaRecordReceiverContext(record, "listener", () -> null);
+		DefaultKafkaListenerObservationConvention.INSTANCE.getHighCardinalityKeyValues(context);
+	}
+}


### PR DESCRIPTION
This change fixes an NPE when group id is null and observation is enabled.