### PR TITLE
Fix KafkaTemplate hiding exceptions when starting observation

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
@@ -805,8 +805,8 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 				this.observationConvention, DefaultKafkaTemplateObservationConvention.INSTANCE,
 				() -> new KafkaRecordSenderContext(producerRecord, this.beanName, this::clusterId),
 				this.observationRegistry);
+		observation.start();
 		try {
-			observation.start();
 			try (Observation.Scope ignored = observation.openScope()) {
 				return doSend(producerRecord, observation);
 			}


### PR DESCRIPTION
This fixes that exceptions thrown from observation.start() are hidden by KafkaTemplate throwing a new exception due to registering observation error without successfully starting the observation.
Signed-off-by: Christian Fredriksson <christian.fredriksson.2@volvocars.com>