### PR TITLE
GH-3810 Move the logging statement after the conditional statement.

### DIFF
--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/utils/KafkaTestUtils.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/utils/KafkaTestUtils.java
@@ -368,14 +368,14 @@ public final class KafkaTestUtils {
 		do {
 			long t1 = System.currentTimeMillis();
 			ConsumerRecords<K, V> received = consumer.poll(Duration.ofMillis(remaining));
+			if (received == null) {
+				throw new IllegalStateException("null received from consumer.poll()");
+			}
 			logger.debug(() -> "Received: " + received.count() + ", "
 					+ received.partitions().stream()
 					.flatMap(p -> received.records(p).stream())
 					// map to same format as send metadata toString()
 					.map(r -> r.topic() + "-" + r.partition() + "@" + r.offset()).toList());
-			if (received == null) {
-				throw new IllegalStateException("null received from consumer.poll()");
-			}
 			if (minRecords < 0) {
 				return received;
 			}


### PR DESCRIPTION
Fixes: #3810

Move the logging statement after the conditional statement.

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
