### PR TITLE
GH-3829: Remove items marked as deprecated in previous generations

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/event/ConsumerPartitionPausedEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/ConsumerPartitionPausedEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2024 the original author or authors.
+ * Copyright 2018-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,16 +42,6 @@ public class ConsumerPartitionPausedEvent extends KafkaEvent {
 	public ConsumerPartitionPausedEvent(Object source, Object container, TopicPartition partition) {
 		super(source, container);
 		this.partition = partition;
-	}
-
-	/**
-	 * Return the paused partition.
-	 * @return the partition.
-	 * @deprecated replaced by {@link #getPartition()}
-	 */
-	@Deprecated(since = "3.3", forRemoval = true)
-	public TopicPartition getPartitions() {
-		return this.partition;
 	}
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractConsumerSeekAware.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractConsumerSeekAware.java
@@ -23,12 +23,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 import org.apache.kafka.common.TopicPartition;
 import org.jspecify.annotations.Nullable;
-
-import org.springframework.util.CollectionUtils;
 
 /**
  * Manages the {@link ConsumerSeekAware.ConsumerSeekCallback} s for the listener. If the
@@ -90,22 +87,6 @@ public abstract class AbstractConsumerSeekAware implements ConsumerSeekAware {
 	}
 
 	/**
-     * Return the callback for the specified topic/partition.
-     * @param topicPartition the topic/partition.
-     * @return the callback (or null if there is no assignment).
-     * @deprecated Replaced by {@link #getSeekCallbacksFor(TopicPartition)}
-     */
-	@Deprecated(since = "3.3", forRemoval = true)
-	@Nullable
-	protected ConsumerSeekCallback getSeekCallbackFor(TopicPartition topicPartition) {
-		List<ConsumerSeekCallback> callbacks = getSeekCallbacksFor(topicPartition);
-		if (CollectionUtils.isEmpty(callbacks)) {
-			return null;
-		}
-		return callbacks.get(0);
-	}
-
-	/**
      * Return the callbacks for the specified topic/partition.
      * @param topicPartition the topic/partition.
      * @return the callbacks (or null if there is no assignment).
@@ -114,22 +95,6 @@ public abstract class AbstractConsumerSeekAware implements ConsumerSeekAware {
 	@Nullable
 	protected List<ConsumerSeekCallback> getSeekCallbacksFor(TopicPartition topicPartition) {
 		return this.topicToCallbacks.get(topicPartition);
-	}
-
-	/**
-	 * The map of callbacks for all currently assigned partitions.
-	 * @return the map.
-	 * @deprecated Replaced by {@link #getTopicsAndCallbacks()}
-	 */
-	@Deprecated(since = "3.3", forRemoval = true)
-	protected Map<TopicPartition, ConsumerSeekCallback> getSeekCallbacks() {
-		Map<TopicPartition, List<ConsumerSeekCallback>> topicsAndCallbacks = getTopicsAndCallbacks();
-		return topicsAndCallbacks.entrySet().stream()
-			.filter(entry -> !entry.getValue().isEmpty())
-			.collect(Collectors.toMap(
-					Map.Entry::getKey,
-					entry -> entry.getValue().get(0)
-			));
 	}
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
@@ -92,8 +92,7 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 
 	private final EnumSet<HeaderNames.HeadersToAdd> whichHeaders = EnumSet.allOf(HeaderNames.HeadersToAdd.class);
 
-	@SuppressWarnings("this-escape")
-	private @Nullable HeaderNames headerNames = getHeaderNames();
+	private @Nullable HeaderNames headerNames;
 
 	private boolean retainExceptionHeader;
 
@@ -875,20 +874,6 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 		PrintWriter printWriter = new PrintWriter(stringWriter, true);
 		cause.printStackTrace(printWriter);
 		return stringWriter.getBuffer().toString();
-	}
-
-	/**
-	 * Override this if you want different header names to be used
-	 * in the sent record.
-	 * @return the header names.
-	 * @since 2.7
-	 * @deprecated since 3.0.9 - provide a supplier instead.
-	 * @see #setHeaderNamesSupplier(Supplier)
-	 */
-	@Nullable
-	@Deprecated(since = "3.0.9", forRemoval = true) // 3.2
-	protected HeaderNames getHeaderNames() {
-		return null;
 	}
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ListenerUtils.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ListenerUtils.java
@@ -87,42 +87,6 @@ public final class ListenerUtils {
 	 * interval for this thread.
 	 * @param container the container or parent container.
 	 * @throws InterruptedException if the thread is interrupted.
-	 * @since 2.7
-	 * @deprecated in favor of
-	 * {@link #unrecoverableBackOff(BackOff, Map, Map, MessageListenerContainer)}.
-	 */
-	@Deprecated(since = "3.1", forRemoval = true) // 3.2
-	public static void unrecoverableBackOff(BackOff backOff, ThreadLocal<BackOffExecution> executions,
-			ThreadLocal<Long> lastIntervals, MessageListenerContainer container) throws InterruptedException {
-
-		BackOffExecution backOffExecution = executions.get();
-		if (backOffExecution == null) {
-			backOffExecution = backOff.start();
-			executions.set(backOffExecution);
-		}
-		Long interval = backOffExecution.nextBackOff();
-		if (interval == BackOffExecution.STOP) {
-			interval = lastIntervals.get();
-			if (interval == null) {
-				interval = Long.valueOf(0);
-			}
-		}
-		lastIntervals.set(interval);
-		if (interval > 0) {
-			stoppableSleep(container, interval);
-		}
-	}
-
-	/**
-	 * Sleep according to the {@link BackOff}; when the {@link BackOffExecution} returns
-	 * {@link BackOffExecution#STOP} sleep for the previous backOff.
-	 * @param backOff the {@link BackOff} to create a new {@link BackOffExecution}.
-	 * @param executions a thread local containing the {@link BackOffExecution} for this
-	 * thread.
-	 * @param lastIntervals a thread local containing the previous {@link BackOff}
-	 * interval for this thread.
-	 * @param container the container or parent container.
-	 * @throws InterruptedException if the thread is interrupted.
 	 * @since 3.1
 	 */
 	public static void unrecoverableBackOff(BackOff backOff, Map<Thread, BackOffExecution> executions,

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DestinationTopicContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DestinationTopicContainer.java
@@ -63,20 +63,6 @@ public interface DestinationTopicContainer {
 
 	/**
 	 * Returns the {@link DestinationTopic} instance registered as
-	 * DLT for the given topic, or null if none is found.
-	 * @param mainListenerId the listener id.
-	 * @param topicName the topic name for which to look the DLT for
-	 * @return The {@link DestinationTopic} instance corresponding to the DLT.
-	 * @deprecated Replaced by {@link #getDltFor(String, String, Exception)}
-	 */
-	@Nullable
-	@Deprecated(since = "3.2", forRemoval = true)
-	default DestinationTopic getDltFor(String mainListenerId, String topicName) {
-		return getDltFor(mainListenerId, topicName, null);
-	}
-
-	/**
-	 * Returns the {@link DestinationTopic} instance registered as
 	 * DLT for the given topic taking into consideration the exception
 	 * thrown, or null if none is found.
 	 * @param mainListenerId the listener id.

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/KafkaUtils.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/KafkaUtils.java
@@ -159,16 +159,6 @@ public final class KafkaUtils {
 	}
 
 	/**
-	 * Set to true to only log record metadata.
-	 * @param onlyMeta true to only log record metadata.
-	 * @since 2.7.12
-	 * @deprecated - no longer used.
-	 */
-	@Deprecated(since = "3.1", forRemoval = true) // 3.2
-	public static void setLogOnlyMetadata(boolean onlyMeta) {
-	}
-
-	/**
 	 * Set a formatter for logging {@link ConsumerRecord}s.
 	 * @param formatter a function to format the record as a String
 	 * @since 2.7.12


### PR DESCRIPTION
Fixes: #3829
Issue: https://github.com/spring-projects/spring-kafka/issues/3829

Since 4.0.0 is a new major version, we can remove all the previously deprecated components.

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
