### PR TITLE
Support reactive KafkaEntity

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/EnableKafkaEntity.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/EnableKafkaEntity.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.context.annotation.Import;
+import org.springframework.kafka.entity.reactive.KafkaEntityDefaultConfiguration;
+import org.springframework.kafka.entity.reactive.KafkaEntityProcessor;
+import org.springframework.kafka.entity.reactive.KafkaEntityPublisher;
+import org.springframework.kafka.entity.reactive.KafkaEntitySubscriber;
+
+/**
+ * Enable Kafka Entities annotated fields. To be used on
+ * {@link org.springframework.context.annotation.Configuration Configuration} classes.
+ *
+ * Note that all fields in beans annotated with  fields in Beans annotated
+ * with @{@link KafkaEntityProcessor} @{@link KafkaEntitySubscriber} @{@link KafkaEntityPublisher} will be detected.
+ *
+ * @author Popovics Boglarka
+ *
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Import(KafkaEntityDefaultConfiguration.class)
+public @interface EnableKafkaEntity {
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/entity/KafkaEntity.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/entity/KafkaEntity.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2016-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.entity;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * define per topic one class or record and mark with @KafkaEntity (mark a field
+ * with @KafkaEntityKey)
+ * Topic must exists.
+ * Topic name will be the name of the entity class with included packagename but
+ * you can use custom Topic name like
+ * this @KafkaEntity(customTopicName="PRODUCT")
+ *
+ * @author Popovics Boglarka
+ */
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface KafkaEntity {
+
+//	readonly true/false
+
+	/**
+	 * Topic name will be the name of the entity class with included packagename
+	 * unless you use this property.
+	 *
+	 * @return custom topic name
+	 */
+	String customTopicName() default "";
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/entity/KafkaEntityException.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/entity/KafkaEntityException.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2016-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.entity;
+
+/**
+ * Thrown by spring-kafka-extensions library if there is a problem creating a
+ * Kafka Entity Bean.
+ *
+ * @author Popovics Boglarka
+ */
+public class KafkaEntityException extends Exception {
+
+	private static final long serialVersionUID = 8485773596430780144L;
+
+	/**
+	 * The name of the Kafka Entity Bean.
+	 */
+	private final String beanName;
+
+	/**
+	 * Constructs a new exception with the specified message and a name of the Kafka
+	 * Entity Bean, which had the problem.
+	 *
+	 * @param beanName name of the Kafka Entity Bean
+	 * @param message  problem bei creating the Kafka Entity Bean
+	 */
+	public KafkaEntityException(String beanName, String message) {
+		super(message);
+		this.beanName = beanName;
+	}
+
+	/**
+	 * Constructs a new exception with the specified cause and a name of the Kafka
+	 * Entity Bean, which had the problem.
+	 *
+	 * @param beanName name of the Kafka Entity Bean
+	 * @param e        problem bei creating the Kafka Entity Bean
+	 */
+	public KafkaEntityException(String beanName, Exception e) {
+		super(e);
+		this.beanName = beanName;
+	}
+
+	/**
+	 * Getter to the name of the Kafka Entity Bean, which had the problem.
+	 *
+	 * @return name of the Kafka Entity Bean
+	 */
+	public String getBeanName() {
+		return this.beanName;
+	}
+
+	@Override
+	public String getMessage() {
+		return this.beanName + ": " + super.getMessage();
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/entity/KafkaEntityKey.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/entity/KafkaEntityKey.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.entity;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Define per topic one class or record and mark with @KafkaEntity (mark a field
+ * with @KafkaEntityKey) .
+ *
+ * @author Popovics Boglarka
+ */
+@Target({ ElementType.FIELD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface KafkaEntityKey {
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/entity/KafkaEntityUtil.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/entity/KafkaEntityUtil.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2016-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.entity;
+
+import io.micrometer.common.util.StringUtils;
+
+/**
+ * Kafka Entity Utility Class.
+ *
+ * @author Popovics Boglarka
+ */
+public final class KafkaEntityUtil {
+
+	private KafkaEntityUtil() {
+		super();
+	}
+
+	/**
+	 * Gets the name of the topic to a @KafkaEntity.
+	 *
+	 * @param entity class which is marked with @KafkaEntity
+	 *
+	 * @return the name of the entity class with included packagename but you can
+	 *         use custom Topic name like
+	 *         this @KafkaEntity(customTopicName="PRODUCT")
+	 */
+	public static String getTopicName(Class<?> entity) {
+		KafkaEntity topic = extractKafkaEntity(entity);
+		return getTopicName(entity, topic);
+	}
+
+	private static String getTopicName(Class<?> entity, KafkaEntity topic) {
+		if (!StringUtils.isEmpty(topic.customTopicName())) {
+			return topic.customTopicName();
+		}
+		return entity.getName();
+	}
+
+	private static KafkaEntity extractKafkaEntity(Class<?> entity) {
+		return (KafkaEntity) entity.getAnnotation(KafkaEntity.class);
+	}
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/entity/reactive/KafkaEntityDefaultConfiguration.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/entity/reactive/KafkaEntityDefaultConfiguration.java
@@ -1,0 +1,307 @@
+/*
+ * Copyright 2016-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.entity.reactive;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.commons.logging.LogFactory;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.ListTopicsResult;
+
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.beans.factory.support.DefaultSingletonBeanRegistry;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.log.LogAccessor;
+import org.springframework.kafka.entity.KafkaEntity;
+import org.springframework.kafka.entity.KafkaEntityException;
+import org.springframework.kafka.entity.KafkaEntityKey;
+import org.springframework.kafka.entity.KafkaEntityUtil;
+
+/**
+ * This Bean creates and registers all KafkaEntity Bean at starting a
+ * spring-boot app.
+ *
+ * @author Popovics Boglarka
+ */
+@Configuration
+public class KafkaEntityDefaultConfiguration implements InitializingBean, DisposableBean {
+
+	private final LogAccessor logger = new LogAccessor(LogFactory.getLog(getClass()));
+
+	private List<String> bootstrapServers = new ArrayList<>(Collections.singletonList("localhost:9092"));
+
+	private ApplicationContext applicationContext;
+
+	private Set<String> beanNames = new HashSet<>();
+
+	/**
+	 * Use this constructor if you want to create an instance manually.
+	 *
+	 * @param applicationContext spring applicationcontext
+	 * @param bootstrapServers   kafka bootstrap URL, default is looking at spirng
+	 *                           application property
+	 *                           spring.kafka.bootstrap-servers, if it is empty than
+	 *                           "localhost:9092"
+	 */
+	public KafkaEntityDefaultConfiguration(@Autowired ApplicationContext applicationContext,
+			@Value("${spring.kafka.bootstrap-servers:localhost:9092}") List<String> bootstrapServers) {
+		super();
+		this.applicationContext = applicationContext;
+		if (bootstrapServers != null && !bootstrapServers.isEmpty()) {
+			this.bootstrapServers = Collections.unmodifiableList(bootstrapServers);
+		}
+		this.logger.warn("bootstrapServers: " + bootstrapServers);
+	}
+
+	private List<KafkaEntityException> errors = new ArrayList<>();
+
+	@Override
+	public void afterPropertiesSet() {
+
+		StringBuilder result = new StringBuilder();
+		String[] allBeans = this.applicationContext.getBeanDefinitionNames();
+		DefaultSingletonBeanRegistry registry = (DefaultSingletonBeanRegistry) this.applicationContext
+				.getAutowireCapableBeanFactory();
+		for (String beanName : allBeans) {
+			result.append(beanName).append("\n");
+
+			if ("kafkaEntityDefaultConfiguration".equals(beanName)) {
+				continue;
+			}
+
+			Object bean = this.applicationContext.getBean(beanName);
+			if (this.logger.isTraceEnabled()) {
+				this.logger.trace(" bean -> " + bean.getClass());
+			}
+			for (Field field : bean.getClass().getDeclaredFields()) {
+				if (this.logger.isTraceEnabled()) {
+					this.logger.trace("    field  -> " + field.getName());
+				}
+				try {
+
+					if (field.isAnnotationPresent(KafkaEntityPublisher.class)
+							|| field.isAnnotationPresent(KafkaEntitySubscriber.class)
+							|| field.isAnnotationPresent(KafkaEntityProcessor.class)) {
+						String newBeanName = bean.getClass().getName() + "#" + field.getName();
+						Class<?> entity = (Class<?>) ((ParameterizedType) field.getGenericType()).getActualTypeArguments()[0];
+						if (!registry.containsSingleton(newBeanName)) {
+							DisposableBean newInstance = null;
+							if (field.isAnnotationPresent(KafkaEntityPublisher.class)) {
+
+								KafkaEntityPublisher kafkaEntityPublisher = field
+										.getAnnotation(KafkaEntityPublisher.class);
+
+								newInstance = registerKafkaEntityPublisherBean(bean, entity, newBeanName,
+										kafkaEntityPublisher);
+
+							}
+							else if (field.isAnnotationPresent(KafkaEntitySubscriber.class)) {
+								KafkaEntitySubscriber kafkaEntitySubscriber = field
+										.getAnnotation(KafkaEntitySubscriber.class);
+
+								newInstance = registerKafkaEntitySubscriberBean(bean, entity, newBeanName, kafkaEntitySubscriber);
+
+							}
+							else if (field.isAnnotationPresent(KafkaEntityProcessor.class)) {
+								KafkaEntityProcessor kafkaEntityProcessor = field.getAnnotation(KafkaEntityProcessor.class);
+
+								newInstance = registerKafkaEntityProcessorBean(bean, entity, newBeanName, kafkaEntityProcessor);
+							}
+							registerBean(registry, bean, field, newBeanName, newInstance);
+						}
+					}
+				}
+				catch (KafkaEntityException e) {
+					this.logger.error(e, "Error by registering Kafka Entity Bean");
+					this.errors.add(e);
+				}
+				catch (Exception e) {
+					KafkaEntityException kafkaEx = new KafkaEntityException(beanName, e);
+					this.logger.error(kafkaEx, "Error by registering Kafka Entity Bean");
+					this.errors.add(kafkaEx);
+				}
+			}
+		}
+		String string = result.toString();
+		if (this.logger.isTraceEnabled()) {
+			this.logger.trace("postConstruct-getAllBeans(): " + string);
+		}
+
+	}
+
+	private DisposableBean registerKafkaEntityPublisherBean(Object bean, Class<?> entity, String newBeanName,
+			KafkaEntityPublisher kafkaEntityPublisher)
+			throws KafkaEntityException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+
+		if (this.logger.isDebugEnabled()) {
+			this.logger.debug("registering " + newBeanName + " as Publisher");
+		}
+		handleKafkaEntity(newBeanName, entity);
+
+		Class<SimpleKafkaEntityPublisher> clazz = SimpleKafkaEntityPublisher.class;
+		Method method = clazz.getMethod("create", List.class, KafkaEntityPublisher.class, Class.class, String.class);
+
+		Object obj = method.invoke(null, this.bootstrapServers, kafkaEntityPublisher, entity, newBeanName);
+		SimpleKafkaEntityPublisher<?, ?> newInstance = (SimpleKafkaEntityPublisher<?, ?>) obj;
+
+		return newInstance;
+	}
+
+	private DisposableBean registerKafkaEntitySubscriberBean(Object bean, Class<?> entity, String newBeanName,
+			KafkaEntitySubscriber kafkaEntitySubscriber)
+			throws KafkaEntityException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+
+		if (this.logger.isDebugEnabled()) {
+			this.logger.debug("registering " + newBeanName + " as Subscriber");
+		}
+		handleKafkaEntity(newBeanName, entity);
+
+		Class<SimpleKafkaEntitySubscriber> clazz = SimpleKafkaEntitySubscriber.class;
+		Method method = clazz.getMethod("create", List.class, KafkaEntitySubscriber.class, Class.class, String.class);
+
+		Object obj = method.invoke(null, this.bootstrapServers, kafkaEntitySubscriber, entity, newBeanName);
+		SimpleKafkaEntitySubscriber<?, ?> newInstance = (SimpleKafkaEntitySubscriber<?, ?>) obj;
+
+		return newInstance;
+	}
+
+	private DisposableBean registerKafkaEntityProcessorBean(Object bean, Class<?> entity, String newBeanName,
+			KafkaEntityProcessor kafkaEntityProcessor)
+			throws KafkaEntityException, NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+
+		if (this.logger.isDebugEnabled()) {
+			this.logger.debug("registering " + newBeanName + " as Processor");
+		}
+		handleKafkaEntity(newBeanName, entity);
+
+		Class<SimpleKafkaEntityProcessor> clazz = SimpleKafkaEntityProcessor.class;
+		Method method = clazz.getMethod("create", List.class, KafkaEntityProcessor.class, Class.class, String.class);
+
+		Object obj = method.invoke(null, this.bootstrapServers, kafkaEntityProcessor, entity, newBeanName);
+		SimpleKafkaEntityProcessor<?, ?> newInstance = (SimpleKafkaEntityProcessor<?, ?>) obj;
+
+		return newInstance;
+	}
+
+	private void registerBean(DefaultSingletonBeanRegistry registry, Object bean, Field field, String newBeanName,
+			DisposableBean newInstance) throws IllegalAccessException {
+		registry.registerSingleton(newBeanName, newInstance);
+		registry.registerDisposableBean(newBeanName, newInstance);
+		field.setAccessible(true);
+		field.set(bean, newInstance);
+		this.beanNames.add(newBeanName);
+	}
+
+	private void handleKafkaEntity(String beanName, Class<?> entity) throws KafkaEntityException {
+		if (!entity.isAnnotationPresent(KafkaEntity.class)) {
+			throw new KafkaEntityException(beanName, entity.getName() + " must be a @KafkaEntity");
+		}
+
+		boolean foundKeyAnnotation = false;
+		for (Field field : entity.getDeclaredFields()) {
+			if (this.logger.isTraceEnabled()) {
+				this.logger.trace("    field  -> " + field.getName());
+			}
+			if (field.isAnnotationPresent(KafkaEntityKey.class)) {
+				foundKeyAnnotation = true;
+				break;
+			}
+		}
+
+		if (!foundKeyAnnotation) {
+			throw new KafkaEntityException(beanName, entity.getName() + " @" + KafkaEntityKey.class.getSimpleName()
+					+ " is mandatory in @" + KafkaEntity.class.getSimpleName());
+		}
+
+		try {
+			checkTopic(entity);
+		}
+		catch (InterruptedException | ExecutionException e) {
+			throw new KafkaEntityException(beanName, e);
+		}
+	}
+
+	private void checkTopic(Class<?> entity) throws InterruptedException, ExecutionException, KafkaEntityException {
+		Map<String, Object> conf = new HashMap<>();
+		conf.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, this.bootstrapServers);
+		conf.put(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, "5000");
+		try (AdminClient admin = AdminClient.create(conf);) {
+
+			ListTopicsResult listTopics = admin.listTopics();
+			Set<String> names = listTopics.names().get();
+			if (this.logger.isTraceEnabled()) {
+				this.logger.trace("names: " + names);
+			}
+			String topicName = KafkaEntityUtil.getTopicName(entity);
+			boolean contains = names.contains(topicName);
+			if (!contains) {
+				throw new KafkaEntityException(topicName,
+						"Topic " + topicName + " does not exist in " + this.bootstrapServers);
+			}
+		}
+	}
+
+	/**
+	 * To get the exceptions, which were created while afterPropertiesSet() .
+	 * @return list of KafkaEntityException
+	 */
+	public List<KafkaEntityException> getErrors() {
+		return Collections.unmodifiableList(this.errors);
+	}
+
+	/**
+	 * It throws the first error, which happenened at afterPropertiesSet() if any
+	 * happpened.
+	 * @throws KafkaEntityException the first exception
+	 */
+	public void throwFirstError() throws KafkaEntityException {
+		if (!this.errors.isEmpty()) {
+			throw this.errors.get(0);
+		}
+	}
+
+	@Override
+	public void destroy() throws Exception {
+
+		DefaultSingletonBeanRegistry registry = (DefaultSingletonBeanRegistry) this.applicationContext
+				.getAutowireCapableBeanFactory();
+
+		this.beanNames.stream().forEach(beanName -> {
+			if (this.logger.isDebugEnabled()) {
+				this.logger.debug("destroying " + beanName);
+			}
+			registry.destroySingleton(beanName);
+		});
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/entity/reactive/KafkaEntityPollingRunnable.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/entity/reactive/KafkaEntityPollingRunnable.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2016-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.entity.reactive;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.commons.logging.LogFactory;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+
+import org.springframework.core.log.LogAccessor;
+import org.springframework.kafka.entity.KafkaEntityUtil;
+import org.springframework.kafka.entity.reactive.SimpleKafkaEntityPublisher.PublisherWrapper;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonKeyDeserializer;
+
+/**
+ * This runnable is constantly polling a kafka-consumer for 10 sec after started
+ * until it is stopped if there is minimum 1 subscriber.
+ *
+ * @param <T> class of the entity, representing messages
+ * @param <K> the key from the entity
+ *
+ * @author Popovics Boglarka
+ */
+public class KafkaEntityPollingRunnable<T, K> implements Runnable {
+
+	private final LogAccessor logger = new LogAccessor(LogFactory.getLog(getClass()));
+
+	private final String groupid;
+
+	private final Class<T> clazz;
+
+	private final Class<K> clazzKey;
+
+	private final AtomicBoolean stopped = new AtomicBoolean(false);
+
+	private final AtomicBoolean started = new AtomicBoolean(false);
+
+	/** The array of currently subscribed subscribers. */
+	private final AtomicReference<PublisherWrapper<T, K>[]> subscribers;
+
+	private final List<String> bootstrapServers;
+
+	private final String beanName;
+
+	KafkaEntityPollingRunnable(String groupid, Class<T> clazz, Class<K> clazzKey,
+			AtomicReference<PublisherWrapper<T, K>[]> subscribers, List<String> bootstrapServers,
+			String beanName) {
+		super();
+		this.groupid = groupid;
+		this.clazz = clazz;
+		this.clazzKey = clazzKey;
+		this.subscribers = subscribers;
+		this.bootstrapServers = bootstrapServers;
+		this.beanName = beanName;
+	}
+
+	@Override
+	public void run() {
+
+		Map<String, Object> properties = new HashMap<>();
+		properties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, this.bootstrapServers);
+		properties.put(ConsumerConfig.GROUP_ID_CONFIG, this.groupid);
+
+		properties.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+		JsonDeserializer<T> valueDeserializer = new JsonDeserializer<>(getClazz());
+		JsonKeyDeserializer<K> keyDeserializer = new JsonKeyDeserializer<>(getClazzKey());
+
+		valueDeserializer.addTrustedPackages(getClazz().getPackageName());
+		keyDeserializer.addTrustedPackages(getClazzKey().getPackageName());
+
+		try (KafkaConsumer<K, T> kafkaConsumer = new KafkaConsumer<K, T>(properties, keyDeserializer,
+				valueDeserializer);) {
+
+			kafkaConsumer.subscribe(List.of(KafkaEntityUtil.getTopicName(getClazz())));
+
+			kafkaConsumer.poll(Duration.ofSeconds(10L));
+
+			kafkaConsumer.seekToEnd(Collections.emptyList());
+			kafkaConsumer.commitSync();
+
+			// wait until kafkaConsumer is ready and offset setted
+
+			LocalDateTime then = LocalDateTime.now();
+			while (kafkaConsumer.committed(kafkaConsumer.assignment()).isEmpty()) {
+				if (ChronoUnit.SECONDS.between(then, LocalDateTime.now()) >= 60) {
+					throw new RuntimeException("KafkaConsumer is not ready in 60sec.");
+				}
+			}
+
+			if (this.logger.isDebugEnabled()) {
+				this.logger.debug("started " + this.beanName + "...");
+			}
+			while (!this.stopped.get()) {
+				this.started.set(true);
+
+				if (this.subscribers.get().length > 0) {
+					this.logger.info("POLL-" + this.groupid + " to " + this.subscribers.get().length + " subscribers");
+					ConsumerRecords<K, T> poll = kafkaConsumer.poll(Duration.ofSeconds(10L));
+
+					if (this.logger.isDebugEnabled()) {
+						this.logger.debug("poll.count: " + poll.count());
+					}
+
+					poll.forEach(r -> {
+
+						if (this.logger.isTraceEnabled()) {
+							this.logger.trace("polled:" + r);
+						}
+
+						for (PublisherWrapper<T, K> pd : this.subscribers.get()) {
+							pd.onNext(r.value());
+						}
+					});
+					kafkaConsumer.commitSync();
+				}
+			}
+			kafkaConsumer.unsubscribe();
+			this.started.set(false);
+		}
+	}
+
+	/**
+	 * Getter to message class.
+	 *
+	 * @return message class
+	 */
+	public Class<T> getClazz() {
+		return this.clazz;
+	}
+
+	/**
+	 * Getter to message key class.
+	 *
+	 * @return message key class
+	 */
+	public Class<K> getClazzKey() {
+		return this.clazzKey;
+	}
+
+	/**
+	 * Getter to is the polling stopped.
+	 *
+	 * @return stopped
+	 */
+	public AtomicBoolean getStopped() {
+		return this.stopped;
+	}
+
+	/**
+	 * Getter to is the polling started.
+	 *
+	 * @return started
+	 */
+	public AtomicBoolean getStarted() {
+		return this.started;
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/entity/reactive/KafkaEntityProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/entity/reactive/KafkaEntityProcessor.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.entity.reactive;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * To write data to a topic (produce)
+ * if you need the RecordMetadata from the Kafka Message than you can use
+ * KafkaEntityProcessor .
+ * In a Spring Bean just inject a KafkaEntityProcessor.
+ *
+ * default is transactional=true
+ *
+ * @author Popovics Boglarka
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface KafkaEntityProcessor {
+
+	/**
+	 * If the Kafka Producer should create a Kafka Transaction. default is true
+	 *
+	 * @return transactional
+	 */
+	boolean transactional() default true;
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/entity/reactive/KafkaEntityPublisher.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/entity/reactive/KafkaEntityPublisher.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2016-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.entity.reactive;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * To read data from a topic (consume) in a Spring Bean just inject a
+ * KafkaEntityPublisher .
+ *
+ * @author Popovics Boglarka
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface KafkaEntityPublisher {
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/entity/reactive/KafkaEntitySubscriber.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/entity/reactive/KafkaEntitySubscriber.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2016-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.entity.reactive;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * To write data to a topic (produce) in a Spring Bean just inject a
+ * KafkaEntitySubscriber .
+ *
+ * default is transactional=true
+ *
+ * @author Popovics Boglarka
+ */
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface KafkaEntitySubscriber {
+
+	/**
+	 * If the Kafka Producer should create a Kafka Transaction. default is true
+	 *
+	 * @return transactional
+	 */
+	boolean transactional() default true;
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/entity/reactive/KafkaProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/entity/reactive/KafkaProcessor.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.entity.reactive;
+
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.reactivestreams.Processor;
+
+public interface KafkaProcessor<T> extends Processor<T, RecordMetadata> {
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/entity/reactive/SimpleKafkaEntityProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/entity/reactive/SimpleKafkaEntityProcessor.java
@@ -1,0 +1,518 @@
+/*
+ * Copyright 2016-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.entity.reactive;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+
+import org.apache.commons.logging.LogFactory;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.jspecify.annotations.NonNull;
+import org.reactivestreams.Processor;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.core.Disposable;
+import reactor.core.Exceptions;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Operators;
+import reactor.core.publisher.SignalType;
+
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.core.log.LogAccessor;
+import org.springframework.kafka.entity.KafkaEntityException;
+import org.springframework.kafka.entity.KafkaEntityKey;
+import org.springframework.kafka.entity.KafkaEntityUtil;
+import org.springframework.kafka.support.serializer.JsonKeySerializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+/**
+ * Implementation class for @KafkaEntityProcessor .
+ *
+ * @param <T> class of the Kafka Entity, representing messages
+ * @param <K> class of the Kafka Entity Key of the Kafka Entity
+ *
+ * @author Popovics Boglarka
+ */
+public final class SimpleKafkaEntityProcessor<T, K> extends Flux<RecordMetadata>
+		implements KafkaProcessor<T>, Processor<T, RecordMetadata>, DisposableBean, InitializingBean {
+
+	private final LogAccessor logger = new LogAccessor(LogFactory.getLog(getClass()));
+
+	/** The terminated indicator for the subscribers array. */
+	@SuppressWarnings("rawtypes")
+	static final ProcessorWrapper[] TERMINATED = new ProcessorWrapper[0];
+
+	/** An empty subscribers array to avoid allocating it all the time. */
+	@SuppressWarnings("rawtypes")
+	static final ProcessorWrapper[] EMPTY = new ProcessorWrapper[0];
+
+	/** The array of currently subscribed subscribers. */
+	final AtomicReference<ProcessorWrapper<T, K>[]> subscribers;
+
+	private String clientid;
+
+	private KafkaProducer<K, T> kafkaProducer;
+
+	private Class<T> clazz;
+
+	private String topic;
+
+	/** The error, write before terminating and read after checking subscribers. */
+	Throwable error;
+
+	private Field keyField;
+
+	private boolean transactional;
+
+	private List<String> bootstrapServers;
+
+	/**
+	 * Constructs a SimpleKafkaEntityProcessor.
+	 *
+	 * @param <T>                  the value type
+	 * @param <K>                  the key type
+	 * @param bootstrapServers     List of bootstrapServers
+	 * @param kafkaEntityProcessor annotation
+	 * @param entity               class of the Kafka Entity, representing messages
+	 * @param beanName             name of the Kafka Entity Bean
+	 *
+	 * @return the new SimpleKafkaEntityProcessor
+	 * @throws KafkaEntityException problem at creation
+	 */
+	// @CheckReturnValue
+	@NonNull
+	public static <T, K> SimpleKafkaEntityProcessor<T, K> create(List<String> bootstrapServers,
+			KafkaEntityProcessor kafkaEntityProcessor, Class<T> entity, String beanName) throws KafkaEntityException {
+		return new SimpleKafkaEntityProcessor<>(bootstrapServers, kafkaEntityProcessor, entity, beanName);
+	}
+
+	SimpleKafkaEntityProcessor(List<String> bootstrapServers, KafkaEntityProcessor kafkaEntityProcessor,
+			Class<T> entity, String beanName) {
+
+		this.bootstrapServers = bootstrapServers;
+		this.subscribers = new AtomicReference<>(EMPTY);
+
+		this.clazz = entity;
+		this.clientid = beanName;
+		this.topic = KafkaEntityUtil.getTopicName(this.clazz);
+
+		this.transactional = kafkaEntityProcessor.transactional();
+
+		// presents of @KafkaEntityKey is checked in KafkaEntityConfig
+		for (Field field : this.clazz.getDeclaredFields()) {
+			if (this.logger.isDebugEnabled()) {
+				this.logger.debug("    field  -> " + field.getName());
+			}
+			if (field.isAnnotationPresent(KafkaEntityKey.class)) {
+				field.setAccessible(true);
+				this.keyField = field;
+				break;
+			}
+		}
+
+		Map<String, Object> configProps = new HashMap<>();
+		configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+		configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, JsonKeySerializer.class);
+		configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+		configProps.put(ProducerConfig.CLIENT_ID_CONFIG, this.clientid);
+
+		if (this.transactional) {
+			configProps.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, beanName + "-transactional-id");
+			configProps.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true");
+		}
+
+		JsonSerializer<T> valueSerializer = new JsonSerializer<>();
+		JsonKeySerializer<K> keySerializer = new JsonKeySerializer<>();
+
+		this.kafkaProducer = new KafkaProducer<K, T>(configProps, keySerializer, valueSerializer);
+		if (this.transactional) {
+			this.logger.info("initTransactions-begin " + beanName);
+			this.kafkaProducer.initTransactions();
+			this.logger.info("initTransactions-end " + beanName);
+		}
+	}
+
+	private K extractKey(T event) throws IllegalArgumentException, IllegalAccessException {
+		return (K) this.keyField.get(event);
+	}
+
+	@Override
+	public void onSubscribe(Subscription d) {
+
+		if (this.subscribers.get() == TERMINATED) {
+			d.cancel();
+		}
+
+		if (this.transactional) {
+			this.kafkaProducer.beginTransaction();
+		}
+		d.request(Long.MAX_VALUE);
+	}
+
+	@Override
+	public void onNext(T t) {
+		this.logger.info("onNext: " + t);
+		CompletableFuture<RecordMetadata> completableFuture = new CompletableFuture<>();
+		K key;
+		try {
+			key = extractKey(t);
+
+			ProducerRecord<K, T> rec = new ProducerRecord<K, T>(this.topic, key, t);
+			Future<RecordMetadata> send = this.kafkaProducer.send(rec);
+			completableFuture.complete(send.get());
+		}
+		catch (InterruptedException | ExecutionException e) {
+			completableFuture.completeExceptionally(e);
+		}
+		catch (IllegalAccessException e) {
+			completableFuture.completeExceptionally(e);
+		}
+
+		try {
+			RecordMetadata r = completableFuture.get();
+			for (ProcessorWrapper<T, K> pd : this.subscribers.get()) {
+				pd.onNext(r);
+			}
+		}
+		catch (InterruptedException | ExecutionException e) {
+			onError(e);
+		}
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public void onError(Throwable t) {
+		if (this.subscribers.get() == TERMINATED) {
+			onError(t);
+			return;
+		}
+		this.error = t;
+
+		for (ProcessorWrapper<T, K> pd : this.subscribers.getAndSet(TERMINATED)) {
+			pd.onError(t);
+		}
+		if (this.transactional) {
+			this.kafkaProducer.abortTransaction();
+		}
+		return;
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public void onComplete() {
+		if (this.subscribers.get() == TERMINATED) {
+			return;
+		}
+		for (ProcessorWrapper<T, K> pd : this.subscribers.getAndSet(TERMINATED)) {
+			pd.onComplete();
+		}
+		if (this.transactional) {
+			this.kafkaProducer.commitTransaction();
+		}
+	}
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+
+	}
+
+	@Override
+	public void destroy() throws Exception {
+		this.kafkaProducer.close();
+	}
+
+	@Override
+	public void subscribe(CoreSubscriber<? super RecordMetadata> actual) {
+		ProcessorWrapper<T, K> ps = new ProcessorWrapper<>(actual, this);
+		actual.onSubscribe(ps);
+		if (add(ps)) {
+			// if cancellation happened while a successful add, the remove() didn't work
+			// so we need to do it again
+			if (ps.isDisposed()) {
+				remove(ps);
+			}
+		}
+		else {
+			Throwable ex = this.error;
+			if (ex != null) {
+				actual.onError(ex);
+			}
+			else {
+				actual.onComplete();
+			}
+		}
+	}
+
+	/**
+	 * Tries to add the given subscriber to the subscribers array atomically or
+	 * returns false if the Processor has terminated.
+	 *
+	 * @param ps the subscriber to add
+	 *
+	 * @return true if successful, false if the Processor has terminated
+	 */
+	boolean add(ProcessorWrapper<T, K> ps) {
+		for (;;) {
+			ProcessorWrapper<T, K>[] a = this.subscribers.get();
+			if (a == TERMINATED) {
+				return false;
+			}
+
+			int n = a.length;
+			@SuppressWarnings("unchecked")
+			ProcessorWrapper<T, K>[] b = new ProcessorWrapper[n + 1];
+			System.arraycopy(a, 0, b, 0, n);
+			b[n] = ps;
+
+			if (this.subscribers.compareAndSet(a, b)) {
+				return true;
+			}
+		}
+	}
+
+	/**
+	 * Atomically removes the given subscriber if it is subscribed to the Processor.
+	 *
+	 * @param ps the Processor to remove
+	 */
+	@SuppressWarnings("unchecked")
+	void remove(ProcessorWrapper<T, K> ps) {
+		for (;;) {
+			ProcessorWrapper<T, K>[] a = this.subscribers.get();
+			if (a == TERMINATED || a == EMPTY) {
+				return;
+			}
+
+			int n = a.length;
+			int j = -1;
+			for (int i = 0; i < n; i++) {
+				if (a[i] == ps) {
+					j = i;
+					break;
+				}
+			}
+
+			if (j < 0) {
+				return;
+			}
+
+			ProcessorWrapper<T, K>[] b;
+
+			if (n == 1) {
+				b = EMPTY;
+			}
+			else {
+				b = new ProcessorWrapper[n - 1];
+				System.arraycopy(a, 0, b, 0, j);
+				System.arraycopy(a, j + 1, b, j, n - j - 1);
+			}
+			if (this.subscribers.compareAndSet(a, b)) {
+				return;
+			}
+		}
+	}
+
+	/**
+	 * Wraps the actual subscriber, tracks its requests and makes cancellation to
+	 * remove itself from the current subscribers array.
+	 *
+	 * @param <T> the value type
+	 * @param <K> the key type
+	 */
+	static final class ProcessorWrapper<T, K> extends AtomicBoolean
+			implements CoreSubscriber<RecordMetadata>, Subscription, Disposable {
+
+		private static final long serialVersionUID = 1L;
+
+		private final LogAccessor logger = new LogAccessor(LogFactory.getLog(getClass()));
+
+		/** The actual subscriber. */
+		final CoreSubscriber<? super RecordMetadata> downstream;
+
+		/** The Processor state. */
+		final SimpleKafkaEntityProcessor<T, K> parent;
+
+		/**
+		 * Constructs a ProcessorWrapper, wraps the actual subscriber and the state.
+		 *
+		 * @param actual the actual subscriber
+		 * @param parent the parent PublishProcessor
+		 */
+		ProcessorWrapper(CoreSubscriber<? super RecordMetadata> actual, SimpleKafkaEntityProcessor<T, K> parent) {
+			this.downstream = actual;
+			this.parent = parent;
+		}
+
+		@Override
+		public void dispose() {
+			if (compareAndSet(false, true)) {
+				this.parent.remove(this);
+			}
+			cancel();
+		}
+
+		volatile Subscription subscription;
+
+		static AtomicReferenceFieldUpdater<ProcessorWrapper, Subscription> S =
+				AtomicReferenceFieldUpdater.newUpdater(ProcessorWrapper.class, Subscription.class, "subscription");
+
+		/**
+		 * Return current {@link Subscription} .
+		 *
+		 * @return current {@link Subscription}
+		 */
+		protected Subscription upstream() {
+			return this.subscription;
+		}
+
+		@Override
+		public boolean isDisposed() {
+			return this.subscription == Operators.cancelledSubscription();
+		}
+
+		@Override
+		public void onSubscribe(Subscription s) {
+			if (Operators.setOnce(S, this, s)) {
+				try {
+					this.downstream.onSubscribe(s);
+					this.subscription.request(Long.MAX_VALUE);
+				}
+				catch (Throwable throwable) {
+					onError(Operators.onOperatorError(s, throwable, currentContext()));
+				}
+			}
+		}
+
+		@Override
+		public void onNext(RecordMetadata value) {
+			Objects.requireNonNull(value, "onNext");
+			try {
+				if (!get()) {
+					this.downstream.onNext(value);
+				}
+			}
+			catch (Throwable throwable) {
+				onError(Operators.onOperatorError(this.subscription, throwable, value, currentContext()));
+			}
+		}
+
+		@Override
+		public void onError(Throwable t) {
+			Objects.requireNonNull(t, "onError");
+
+			if (S.getAndSet(this, Operators.cancelledSubscription()) == Operators
+					.cancelledSubscription()) {
+				//already cancelled concurrently
+				Operators.onErrorDropped(t, currentContext());
+				return;
+			}
+
+			try {
+				if (!get()) {
+					this.downstream.onError(t);
+				}
+				throw Exceptions.errorCallbackNotImplemented(t);
+			}
+			catch (Throwable e) {
+				e = Exceptions.addSuppressed(e, t);
+				Operators.onErrorDropped(e, currentContext());
+			}
+			finally {
+				safeHookFinally(SignalType.ON_ERROR);
+			}
+		}
+
+		@Override
+		public void onComplete() {
+			if (S.getAndSet(this, Operators.cancelledSubscription()) != Operators
+					.cancelledSubscription()) {
+				//we're sure it has not been concurrently cancelled
+				try {
+					if (!get()) {
+						this.downstream.onComplete();
+					}
+				}
+				catch (Throwable throwable) {
+					//onError itself will short-circuit due to the CancelledSubscription being set above
+					onError(Operators.onOperatorError(throwable, currentContext()));
+				}
+				finally {
+					safeHookFinally(SignalType.ON_COMPLETE);
+				}
+			}
+		}
+
+		@Override
+		public void request(long n) {
+			if (Operators.validate(n)) {
+				Subscription s = this.subscription;
+				if (s != null) {
+					s.request(n);
+				}
+			}
+		}
+
+		/**
+		 * {@link #request(long) Request} an unbounded amount.
+		 */
+		public void requestUnbounded() {
+			request(Long.MAX_VALUE);
+		}
+
+		@Override
+		public void cancel() {
+			if (Operators.terminate(S, this)) {
+				try {
+					// do nothing
+				}
+				catch (Throwable throwable) {
+					onError(Operators.onOperatorError(this.subscription, throwable, currentContext()));
+				}
+				finally {
+					safeHookFinally(SignalType.CANCEL);
+				}
+			}
+		}
+
+		void safeHookFinally(SignalType type) {
+			try {
+				// do nothing
+			}
+			catch (Throwable finallyFailure) {
+				Operators.onErrorDropped(finallyFailure, currentContext());
+			}
+		}
+
+		@Override
+		public String toString() {
+			return getClass().getSimpleName();
+		}
+	}
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/entity/reactive/SimpleKafkaEntityPublisher.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/entity/reactive/SimpleKafkaEntityPublisher.java
@@ -1,0 +1,356 @@
+/*
+ * Copyright 2016-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.entity.reactive;
+
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.commons.logging.LogFactory;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.DeleteConsumerGroupsResult;
+import org.apache.kafka.common.KafkaFuture;
+import org.jspecify.annotations.NonNull;
+import org.reactivestreams.Subscription;
+import reactor.core.CoreSubscriber;
+import reactor.core.Disposable;
+import reactor.core.publisher.Flux;
+
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.core.log.LogAccessor;
+import org.springframework.kafka.entity.KafkaEntityException;
+import org.springframework.kafka.entity.KafkaEntityKey;
+
+/**
+ * Implementation class for @KafkaEntityPublisher .
+ *
+ * @param <T> class of the entity, representing messages
+ * @param <K> the key from the entity
+ *
+ * @author Popovics Boglarka
+ */
+public class SimpleKafkaEntityPublisher<T, K> extends Flux<T> implements DisposableBean, InitializingBean {
+
+	private final LogAccessor logger = new LogAccessor(LogFactory.getLog(getClass()));
+
+	private List<String> bootstrapServers;
+
+	private String groupid;
+
+	private Class<T> clazz;
+
+	private Class<K> clazzKey;
+
+	private final KafkaEntityPollingRunnable<T, K> pollingRunnable;
+
+	private String beanName;
+
+	SimpleKafkaEntityPublisher(List<String> bootstrapServers, KafkaEntityPublisher kafkaEntityPublisher, Class<T> entity, String beanName)
+			throws KafkaEntityException {
+		this.bootstrapServers = bootstrapServers;
+		this.clazz = entity;
+		this.groupid = /* getTopicName() + "-Subscriber-" + */ beanName;
+
+		// presents of @KafkaEntityKey is checked in KafkaEntityConfig
+		for (Field field : this.clazz.getDeclaredFields()) {
+			if (this.logger.isDebugEnabled()) {
+				this.logger.debug("    field  -> " + field.getName());
+			}
+			if (field.isAnnotationPresent(KafkaEntityKey.class)) {
+				field.setAccessible(true);
+				this.clazzKey = (Class<K>) field.getType();
+				break;
+			}
+		}
+
+		this.subscribers = new AtomicReference<>(EMPTY);
+
+		this.beanName = beanName;
+
+		this.pollingRunnable = new KafkaEntityPollingRunnable<T, K>(this.groupid, this.clazz, this.clazzKey, this.subscribers,
+				bootstrapServers, beanName);
+
+		start();
+	}
+
+	private void start() throws KafkaEntityException {
+
+		if (this.pollingRunnable.getStarted().get()) {
+			this.logger.warn("already started...");
+			return;
+		}
+
+		if (this.logger.isDebugEnabled()) {
+			this.logger.debug("starting " + this.beanName + "...");
+		}
+
+		Thread pollingThread = new Thread(this.pollingRunnable);
+		pollingThread.setName(this.beanName + "Thread");
+		pollingThread.start();
+
+		this.logger.info("waiting the consumer to start in " + this.beanName + "Thread...");
+		LocalDateTime then = LocalDateTime.now();
+		while (!this.pollingRunnable.getStarted().get()) {
+			if (ChronoUnit.SECONDS.between(then, LocalDateTime.now()) >= 300) {
+				throw new KafkaEntityException(this.beanName, "KafkaConsumer could not start in 300 sec.");
+			}
+		}
+	}
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+
+	}
+
+	@Override
+	public void destroy() throws Exception {
+
+		this.logger.warn("deleting a Consumer Group for " + this.beanName);
+
+		this.pollingRunnable.getStopped().set(true);
+
+		this.logger.info("waiting polling to stop");
+		LocalDateTime then = LocalDateTime.now();
+		while (this.pollingRunnable.getStarted().get()) {
+			if (ChronoUnit.SECONDS.between(then, LocalDateTime.now()) >= 20) {
+				break;
+			}
+		}
+
+		final Properties properties = new Properties();
+		properties.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, this.bootstrapServers);
+		properties.put(AdminClientConfig.REQUEST_TIMEOUT_MS_CONFIG, "1000");
+		properties.put(AdminClientConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, "5000");
+
+		try (AdminClient adminClient = AdminClient.create(properties);) {
+			String consumerGroupToBeDeleted = this.groupid;
+			DeleteConsumerGroupsResult deleteConsumerGroupsResult = adminClient
+					.deleteConsumerGroups(Arrays.asList(consumerGroupToBeDeleted));
+
+			KafkaFuture<Void> resultFuture = deleteConsumerGroupsResult.all();
+			resultFuture.get();
+		}
+		catch (Exception e) {
+			// we cannot do anything at this point
+			this.logger.error(e.getMessage());
+		}
+
+	}
+
+	/** The terminated indicator for the subscribers array. */
+	@SuppressWarnings("rawtypes")
+	static final PublisherWrapper[] TERMINATED = new PublisherWrapper[0];
+
+	/** An empty subscribers array to avoid allocating it all the time. */
+	@SuppressWarnings("rawtypes")
+	static final PublisherWrapper[] EMPTY = new PublisherWrapper[0];
+
+	/** The array of currently subscribed subscribers. */
+	final AtomicReference<PublisherWrapper<T, K>[]> subscribers;
+
+	/** The error, write before terminating and read after checking subscribers. */
+	Throwable error;
+
+	/**
+	 * Constructs a SimpleKafkaPublisherHandler.
+	 *
+	 * @param <T>                  the value type
+	 * @param <K>                  the key type
+	 * @param bootstrapServers     List of bootstrapServers
+	 * @param kafkaEntityPublisher annotation
+	 * @param entity               class of the Kafka Entity, representing messages
+	 * @param beanName             name of the Kafka Entity Bean
+	 *
+	 * @return the new SimpleKafkaPublisherHandler
+	 * @throws KafkaEntityException problem at creation
+	 */
+	// @CheckReturnValue
+	@NonNull
+	public static <T, K> SimpleKafkaEntityPublisher<T, K> create(List<String> bootstrapServers, KafkaEntityPublisher kafkaEntityPublisher,
+			Class<T> entity, String beanName) throws KafkaEntityException {
+		return new SimpleKafkaEntityPublisher<T, K>(bootstrapServers, kafkaEntityPublisher, entity, beanName);
+	}
+
+	@Override
+	public void subscribe(CoreSubscriber<? super T> actual) {
+		PublisherWrapper<T, K> ps = new PublisherWrapper<>(actual, this);
+		actual.onSubscribe(ps);
+		if (add(ps)) {
+			// if cancellation happened while a successful add, the remove() didn't work
+			// so we need to do it again
+			if (ps.isDisposed()) {
+				remove(ps);
+			}
+		}
+		else {
+			Throwable ex = this.error;
+			if (ex != null) {
+				actual.onError(ex);
+			}
+			else {
+				actual.onComplete();
+			}
+		}
+
+	}
+
+	/**
+	 * Tries to add the given subscriber to the subscribers array atomically or
+	 * returns false if the Processor has terminated.
+	 *
+	 * @param ps the subscriber to add
+	 *
+	 * @return true if successful, false if the Processor has terminated
+	 */
+	boolean add(PublisherWrapper<T, K> ps) {
+		for (;;) {
+			PublisherWrapper<T, K>[] a = this.subscribers.get();
+			if (a == TERMINATED) {
+				return false;
+			}
+
+			int n = a.length;
+			@SuppressWarnings("unchecked")
+			PublisherWrapper<T, K>[] b = new PublisherWrapper[n + 1];
+			System.arraycopy(a, 0, b, 0, n);
+			b[n] = ps;
+
+			if (this.subscribers.compareAndSet(a, b)) {
+				return true;
+			}
+		}
+	}
+
+	/**
+	 * Atomically removes the given subscriber if it is subscribed to the Processor.
+	 *
+	 * @param ps the Processor to remove
+	 */
+	@SuppressWarnings("unchecked")
+	void remove(PublisherWrapper<T, K> ps) {
+		for (;;) {
+			PublisherWrapper<T, K>[] a = this.subscribers.get();
+			if (a == TERMINATED || a == EMPTY) {
+				return;
+			}
+
+			int n = a.length;
+			int j = -1;
+			for (int i = 0; i < n; i++) {
+				if (a[i] == ps) {
+					j = i;
+					break;
+				}
+			}
+
+			if (j < 0) {
+				return;
+			}
+
+			PublisherWrapper<T, K>[] b;
+
+			if (n == 1) {
+				b = EMPTY;
+			}
+			else {
+				b = new PublisherWrapper[n - 1];
+				System.arraycopy(a, 0, b, 0, j);
+				System.arraycopy(a, j + 1, b, j, n - j - 1);
+			}
+			if (this.subscribers.compareAndSet(a, b)) {
+				return;
+			}
+		}
+	}
+
+	/**
+	 * Wraps the actual subscriber, tracks its requests and makes cancellation to
+	 * remove itself from the current subscribers array.
+	 *
+	 * @param <T> the value type
+	 * @param <K> the key type
+	 */
+	static final class PublisherWrapper<T, K> extends AtomicBoolean implements CoreSubscriber<T>, Subscription, Disposable {
+
+		/** The actual subscriber. */
+		final CoreSubscriber<? super T> downstream;
+
+		/** The Processor state. */
+		final SimpleKafkaEntityPublisher<T, K> parent;
+
+		/**
+		 * Constructs a PublishSubscriber, wraps the actual subscriber and the state.
+		 *
+		 * @param actual the actual subscriber
+		 * @param parent the parent PublishProcessor
+		 */
+		PublisherWrapper(CoreSubscriber<? super T> actual, SimpleKafkaEntityPublisher<T, K> parent) {
+			this.downstream = actual;
+			this.parent = parent;
+		}
+
+		@Override
+		public void dispose() {
+			if (compareAndSet(false, true)) {
+				this.parent.remove(this);
+			}
+		}
+
+		@Override
+		public void onSubscribe(Subscription s) {
+			this.downstream.onSubscribe(s);
+		}
+
+		@Override
+		public void onNext(T t) {
+			if (!get()) {
+				this.downstream.onNext(t);
+			}
+		}
+
+		@Override
+		public void onError(Throwable t) {
+			this.downstream.onError(t);
+		}
+
+		@Override
+		public void onComplete() {
+			if (!get()) {
+				this.downstream.onComplete();
+			}
+		}
+
+		@Override
+		public void request(long n) {
+			compareAndSet(true, false);
+		}
+
+		@Override
+		public void cancel() {
+			dispose();
+		}
+
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/entity/reactive/SimpleKafkaEntitySubscriber.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/entity/reactive/SimpleKafkaEntitySubscriber.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2016-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.entity.reactive;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import org.apache.commons.logging.LogFactory;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.jspecify.annotations.NonNull;
+import org.reactivestreams.Subscription;
+import reactor.core.publisher.BaseSubscriber;
+import reactor.core.publisher.SignalType;
+
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.core.log.LogAccessor;
+import org.springframework.kafka.entity.KafkaEntityException;
+import org.springframework.kafka.entity.KafkaEntityKey;
+import org.springframework.kafka.entity.KafkaEntityUtil;
+import org.springframework.kafka.support.serializer.JsonKeySerializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+/**
+ * Implementation class for @KafkaEntitySubscriber.
+ *
+ * @param <T> class of the entity, representing messages
+ * @param <K> the key from the entity
+ *
+ * @author Popovics Boglarka
+ */
+public final class SimpleKafkaEntitySubscriber<T, K> extends BaseSubscriber<T> implements DisposableBean, InitializingBean {
+
+	private final LogAccessor logger = new LogAccessor(LogFactory.getLog(getClass()));
+
+	private String clientid;
+
+	private KafkaProducer<K, T> kafkaProducer;
+
+	private Class<T> clazz;
+
+	private String topic;
+
+	/** The error, write before terminating and read after checking subscribers. */
+	Throwable error;
+
+	private Field keyField;
+
+	private boolean transactional;
+
+	private List<String> bootstrapServers;
+
+	/**
+	 * Constructs a SimpleKafkaSubscriber.
+	 *
+	 * @param <T>                   the value type
+	 * @param <K>                   the key type
+	 * @param bootstrapServers      List of bootstrapServers
+	 * @param kafkaEntitySubscriber annotation
+	 * @param entity                class of the Kafka Entity, representing messages
+	 * @param beanName              name of the Kafka Entity Bean
+	 *
+	 * @return the new SimpleKafkaSubscriber
+	 * @throws KafkaEntityException problem at creation
+	 */
+	@NonNull
+	public static <T, K> SimpleKafkaEntitySubscriber<T, K> create(List<String> bootstrapServers, KafkaEntitySubscriber kafkaEntitySubscriber, Class<T> entity,
+			String beanName) throws KafkaEntityException {
+		return new SimpleKafkaEntitySubscriber<>(bootstrapServers, kafkaEntitySubscriber, entity, beanName);
+	}
+
+	SimpleKafkaEntitySubscriber(List<String> bootstrapServers, KafkaEntitySubscriber kafkaEntitySubscriber, Class<T> entity, String beanName) throws KafkaEntityException {
+		this.bootstrapServers = bootstrapServers;
+		this.clazz = entity;
+		this.clientid = beanName;
+		this.topic = KafkaEntityUtil.getTopicName(this.clazz);
+		this.transactional = kafkaEntitySubscriber.transactional();
+
+		// presents of @KafkaEntityKey is checked in KafkaEntityConfig
+		for (Field field : this.clazz.getDeclaredFields()) {
+			if (this.logger.isDebugEnabled())  {
+				this.logger.debug("    field  -> " + field.getName());
+			}
+			if (field.isAnnotationPresent(KafkaEntityKey.class)) {
+				field.setAccessible(true);
+				this.keyField = field;
+				break;
+			}
+		}
+
+		Map<String, Object> configProps = new HashMap<>();
+		configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+		configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, JsonKeySerializer.class);
+		configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+		configProps.put(ProducerConfig.CLIENT_ID_CONFIG, this.clientid);
+
+		if (this.transactional) {
+			configProps.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, beanName + "-transactional-id");
+			configProps.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, "true");
+		}
+
+		JsonSerializer<T> valueSerializer = new JsonSerializer<>();
+		JsonKeySerializer<K> keySerializer = new JsonKeySerializer<>();
+
+		this.kafkaProducer = new KafkaProducer<K, T>(configProps, keySerializer, valueSerializer);
+
+		if (this.transactional) {
+			this.logger.info("initTransactions-begin " + beanName);
+			this.kafkaProducer.initTransactions();
+			this.logger.info("initTransactions-end " + beanName);
+		}
+	}
+
+	private K extractKey(T event) throws IllegalArgumentException, IllegalAccessException {
+		return (K) this.keyField.get(event);
+	}
+
+	@Override
+	public void hookOnSubscribe(Subscription d) {
+		if (this.transactional) {
+			this.kafkaProducer.beginTransaction();
+		}
+		super.hookOnSubscribe(d);
+	}
+
+	@Override
+	public void hookOnNext(T t) {
+		CompletableFuture<RecordMetadata> completableFuture = new CompletableFuture<>();
+		K key;
+		try {
+			key = extractKey(t);
+
+			ProducerRecord<K, T> rec = new ProducerRecord<K, T>(this.topic, key, t);
+			Future<RecordMetadata> send = this.kafkaProducer.send(rec);
+			completableFuture.complete(send.get());
+		}
+		catch (InterruptedException | ExecutionException e) {
+			completableFuture.completeExceptionally(e);
+		}
+		catch (IllegalAccessException e) {
+			completableFuture.completeExceptionally(e);
+		}
+
+		try {
+			completableFuture.get();
+		}
+		catch (InterruptedException | ExecutionException e) {
+			onError(e);
+		}
+
+		super.hookOnNext(t);
+	}
+
+	@Override
+	public void hookOnError(Throwable t) {
+		this.logger.error(t, "onError");
+		if (this.transactional) {
+			this.kafkaProducer.abortTransaction();
+		}
+		super.hookOnError(t);
+	}
+
+	@Override
+	public void hookOnComplete() {
+		if (this.transactional) {
+			this.kafkaProducer.commitTransaction();
+		}
+		super.hookOnComplete();
+	}
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+
+	}
+
+	@Override
+	public void destroy() throws Exception {
+		this.kafkaProducer.close();
+	}
+
+	@Override
+	protected void hookFinally(SignalType type) {
+		super.hookFinally(type);
+	}
+
+	@Override
+	protected void hookOnCancel() {
+		super.hookOnCancel();
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/mapping/DefaultJackson2JavaKeyTypeMapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/mapping/DefaultJackson2JavaKeyTypeMapper.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support.mapping;
+
+/**
+ * Same as DefaultJackson2JavaTypeMapper only the classIdFieldName is other.
+ *
+ * @author Popovics Boglarka
+ */
+public class DefaultJackson2JavaKeyTypeMapper extends DefaultJackson2JavaTypeMapper {
+
+	/**
+	 * Default constructor, use this.
+	 */
+	public DefaultJackson2JavaKeyTypeMapper() {
+		super();
+	}
+
+	@Override
+	public String getClassIdFieldName() {
+		// DEFAULT_KEY_CLASSID_FIELD_NAME
+		return "__Key_TypeId__";
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonKeyDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonKeyDeserializer.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2015-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support.serializer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.kafka.support.mapping.DefaultJackson2JavaKeyTypeMapper;
+import org.springframework.kafka.support.mapping.Jackson2JavaTypeMapper;
+
+/**
+ * Same as JsonDeserializer only the classIdFieldName is other because using
+ * DefaultJackson2JavaKeyTypeMapper.
+ *
+ * @param <T> class of the entity, representing messages
+ *
+ * @author Popovics Boglarka
+ */
+public class JsonKeyDeserializer<T> extends JsonDeserializer<T> {
+
+	@Override
+	public Jackson2JavaTypeMapper getTypeMapper() {
+		return new DefaultJackson2JavaKeyTypeMapper();
+	}
+
+	/**
+	 * Construct an instance with a default {@link ObjectMapper}.
+	 */
+	public JsonKeyDeserializer() {
+		super((Class<T>) null, true);
+	}
+
+	/**
+	 * Construct an instance with the provided {@link ObjectMapper}.
+	 *
+	 * @param objectMapper a custom object mapper.
+	 */
+	public JsonKeyDeserializer(ObjectMapper objectMapper) {
+		super((Class<T>) null, objectMapper, true);
+		setTypeMapper(new DefaultJackson2JavaKeyTypeMapper());
+	}
+
+	/**
+	 * Construct an instance with the provided target type.
+	 *
+	 * @param targetType the target type to use if no type info headers are present.
+	 */
+	public JsonKeyDeserializer(@Nullable Class<? super T> targetType) {
+		super(targetType);
+		setTypeMapper(new DefaultJackson2JavaKeyTypeMapper());
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonKeySerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonKeySerializer.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support.serializer;
+
+import org.springframework.kafka.support.mapping.DefaultJackson2JavaKeyTypeMapper;
+import org.springframework.kafka.support.mapping.Jackson2JavaTypeMapper;
+
+/**
+ * Same as JsonSerializer only using DefaultJackson2JavaKeyTypeMapper.
+ *
+ * @param <T> class of the entity, representing messages
+ *
+ * @author Popovics Boglarka
+ */
+public class JsonKeySerializer<T> extends JsonSerializer<T> {
+
+	@Override
+	public Jackson2JavaTypeMapper getTypeMapper() {
+		return new DefaultJackson2JavaKeyTypeMapper();
+	}
+
+	/**
+	 * Default constructor, use this.
+	 */
+	public JsonKeySerializer() {
+		super();
+		setTypeMapper(new DefaultJackson2JavaKeyTypeMapper());
+	}
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/entity/City.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/entity/City.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2016-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.entity;
+
+/**
+ * @author Popovics Boglarka
+ */
+@KafkaEntity
+public record City(@KafkaEntityKey String name) {
+
+	public String name() {
+		return name;
+	}
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/entity/CityGroup.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/entity/CityGroup.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2016-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.entity;
+
+import java.util.Objects;
+
+/**
+ * @author Popovics Boglarka
+ */
+@KafkaEntity
+public class CityGroup {
+	@KafkaEntityKey
+	private ComplexKey complexKey;
+
+	private String country;
+
+	public CityGroup() {
+		super();
+	}
+
+	public CityGroup(ComplexKey complexKey, String country) {
+		super();
+		this.complexKey = complexKey;
+		this.country = country;
+	}
+
+	public ComplexKey getComplexKey() {
+		return complexKey;
+	}
+
+	public void setComplexKey(ComplexKey complexKey) {
+		this.complexKey = complexKey;
+	}
+
+	public String getCountry() {
+		return country;
+	}
+
+	public void setCountry(String country) {
+		this.country = country;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(complexKey, country);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		CityGroup other = (CityGroup) obj;
+		return Objects.equals(complexKey, other.complexKey) && Objects.equals(country, other.country);
+	}
+
+	@Override
+	public String toString() {
+		return "CityGroup [complexKey=" + complexKey + ", country=" + country + "]";
+	}
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/entity/ComplexKey.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/entity/ComplexKey.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2016-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.entity;
+
+import java.util.Objects;
+
+/**
+ * @author Popovics Boglarka
+ */
+public class ComplexKey {
+
+	private long id;
+
+	private String name;
+
+	public ComplexKey() {
+		super();
+	}
+
+	public ComplexKey(long id, String name) {
+		super();
+		this.id = id;
+		this.name = name;
+	}
+
+	public long getId() {
+		return id;
+	}
+
+	public void setId(long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id, name);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		ComplexKey other = (ComplexKey) obj;
+		return id == other.id && Objects.equals(name, other.name);
+	}
+
+	@Override
+	public String toString() {
+		return "ComplexKey [id=" + id + ", name=" + name + "]";
+	}
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/entity/ComplexKeyRecord.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/entity/ComplexKeyRecord.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.entity;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * @author Popovics Boglarka
+ */
+public record ComplexKeyRecord(UUID uuid, LocalDateTime created) {
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/entity/Place.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/entity/Place.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.entity;
+
+/**
+ * @author Popovics Boglarka
+ */
+@KafkaEntity
+public record Place(@KafkaEntityKey String id) {
+
+	public String id() {
+		return id;
+	}
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/entity/PlaceVersion.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/entity/PlaceVersion.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2016-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.entity;
+
+import java.util.Objects;
+
+/**
+ * @author Popovics Boglarka
+ */
+@KafkaEntity
+public class PlaceVersion {
+
+	@KafkaEntityKey
+	private ComplexKeyRecord complexKeyRecord;
+
+	private String placeName;
+
+	public PlaceVersion() {
+		super();
+	}
+
+	public PlaceVersion(ComplexKeyRecord complexKeyRecord, String placeName) {
+		super();
+		this.complexKeyRecord = complexKeyRecord;
+		this.placeName = placeName;
+	}
+
+	public ComplexKeyRecord getComplexKeyRecord() {
+		return complexKeyRecord;
+	}
+
+	public void setComplexKeyRecord(ComplexKeyRecord complexKeyRecord) {
+		this.complexKeyRecord = complexKeyRecord;
+	}
+
+	public String getPlaceName() {
+		return placeName;
+	}
+
+	public void setPlaceName(String placeName) {
+		this.placeName = placeName;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(complexKeyRecord, placeName);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		PlaceVersion other = (PlaceVersion) obj;
+		return Objects.equals(complexKeyRecord, other.complexKeyRecord)
+				&& Objects.equals(placeName, other.placeName);
+	}
+
+	@Override
+	public String toString() {
+		return "PlaceVersion [complexKeyRecord=" + complexKeyRecord + ", placeName=" + placeName + "]";
+	}
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/entity/Product.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/entity/Product.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2016-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.entity;
+
+import java.util.Objects;
+
+/**
+ * @author Popovics Boglarka
+ */
+@KafkaEntity(customTopicName = "PRODUCT")
+public class Product {
+
+	@KafkaEntityKey
+	private String id;
+
+	private String title;
+
+	private String description;
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj == null) {
+			return false;
+		}
+		if (getClass() != obj.getClass()) {
+			return false;
+		}
+		Product other = (Product) obj;
+		return Objects.equals(id, other.id);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id);
+	}
+
+	@Override
+	public String toString() {
+		return "Product [id=" + id + ", title=" + title + ", description=" + description + "]";
+	}
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/entity/Student.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/entity/Student.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.entity;
+
+/**
+ * @author Popovics Boglarka
+ */
+@KafkaEntity
+public record Student(@KafkaEntityKey String studentid, int age) {
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/entity/User.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/entity/User.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2016-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.entity;
+
+/**
+ * @author Popovics Boglarka
+ */
+@KafkaEntity
+public record User(String userid) {
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/entity/reactive/EnableKafkaEntityProcessorTest.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/entity/reactive/EnableKafkaEntityProcessorTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2016-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.entity.reactive;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.logging.LogFactory;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Processor;
+import reactor.core.publisher.BaseSubscriber;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.log.LogAccessor;
+import org.springframework.kafka.annotation.EnableKafkaEntity;
+import org.springframework.kafka.entity.KafkaEntityException;
+import org.springframework.kafka.entity.Product;
+import org.springframework.kafka.entity.Student;
+import org.springframework.kafka.entity.User;
+import org.springframework.kafka.entity.reactive.EnableKafkaEntityProcessorTest.SpringKafkaEntityProcessorTestConfiguration;
+import org.springframework.kafka.test.condition.LogLevels;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.stereotype.Service;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+/**
+ * @author Popovics Boglarka
+ */
+@SpringJUnitConfig(SpringKafkaEntityProcessorTestConfiguration.class)
+@DirtiesContext
+@EmbeddedKafka(topics = {
+
+		EnableKafkaEntityProcessorTest.TOPIC_CITY, EnableKafkaEntityProcessorTest.TOPIC_PLACE,
+		EnableKafkaEntityProcessorTest.TOPIC_PRODUCT, EnableKafkaEntityProcessorTest.TOPIC_USER,
+		EnableKafkaEntityProcessorTest.TOPIC_STUDENT }, partitions = 1, brokerProperties = {
+				"offsets.topic.replication.factor=1", "offset.storage.replication.factor=1",
+				"transaction.state.log.replication.factor=1", "transaction.state.log.min.isr=1" })
+public class EnableKafkaEntityProcessorTest {
+
+	private final LogAccessor logger = new LogAccessor(LogFactory.getLog(getClass()));
+
+	@Autowired
+	private OtherKafkaEntityProcessorService processorService;
+
+	@Autowired
+	private KafkaEntityDefaultConfiguration kafkaEntityDefaultConfiguration;
+
+	public static final String TOPIC_PRODUCT = "PRODUCT";
+
+	public static final String TOPIC_USER = "org.springframework.kafka.entity.User";
+
+	public static final String TOPIC_STUDENT = "org.springframework.kafka.entity.Student";
+
+	public static final String TOPIC_CITY = "org.springframework.kafka.entity.City";
+
+	public static final String TOPIC_PLACE = "org.springframework.kafka.entity.Place";
+
+	@LogLevels(categories = { "org.springframework.kafka.entity", "reactor.core.publisher" }, level = "TRACE")
+	@Test
+	public void test_sendEvent() throws KafkaEntityException, InterruptedException, ExecutionException {
+
+		Product event = new Product();
+		event.setId("123456");
+		RecordMetadata sendEventMetadata = processorService.sendEvent(event);
+		Assertions.assertNotNull(sendEventMetadata);
+		logger.info("sendEventMetadata: " + sendEventMetadata.offset());
+
+	}
+
+	@LogLevels(categories = { "org.springframework.kafka.entity", "reactor.core.publisher" }, level = "TRACE")
+	@Test
+	public void test_sendUser() throws KafkaEntityException, InterruptedException, ExecutionException {
+
+		User event = new User("abcdef");
+		Assertions.assertThrows(NullPointerException.class, () -> processorService.sendUser(event));
+
+		KafkaEntityException ex = Assertions.assertThrows(KafkaEntityException.class,
+				() -> kafkaEntityDefaultConfiguration.throwFirstError());
+		Assertions.assertEquals(
+				"org.springframework.kafka.entity.reactive.EnableKafkaEntityProcessorTest$OtherKafkaEntityProcessorService#userProcessor: org.springframework.kafka.entity.User @KafkaEntityKey is mandatory in @KafkaEntity",
+				ex.getMessage());
+	}
+
+	@LogLevels(categories = { "org.springframework.kafka.entity", "reactor.core.publisher" }, level = "TRACE")
+	@Test
+	public void test_sendStudent() throws KafkaEntityException, InterruptedException, ExecutionException {
+
+		Student event = new Student("hrs123", 23);
+		RecordMetadata sendStudentMetadata = processorService.sendStudent(event);
+		Assertions.assertNotNull(sendStudentMetadata);
+		logger.info("sendStudentMetadata: " + sendStudentMetadata.offset());
+
+	}
+
+	@Service
+	public static class OtherKafkaEntityProcessorService {
+
+		private final LogAccessor logger = new LogAccessor(LogFactory.getLog(getClass()));
+
+		@KafkaEntityProcessor
+		private Processor<Product, RecordMetadata> productProcessor;
+
+		@KafkaEntityProcessor
+		private Processor<User, RecordMetadata> userProcessor;
+
+		@KafkaEntityProcessor(transactional = false)
+		private KafkaProcessor<Student> studentProcessor;
+
+		public RecordMetadata sendEvent(Product p) throws InterruptedException {
+			CountDownLatch countDownLatch = new CountDownLatch(1);
+			List<RecordMetadata> ret = new ArrayList<>();
+			productProcessor.subscribe(new BaseSubscriber<>() {
+				@Override
+				protected void hookOnNext(RecordMetadata r) {
+					logger.trace("received: " + r);
+					ret.add(r);
+					countDownLatch.countDown();
+				}
+			});
+			Mono.just(p).subscribe(productProcessor);
+			logger.warn("waiting 30_000");
+			countDownLatch.await(30, TimeUnit.SECONDS);
+			return ret.get(0);
+		}
+
+		public RecordMetadata sendUser(User u) throws InterruptedException {
+			CountDownLatch countDownLatch = new CountDownLatch(1);
+			List<RecordMetadata> ret = new ArrayList<>();
+			userProcessor.subscribe(new BaseSubscriber<>() {
+				@Override
+				protected void hookOnNext(RecordMetadata r) {
+					logger.trace("received: " + r);
+					ret.add(r);
+					countDownLatch.countDown();
+				}
+			});
+			Mono.just(u).subscribe(userProcessor);
+			logger.warn("waiting 30_000");
+			countDownLatch.await(30, TimeUnit.SECONDS);
+			return ret.get(0);
+		}
+
+		public RecordMetadata sendStudent(Student s) throws InterruptedException {
+			CountDownLatch countDownLatch = new CountDownLatch(1);
+			List<RecordMetadata> ret = new ArrayList<>();
+			studentProcessor.subscribe(new BaseSubscriber<>() {
+				@Override
+				protected void hookOnNext(RecordMetadata r) {
+					logger.trace("received: " + r);
+					ret.add(r);
+					countDownLatch.countDown();
+				}
+			});
+			Flux.fromIterable(Arrays.asList(s)).subscribe(studentProcessor);
+			logger.warn("waiting 30_000");
+			countDownLatch.await(30, TimeUnit.SECONDS);
+			return ret.get(0);
+		}
+
+	}
+
+	@Configuration
+	@ComponentScan(basePackageClasses = { SpringKafkaEntityProcessorTestConfiguration.class,
+			OtherKafkaEntityProcessorService.class })
+	@EnableKafkaEntity
+	public static class SpringKafkaEntityProcessorTestConfiguration {
+
+	}
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/entity/reactive/EnableKafkaEntityPublisherTest.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/entity/reactive/EnableKafkaEntityPublisherTest.java
@@ -1,0 +1,361 @@
+/*
+ * Copyright 2016-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.entity.reactive;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.logging.LogFactory;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
+import reactor.core.Disposable;
+import reactor.core.publisher.BaseSubscriber;
+import reactor.core.publisher.Flux;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.log.LogAccessor;
+import org.springframework.kafka.annotation.EnableKafkaEntity;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.entity.ComplexKeyRecord;
+import org.springframework.kafka.entity.Place;
+import org.springframework.kafka.entity.PlaceVersion;
+import org.springframework.kafka.entity.reactive.EnableKafkaEntityPublisherTest.KafkaProducerConfig;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.kafka.support.serializer.JsonKeySerializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.condition.LogLevels;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+/**
+ * @author Popovics Boglarka
+ */
+@SpringJUnitConfig(KafkaProducerConfig.class)
+@DirtiesContext
+@EmbeddedKafka(topics = { EnableKafkaEntityPublisherTest.TOPIC_PLACE,
+		EnableKafkaEntityPublisherTest.TOPIC_PLACEVERSION }, partitions = 1, brokerProperties = {
+				"offsets.topic.replication.factor=1", "offset.storage.replication.factor=1",
+				"transaction.state.log.replication.factor=1", "transaction.state.log.min.isr=1" })
+public class EnableKafkaEntityPublisherTest {
+
+	private final LogAccessor logger = new LogAccessor(LogFactory.getLog(getClass()));
+
+	@Autowired
+	private ExampleKafkaEntityPublisherService placePublisherService;
+
+	@Autowired
+	private ExampleKafkaEntityPlaceVersionPublisherService placeVersionPublisherService;
+
+	@Autowired
+	private KafkaTemplate<String, Place> kafkaProducer;
+
+	@Autowired
+	private KafkaTemplate<ComplexKeyRecord, PlaceVersion> kafkaPlaceVersionProducer;
+
+	public static final String TOPIC_PLACE = "org.springframework.kafka.entity.Place";
+
+	public static final String TOPIC_PLACEVERSION = "org.springframework.kafka.entity.PlaceVersion";
+
+	@LogLevels(categories = { "org.springframework.kafka.entity", "reactor.core.publisher" }, level = "TRACE")
+	@Test
+	public void test_sendEvent_PlaceVersion() throws Exception {
+
+		List<PlaceVersion> eventList = new ArrayList<>();
+
+		List<PlaceVersion> sending = List.of(
+				new PlaceVersion(new ComplexKeyRecord(UUID.randomUUID(), LocalDateTime.now()), "absolute now"),
+				new PlaceVersion(new ComplexKeyRecord(UUID.fromString("ee3968cc-3d74-44c0-8645-31e3546c963f"),
+						LocalDateTime.of(2025, 04, 21, 12, 24)), "fix date and uuid"));
+
+		CountDownLatch placeVersionReceivedCounter = new CountDownLatch(sending.size());
+		Publisher<PlaceVersion> placePublisher = placeVersionPublisherService.getPlaceVersionPublisher();
+		Assertions.assertNotNull(placePublisher);
+		@NonNull
+		BaseSubscriber<PlaceVersion> connect = new BaseSubscriber<>() {
+			@Override
+			protected void hookOnNext(PlaceVersion r) {
+				logger.info("received: " + r);
+				eventList.add(r);
+
+				placeVersionReceivedCounter.countDown();
+			}
+		};
+		placePublisher.subscribe(connect);
+
+		CountDownLatch placeVersionSentCounter = new CountDownLatch(sending.size());
+		publishPlaceVersionMessages(placeVersionSentCounter, 0, sending);
+
+		logger.warn("waiting maximum 60_000");
+		placeVersionSentCounter.await(60, TimeUnit.SECONDS);
+		placeVersionReceivedCounter.await(60, TimeUnit.SECONDS);
+
+		logger.warn("asserting");
+		Assertions.assertEquals(sending, eventList);
+
+	}
+
+	@LogLevels(categories = { "org.springframework.kafka.entity", "reactor.core.publisher" }, level = "TRACE")
+	@Test
+	public void test_sendEvent_Place() throws Exception {
+
+		List<Place> eventList = new ArrayList<>();
+		List<Place> eventListOther = new ArrayList<>();
+		List<Place> eventListBefore = new ArrayList<>();
+		List<Place> eventListThird = new ArrayList<>();
+
+		int sendingFirstCount = 2;
+		int sendingSecondCount = 3;
+
+		CountDownLatch beforeCounter = new CountDownLatch(sendingFirstCount + sendingSecondCount);
+		Publisher<Place> placePublisherBefore = placePublisherService.getPlacePublisherBefore();
+		Assertions.assertNotNull(placePublisherBefore);
+		@NonNull
+		BaseSubscriber<Place> connectBefore = new BaseSubscriber<>() {
+			@Override
+			protected void hookOnNext(Place r) {
+				logger.info("received-Before: " + r);
+				eventListBefore.add(r);
+
+				beforeCounter.countDown();
+			}
+		};
+		placePublisherBefore.subscribe(connectBefore);
+
+		CountDownLatch receivedCounter = new CountDownLatch(sendingFirstCount);
+		Flux<Place> placePublisher = placePublisherService.getPlacePublisher();
+
+		Disposable connect1 = placePublisher.subscribe(r -> {
+			logger.info("received: " + r);
+			eventList.add(r);
+			receivedCounter.countDown();
+		});
+
+		logger.warn("waiting 30_0000");
+		Thread.sleep(30_000);
+
+		CountDownLatch sentCounter = new CountDownLatch(sendingFirstCount);
+		publishMessages(sentCounter, 100, sendingFirstCount);
+		logger.warn("sentCounter.await() maximum 40_000");
+		sentCounter.await(40, TimeUnit.SECONDS);
+
+		logger.warn("waiting maximum 40_000");
+		receivedCounter.await(40, TimeUnit.SECONDS);
+		connect1.dispose();
+
+		Publisher<Place> placePublisherOther = placePublisherService.getPlacePublisherOther();
+		@NonNull
+		BaseSubscriber<Place> connect2 = new BaseSubscriber<>() {
+			@Override
+			protected void hookOnNext(Place r) {
+				logger.info("received-other: " + r);
+				eventListOther.add(r);
+			}
+		};
+		placePublisherOther.subscribe(connect2);
+
+		logger.warn("waiting 30_000");
+		Thread.sleep(30_000);
+		connect2.dispose();
+
+		CountDownLatch thirdCounter = new CountDownLatch(sendingSecondCount);
+		Publisher<Place> placePublisherThird = placePublisherService.getPlacePublisherThird();
+		@NonNull
+		BaseSubscriber<Place> connectThird = new BaseSubscriber<>() {
+			@Override
+			protected void hookOnNext(Place r) {
+				logger.info("received-Third: " + r);
+				eventListThird.add(r);
+				thirdCounter.countDown();
+			}
+		};
+		placePublisherThird.subscribe(connectThird);
+
+		CountDownLatch sentCounterSecond = new CountDownLatch(sendingSecondCount);
+		// send events
+		publishMessages(sentCounterSecond, 200, sendingSecondCount);
+		logger.warn("sentCounterSecond.await() max 30_000");
+		sentCounterSecond.await(30, TimeUnit.SECONDS);
+
+		logger.warn("waiting maximum 90_000");
+		thirdCounter.await(90, TimeUnit.SECONDS);
+
+		logger.warn("waiting maximum 120_000");
+		beforeCounter.await(120, TimeUnit.SECONDS);
+
+		logger.info("eventList      : " + eventList);
+		logger.info("eventListOther : " + eventListOther);
+		logger.info("eventListBefore: " + eventListBefore);
+		logger.info("eventListThird : " + eventListThird);
+		Assertions.assertEquals(sendingFirstCount, eventList.size(), "eventList");
+		Assertions.assertEquals(0, eventListOther.size(), "eventListOther");
+		Assertions.assertEquals(sendingFirstCount + sendingSecondCount, eventListBefore.size(), "eventListBefore");
+		Assertions.assertEquals(sendingSecondCount, eventListThird.size(), "eventListThird");
+
+		connectThird.dispose();
+		connectBefore.dispose();
+	}
+
+	void publishMessages(CountDownLatch sentCounter, int i, int count) throws Exception {
+
+		logger.warn("publishMessages " + i + " " + count);
+
+		for (int placeInt = 0; placeInt < count; placeInt++) {
+
+			Place p2 = new Place("p" + (i++) + "id");
+			ProducerRecord<String, Place> p2Record = new ProducerRecord<>(TOPIC_PLACE, p2.id(), p2);
+			sendPlace(sentCounter, p2Record);
+		}
+	}
+
+	void publishPlaceVersionMessages(CountDownLatch sentCounter, int i, List<PlaceVersion> placeVersionList)
+			throws Exception {
+
+		logger.warn("publishPlaceVersionMessages " + i + " " + placeVersionList.size());
+
+		for (PlaceVersion pV : placeVersionList) {
+
+			ProducerRecord<ComplexKeyRecord, PlaceVersion> p2Record = new ProducerRecord<>(TOPIC_PLACEVERSION,
+					pV.getComplexKeyRecord(), pV);
+			sendPlaceVersion(sentCounter, p2Record);
+		}
+	}
+
+	private void sendPlace(CountDownLatch sentCounter, ProducerRecord<String, Place> record)
+			throws InterruptedException, ExecutionException {
+		CompletableFuture<SendResult<String, Place>> sendingIntoTheFuture = kafkaProducer.send(record);
+
+		sendingIntoTheFuture.get();
+		while (!sendingIntoTheFuture.isDone()) {
+			logger.info("waiting");
+		}
+		sentCounter.countDown();
+	}
+
+	private void sendPlaceVersion(CountDownLatch sentCounter, ProducerRecord<ComplexKeyRecord, PlaceVersion> record)
+			throws InterruptedException, ExecutionException {
+		CompletableFuture<SendResult<ComplexKeyRecord, PlaceVersion>> sendingIntoTheFuture = kafkaPlaceVersionProducer
+				.send(record);
+
+		sendingIntoTheFuture.get();
+		while (!sendingIntoTheFuture.isDone()) {
+			logger.info("waiting");
+		}
+		sentCounter.countDown();
+	}
+
+	@Service
+	public static class ExampleKafkaEntityPublisherService {
+
+		@KafkaEntityPublisher
+		private Flux<Place> placePublisher;
+
+		@KafkaEntityPublisher
+		private Publisher<Place> placePublisherOther;
+
+		@KafkaEntityPublisher
+		private Publisher<Place> placePublisherThird;
+
+		@KafkaEntityPublisher
+		private Publisher<Place> placePublisherBefore;
+
+		public Flux<Place> getPlacePublisher() {
+			return placePublisher.log();
+		}
+
+		public Publisher<Place> getPlacePublisherOther() {
+			return placePublisherOther;
+		}
+
+		public Publisher<Place> getPlacePublisherThird() {
+			return placePublisherThird;
+		}
+
+		public Publisher<Place> getPlacePublisherBefore() {
+			return placePublisherBefore;
+		}
+
+	}
+
+	@Service
+	public static class ExampleKafkaEntityPlaceVersionPublisherService {
+
+		@KafkaEntityPublisher
+		private Publisher<PlaceVersion> placeVersionPublisher;
+
+		public Publisher<PlaceVersion> getPlaceVersionPublisher() {
+			return placeVersionPublisher;
+		}
+
+	}
+
+	@Configuration
+	@ComponentScan(basePackageClasses = { ExampleKafkaEntityPublisherService.class,
+			ExampleKafkaEntityPlaceVersionPublisherService.class })
+	@EnableKafkaEntity
+	public static class KafkaProducerConfig {
+
+		@Autowired
+		private EmbeddedKafkaBroker embeddedKafka;
+
+		@Bean
+		public ProducerFactory<String, Place> producerFactory() {
+
+			Map<String, Object> config = KafkaTestUtils.producerProps(embeddedKafka);
+
+			return new DefaultKafkaProducerFactory<>(config, new JsonKeySerializer<String>(),
+					new JsonSerializer<Place>());
+		}
+
+		@Bean
+		public KafkaTemplate<String, Place> kafkaProducer() {
+			return new KafkaTemplate<>(producerFactory());
+		}
+
+		@Bean
+		public ProducerFactory<ComplexKeyRecord, PlaceVersion> placeVersionProducerFactory() {
+			Map<String, Object> config = KafkaTestUtils.producerProps(embeddedKafka);
+
+			return new DefaultKafkaProducerFactory<>(config, new JsonKeySerializer<ComplexKeyRecord>(),
+					new JsonSerializer<PlaceVersion>());
+		}
+
+		@Bean
+		public KafkaTemplate<ComplexKeyRecord, PlaceVersion> kafkaPlaceVerionProducer() {
+			return new KafkaTemplate<>(placeVersionProducerFactory());
+		}
+	}
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/entity/reactive/EnableKafkaEntitySubscriberTest.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/entity/reactive/EnableKafkaEntitySubscriberTest.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2016-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.entity.reactive;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.commons.logging.LogFactory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Subscriber;
+import reactor.core.publisher.Flux;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.log.LogAccessor;
+import org.springframework.kafka.annotation.EnableKafkaEntity;
+import org.springframework.kafka.entity.City;
+import org.springframework.kafka.entity.CityGroup;
+import org.springframework.kafka.entity.ComplexKey;
+import org.springframework.kafka.entity.reactive.EnableKafkaEntitySubscriberTest.SpringKafkaEntitySubscriberTestConfiguration;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.condition.LogLevels;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.stereotype.Service;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+/**
+ * @author Popovics Boglarka
+ */
+@SpringJUnitConfig(SpringKafkaEntitySubscriberTestConfiguration.class)
+@DirtiesContext
+@EmbeddedKafka(topics = {EnableKafkaEntitySubscriberTest.TOPIC_CITY, EnableKafkaEntitySubscriberTest.TOPIC_CITYGROUP}, partitions = 1, brokerProperties = {
+		"offsets.topic.replication.factor=1",
+		"offset.storage.replication.factor=1", "transaction.state.log.replication.factor=1",
+		"transaction.state.log.min.isr=1" })
+public class EnableKafkaEntitySubscriberTest {
+
+	private final LogAccessor logger = new LogAccessor(LogFactory.getLog(getClass()));
+
+	@Autowired
+	private ExampleKafkaEntitySubscriberService subscriber;
+
+	@Autowired
+	private ExampleKafkaEntitySubscriberNoTransactionService subscriberNoTr;
+
+	@Autowired
+	private ExampleKafkaEntitySubscriberCityGroupService subscriberCityGroup;
+
+	@Autowired
+	private EmbeddedKafkaBroker embeddedKafka;
+
+	public static final String TOPIC_CITY = "org.springframework.kafka.entity.City";
+
+	public static final String TOPIC_CITYGROUP = "org.springframework.kafka.entity.CityGroup";
+
+	@LogLevels(categories = { "org.springframework.kafka.entity", "reactor.core.publisher" }, level = "TRACE")
+	@Test
+	public void test_sendCity() throws Exception {
+
+		List<City> eventList = subscriber.getInput();
+		Subscriber<City> productSubscriber = subscriber.getCitySubscriber();
+
+		Assertions.assertNotNull(productSubscriber);
+
+		CountDownLatch consumerInitialized = new CountDownLatch(1);
+		CountDownLatch consumerFinished = new CountDownLatch(1);
+
+		AtomicInteger sum = new AtomicInteger();
+		new Thread(new TestConsumerRunnable<City, String>("test_sendCity()", eventList.size(), TOPIC_CITY, embeddedKafka,
+				consumerInitialized, consumerFinished, sum, City.class, String.class)).start();
+
+		logger.warn("waiting maximum 200_000");
+		consumerInitialized.await(200, TimeUnit.SECONDS);
+
+		Flux.fromIterable(eventList).log().subscribe(productSubscriber);
+
+		logger.warn("waiting maximum 200_000");
+		consumerFinished.await(200, TimeUnit.SECONDS);
+		Assertions.assertEquals(eventList.size(), sum.get());
+
+	}
+
+	@LogLevels(categories = { "org.springframework.kafka.entity", "reactor.core.publisher" }, level = "TRACE")
+	@Test
+	public void test_sendCity_no_transaction() throws Exception {
+
+		List<City> eventList = subscriberNoTr.getInput();
+
+		Subscriber<City> productSubscriber = subscriberNoTr.getCitySubscriber();
+
+		Assertions.assertNotNull(productSubscriber);
+
+		CountDownLatch consumerInitialized = new CountDownLatch(1);
+		CountDownLatch consumerFinished = new CountDownLatch(1);
+
+		AtomicInteger sum = new AtomicInteger();
+		new Thread(new TestConsumerRunnable<City, String>("test_sendCity_no_transaction()", eventList.size(), TOPIC_CITY, embeddedKafka,
+				consumerInitialized, consumerFinished, sum, City.class, String.class)).start();
+
+		logger.warn("waiting maximum 200_000");
+		consumerInitialized.await(200, TimeUnit.SECONDS);
+
+		Flux.fromIterable(eventList).log().subscribe(productSubscriber);
+
+		logger.warn("waiting maximum 200_000");
+		consumerFinished.await(200, TimeUnit.SECONDS);
+		Assertions.assertEquals(eventList.size(), sum.get());
+	}
+
+	@LogLevels(categories = { "org.springframework.kafka.entity", "reactor.core.publisher" }, level = "TRACE")
+	@Test
+	public void test_sendCityGroup_with_ComplexKey() throws Exception {
+
+		List<CityGroup> eventList = subscriberCityGroup.getInput();
+		Subscriber<CityGroup> productSubscriber = subscriberCityGroup.getCityGroupSubscriber();
+
+		Assertions.assertNotNull(productSubscriber);
+
+		CountDownLatch consumerInitialized = new CountDownLatch(1);
+		CountDownLatch consumerFinished = new CountDownLatch(1);
+
+		AtomicInteger sum = new AtomicInteger();
+		new Thread(new TestConsumerRunnable<CityGroup, ComplexKey>("test_sendCityGroup_with_ComplexKey()", eventList.size(), TOPIC_CITYGROUP, embeddedKafka,
+				consumerInitialized, consumerFinished, sum, CityGroup.class, ComplexKey.class)).start();
+
+		logger.warn("waiting maximum 200_000");
+		consumerInitialized.await(200, TimeUnit.SECONDS);
+
+		Flux.fromIterable(eventList).log().subscribe(productSubscriber);
+
+		logger.warn("waiting maximum 200_000");
+		consumerFinished.await(200, TimeUnit.SECONDS);
+		Assertions.assertEquals(eventList.size(), sum.get());
+	}
+
+	@Service
+	public static class ExampleKafkaEntitySubscriberNoTransactionService {
+
+		@KafkaEntitySubscriber(transactional = false)
+		private Subscriber<City> citySubscriber;
+
+		private List<City> input = List.of(new City("Debrecen"), new City("Linz"), new City("Szeged"));
+
+		public Subscriber<City> getCitySubscriber() {
+			return citySubscriber;
+		}
+
+		public List<City> getInput() {
+			return input;
+		}
+
+	}
+
+	@Service
+	public static class ExampleKafkaEntitySubscriberService {
+
+		@KafkaEntitySubscriber
+		private Subscriber<City> citySubscriber;
+
+		private List<City> input = List.of(new City("Budapest"), new City("Wien"));
+
+		public Subscriber<City> getCitySubscriber() {
+			return citySubscriber;
+		}
+
+		public List<City> getInput() {
+			return input;
+		}
+
+	}
+
+	@Service
+	public static class ExampleKafkaEntitySubscriberCityGroupService {
+		@KafkaEntitySubscriber
+		private Subscriber<CityGroup> cityGroupSubscriber;
+
+		private List<CityGroup> input = List.of(new CityGroup(new ComplexKey(111, "group1"), "Hungary"), new CityGroup(new ComplexKey(6, "aus"), "Austria"), new CityGroup(new ComplexKey(40, "40"), "Germany"));
+
+		public Subscriber<CityGroup> getCityGroupSubscriber() {
+			return cityGroupSubscriber;
+		}
+
+		public List<CityGroup> getInput() {
+			return input;
+		}
+
+	}
+
+	@Configuration
+	@ComponentScan(basePackageClasses = { ExampleKafkaEntitySubscriberNoTransactionService.class,
+			ExampleKafkaEntitySubscriberService.class, ExampleKafkaEntitySubscriberCityGroupService.class })
+	@EnableKafkaEntity
+	public static class SpringKafkaEntitySubscriberTestConfiguration {
+
+	}
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/entity/reactive/SimpleKafkaEntityProcessorTest.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/entity/reactive/SimpleKafkaEntityProcessorTest.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2016-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.entity.reactive;
+
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.logging.LogFactory;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Processor;
+import reactor.core.publisher.BaseSubscriber;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.log.LogAccessor;
+import org.springframework.kafka.annotation.EnableKafkaEntity;
+import org.springframework.kafka.entity.KafkaEntityException;
+import org.springframework.kafka.entity.Product;
+import org.springframework.kafka.entity.Student;
+import org.springframework.kafka.entity.User;
+import org.springframework.kafka.entity.reactive.SimpleKafkaEntityProcessorTest.SpringKafkaEntityProcessorTestConfiguration;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.condition.LogLevels;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+/**
+ * @author Popovics Boglarka
+ */
+@SpringJUnitConfig(SpringKafkaEntityProcessorTestConfiguration.class)
+@DirtiesContext
+@EmbeddedKafka(topics = { SimpleKafkaEntityProcessorTest.TOPIC_PRODUCT, SimpleKafkaEntityProcessorTest.TOPIC_USER,
+		SimpleKafkaEntityProcessorTest.TOPIC_STUDENT }, partitions = 1, brokerProperties = {
+				"offsets.topic.replication.factor=1", "offset.storage.replication.factor=1",
+				"transaction.state.log.replication.factor=1", "transaction.state.log.min.isr=1" })
+public class SimpleKafkaEntityProcessorTest {
+
+	private final LogAccessor logger = new LogAccessor(LogFactory.getLog(getClass()));
+
+	@Autowired
+	private EmbeddedKafkaBroker embeddedKafka;
+
+	public static final String TOPIC_PRODUCT = "PRODUCT";
+
+	public static final String TOPIC_USER = "org.springframework.kafka.entity.User";
+
+	public static final String TOPIC_STUDENT = "org.springframework.kafka.entity.Student";
+
+	@LogLevels(categories = { "org.springframework.kafka.entity", "reactor.core.publisher" }, level = "TRACE")
+	@Test
+	public void test_sendEvent() throws KafkaEntityException, InterruptedException, ExecutionException {
+
+		Product event = new Product();
+		event.setId("123456");
+
+		Processor<Product, RecordMetadata> productProcessor = new SimpleKafkaEntityProcessor<Product, String>(
+				List.of(embeddedKafka.getBrokersAsString()), new KafkaEntityProcessor() {
+
+					@Override
+					public Class<? extends Annotation> annotationType() {
+						return KafkaEntityProcessor.class;
+					}
+
+					@Override
+					public boolean transactional() {
+						return false;
+					}
+
+				}, Product.class, "test_sendEvent");
+
+		CountDownLatch countDownLatch = new CountDownLatch(1);
+		List<RecordMetadata> ret = new ArrayList<>();
+		productProcessor.subscribe(new BaseSubscriber<>() {
+			@Override
+			protected void hookOnNext(RecordMetadata r) {
+				logger.trace("received: " + r);
+				ret.add(r);
+				countDownLatch.countDown();
+			}
+		});
+		Mono.just(event).subscribe(productProcessor);
+		logger.warn("waiting 30_000");
+		countDownLatch.await(30, TimeUnit.SECONDS);
+		RecordMetadata sendEventMetadata = ret.get(0);
+
+		Assertions.assertNotNull(sendEventMetadata);
+		logger.info("sendEventMetadata: " + sendEventMetadata.offset());
+
+		Assertions.assertEquals(TOPIC_PRODUCT, sendEventMetadata.topic());
+
+	}
+
+	@LogLevels(categories = { "org.springframework.kafka.entity", "reactor.core.publisher" }, level = "TRACE")
+	@Test
+	public void test_sendUser() throws KafkaEntityException, InterruptedException, ExecutionException {
+
+		User event = new User("abcdef");
+
+		Processor<User, RecordMetadata> userProcessor = new SimpleKafkaEntityProcessor<User, String>(
+				List.of(embeddedKafka.getBrokersAsString()), new KafkaEntityProcessor() {
+
+					@Override
+					public Class<? extends Annotation> annotationType() {
+						return KafkaEntityProcessor.class;
+					}
+
+					@Override
+					public boolean transactional() {
+						return false;
+					}
+
+				}, User.class, "test_sendUser");
+
+		CountDownLatch countDownLatch = new CountDownLatch(1);
+		List<RecordMetadata> ret = new ArrayList<>();
+		userProcessor.subscribe(new BaseSubscriber<>() {
+			@Override
+			protected void hookOnNext(RecordMetadata r) {
+				logger.trace("received: " + r);
+				ret.add(r);
+				countDownLatch.countDown();
+			}
+		});
+		Mono.just(event).subscribe(userProcessor);
+		logger.warn("waiting 5_000");
+		countDownLatch.await(5, TimeUnit.SECONDS);
+
+		// it has no KafkaEntityKey
+		Assertions.assertEquals(0, ret.size());
+	}
+
+	@LogLevels(categories = { "org.springframework.kafka.entity", "reactor.core.publisher" }, level = "TRACE")
+	@Test
+	public void test_sendStudent() throws KafkaEntityException, InterruptedException, ExecutionException {
+
+		Student event = new Student("hrs123", 23);
+
+		Processor<Student, RecordMetadata> studentProcessor = new SimpleKafkaEntityProcessor<Student, String>(
+				List.of(embeddedKafka.getBrokersAsString()), new KafkaEntityProcessor() {
+
+					@Override
+					public Class<? extends Annotation> annotationType() {
+						return KafkaEntityProcessor.class;
+					}
+
+					@Override
+					public boolean transactional() {
+						return false;
+					}
+
+				}, Student.class, "test_sendStudent");
+
+		CountDownLatch countDownLatch = new CountDownLatch(1);
+		List<RecordMetadata> ret = new ArrayList<>();
+		studentProcessor.subscribe(new BaseSubscriber<>() {
+			@Override
+			protected void hookOnNext(RecordMetadata r) {
+				logger.trace("received: " + r);
+				ret.add(r);
+				countDownLatch.countDown();
+			}
+		});
+		Flux.fromIterable(Arrays.asList(event)).subscribe(studentProcessor);
+		logger.warn("waiting 30_000");
+		countDownLatch.await(30, TimeUnit.SECONDS);
+		RecordMetadata sendStudentMetadata = ret.get(0);
+
+		Assertions.assertNotNull(sendStudentMetadata);
+		logger.info("sendStudentMetadata: " + sendStudentMetadata.offset());
+
+		Assertions.assertEquals(TOPIC_STUDENT, sendStudentMetadata.topic());
+
+	}
+
+	@Configuration
+	@EnableKafkaEntity
+	public static class SpringKafkaEntityProcessorTestConfiguration {
+
+	}
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/entity/reactive/SimpleKafkaEntityPublisherTest.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/entity/reactive/SimpleKafkaEntityPublisherTest.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2016-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.entity.reactive;
+
+import java.lang.annotation.Annotation;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.logging.LogFactory;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Publisher;
+import reactor.core.publisher.BaseSubscriber;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.log.LogAccessor;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.entity.ComplexKeyRecord;
+import org.springframework.kafka.entity.PlaceVersion;
+import org.springframework.kafka.entity.reactive.SimpleKafkaEntityPublisherTest.KafkaProducerConfig;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.kafka.support.serializer.JsonKeySerializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.condition.LogLevels;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+/**
+ * @author Popovics Boglarka
+ */
+@SpringJUnitConfig(KafkaProducerConfig.class)
+@DirtiesContext
+@EmbeddedKafka(topics = { SimpleKafkaEntityPublisherTest.TOPIC_PLACEVERSION }, partitions = 1, brokerProperties = {
+		"offsets.topic.replication.factor=1", "offset.storage.replication.factor=1",
+		"transaction.state.log.replication.factor=1", "transaction.state.log.min.isr=1" })
+public class SimpleKafkaEntityPublisherTest {
+
+	private final LogAccessor logger = new LogAccessor(LogFactory.getLog(getClass()));
+
+	@Autowired
+	private EmbeddedKafkaBroker embeddedKafka;
+
+	@Autowired
+	private KafkaTemplate<ComplexKeyRecord, PlaceVersion> kafkaPlaceVersionProducer;
+
+	public static final String TOPIC_PLACEVERSION = "org.springframework.kafka.entity.PlaceVersion";
+
+	void publishPlaceVersionMessages(CountDownLatch sentCounter, int i, List<PlaceVersion> placeVersionList)
+			throws Exception {
+
+		logger.warn("publishPlaceVersionMessages " + i + " " + placeVersionList.size());
+
+		for (PlaceVersion pV : placeVersionList) {
+
+			ProducerRecord<ComplexKeyRecord, PlaceVersion> p2Record = new ProducerRecord<>(TOPIC_PLACEVERSION,
+					pV.getComplexKeyRecord(), pV);
+			sendPlaceVersion(sentCounter, p2Record);
+		}
+	}
+
+	@LogLevels(categories = { "org.springframework.kafka.entity", "reactor.core.publisher" }, level = "TRACE")
+	@Test
+	public void test_sendEvent_PlaceVersion() throws Exception {
+
+		List<PlaceVersion> eventList = new ArrayList<>();
+
+		List<PlaceVersion> sending = List.of(
+				new PlaceVersion(new ComplexKeyRecord(UUID.randomUUID(), LocalDateTime.now()), "absolute now"),
+				new PlaceVersion(new ComplexKeyRecord(UUID.fromString("ee3968cc-3d74-44c0-8645-31e3546c963f"),
+						LocalDateTime.of(2025, 04, 21, 12, 24)), "fix date and uuid"));
+
+		CountDownLatch placeVersionReceivedCounter = new CountDownLatch(sending.size());
+		Publisher<PlaceVersion> placeVersionPublisher = new SimpleKafkaEntityPublisher<PlaceVersion, ComplexKeyRecord>(
+				List.of(embeddedKafka.getBrokersAsString()), new KafkaEntityPublisher() {
+
+					@Override
+					public Class<? extends Annotation> annotationType() {
+						return KafkaEntityPublisher.class;
+					}
+
+				}, PlaceVersion.class, "test_sendEvent_PlaceVersion");
+		Assertions.assertNotNull(placeVersionPublisher);
+		@NonNull
+		BaseSubscriber<PlaceVersion> connect = new BaseSubscriber<>() {
+			@Override
+			protected void hookOnNext(PlaceVersion r) {
+				logger.info("received: " + r);
+				eventList.add(r);
+
+				placeVersionReceivedCounter.countDown();
+			}
+		};
+		placeVersionPublisher.subscribe(connect);
+
+		CountDownLatch placeVersionSentCounter = new CountDownLatch(sending.size());
+
+		publishPlaceVersionMessages(placeVersionSentCounter, 0, sending);
+
+		logger.warn("waiting maximum 90_000");
+		placeVersionSentCounter.await(90, TimeUnit.SECONDS);
+		placeVersionReceivedCounter.await(90, TimeUnit.SECONDS);
+
+		logger.warn("asserting");
+		Assertions.assertEquals(sending, eventList);
+
+	}
+
+	private void sendPlaceVersion(CountDownLatch sentCounter, ProducerRecord<ComplexKeyRecord, PlaceVersion> record)
+			throws InterruptedException, ExecutionException {
+		CompletableFuture<SendResult<ComplexKeyRecord, PlaceVersion>> sendingIntoTheFuture = kafkaPlaceVersionProducer
+				.send(record);
+
+		sendingIntoTheFuture.get();
+		while (!sendingIntoTheFuture.isDone()) {
+			logger.info("waiting");
+		}
+		sentCounter.countDown();
+	}
+
+	@Configuration
+	public static class KafkaProducerConfig {
+
+		@Autowired
+		private EmbeddedKafkaBroker embeddedKafka;
+
+		@Bean
+		public ProducerFactory<ComplexKeyRecord, PlaceVersion> placeVersionProducerFactory() {
+			Map<String, Object> config = KafkaTestUtils.producerProps(embeddedKafka);
+
+			return new DefaultKafkaProducerFactory<>(config, new JsonKeySerializer<ComplexKeyRecord>(),
+					new JsonSerializer<PlaceVersion>());
+		}
+
+		@Bean
+		public KafkaTemplate<ComplexKeyRecord, PlaceVersion> kafkaPlaceVerionProducer() {
+			return new KafkaTemplate<>(placeVersionProducerFactory());
+		}
+	}
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/entity/reactive/SimpleKafkaEntitySubscriberTest.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/entity/reactive/SimpleKafkaEntitySubscriberTest.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2016-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.entity.reactive;
+
+import java.lang.annotation.Annotation;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.commons.logging.LogFactory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.reactivestreams.Subscriber;
+import reactor.core.publisher.Flux;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.log.LogAccessor;
+import org.springframework.kafka.entity.City;
+import org.springframework.kafka.entity.CityGroup;
+import org.springframework.kafka.entity.ComplexKey;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.condition.LogLevels;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+/**
+ * @author Popovics Boglarka
+ */
+@SpringJUnitConfig
+@DirtiesContext
+@EmbeddedKafka(topics = { SimpleKafkaEntitySubscriberTest.TOPIC_CITY,
+		SimpleKafkaEntitySubscriberTest.TOPIC_CITYGROUP }, partitions = 1, brokerProperties = {
+				"offsets.topic.replication.factor=1", "offset.storage.replication.factor=1",
+				"transaction.state.log.replication.factor=1", "transaction.state.log.min.isr=1" })
+public class SimpleKafkaEntitySubscriberTest {
+
+	private final LogAccessor logger = new LogAccessor(LogFactory.getLog(getClass()));
+
+	@Autowired
+	private EmbeddedKafkaBroker embeddedKafka;
+
+	public static final String TOPIC_CITY = "org.springframework.kafka.entity.City";
+
+	public static final String TOPIC_CITYGROUP = "org.springframework.kafka.entity.CityGroup";
+
+	@LogLevels(categories = { "org.springframework.kafka.entity", "reactor.core.publisher" }, level = "TRACE")
+	@Test
+	public void test_sendCity() throws Exception {
+
+		List<City> eventList = List.of(new City("Budapest"), new City("Wien"));
+
+		CountDownLatch consumerInitialized = new CountDownLatch(1);
+		CountDownLatch consumerFinished = new CountDownLatch(1);
+
+		AtomicInteger sum = new AtomicInteger();
+		new Thread(new TestConsumerRunnable<City, String>("test_sendCity()", eventList.size(), TOPIC_CITY,
+				embeddedKafka, consumerInitialized, consumerFinished, sum, City.class, String.class)).start();
+
+		logger.warn("waiting maximum 200_000");
+		consumerInitialized.await(200, TimeUnit.SECONDS);
+
+		Subscriber<City> productSubscriber = new SimpleKafkaEntitySubscriber<City, String>(
+				List.of(embeddedKafka.getBrokersAsString()), new KafkaEntitySubscriber() {
+
+					@Override
+					public Class<? extends Annotation> annotationType() {
+						return KafkaEntitySubscriber.class;
+					}
+
+					@Override
+					public boolean transactional() {
+						return false;
+					}
+				}, City.class, "test_sendCity");
+
+		Flux.fromIterable(eventList).subscribe(productSubscriber);
+
+		logger.warn("waiting maximum 200_000");
+		consumerFinished.await(200, TimeUnit.SECONDS);
+		Assertions.assertEquals(eventList.size(), sum.get());
+
+	}
+
+	@LogLevels(categories = { "org.springframework.kafka.entity", "reactor.core.publisher" }, level = "TRACE")
+	@Test
+	public void test_sendCity_no_transaction() throws Exception {
+
+		List<City> eventList = List.of(new City("Budapest"), new City("Hamburg"));
+
+		CountDownLatch consumerInitialized = new CountDownLatch(1);
+		CountDownLatch consumerFinished = new CountDownLatch(1);
+
+		AtomicInteger sum = new AtomicInteger();
+		new Thread(new TestConsumerRunnable<City, String>("test_sendCity()", eventList.size(), TOPIC_CITY,
+				embeddedKafka, consumerInitialized, consumerFinished, sum, City.class, String.class)).start();
+
+		logger.warn("waiting maximum 200_000");
+		consumerInitialized.await(200, TimeUnit.SECONDS);
+
+		Subscriber<City> productSubscriber = new SimpleKafkaEntitySubscriber<City, String>(
+				List.of(embeddedKafka.getBrokersAsString()), new KafkaEntitySubscriber() {
+
+					@Override
+					public Class<? extends Annotation> annotationType() {
+						return KafkaEntitySubscriber.class;
+					}
+
+					@Override
+					public boolean transactional() {
+						return false;
+					}
+				}, City.class, "test_sendCity_no_transaction");
+
+		Flux.fromIterable(eventList).subscribe(productSubscriber);
+
+		logger.warn("waiting maximum 200_000");
+		consumerFinished.await(200, TimeUnit.SECONDS);
+		Assertions.assertEquals(eventList.size(), sum.get());
+	}
+
+	@LogLevels(categories = { "org.springframework.kafka.entity", "reactor.core.publisher" }, level = "TRACE")
+	@Test
+	public void test_sendCityGroup_with_ComplexKey() throws Exception {
+
+		List<CityGroup> eventList = List.of(new CityGroup(new ComplexKey(111, "group1"), "Hungary"),
+				new CityGroup(new ComplexKey(6, "aus"), "Austria"), new CityGroup(new ComplexKey(40, "40"), "Germany"));
+
+		CountDownLatch consumerInitialized = new CountDownLatch(1);
+		CountDownLatch consumerFinished = new CountDownLatch(1);
+
+		AtomicInteger sum = new AtomicInteger();
+		new Thread(new TestConsumerRunnable<CityGroup, ComplexKey>("test_sendCityGroup_with_ComplexKey()",
+				eventList.size(), TOPIC_CITYGROUP, embeddedKafka, consumerInitialized, consumerFinished, sum,
+				CityGroup.class, ComplexKey.class)).start();
+
+		logger.warn("waiting maximum 200_000");
+		consumerInitialized.await(200, TimeUnit.SECONDS);
+
+		Subscriber<CityGroup> productSubscriber = new SimpleKafkaEntitySubscriber<CityGroup, ComplexKey>(
+				List.of(embeddedKafka.getBrokersAsString()), new KafkaEntitySubscriber() {
+
+					@Override
+					public Class<? extends Annotation> annotationType() {
+						return KafkaEntitySubscriber.class;
+					}
+
+					@Override
+					public boolean transactional() {
+						return false;
+					}
+				}, CityGroup.class, "test_sendCityGroup_with_ComplexKey");
+
+		Flux.fromIterable(eventList).subscribe(productSubscriber);
+
+		logger.warn("waiting maximum 200_000");
+		consumerFinished.await(200, TimeUnit.SECONDS);
+		Assertions.assertEquals(eventList.size(), sum.get());
+
+	}
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/entity/reactive/TestConsumerRunnable.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/entity/reactive/TestConsumerRunnable.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2016-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.entity.reactive;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.commons.logging.LogFactory;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+
+import org.springframework.core.log.LogAccessor;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonKeyDeserializer;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+
+/**
+ * @param <T> class of the entity, representing messages
+ * @param <K> the key from the entity
+ *
+ * @author Popovics Boglarka
+ */
+public class TestConsumerRunnable<T, K> implements Runnable {
+
+	private final LogAccessor logger = new LogAccessor(LogFactory.getLog(getClass()));
+
+	private String testName;
+
+	private int expectedSum;
+
+	private String topic;
+
+	private EmbeddedKafkaBroker embeddedKafka;
+
+	private CountDownLatch consumerInitialized;
+
+	private CountDownLatch consumerFinished;
+
+	private AtomicInteger sum;
+
+	private Class<T> valueClazz;
+
+	private Class<K> keyClazz;
+
+	public TestConsumerRunnable(String testName, int expectedSum, String topic, EmbeddedKafkaBroker embeddedKafka,
+			CountDownLatch consumerInitialized, CountDownLatch consumerFinished, AtomicInteger sum, Class<T> valueClazz,
+			Class<K> keyClazz) {
+		super();
+		this.testName = testName;
+		this.expectedSum = expectedSum;
+		this.topic = topic;
+		this.embeddedKafka = embeddedKafka;
+		this.consumerInitialized = consumerInitialized;
+		this.consumerFinished = consumerFinished;
+		this.sum = sum;
+		this.valueClazz = valueClazz;
+		this.keyClazz = keyClazz;
+	}
+
+	@Override
+	public void run() {
+
+		Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(this.getClass().getName(), "false",
+				embeddedKafka);
+		consumerProps.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+		JsonDeserializer<T> valueDeserializer = new JsonDeserializer<>(valueClazz);
+		JsonKeyDeserializer<K> keyDeserializer = new JsonKeyDeserializer<>(keyClazz);
+
+		valueDeserializer.addTrustedPackages(valueClazz.getPackageName());
+		keyDeserializer.addTrustedPackages(keyClazz.getPackageName());
+
+		try (KafkaConsumer<K, T> kafkaConsumer = new KafkaConsumer<K, T>(consumerProps, keyDeserializer,
+				valueDeserializer);) {
+			kafkaConsumer.subscribe(List.of(topic));
+
+			kafkaConsumer.poll(Duration.ofSeconds(10L));
+
+			kafkaConsumer.seekToEnd(Collections.emptyList());
+			kafkaConsumer.commitSync();
+			// wait until kafkaConsumer is ready and offset setted
+			LocalDateTime then = LocalDateTime.now();
+			while (kafkaConsumer.committed(kafkaConsumer.assignment()).isEmpty()) {
+				if (ChronoUnit.SECONDS.between(then, LocalDateTime.now()) >= 100) {
+					throw new RuntimeException("KafkaConsumer is not ready in 100sec.");
+				}
+			}
+			if (logger.isDebugEnabled()) {
+				logger.debug("started " + testName + "...");
+			}
+
+			do {
+				if (ChronoUnit.SECONDS.between(then, LocalDateTime.now()) >= 180) {
+					throw new RuntimeException("KafkaConsumer polling is timed out.");
+				}
+				ConsumerRecords<K, T> poll = kafkaConsumer.poll(Duration.ofSeconds(10));
+				if (logger.isTraceEnabled()) {
+					poll.forEach(cr -> logger.trace("polled: " + cr.value()));
+				}
+				sum.addAndGet(poll.count());
+				if (logger.isTraceEnabled()) {
+					logger.trace("polling... sum=" + sum);
+				}
+				consumerInitialized.countDown();
+			} while (sum.get() < expectedSum);
+
+			kafkaConsumer.unsubscribe();
+		}
+		finally {
+			consumerFinished.countDown();
+		}
+	}
+}


### PR DESCRIPTION
Hi Spring Team, 
I'm a big fan of your work. I've recently made some projects with apache kafka and found your spring-kafka library very impressive. I thought a reactive entity approach to reading/writing the kafka topics can be a good new feature. Ealier I made a spring-kafka-extension library, now I thought, I create a PR.

Imagine that you have per Topic one KafkaEntity and you can read (consume) and write (produce) them performant, easily and reactive.

When enabling with `@EnableKafkaEntity` than it create automatic a Publisher, a Subscriber or a Processor to every KafkaEntity! All you need to do is to use the custom `@KafkaEntity`,` @KafkaEntityKey`, `@KafkaEntityPublisher`,` @KafkaEntitySubscriber` and `@KafkaEntityProcessor` annotations!

![support-reactive-kafkaentity](https://github.com/user-attachments/assets/e8f3ae70-919d-4918-a4d1-aad93b3a17c6)

# how to use:
## enable KafkaEntity

```java
@Configuration
@EnableKafkaEntity
public class KafkaEntityEnvironment {
}
```

## define per topic a KafkaEntity
one class or record and mark with `@KafkaEntity` (mark a field with `@KafkaEntityKey`) 
Topic name will be the name of the entity class with included packagename
but you can use custom Topic name like this `@KafkaEntity(customTopicName = "PRODUCT")`

for example:

```java
package net.csini.spring.kafka.entity;

import org.springframework.kafka.entity.KafkaEntity;
import org.springframework.kafka.entity.KafkaEntityKey;

@KafkaEntity
public record Student(@KafkaEntityKey String studentid, int age) {

}
```
Topic name will be `net.csini.spring.kafka.entity.Student`
```java
package net.csini.spring.topic;

import org.springframework.kafka.entity.KafkaEntity;

@KafkaEntity
public class Product {

	@org.springframework.kafka.entity.KafkaEntityKey
	private String id;

	private String title;

	private String description;
	
}
```
Topic name will be `net.csini.spring.topic.Product`

## write data to a topic (produce)
in a Spring Bean just inject a **KafkaEntitySubscriber** (we assume, that City is as KafkaEntity defined)

default is `transactional=true`

```java
import java.util.List;

import net.csini.spring.kafka.entity.City;
import org.reactivestreams.Subscriber;
import reactor.core.publisher.Flux;

import org.springframework.stereotype.Service;
import org.springframework.kafka.entity.KafkaEntitySubscriber;

@Service
public class ExampleKafkaEntitySubscriberService {
	
	@KafkaEntitySubscriber
	private Subscriber<City> citySubscriber;
	
	private List<City> input = List.of(new City("Budapest"), new City("Wien"));

	public void sendCitiesToKafkaTopic(){
		Flux.fromIterable(input).subscribe(citySubscriber);
	}
}
```

if you need the **RecordMetadata** from the Kafka Message than you can use KafkaEntityProcessor

in a Spring Bean just inject a **KafkaEntityProcessor** (we assume, that User is defined as a KafkaEntity)

default is `transactional=true`

```java
import java.util.ArrayList;
import java.util.List;

import net.csini.spring.kafka.entity.User;
import org.apache.kafka.clients.producer.RecordMetadata;
import org.reactivestreams.Processor;
import reactor.core.publisher.BaseSubscriber;
import reactor.core.publisher.Mono;

import org.springframework.stereotype.Service;
import org.springframework.kafka.entity.KafkaProcessor;
import org.springframework.kafka.entity.KafkaEntityProcessor;

@Service
public class OtherKafkaEntityProcessorService {

	@KafkaEntityProcessor(transactional = false)
	private KafkaProcessor<User> userProcessor;

	public RecordMetadata sendUserToKafkaTopic(User u) {
		List<RecordMetadata> ret = new ArrayList<>();
		userProcessor.subscribe(new BaseSubscriber<>() {
			@Override
			protected void hookOnNext(RecordMetadata r) {
				ret.add(r);
			}
		});
		Mono.just(u).subscribe(userProcessor);

                // implement to wait for receive data, than return

		return ret.get(0);
	}

}
```

## read data from a topic (consume)
in a Spring Bean just inject a **KafkaEntityPublisher** (we assume Place is defined as a KafkaEntity)

```java
import net.csini.spring.kafka.entity.Place;
import reactor.core.publisher.BaseSubscriber;
import org.reactivestreams.Publisher;

import org.springframework.stereotype.Service;
import org.springframework.kafka.entity.KafkaEntityPublisher;


@Service
public class ExampleKafkaEntityPublisherService {

	@KafkaEntityPublisher
	private Publisher<Place> placePublisher;
	
	public void readPlacesFromKafkaTopic() throws Exception {

		List<Place> eventList = new ArrayList<>();
		
	        placePublisher.subscribe(new BaseSubscriber<>() {
			@Override
			protected void hookOnNext(Place r) {
				eventList.add(r);
			}
		});
	}
}
```

