### PR TITLE
GH-3880: The DefaultHandler resolves an incorrect value for the parameter annotated with @Header.

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/receiving-messages/class-level-kafkalistener.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/receiving-messages/class-level-kafkalistener.adoc
@@ -62,3 +62,25 @@ void listen(Object in, @Header(KafkaHeaders.RECORD_METADATA) ConsumerRecordMetad
     ...
 }
 ----
+
+Also, this won't work as well.
+The `topic` is resolved to the `payload`.
+
+[source, java]
+----
+@KafkaHandler(isDefault = true)
+public void listenDefault(String payload, @Header(KafkaHeaders.RECEIVED_TOPIC) String topic) {
+    // payload.equals(topic) is True.
+    ...
+}
+----
+
+If there are use cases in which discrete custom headers are required in a default method, use this:
+[source, java]
+----
+@KafkaHandler(isDefault = true)
+void listenDefault(String payload, @Headers Map<String, Object> headers) {
+    Object myValue = headers.get("MyCustomHeader");
+    ...
+}
+----


### PR DESCRIPTION
- Fixes #3880 

```java
// HandlerAdapter.java
Object[] args = new Object[providedArgs.length + 1];
args[0] = message.getPayload();
System.arraycopy(providedArgs, 0, args, 1, providedArgs.length);
return this.delegatingHandler.invoke(message, args);
```
If `defaultHandler` is set, the above code is executed.
During this call stack, the `args` array contains a payload of `KafkaMessage`, which is then passed to the invoked method.

[InvocableHandlerMethod.java (L212-L224)](https://github.com/spring-projects/spring-framework/blob/ecdb63371e99b4a285903106dcc06e90b355db53/spring-web/src/main/java/org/springframework/web/method/support/InvocableHandlerMethod.java#L212-L224)

```java

protected @Nullable Object[] getMethodArgumentValues(Message<?> message, @Nullable Object... providedArgs) throws Exception {
		MethodParameter[] parameters = getMethodParameters();
                 ...
 
		@Nullable Object[] args = new Object[parameters.length];
		for (int i = 0; i < parameters.length; i++) {
                 ...
			args[i] = findProvidedArgument(parameter, providedArgs); // Resolved by ProvidedArgs
			if (args[i] != null) {
				continue;
			}
                 ...
			try {
				args[i] = this.resolvers.resolveArgument(parameter, message); // Resolved By @Header
			}

```
each paramater's value is resolved here. 

```java
protected static @Nullable Object findProvidedArgument(MethodParameter parameter, @Nullable Object... providedArgs) {
		if (!ObjectUtils.isEmpty(providedArgs)) {
			for (Object providedArg : providedArgs) {
				if (parameter.getParameterType().isInstance(providedArg)) {
					return providedArg;
				}
			}
		}
		return null;
	}
```

However, the method `findProvidedArgument(...)` resolves parameter by only checking `parameterType`.
So, if either the payload type or the parameter type annotated with `@Header` is `String`, 
the payload and the annotated parameter will have the same value. 




