### PR TITLE
Rephrase replication factor documentation

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryableTopic.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryableTopic.java
@@ -119,7 +119,7 @@ public @interface RetryableTopic {
 	/**
 	 * The replication factor for the automatically created topics. Expressions must
 	 * resolve to a short or a String that can be parsed as such. Default is -1 to use the
-	 * broker default if the broker is earlier than version 2.4, an explicit value is
+	 * broker default. If the broker is earlier than version 2.4, an explicit value is
 	 * required.
 	 *
 	 * @return the replication factor.

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationBuilder.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationBuilder.java
@@ -432,8 +432,8 @@ public class RetryTopicConfigurationBuilder {
 	 * Configure the topic creation behavior to auto create topics with the provided
 	 * properties.
 	 * @param numPartitions the number of partitions.
-	 * @param replicationFactor the replication factor (-1 to use the broker default if the
-	 * broker is version 2.4 or later).
+	 * @param replicationFactor the replication factor (-1 to use the broker default. If the
+	 * broker is earlier than version 2.4, an explicit value is required).
 	 * @return the builder.
 	 */
 	public RetryTopicConfigurationBuilder autoCreateTopicsWith(@Nullable Integer numPartitions, @Nullable Short replicationFactor) {
@@ -447,8 +447,8 @@ public class RetryTopicConfigurationBuilder {
 	 * properties.
 	 * @param shouldCreate true to auto create.
 	 * @param numPartitions the number of partitions.
-	 * @param replicationFactor the replication factor (-1 to use the broker default if the
-	 * broker is version 2.4 or later).
+	 * @param replicationFactor the replication factor (-1 to use the broker default. If the
+	 * broker is earlier than version 2.4, an explicit value is required).
 	 * @return the builder.
 	 */
 	public RetryTopicConfigurationBuilder autoCreateTopics(@Nullable Boolean shouldCreate, @Nullable Integer numPartitions,


### PR DESCRIPTION

- (1) Fix docs in `RetryableTopic` - The sentence was not properly separated. I think it was confusing.
- (2) Repharased docs in `RetryTopicConfigurationBuilder` to match the wording used in other sections, e.g. change history
https://github.com/spring-projects/spring-kafka/blob/b68db559c4367918c76ed81cef1302ae4892e28a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/appendix/change-history.adoc?plain=1#L298-L299