### PR TITLE
Correct `DeadLetterPublishingRecoverer` example to use `KafkaOperations`

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/annotation-error-handling.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/annotation-error-handling.adoc
@@ -702,7 +702,7 @@ Here is an example of configuring the publisher with `KafkaTemplate`+++s+++ that
 @Bean
 public DeadLetterPublishingRecoverer publisher(KafkaTemplate<?, ?> stringTemplate,
         KafkaTemplate<?, ?> bytesTemplate) {
-    Map<Class<?>, KafkaTemplate<?, ?>> templates = new LinkedHashMap<>();
+    Map<Class<?>, KafkaOperations<?, ?>> templates = new LinkedHashMap<>();
     templates.put(String.class, stringTemplate);
     templates.put(byte[].class, bytesTemplate);
     return new DeadLetterPublishingRecoverer(templates);


### PR DESCRIPTION
`DeadLetterPublishingRecoverer` ctor cannot take `Map<Class<?>, KafkaTemplate<?, ?>` as parameter, because constructor is `Map<Class<?>, KafkaOperations<? extends Object, ? extends Object>>`.

```
$ ./gradlew build
...

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':compileJava'.
> Compilation failed; see the compiler output below.
  /.../config/KafkaConfig.java:161: error: no suitable constructor found for DeadLetterPublishingRecoverer(Map<Class<?>,KafkaTemplate<?,?>>)
          return new DeadLetterPublishingRecoverer(templates);
                 ^
      constructor DeadLetterPublishingRecoverer.DeadLetterPublishingRecoverer(KafkaOperations<? extends Object,? extends Object>) is not applicable
        (argument mismatch; Map<Class<?>,KafkaTemplate<?,?>> cannot be converted to KafkaOperations<? extends Object,? extends Object>)
      constructor DeadLetterPublishingRecoverer.DeadLetterPublishingRecoverer(Map<Class<?>,KafkaOperations<? extends Object,? extends Object>>) is not applicable
        (argument mismatch; Map<Class<?>,KafkaTemplate<?,?>> cannot be converted to Map<Class<?>,KafkaOperations<? extends Object,? extends Object>>)
  Note: Some messages have been simplified; recompile with -Xdiags:verbose to get full output
  1 error

* Try:
> Check your code and dependencies to fix the compilation error(s)
> Run with --scan to get full insights.

BUILD FAILED in 981ms
1 actionable task: 1 executed
```

I guess type should be like this `Map<Class<?>, ? extends KafkaOperations<? extends Object, ? extends Object>>` to get KafkaTemplate as parameter, but I'm not sure if changing signature is ok. Overloading is not possible because of type erasure.

So I only updated docs first, to upcast explicitly.

Any opinion would be helpful. Thanks