### PR TITLE
Replace deprecated `FixedDelay` in docs

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/retrytopic/topic-naming.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/retrytopic/topic-naming.adoc
@@ -79,7 +79,7 @@ NOTE: The previous `FixedDelayStrategy` is now deprecated, and can be replaced b
 
 [source, java]
 ----
-@RetryableTopic(backoff = @Backoff(2_000), fixedDelayTopicStrategy = FixedDelayStrategy.SINGLE_TOPIC)
+@RetryableTopic(backoff = @Backoff(2_000), sameIntervalTopicReuseStrategy = SameIntervalTopicReuseStrategy.SINGLE_TOPIC)
 @KafkaListener(topics = "my-annotated-topic")
 public void processMessage(MyPojo message) {
     // ... message processing

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/retrytopic/topic-naming.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/retrytopic/topic-naming.adoc
@@ -94,7 +94,7 @@ public RetryTopicConfiguration myRetryTopic(KafkaTemplate<String, MyPojo> templa
             .newInstance()
             .fixedBackOff(3_000)
             .maxAttempts(5)
-            .useSingleTopicForFixedDelays()
+            .useSingleTopicForSameIntervals()
             .create(template);
 }
 ----

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/EnableKafkaRetryTopic.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/EnableKafkaRetryTopic.java
@@ -39,7 +39,7 @@ import org.springframework.kafka.retrytopic.RetryTopicConfigurationSupport;
  * &#064;Component
  * public class MyListener {
  *
- *     &#064;RetryableTopic(fixedDelayTopicStrategy = FixedDelayStrategy.SINGLE_TOPIC, backoff = @Backoff(4000))
+ *     &#064;RetryableTopic(sameIntervalTopicReuseStrategy = SameIntervalTopicReuseStrategy.SINGLE_TOPIC, backoff = @Backoff(4000))
  *     &#064;KafkaListener(topics =  "myTopic")
  * 	   public void listen(String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic) {
  *	       logger.info("Message {} received in topic {} ", message, receivedTopic);


### PR DESCRIPTION
- `FixedDelay(Topic)Strategy` -> `SameIntervalTopicReuseStrategy`
- (on RetryTopicConfigurationBuilder) `useSingleTopicForFixedDelays` -> `useSingleTopicForSameIntervals`