### PR TITLE
#3917 A constructor that fails to validate null value properly

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonMixedErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonMixedErrorHandler.java
@@ -46,7 +46,7 @@ public class CommonMixedErrorHandler implements CommonErrorHandler {
 	 */
 	public CommonMixedErrorHandler(CommonErrorHandler recordErrorHandler, CommonErrorHandler batchErrorHandler) {
 		Assert.notNull(recordErrorHandler, "'recordErrorHandler' cannot be null");
-		Assert.notNull(recordErrorHandler, "'batchErrorHandler' cannot be null");
+		Assert.notNull(batchErrorHandler, "'batchErrorHandler' cannot be null");
 		this.recordErrorHandler = recordErrorHandler;
 		this.batchErrorHandler = batchErrorHandler;
 	}


### PR DESCRIPTION
#3917 A constructor that fails to validate null value properly

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
