### PR TITLE
Altered the example in EmbeddedKafkaHolder usage

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/testing.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/testing.adoc
@@ -162,21 +162,20 @@ public final class EmbeddedKafkaHolder {
 
     public static EmbeddedKafkaBroker getEmbeddedKafka() {
         if (!started) {
-            try {
-                embeddedKafka.afterPropertiesSet();
-            }
-            catch (Exception e) {
-                throw new KafkaException("Embedded broker failed to start", e);
-            }
-            started = true;
+            synchronized (this) {
+		if (!started) {
+		    try {
+	                embeddedKafka.afterPropertiesSet();
+		    }
+	            catch (Exception e) {
+	                throw new KafkaException("Embedded broker failed to start", e);
+		    }
+	            started = true;
+		}
+	    }
         }
         return embeddedKafka;
     }
-
-    private EmbeddedKafkaHolder() {
-        super();
-    }
-
 }
 ----
 


### PR DESCRIPTION
Integration tests with an EmbeddedKafka instance are sometimes run in parallel in Junit. The current example is not thread safe, so I think the official documentation should account for that.
