### PR TITLE
GH-3879: Add cache to optimize header match performance.

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/AbstractKafkaHeaderMapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/AbstractKafkaHeaderMapper.java
@@ -66,11 +66,13 @@ public abstract class AbstractKafkaHeaderMapper implements KafkaHeaderMapper {
 
 	private final List<HeaderMatcher> matchers = new ArrayList<>();
 
-	private final ConcurrentLruCache<String, Boolean> matcherResultCache = new ConcurrentLruCache<>(1000, this::doesMatchInternal);
+	private final ConcurrentLruCache<String, Boolean> matcherResultCache =
+			new ConcurrentLruCache<>(1000, this::doesMatchInternal);
 
 	private final List<HeaderMatcher> multiValueHeaderMatchers = new ArrayList<>();
 
-	private final ConcurrentLruCache<String, Boolean> multiValueMatcherResultCache = new ConcurrentLruCache<>(1000, this::doesMatchMultiValueHeaderInternal);
+	private final ConcurrentLruCache<String, Boolean> multiValueMatcherResultCache =
+			new ConcurrentLruCache<>(1000, this::doesMatchMultiValueHeaderInternal);
 
 	private final Map<String, Boolean> rawMappedHeaders = new HashMap<>();
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/AbstractKafkaHeaderMapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/AbstractKafkaHeaderMapper.java
@@ -444,7 +444,7 @@ public abstract class AbstractKafkaHeaderMapper implements KafkaHeaderMapper {
 	/**
 	 * A Cache that remembers whether a header name matches the multi-value pattern.
 	 */
-	class HeaderPatternMatchCache {
+	private static final class HeaderPatternMatchCache {
 
 		private static final int MAX_SIZE = 1000;
 
@@ -452,19 +452,19 @@ public abstract class AbstractKafkaHeaderMapper implements KafkaHeaderMapper {
 
 		private final ConcurrentLruCache<String, Boolean> singleValueHeaderPatternMatchCache = new ConcurrentLruCache<>(MAX_SIZE, key -> Boolean.TRUE);
 
-		public boolean isMultiValuePattern(String headerName) {
+		boolean isMultiValuePattern(String headerName) {
 			return this.multiValueHeaderPatternMatchCache.contains(headerName);
 		}
 
-		public boolean isSingleValuePattern(String headerName) {
+		boolean isSingleValuePattern(String headerName) {
 			return this.singleValueHeaderPatternMatchCache.contains(headerName);
 		}
 
-		public void cacheAsSingleValueHeader(String headerName) {
+		void cacheAsSingleValueHeader(String headerName) {
 			this.singleValueHeaderPatternMatchCache.get(headerName);
 		}
 
-		public void cacheAsMultiValueHeader(String headerName) {
+		void cacheAsMultiValueHeader(String headerName) {
 			this.multiValueHeaderPatternMatchCache.get(headerName);
 		}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/DefaultKafkaHeaderMapperTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/DefaultKafkaHeaderMapperTests.java
@@ -416,8 +416,7 @@ public class DefaultKafkaHeaderMapperTests {
 	}
 
 	@ParameterizedTest
-	@ValueSource(ints = {2000})
-//	@ValueSource(ints = {500, 1000, 2000})
+	@ValueSource(ints = {500, 1000, 2000})
 	void hugeNumberOfSingleValueHeaderToTest(int numberOfSingleValueHeaderCount) {
 		// GIVEN
 		Headers rawHeaders = new RecordHeaders();


### PR DESCRIPTION
Fixes: #3879
Issue link: #3879

In previous discussion, we decided to use `LinkedHashMap` for `LruCache` Implementation. 
However, I think that we missed concurrency of KafkaListenerContainer. 
We can set concurrency when we create KafkaListener like `@KafkaListener(concurrency = 10, ....)`. 

But, `LinkedHashMap` is not thread-safe. 
So, I use `ConcurrentLruCache` provided by `spring-framework` to ensure thread-safe. 
