### PR TITLE
spring-projectsGH-3542: Adds the ability to add record interceptors instead of override them

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractMessageListenerContainer.java
@@ -16,6 +16,7 @@
 
 package org.springframework.kafka.listener;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -114,7 +115,8 @@ public abstract class AbstractMessageListenerContainer<K, V>
 
 	private int topicCheckTimeout = DEFAULT_TOPIC_CHECK_TIMEOUT;
 
-	private @Nullable RecordInterceptor<K, V> recordInterceptor;
+	// TODO: HERE ASH
+	private List<RecordInterceptor<K, V>> recordInterceptors = new ArrayList<>();
 
 	private @Nullable BatchInterceptor<K, V> batchInterceptor;
 
@@ -460,8 +462,8 @@ public abstract class AbstractMessageListenerContainer<K, V>
 		this.kafkaAdmin = kafkaAdmin;
 	}
 
-	protected @Nullable RecordInterceptor<K, V> getRecordInterceptor() {
-		return this.recordInterceptor;
+	protected List<RecordInterceptor<K, V>> getRecordInterceptors() {
+		return this.recordInterceptors;
 	}
 
 	/**
@@ -472,7 +474,9 @@ public abstract class AbstractMessageListenerContainer<K, V>
 	 * @see #setInterceptBeforeTx(boolean)
 	 */
 	public void setRecordInterceptor(@Nullable RecordInterceptor<K, V> recordInterceptor) {
-		this.recordInterceptor = recordInterceptor;
+		if (recordInterceptor != null) {
+			this.recordInterceptors.add(recordInterceptor);
+		}
 	}
 
 	protected @Nullable BatchInterceptor<K, V> getBatchInterceptor() {

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
@@ -60,6 +60,7 @@ import org.springframework.util.Assert;
  * @author Tomaz Fernandes
  * @author Wang Zhiyang
  * @author Lokesh Alamuri
+ * @author Sanghyeok An
  */
 public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageListenerContainer<K, V> {
 
@@ -282,7 +283,9 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 		container.setClientIdSuffix(this.concurrency > 1 || this.alwaysClientIdSuffix ? "-" + index : "");
 		container.setCommonErrorHandler(getCommonErrorHandler());
 		container.setAfterRollbackProcessor(getAfterRollbackProcessor());
-		container.setRecordInterceptor(getRecordInterceptor());
+		for (RecordInterceptor<K, V> recordInterceptor : getRecordInterceptors()) {
+			container.setRecordInterceptor(recordInterceptor);
+		}
 		container.setBatchInterceptor(getBatchInterceptor());
 		container.setInterceptBeforeTx(isInterceptBeforeTx());
 		container.setListenerInfo(getListenerInfo());


### PR DESCRIPTION
Fixes: #3542
Issue link: #3542

What?
Change `RecordInterceptor` to `List<RecordInterceptor>` in `MessageListenerContainer`.

Why?
To allow adding multiple `RecordInterceptor` instances instead of overriding the existing one. Currently, only a single `RecordInterceptor` is supported. Users may want to register multiple `RecordInterceptors`. There are some workarounds, but they are not clean or ideal solutions.

By supporting `List<RecordInterceptor`>, users can add their own interceptors via `setRecordInterceptor(...)`.