### PR TITLE
GH-3935: Migrate to io.spring.nullability Gradle plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ plugins {
 	id 'io.spring.nohttp' version '0.0.11'
 	id 'io.spring.dependency-management' version '1.1.7' apply false
 	id 'io.freefair.aggregate-javadoc' version '8.11'
-	id 'net.ltgt.errorprone' version '4.1.0' apply false
+	id 'io.spring.nullability' version '0.0.1' apply false
 }
 
 apply plugin: 'io.spring.nohttp'
@@ -127,7 +127,7 @@ configure(javaProjects) { subproject ->
 	apply plugin: 'checkstyle'
 	apply plugin: 'kotlin'
 	apply plugin: 'kotlin-spring'
-	apply plugin: 'net.ltgt.errorprone'
+	apply plugin: 'io.spring.nullability'
 
 	apply from: "${rootProject.projectDir}/gradle/publish-maven.gradle"
 
@@ -145,15 +145,6 @@ configure(javaProjects) { subproject ->
 	tasks.withType(JavaCompile).configureEach {
 		sourceCompatibility = JavaVersion.VERSION_17
 		options.encoding = 'UTF-8'
-		options.errorprone {
-			disableAllChecks = true
-			if (!name.toLowerCase().contains('test')) {
-				option('NullAway:OnlyNullMarked', 'true')
-				option('NullAway:CustomContractAnnotations', 'org.springframework.lang.Contract')
-				option('NullAway:JSpecifyMode', 'true')
-				error('NullAway')
-			}
-		}
 	}
 
 	compileTestKotlin {
@@ -187,9 +178,6 @@ configure(javaProjects) { subproject ->
 		}
 		testImplementation "org.hamcrest:hamcrest-core:$hamcrestVersion"
 		optionalApi "org.assertj:assertj-core:$assertjVersion"
-
-		errorprone 'com.uber.nullaway:nullaway:0.12.7'
-		errorprone 'com.google.errorprone:error_prone_core:2.36.0'
 	}
 
 	// enable all compiler warnings; individual projects may customize further


### PR DESCRIPTION
Fixes: #3935

Replaced the Error Prone and NullAway Gradle configuration and dependencies with the `io.spring.nullability` plugin to align null-safety checks with Spring Framework's nullability standards.

* Removed `net.ltgt.errorprone` plugin
* Removed ErrorProne and NullAway dependencies from the build configuration
* Applied `io.spring.nullability` plugin

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
