### PR TITLE
Ensure correct ordering of delegates regardless of user input

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingByTypeSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingByTypeSerializer.java
@@ -65,12 +65,12 @@ public class DelegatingByTypeSerializer implements Serializer<Object> {
 	}
 
 	/**
-	 * Construct an instance with the map of delegates; keys matched exactly or if the
-	 * target object is assignable to the key, depending on the assignable argument.
-	 * If assignable, entries are checked in the natural entry order so an ordered map
-	 * such as a {@link LinkedHashMap} is recommended.
-	 * @param delegates the delegates.
-	 * @param assignable whether the target is assignable to the key.
+	 * Construct an instance with the map of delegates.
+	 * If {@code assignable} is {@code false}, only exact key matches are considered.
+	 * If {@code assignable} is {@code true}, a delegate is selected if its key class
+	 * is assignable from the target object's class. When multiple matches are possible,
+	 * the most specific matching class is selected — that is, the closest match in the
+	 * class hierarchy.
 	 * @since 2.8.3
 	 */
 	public DelegatingByTypeSerializer(Map<Class<?>, Serializer<?>> delegates, boolean assignable) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingByTypeSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingByTypeSerializer.java
@@ -34,6 +34,7 @@ import org.springframework.util.Assert;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Wang Zhiyang
+ * @author Mahesh Aravind V
  *
  * @since 2.7.9
  *

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingByTypeSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingByTypeSerializer.java
@@ -41,20 +41,24 @@ import org.springframework.util.Assert;
  */
 public class DelegatingByTypeSerializer implements Serializer<Object> {
 
-	private final Map<Class<?>, Serializer<?>> delegates = new LinkedHashMap<>();
-
-	private final boolean assignable;
-
 	private static final Comparator<Entry<Class<?>, Serializer<?>>> DELEGATES_ASSIGNABILITY_COMPARATOR =
 			(entry1, entry2) -> {
 				Class<?> type1 = entry1.getKey();
 				Class<?> type2 = entry2.getKey();
 
-				if (type1.isAssignableFrom(type2)) return 1;
-				if (type2.isAssignableFrom(type1)) return -1;
+				if (type1.isAssignableFrom(type2)) {
+					return 1;
+				}
+				if (type2.isAssignableFrom(type1)) {
+					return -1;
+				}
 
 				return 0;
 			};
+
+	private final Map<Class<?>, Serializer<?>> delegates = new LinkedHashMap<>();
+
+	private final boolean assignable;
 
 	/**
 	 * Construct an instance with the map of delegates; keys matched exactly.
@@ -71,6 +75,11 @@ public class DelegatingByTypeSerializer implements Serializer<Object> {
 	 * is assignable from the target object's class. When multiple matches are possible,
 	 * the most specific matching class is selected — that is, the closest match in the
 	 * class hierarchy.
+	 *
+	 * @param delegates the delegates
+	 * @param assignable true if {@link #findDelegate(Object, Map)} should consider assignability to
+	 * the key rather than an exact match.
+	 *
 	 * @since 2.8.3
 	 */
 	public DelegatingByTypeSerializer(Map<Class<?>, Serializer<?>> delegates, boolean assignable) {
@@ -79,7 +88,8 @@ public class DelegatingByTypeSerializer implements Serializer<Object> {
 
 		if (!assignable) {
 			this.delegates.putAll(delegates);
-		} else {
+		}
+		else {
 			List<Entry<Class<?>, Serializer<?>>> sortedDelegates = delegates.entrySet().stream()
 					.sorted(DELEGATES_ASSIGNABILITY_COMPARATOR).toList();
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/DelegatingByTypeSerializerTest.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/DelegatingByTypeSerializerTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021-2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support.serializer;
+
+import org.apache.kafka.common.serialization.Serializer;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+class DelegatingByTypeSerializerTest {
+	@Nested
+	class AssignableTest {
+		@Test
+		void shouldOrderDelegatesSoChildComesBeforeParent() {
+			class Parent {}
+			class Child extends Parent {}
+			Serializer mockParentSerializer = mock(Serializer.class);
+			Serializer mockChildSerializer = mock(Serializer.class);
+
+			// Using LinkedHashMap to ensure the order is always wrong
+			Map<Class<?>, Serializer<?>> delegates = new LinkedHashMap<>();
+			delegates.put(Parent.class, mockParentSerializer);
+			delegates.put(Child.class, mockChildSerializer);
+
+			DelegatingByTypeSerializer serializer = new DelegatingByTypeSerializer(delegates, true);
+
+
+			Serializer childSerializer = serializer.findDelegate(mock(Child.class));
+			Serializer parentSerializer = serializer.findDelegate(mock(Parent.class));
+
+
+			assertEquals(mockChildSerializer, childSerializer);
+			assertEquals(mockParentSerializer, parentSerializer);
+		}
+	}
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/DelegatingByTypeSerializerTest.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/DelegatingByTypeSerializerTest.java
@@ -26,6 +26,10 @@ import java.util.Map;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
 
+/**
+ * @author Mahesh Aravind V
+ *
+ */
 class DelegatingByTypeSerializerTest {
 	@Nested
 	class AssignableTest {

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/DelegatingByTypeSerializerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/DelegatingByTypeSerializerTests.java
@@ -16,27 +16,29 @@
 
 package org.springframework.kafka.support.serializer;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
+
 import org.apache.kafka.common.serialization.Serializer;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
-
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 
 /**
  * @author Mahesh Aravind V
  *
  */
-class DelegatingByTypeSerializerTest {
+class DelegatingByTypeSerializerTests {
 	@Nested
 	class AssignableTest {
 		@Test
 		void shouldOrderDelegatesSoChildComesBeforeParent() {
-			class Parent {}
-			class Child extends Parent {}
+			class Parent { }
+
+			class Child extends Parent { }
+
 			Serializer mockParentSerializer = mock(Serializer.class);
 			Serializer mockChildSerializer = mock(Serializer.class);
 
@@ -52,8 +54,8 @@ class DelegatingByTypeSerializerTest {
 			Serializer parentSerializer = serializer.findDelegate(mock(Parent.class));
 
 
-			assertEquals(mockChildSerializer, childSerializer);
-			assertEquals(mockParentSerializer, parentSerializer);
+			assertThat(childSerializer).isEqualTo(mockChildSerializer);
+			assertThat(parentSerializer).isEqualTo(mockParentSerializer);
 		}
 	}
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
Ensure correct ordering of delegates regardless of user input. 
Fixes: #3953