### PR TITLE
Replace Spring Retry usage to core retry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -71,8 +71,7 @@ ext {
 	scalaVersion = '2.13'
 	springBootVersion = '3.5.0' // docs module
 	springDataVersion = '2025.1.0-M5'
-	springRetryVersion = '2.0.12'
-	springVersion = '7.0.0-M8'
+	springVersion = '7.0.0-SNAPSHOT'
 
 	idPrefix = 'kafka'
 
@@ -249,9 +248,6 @@ project ('spring-kafka') {
 		api 'org.springframework:spring-context'
 		api 'org.springframework:spring-messaging'
 		api 'org.springframework:spring-tx'
-		api ("org.springframework.retry:spring-retry:$springRetryVersion") {
-			exclude group: 'org.springframework'
-		}
 		api "org.apache.kafka:kafka-clients:$kafkaVersion"
 		api 'io.micrometer:micrometer-observation'
 		optionalApi "org.apache.kafka:kafka-streams:$kafkaVersion"
@@ -322,7 +318,6 @@ project ('spring-kafka-test') {
 		api "org.apache.logging.log4j:log4j-slf4j-impl:$log4jVersion"
 		api 'org.springframework:spring-context'
 		api 'org.springframework:spring-test'
-		api "org.springframework.retry:spring-retry:$springRetryVersion"
 
 		api "org.apache.kafka:kafka-clients:$kafkaVersion:test"
 		api "org.apache.kafka:kafka-server:$kafkaVersion"

--- a/samples/sample-04/src/main/java/com/example/Application.java
+++ b/samples/sample-04/src/main/java/com/example/Application.java
@@ -26,7 +26,7 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.annotation.RetryableTopic;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.messaging.handler.annotation.Header;
-import org.springframework.retry.annotation.Backoff;
+import org.springframework.kafka.annotation.Backoff;
 
 /**
  * Sample shows use of topic-based retry.

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/annotation-error-handling.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/annotation-error-handling.adoc
@@ -228,7 +228,7 @@ The exceptions that are considered fatal, by default, are:
 since these exceptions are unlikely to be resolved on a retried delivery.
 
 You can add more exception types to the not-retryable category, or completely replace the map of classified exceptions.
-See the Javadocs for `DefaultErrorHandler.addNotRetryableException()` and `DefaultErrorHandler.setClassifications()` for more information, as well as those for the `spring-retry` `BinaryExceptionClassifier`.
+See the Javadocs for `DefaultErrorHandler.addNotRetryableException()` and `DefaultErrorHandler.setClassifications()` for more information, as well as `ExceptionMatcher`.
 
 Here is an example that adds `IllegalArgumentException` to the not-retryable exceptions:
 
@@ -502,7 +502,7 @@ The exceptions that are considered fatal, by default, are:
 since these exceptions are unlikely to be resolved on a retried delivery.
 
 You can add more exception types to the not-retryable category, or completely replace the map of classified exceptions.
-See the Javadocs for `DefaultAfterRollbackProcessor.setClassifications()` for more information, as well as those for the `spring-retry` `BinaryExceptionClassifier`.
+See the Javadocs for `DefaultAfterRollbackProcessor.setClassifications()` for more information, as well as `ExceptionMatcher`.
 
 Here is an example that adds `IllegalArgumentException` to the not-retryable exceptions:
 

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/serdes.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/serdes.adoc
@@ -400,9 +400,10 @@ ConsumerFactory cf = new DefaultKafkaConsumerFactory(myConsumerConfigs,
     new RetryingDeserializer(myUnreliableValueDeserializer, retryTemplate));
 ----
 
-Starting with version `3.1.2`, a `RecoveryCallback` can be set on the `RetryingDeserializer` optionally.
+A recovery callback be set on the `RetryingDeserializer`, to return a fallback object
+if all retries are exhausted.
 
-Refer to the https://github.com/spring-projects/spring-retry[spring-retry] project for configuration of the `RetryTemplate` with a retry policy, back off policy, etc.
+Refer to the https://github.com/spring-projects/spring-framework[Spring Framework] project for configuration of the `RetryTemplate` with a retry policy, back off, etc.
 
 
 [[messaging-message-conversion]]

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/BackOff.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/BackOff.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2018-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.core.retry.RetryPolicy;
+import org.springframework.format.annotation.DurationFormat;
+import org.springframework.util.backoff.ExponentialBackOff;
+import org.springframework.util.backoff.FixedBackOff;
+
+/**
+ * Collects metadata for creating a {@link org.springframework.util.backoff.BackOff BacOff}
+ * instance as part of a {@link RetryPolicy}. Values can be provided as is or using a
+ * {@code *String} equivalent that supports more format, as well as expression evaluations.
+ * <p>
+ * The available attributes lead to the following:
+ * <ul>
+ * <li>With no explicit settings, the default is a {@link FixedBackOff} with a delay of
+ * {@value #DEFAULT_DELAY} ms</li>
+ * <li>With only {@link #delay()} set: the backoff is a fixed delay with that value</li>
+ * <li>In all other cases, an {@link ExponentialBackOff} is created with the values of
+ * {@link #delay()} (default: {@value RetryPolicy.Builder#DEFAULT_DELAY} ms),
+ * {@link #maxDelay()} (default: no maximum), {@link #multiplier()}
+ * (default: {@value RetryPolicy.Builder#DEFAULT_MULTIPLIER}) and {@link #jitter()}
+ * (default: no jitter).</li>
+ * </ul>
+ *
+ * @author Dave Syer
+ * @author Gary Russell
+ * @author Aftab Shaikh
+ * @author Stephane Nicoll
+ * @since 4.0
+ */
+@Target(ElementType.ANNOTATION_TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface BackOff {
+
+	/**
+	 * Default {@link #delay()} in milliseconds.
+	 */
+	long DEFAULT_DELAY = 1000;
+
+	/**
+	 * Alias for {@link #delay()}.
+	 * <p>Intended to be used when no other attributes are needed, for example:
+	 * {@code @BackOff(2000)}.
+	 *
+	 * @return the based delay in milliseconds (default{@value DEFAULT_DELAY})
+	 */
+	@AliasFor("delay")
+	long value() default DEFAULT_DELAY;
+
+	/**
+	 * Specify the base delay after the initial invocation.
+	 * <p>If only a {@code delay} is specified, a {@link FixedBackOff} with that value
+	 * as the interval is configured.
+	 * <p>If a {@linkplain #multiplier() multiplier} is specified, this serves as the
+	 * initial delay to multiply from.
+	 * <p>The default is {@value DEFAULT_DELAY} milliseconds.
+	 *
+	 * @return the based delay in milliseconds (default{@value DEFAULT_DELAY})
+	 */
+	@AliasFor("value")
+	long delay() default DEFAULT_DELAY;
+
+	/**
+	 * Specify the base delay after the initial invocation using a String format. If
+	 * this is specified, takes precedence over {@link #delay()}.
+	 * <p>The delay String can be in several formats:
+	 * <ul>
+	 * <li>a plain long &mdash; which is interpreted to represent a duration in
+	 * milliseconds</li>
+	 * <li>any of the known {@link DurationFormat.Style}: the {@link DurationFormat.Style#ISO8601 ISO8601}
+	 * style or the {@link DurationFormat.Style#SIMPLE SIMPLE} style &mdash; using
+	 * milliseconds as fallback if the string doesn't contain an explicit unit</li>
+	 * <li>Regular expressions, such as {@code ${example.property}} to use the
+	 * {@code example.property} from the environment</li>
+	 * </ul>
+	 *
+	 * @return the based delay as a String value &mdash; for example a placeholder
+	 * @see #delay()
+	 */
+	String delayString() default "";
+
+	/**
+	 * Specify the maximum delay for any retry attempt, limiting how far
+	 * {@linkplain #jitter jitter} and the {@linkplain #multiplier() multiplier} can
+	 * increase the {@linkplain #delay() delay}.
+	 * <p>Ignored if only {@link #delay()} is set, otherwise an {@link ExponentialBackOff}
+	 * with the given max delay or an unlimited delay if not set.
+	 *
+	 * @return the maximum delay
+	 */
+	long maxDelay() default 0;
+
+	/**
+	 * Specify the maximum delay for any retry attempt using a String format. If this is
+	 * specified, takes precedence over {@link #maxDelay()}..
+	 * <p>The max delay String can be in several formats:
+	 * <ul>
+	 * <li>a plain long &mdash; which is interpreted to represent a duration in
+	 * milliseconds</li>
+	 * <li>any of the known {@link DurationFormat.Style}: the {@link DurationFormat.Style#ISO8601 ISO8601}
+	 * style or the {@link DurationFormat.Style#SIMPLE SIMPLE} style &mdash; using
+	 * milliseconds as fallback if the string doesn't contain an explicit unit</li>
+	 * <li>Regular expressions, such as {@code ${example.property}} to use the
+	 * {@code example.property} from the environment</li>
+	 * </ul>
+	 *
+	 * @return the max delay as a String value &mdash; for example a placeholder
+	 * @see #maxDelay()
+	 */
+	String maxDelayString() default "";
+
+	/**
+	 * Specify a multiplier for a delay for the next retry attempt, applied to the previous
+	 * delay, starting with the initial {@linkplain #delay() delay} as well as to the
+	 * applicable {@linkplain #jitter() jitter} for each attempt.
+	 * <p>Ignored if only {@link #delay()} is set, otherwise an {@link ExponentialBackOff}
+	 * with the given multiplier or {@code 1.0} if not set.
+	 *
+	 * @return the value to multiply the current interval by for each attempt
+	 */
+	double multiplier() default 0;
+
+	/**
+	 * Specify a multiplier for a delay for the next retry attempt using a String format.
+	 * If this is specified, takes precedence over {@link #multiplier()}.
+	 * <p>The multiplier String can be in several formats:
+	 * <ul>
+	 * <li>a plain double</li>
+	 * <li>Regular expressions, such as {@code ${example.property}} to use the
+	 * {@code example.property} from the environment</li>
+	 * </ul>
+	 *
+	 * @return the value to multiply the current interval by for each attempt &mdash;
+	 * for example a placeholder
+	 * @see #multiplier()
+	 */
+	String multiplierString() default "";
+
+	/**
+	 * Specify a jitter value for the base retry attempt, randomly subtracted or added to
+	 * the calculated delay, resulting in a value between {@code delay - jitter} and
+	 * {@code delay + jitter} but never below the {@linkplain #delay() base delay} or
+	 * above the {@linkplain #maxDelay() max delay}.
+	 * <p>If a {@linkplain #multiplier() multiplier} is specified, it is applied to the
+	 * jitter value as well.
+	 * <p>Ignored if only {@link #delay()} is set, otherwise an {@link ExponentialBackOff}
+	 * with the given jitter or no jitter if not set.
+	 *
+	 * @return the jitter value in milliseconds
+	 * @see #delay()
+	 * @see #maxDelay()
+	 * @see #multiplier()
+	 */
+	long jitter() default 0;
+
+	/**
+	 * Specify a jitter value for the base retry attempt using a String format. If this is
+	 * specified, takes precedence over {@link #jitter()}.
+	 * <p>The jitter String can be in several formats:
+	 * <ul>
+	 * <li>a plain long &mdash; which is interpreted to represent a duration in
+	 * milliseconds</li>
+	 * <li>any of the known {@link DurationFormat.Style}: the {@link DurationFormat.Style#ISO8601 ISO8601}
+	 * style or the {@link DurationFormat.Style#SIMPLE SIMPLE} style &mdash; using
+	 * milliseconds as fallback if the string doesn't contain an explicit unit</li>
+	 * <li>Regular expressions, such as {@code ${example.property}} to use the
+	 * {@code example.property} from the environment</li>
+	 * </ul>
+	 *
+	 * @return the jitter as a String value &mdash; for example a placeholder
+	 * @see #jitter()
+	 */
+	String jitterString() default "";
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/BackOffFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/BackOffFactory.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2018-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.annotation;
+
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.core.retry.RetryPolicy;
+import org.springframework.format.annotation.DurationFormat;
+import org.springframework.format.datetime.standard.DurationFormatterUtils;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+import org.springframework.util.StringValueResolver;
+import org.springframework.util.backoff.FixedBackOff;
+
+/**
+ * Create a {@link org.springframework.util.backoff.BackOff} from the state of a
+ * {@link BackOff @BackOff} annotation.
+ *
+ * @author Stephane Nicoll
+ */
+final class BackOffFactory {
+
+	private static final long DEFAULT_DELAY = 1000;
+
+	private final @Nullable StringValueResolver embeddedValueResolver;
+
+	BackOffFactory(@Nullable StringValueResolver embeddedValueResolver) {
+		this.embeddedValueResolver = embeddedValueResolver;
+	}
+
+	/**
+	 * Create a {@link org.springframework.util.backoff.BackOff} instance based on the
+	 * state of the given {@link BackOff @Backff}. The returned backoff instance has
+	 * unlimited number of attempts as these are controlled externally.
+	 *
+	 * @param annotation the annotation to source the parameters from
+	 * @return a {@link org.springframework.util.backoff.BackOff}
+	 */
+	public org.springframework.util.backoff.BackOff createFromAnnotation(BackOff annotation) { // NOSONAR
+		Duration delay = resolveDuration("delay", () -> annotation.delay() == DEFAULT_DELAY
+				? annotation.value() : annotation.delay(), annotation::delayString);
+		Duration maxDelay = resolveDuration("maxDelay", annotation::maxDelay, annotation::maxDelayString);
+		double multiplier = resolveMultiplier(annotation);
+		Duration jitter = resolveDuration("jitter", annotation::jitter, annotation::jitterString);
+		if (maxDelay == Duration.ZERO && multiplier == 0 && jitter == Duration.ZERO) {
+			Assert.isTrue(!delay.isNegative(),
+					() -> "Invalid delay (%dms): must be >= 0.".formatted(delay.toMillis()));
+			return new FixedBackOff(delay.toMillis());
+		}
+		RetryPolicy.Builder retryPolicyBuilder = RetryPolicy.builder().maxAttempts(Long.MAX_VALUE);
+		retryPolicyBuilder.delay(delay);
+		if (maxDelay != Duration.ZERO) {
+			retryPolicyBuilder.maxDelay(maxDelay);
+		}
+		if (multiplier != 0) {
+			retryPolicyBuilder.multiplier(multiplier);
+		}
+		if (jitter != Duration.ZERO) {
+			retryPolicyBuilder.jitter(jitter);
+		}
+		return retryPolicyBuilder.build().getBackOff();
+	}
+
+	private Duration resolveDuration(String attributeName, Supplier<@Nullable Long> valueRaw,
+			Supplier<String> valueString) {
+		String resolvedValue = resolve(valueString.get());
+		if (StringUtils.hasLength(resolvedValue)) {
+			try {
+				return toDuration(resolvedValue, TimeUnit.MILLISECONDS);
+			}
+			catch (RuntimeException ex) {
+				throw new IllegalArgumentException(
+						"Invalid duration value for '%s': '%s'; %s".formatted(attributeName, resolvedValue, ex));
+			}
+		}
+		Long raw = valueRaw.get();
+		return (raw != null && raw != 0) ? Duration.ofMillis(raw) : Duration.ZERO;
+	}
+
+	private Double resolveMultiplier(BackOff annotation) {
+		String resolvedMultiplier = resolve(annotation.multiplierString());
+		if (StringUtils.hasLength(resolvedMultiplier)) {
+			try {
+				return Double.valueOf(resolvedMultiplier);
+			}
+			catch (NumberFormatException ex) {
+				throw new IllegalArgumentException(
+						"Invalid multiplier: '%s'; %s".formatted(resolvedMultiplier, ex));
+			}
+		}
+		return annotation.multiplier();
+	}
+
+	private @Nullable String resolve(String valueString) {
+		if (StringUtils.hasLength(valueString) && this.embeddedValueResolver != null) {
+			return this.embeddedValueResolver.resolveStringValue(valueString);
+		}
+		return valueString;
+	}
+
+	private static Duration toDuration(String valueToResolve, TimeUnit timeUnit) {
+		DurationFormat.Unit unit = DurationFormat.Unit.fromChronoUnit(timeUnit.toChronoUnit());
+		return DurationFormatterUtils.detectAndParse(valueToResolve, unit);
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryableTopic.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryableTopic.java
@@ -27,7 +27,6 @@ import org.springframework.kafka.retrytopic.ExceptionBasedDltDestination;
 import org.springframework.kafka.retrytopic.RetryTopicConstants;
 import org.springframework.kafka.retrytopic.SameIntervalTopicReuseStrategy;
 import org.springframework.kafka.retrytopic.TopicSuffixingStrategy;
-import org.springframework.retry.annotation.Backoff;
 
 /**
  *
@@ -60,12 +59,12 @@ public @interface RetryableTopic {
 	String attempts() default "3";
 
 	/**
-	 * Specify the backoff properties for retrying this operation. The default is a simple
-	 * {@link Backoff} specification with no properties - see it's documentation for
-	 * defaults.
-	 * @return a backoff specification
+	 * Specify the backOff properties for retrying this operation. The default is a fixed
+	 * backOff of {@value BackOff#DEFAULT_DELAY} ms. See {@link BackOff} for more details
+	 * about the available options
+	 * @return a backOff specification
 	 */
-	Backoff backoff() default @Backoff;
+	BackOff backoff() default @BackOff;
 
 	/**
 	 *

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryableTopicAnnotationProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryableTopicAnnotationProcessor.java
@@ -35,11 +35,10 @@ import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.config.BeanExpressionContext;
 import org.springframework.beans.factory.config.BeanExpressionResolver;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
-import org.springframework.context.expression.BeanFactoryResolver;
+import org.springframework.beans.factory.config.EmbeddedValueResolver;
 import org.springframework.context.expression.StandardBeanExpressionResolver;
 import org.springframework.core.MethodIntrospector;
 import org.springframework.core.annotation.AnnotationUtils;
-import org.springframework.expression.spel.support.StandardEvaluationContext;
 import org.springframework.kafka.core.KafkaOperations;
 import org.springframework.kafka.retrytopic.ExceptionBasedDltDestination;
 import org.springframework.kafka.retrytopic.RetryTopicBeanNames;
@@ -48,12 +47,6 @@ import org.springframework.kafka.retrytopic.RetryTopicConfigurationBuilder;
 import org.springframework.kafka.retrytopic.RetryTopicConfigurer;
 import org.springframework.kafka.retrytopic.RetryTopicConstants;
 import org.springframework.kafka.support.EndpointHandlerMethod;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.backoff.ExponentialBackOffPolicy;
-import org.springframework.retry.backoff.ExponentialRandomBackOffPolicy;
-import org.springframework.retry.backoff.FixedBackOffPolicy;
-import org.springframework.retry.backoff.SleepingBackOffPolicy;
-import org.springframework.retry.backoff.UniformRandomBackOffPolicy;
 import org.springframework.util.Assert;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.ReflectionUtils;
@@ -155,7 +148,7 @@ public class RetryableTopicAnnotationProcessor {
 			autoStartDlt = resolveExpressionAsBoolean(annotation.autoStartDltHandler(), "autoStartDltContainer");
 		}
 		RetryTopicConfigurationBuilder builder = RetryTopicConfigurationBuilder.newInstance()
-				.customBackoff(createBackoffFromAnnotation(annotation.backoff(), this.beanFactory))
+				.customBackoff(createBackOffFactory().createFromAnnotation(annotation.backoff()))
 				.retryTopicSuffix(resolveExpressionAsString(annotation.retryTopicSuffix(), "retryTopicSuffix"))
 				.dltSuffix(resolveExpressionAsString(annotation.dltTopicSuffix(), "dltTopicSuffix"))
 				.dltHandlerMethod(getDltProcessor(clazz, bean))
@@ -185,50 +178,11 @@ public class RetryableTopicAnnotationProcessor {
 		return builder.create(getKafkaTemplate(resolveExpressionAsString(annotation.kafkaTemplate(), "kafkaTemplate"), topics));
 	}
 
-	private SleepingBackOffPolicy<?> createBackoffFromAnnotation(Backoff backoff, @Nullable BeanFactory beanFactory) { // NOSONAR
-		StandardEvaluationContext evaluationContext = new StandardEvaluationContext();
-		if (beanFactory != null) {
-			evaluationContext.setBeanResolver(new BeanFactoryResolver(beanFactory));
+	private BackOffFactory createBackOffFactory() {
+		if (this.beanFactory != null && this.beanFactory instanceof ConfigurableBeanFactory cbf) {
+			return new BackOffFactory(new EmbeddedValueResolver(cbf));
 		}
-
-		// Code from Spring Retry
-		Long min = backoff.delay() == 0 ? backoff.value() : backoff.delay();
-		if (StringUtils.hasText(backoff.delayExpression())) {
-			min = resolveExpressionAsLong(backoff.delayExpression(), "delayExpression", true);
-		}
-		Long max = backoff.maxDelay();
-		if (StringUtils.hasText(backoff.maxDelayExpression())) {
-			max = resolveExpressionAsLong(backoff.maxDelayExpression(), "maxDelayExpression", true);
-		}
-		Double multiplier = backoff.multiplier();
-		if (StringUtils.hasText(backoff.multiplierExpression())) {
-			multiplier = resolveExpressionAsDouble(backoff.multiplierExpression(), "multiplierExpression", true);
-		}
-		if (multiplier != null && multiplier > 0) {
-			ExponentialBackOffPolicy policy = new ExponentialBackOffPolicy();
-			if (backoff.random()) {
-				policy = new ExponentialRandomBackOffPolicy();
-			}
-			if (min != null) {
-				policy.setInitialInterval(min);
-			}
-			policy.setMultiplier(multiplier);
-			if (max != null && min != null && max > min) {
-				policy.setMaxInterval(max);
-			}
-			return policy;
-		}
-		if (max != null && min != null && max > min) {
-			UniformRandomBackOffPolicy policy = new UniformRandomBackOffPolicy();
-			policy.setMinBackOffPeriod(min);
-			policy.setMaxBackOffPeriod(max);
-			return policy;
-		}
-		FixedBackOffPolicy policy = new FixedBackOffPolicy();
-		if (min != null) {
-			policy.setBackOffPeriod(min);
-		}
-		return policy;
+		return new BackOffFactory(null);
 	}
 
 	private Map<String, Set<Class<? extends Throwable>>> createDltRoutingSpecFromAnnotation(ExceptionBasedDltDestination[] routingRules) {
@@ -343,28 +297,6 @@ public class RetryableTopicAnnotationProcessor {
 		else if (resolved != null || required) {
 			throw new IllegalStateException(
 					THE_OSQ + attribute + "] must resolve to an Number or a String that can be parsed as a Long. "
-							+ RESOLVED_TO_OSQ + (resolved == null ? NULL : resolved.getClass())
-									+ CSQ_FOR_OSQ + value + CSQ);
-		}
-		return result;
-	}
-
-	@SuppressWarnings("SameParameterValue")
-	@Nullable
-	private Double resolveExpressionAsDouble(String value, String attribute, boolean required) {
-		Object resolved = resolveExpression(value);
-		Double result = null;
-		if (resolved instanceof String str) {
-			if (required || StringUtils.hasText(str)) {
-				result = Double.parseDouble(str);
-			}
-		}
-		else if (resolved instanceof Number num) {
-			result = num.doubleValue();
-		}
-		else if (resolved != null || required) {
-			throw new IllegalStateException(
-					THE_OSQ + attribute + "] must resolve to an Number or a String that can be parsed as a Double. "
 							+ RESOLVED_TO_OSQ + (resolved == null ? NULL : resolved.getClass())
 									+ CSQ_FOR_OSQ + value + CSQ);
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
@@ -511,7 +511,7 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 		}
 		if (this.skipSameTopicFatalExceptions
 				&& tp.topic().equals(record.topic())
-				&& !getClassifier().classify(exception)) {
+				&& !getExceptionMatcher().match(exception)) {
 			this.logger.error("Recovery of " + KafkaUtils.format(record)
 					+ " skipped because not retryable exception " + exception.toString()
 					+ " and the destination resolver routed back to the same topic");

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordProcessor.java
@@ -44,7 +44,7 @@ public abstract class FailedRecordProcessor extends ExceptionClassifier implemen
 	private final BiFunction<ConsumerRecord<?, ?>, @Nullable Exception, BackOff> noRetriesForClassified =
 			(rec, ex) -> {
 				Exception theEx = ErrorHandlingUtils.unwrapIfNeeded(ex);
-				if (!getClassifier().classify(theEx) || theEx instanceof KafkaBackoffException) {
+				if (!getExceptionMatcher().match(theEx) || theEx instanceof KafkaBackoffException) {
 					return NO_RETRIES_OR_DELAY_BACKOFF;
 				}
 				return this.userBackOffFunction.apply(rec, ex);

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FallbackBatchErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FallbackBatchErrorHandler.java
@@ -150,7 +150,7 @@ class FallbackBatchErrorHandler extends ExceptionClassifier implements CommonErr
 		this.retrying.put(Thread.currentThread(), true);
 		try {
 			ErrorHandlingUtils.retryBatch(thrownException, records, consumer, container, invokeListener, this.backOff,
-					this.seeker, this.recoverer, this.logger, getLogLevel(), this.retryListeners, getClassifier(),
+					this.seeker, this.recoverer, this.logger, getLogLevel(), this.retryListeners, getExceptionMatcher(),
 					this.reclassifyOnExceptionChange);
 		}
 		finally {

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/BackOffValuesGenerator.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/BackOffValuesGenerator.java
@@ -16,26 +16,19 @@
 
 package org.springframework.kafka.retrytopic;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import java.util.stream.LongStream;
+import java.util.stream.Stream;
 
 import org.jspecify.annotations.Nullable;
 
-import org.springframework.retry.backoff.BackOffContext;
-import org.springframework.retry.backoff.BackOffPolicy;
-import org.springframework.retry.backoff.FixedBackOffPolicy;
-import org.springframework.retry.backoff.NoBackOffPolicy;
-import org.springframework.retry.backoff.Sleeper;
-import org.springframework.retry.backoff.SleepingBackOffPolicy;
-import org.springframework.retry.support.RetrySynchronizationManager;
+import org.springframework.util.backoff.BackOff;
+import org.springframework.util.backoff.BackOffExecution;
+import org.springframework.util.backoff.FixedBackOff;
 
 /**
  *
  * Generates the backoff values from the provided maxAttempts value and
- * {@link BackOffPolicy}.
+ * {@link BackOff}.
  *
  * @author Tomaz Fernandes
  * @author Artem Bilan
@@ -46,76 +39,27 @@ import org.springframework.retry.support.RetrySynchronizationManager;
  */
 public class BackOffValuesGenerator {
 
-	private static final BackOffPolicy DEFAULT_BACKOFF_POLICY = new FixedBackOffPolicy();
+	private static final BackOff DEFAULT_BACKOFF = new FixedBackOff(1000);
 
 	private final int numberOfValuesToCreate;
 
-	private final BackOffPolicy backOffPolicy;
+	private final BackOff backOff;
 
-	@SuppressWarnings("this-escape")
-	public BackOffValuesGenerator(int providedMaxAttempts, @Nullable BackOffPolicy providedBackOffPolicy) {
+	public BackOffValuesGenerator(int providedMaxAttempts, @Nullable BackOff providedBackOff) {
 		this.numberOfValuesToCreate = getMaxAttempts(providedMaxAttempts) - 1;
-		BackOffPolicy policy = providedBackOffPolicy != null ? providedBackOffPolicy : DEFAULT_BACKOFF_POLICY;
-		checkBackOffPolicyType(policy);
-		this.backOffPolicy = policy;
+		this.backOff = providedBackOff != null ? providedBackOff : DEFAULT_BACKOFF;
 	}
 
-	public int getMaxAttempts(int providedMaxAttempts) {
+	private static int getMaxAttempts(int providedMaxAttempts) {
 		return providedMaxAttempts != RetryTopicConstants.NOT_SET
 				? providedMaxAttempts
 				: RetryTopicConstants.DEFAULT_MAX_ATTEMPTS;
 	}
 
 	public List<Long> generateValues() {
-		return NoBackOffPolicy.class.isAssignableFrom(this.backOffPolicy.getClass())
-				? generateFromNoBackOffPolicy(this.numberOfValuesToCreate)
-				: generateFromSleepingBackOffPolicy(this.numberOfValuesToCreate, this.backOffPolicy);
-	}
-
-	private void checkBackOffPolicyType(BackOffPolicy providedBackOffPolicy) {
-		if (!(SleepingBackOffPolicy.class.isAssignableFrom(providedBackOffPolicy.getClass())
-				|| NoBackOffPolicy.class.isAssignableFrom(providedBackOffPolicy.getClass()))) {
-			throw new IllegalArgumentException("Either a SleepingBackOffPolicy or a NoBackOffPolicy must be provided. " +
-					"Provided BackOffPolicy: " + providedBackOffPolicy.getClass().getSimpleName());
-		}
-	}
-
-	private List<Long> generateFromSleepingBackOffPolicy(int maxAttempts, BackOffPolicy providedBackOffPolicy) {
-		BackoffRetainerSleeper sleeper = new BackoffRetainerSleeper();
-		SleepingBackOffPolicy<?> retainingBackOffPolicy =
-				((SleepingBackOffPolicy<?>) providedBackOffPolicy).withSleeper(sleeper);
-		BackOffContext backOffContext = retainingBackOffPolicy.start(RetrySynchronizationManager.getContext());
-		IntStream.range(0, maxAttempts)
-				.forEach(index -> retainingBackOffPolicy.backOff(backOffContext));
-
-		return sleeper.getBackoffValues();
-	}
-
-	private List<Long> generateFromNoBackOffPolicy(int maxAttempts) {
-		return LongStream
-				.range(0, maxAttempts)
-				.mapToObj(index -> 0L)
-				.collect(Collectors.toList());
-	}
-
-	/**
-	 * This class is injected in the backoff policy to gather and hold the generated backoff values.
-	 */
-	private static final class BackoffRetainerSleeper implements Sleeper {
-
-		private static final long serialVersionUID = 1L;
-
-		private final transient List<Long> backoffValues = new ArrayList<>();
-
-		@Override
-		public void sleep(long backOffPeriod) {
-			this.backoffValues.add(backOffPeriod);
-		}
-
-		public List<Long> getBackoffValues() {
-			return this.backoffValues;
-		}
-
+		BackOffExecution backOffExecution = this.backOff.start();
+		return Stream.generate(backOffExecution::nextBackOff).
+				limit(this.numberOfValuesToCreate).toList();
 	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DefaultDestinationTopicResolver.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DefaultDestinationTopicResolver.java
@@ -109,7 +109,7 @@ public class DefaultDestinationTopicResolver extends ExceptionClassifier
 	}
 
 	private Boolean isNotFatalException(Exception e) {
-		return getClassifier().classify(e);
+		return getExceptionMatcher().match(e);
 	}
 
 	private Throwable maybeUnwrapException(@Nullable Throwable e) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DestinationTopicPropertiesFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DestinationTopicPropertiesFactory.java
@@ -27,9 +27,9 @@ import java.util.function.BiPredicate;
 
 import org.jspecify.annotations.Nullable;
 
-import org.springframework.classify.BinaryExceptionClassifier;
 import org.springframework.kafka.core.KafkaOperations;
 import org.springframework.kafka.retrytopic.DestinationTopic.Type;
+import org.springframework.kafka.support.ExceptionMatcher;
 import org.springframework.util.StringUtils;
 
 /**
@@ -81,7 +81,7 @@ public class DestinationTopicPropertiesFactory {
 	 * @param retryTopicSuffix the suffix.
 	 * @param dltSuffix the dlt suffix.
 	 * @param backOffValues the back off values.
-	 * @param exceptionClassifier the exception classifier.
+	 * @param exceptionMatcher the exception matcher.
 	 * @param numPartitions the number of partitions.
 	 * @param kafkaOperations the operations.
 	 * @param dltStrategy the dlt strategy.
@@ -91,14 +91,14 @@ public class DestinationTopicPropertiesFactory {
 	 * @since 3.0.12
 	 */
 	public DestinationTopicPropertiesFactory(String retryTopicSuffix, String dltSuffix, List<Long> backOffValues,
-			BinaryExceptionClassifier exceptionClassifier,
+			ExceptionMatcher exceptionMatcher,
 			int numPartitions, KafkaOperations<?, ?> kafkaOperations,
 			DltStrategy dltStrategy,
 			TopicSuffixingStrategy topicSuffixingStrategy,
 			SameIntervalTopicReuseStrategy sameIntervalTopicReuseStrategy,
 			long timeout) {
 
-		this(retryTopicSuffix, dltSuffix, backOffValues, exceptionClassifier, numPartitions, kafkaOperations,
+		this(retryTopicSuffix, dltSuffix, backOffValues, exceptionMatcher, numPartitions, kafkaOperations,
 				dltStrategy, topicSuffixingStrategy, sameIntervalTopicReuseStrategy, timeout, Collections.emptyMap());
 	}
 
@@ -107,7 +107,7 @@ public class DestinationTopicPropertiesFactory {
 	 * @param retryTopicSuffix the suffix.
 	 * @param dltSuffix the dlt suffix.
 	 * @param backOffValues the back off values.
-	 * @param exceptionClassifier the exception classifier.
+	 * @param exceptionMatcher the exception matcher.
 	 * @param numPartitions the number of partitions.
 	 * @param kafkaOperations the operations.
 	 * @param dltStrategy the dlt strategy.
@@ -118,7 +118,7 @@ public class DestinationTopicPropertiesFactory {
 	 * @since 3.2.0
 	 */
 	public DestinationTopicPropertiesFactory(@Nullable String retryTopicSuffix, @Nullable String dltSuffix, List<Long> backOffValues,
-			BinaryExceptionClassifier exceptionClassifier,
+			ExceptionMatcher exceptionMatcher,
 			int numPartitions, KafkaOperations<?, ?> kafkaOperations,
 			DltStrategy dltStrategy,
 			TopicSuffixingStrategy topicSuffixingStrategy,
@@ -140,7 +140,7 @@ public class DestinationTopicPropertiesFactory {
 		// Max Attempts to include the initial try.
 		this.maxAttempts = backOffValuesSize + 1;
 		this.shouldRetryOn = (attempt, throwable) -> attempt < this.maxAttempts
-				&& exceptionClassifier.classify(throwable);
+				&& exceptionMatcher.match(throwable);
 		this.retryTopicsAmount = backOffValuesSize - reusableTopicAttempts();
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
@@ -135,7 +135,7 @@ import org.springframework.kafka.support.TopicForRetryable;
  *         }</code>
  * </pre>
  * <p>Some other options include: auto-creation of topics, backoff,
- * retryOn / notRetryOn / transversing as in {@link org.springframework.retry.support.RetryTemplate},
+ * retryOn / notRetryOn / transversing as in {@link org.springframework.core.retry.RetryTemplate},
  * single-topic fixed backoff processing, custom dlt listener beans, custom topic
  * suffixes and providing specific listenerContainerFactories.
  *
@@ -245,7 +245,7 @@ import org.springframework.kafka.support.TopicForRetryable;
  * @see RetryTopicConfigurationBuilder
  * @see org.springframework.kafka.annotation.RetryableTopic
  * @see org.springframework.kafka.annotation.KafkaListener
- * @see org.springframework.retry.annotation.Backoff
+ * @see org.springframework.kafka.annotation.BackOff
  * @see org.springframework.kafka.listener.DefaultErrorHandler
  * @see org.springframework.kafka.listener.DeadLetterPublishingRecoverer
  *

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/ExceptionMatcher.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/ExceptionMatcher.java
@@ -1,0 +1,257 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.util.Assert;
+
+/**
+ * Configurable exception matcher with support for identifying matching exception in
+ * nested causes. The matcher can be configured in two ways:
+ * <ol>
+ * <li>With an {@linkplain #forAllowList() allow list}, only the registered exception
+ * matches. This includes exceptions that extends from any registered exception, or
+ * implement it if that's an interface.</li>
+ * <li>With a {@linkplain #forDenyList() () deny list}, an exception match only if
+ * it isn't found amongst the registered exceptions. As for the allow list, any
+ * exception that extends or implements one of the registered exception will lead it
+ * to not match.</li>
+ * </ol>
+ * By default, only the given {@link Throwable} is inspected. To also search nested
+ * causes, {@link #traverseCauses} should be enabled.
+ *
+ * @author Stephane Nicoll
+ * @author Dave Syer
+ * @author Gary Russell
+ */
+public class ExceptionMatcher {
+
+	private final Map<Class<? extends Throwable>, Boolean> entries;
+
+	private final boolean defaultMatch;
+
+	private boolean traverseCauses;
+
+	protected ExceptionMatcher(Map<Class<? extends Throwable>, Boolean> entries,
+			boolean matchIfNotFound, boolean traverseCauses) {
+		this.entries = new HashMap<>(entries);
+		this.defaultMatch = matchIfNotFound;
+		this.traverseCauses = traverseCauses;
+	}
+
+	/**
+	 * Create an instance with a list of exceptions. The {@code shouldMatchIfFound}
+	 * parameter determines what should happen if an exception is found within that list.
+	 * @param exceptionTypes the exceptions to register
+	 * @param shouldMatchIfFound match result if a candidate exception is found amongst
+	 * the given list
+	 */
+	public ExceptionMatcher(Collection<Class<? extends Throwable>> exceptionTypes, boolean shouldMatchIfFound) {
+		this(buildEntries(exceptionTypes, shouldMatchIfFound), !shouldMatchIfFound, false);
+	}
+
+	private static Map<Class<? extends Throwable>, Boolean> buildEntries(
+			Collection<Class<? extends Throwable>> exceptionType, boolean value) {
+		Map<Class<? extends Throwable>, Boolean> cache = new HashMap<>();
+		for (Class<? extends Throwable> type : exceptionType) {
+			cache.put(type, value);
+		}
+		return cache;
+	}
+
+	/**
+	 * Create a matcher that matches any {@link Exception}, but not errors.
+	 *
+	 * @return a matcher that match any exception, but not errors
+	 */
+	public static ExceptionMatcher defaultMatcher() {
+		return new ExceptionMatcher(Collections.<Class<? extends Throwable>, Boolean>singletonMap(Exception.class, true), false, false);
+	}
+
+	/**
+	 * Create a builder for a matcher that only match an exception that is found in
+	 * the configurable list of exception types.
+	 *
+	 * @return a {@link Builder} that configures an allow list of exceptions
+	 */
+	public static Builder forAllowList() {
+		return new Builder(true);
+	}
+
+	/**
+	 * Create a builder for a matcher that only match an exception that is not found in
+	 * the configurable list of exception types.
+	 *
+	 * @return a {@link Builder} that configures a deny list of exceptions
+	 */
+	public static Builder forDenyList() {
+		return new Builder(false);
+	}
+
+	/**
+	 * Specify if this match should traverse nested causes to check for the
+	 * presence of a matching exception.
+	 *
+	 * @param traverseCauses whether to traverse causes
+	 */
+	public void setTraverseCauses(boolean traverseCauses) {
+		this.traverseCauses = traverseCauses;
+	}
+
+	/**
+	 * Specify if the given {@link Throwable} match this instance.
+	 *
+	 * @param exception the exception to check
+	 * @return {@code true} if this exception match this instance, {@code false} otherwise
+	 */
+	public boolean match(@Nullable Throwable exception) {
+		boolean match = matchInCache(exception);
+		if (!this.traverseCauses || exception == null) {
+			return match;
+		}
+		/*
+		 * If the result is the default, we need to find out if it was by default or so
+		 * configured; if default, try the cause(es).
+		 */
+		if (match == this.defaultMatch) {
+			Throwable cause = exception;
+			do {
+				if (this.entries.containsKey(cause.getClass())) {
+					return match; // non-default classification
+				}
+				cause = cause.getCause();
+				match = match(cause);
+			}
+			while (cause != null && match == this.defaultMatch);
+		}
+		return match;
+	}
+
+	protected Map<Class<? extends Throwable>, Boolean> getEntries() {
+		return this.entries;
+	}
+
+	private boolean matchInCache(@Nullable Throwable classifiable) {
+		if (classifiable == null) {
+			return this.defaultMatch;
+		}
+
+		Class<? extends Throwable> exceptionClass = classifiable.getClass();
+		if (this.entries.containsKey(exceptionClass)) {
+			return this.entries.get(exceptionClass);
+		}
+
+		// check for subclasses
+		Boolean value = null;
+		for (Class<?> cls = exceptionClass.getSuperclass(); !cls.equals(Object.class)
+				&& value == null; cls = cls.getSuperclass()) {
+			value = this.entries.get(cls);
+		}
+
+		// check for interfaces subclasses
+		if (value == null) {
+			for (Class<?> cls = exceptionClass; !cls.equals(Object.class) && value == null; cls = cls.getSuperclass()) {
+				for (Class<?> ifc : cls.getInterfaces()) {
+					value = this.entries.get(ifc);
+					if (value != null) {
+						break;
+					}
+				}
+			}
+		}
+
+		// ConcurrentHashMap doesn't allow nulls
+		if (value != null) {
+			this.entries.put(exceptionClass, value);
+		}
+		if (value == null) {
+			value = this.defaultMatch;
+		}
+		return value;
+	}
+
+	/**
+	 * Fluent API for configuring an {@link ExceptionMatcher}.
+	 */
+	public static class Builder {
+
+		private final boolean matchIfFound;
+
+		private final Set<Class<? extends Throwable>> exceptionClasses = new LinkedHashSet<>();
+
+		private boolean traverseCauses = false;
+
+		protected Builder(boolean matchIfFound) {
+			this.matchIfFound = matchIfFound;
+		}
+
+		/**
+		 * Add an exception type.
+		 *
+		 * @param exceptionType the exception type to add
+		 * @return {@code this}
+		 */
+		public Builder add(Class<? extends Throwable> exceptionType) {
+			Assert.notNull(exceptionType, "Exception class can not be null");
+			this.exceptionClasses.add(exceptionType);
+			return this;
+		}
+
+		/**
+		 * Add all exception type from the given collection.
+		 *
+		 * @param exceptionTypes the exception types to add
+		 * @return {@code this}
+		 */
+		public Builder addAll(Collection<Class<? extends Throwable>> exceptionTypes) {
+			this.exceptionClasses.addAll(exceptionTypes);
+			return this;
+		}
+
+		/**
+		 * Specify if the matcher should traverse nested causes to check for the presence
+		 * of a matching exception.
+		 *
+		 * @param traverseCauses whether to traverse causes
+		 * @return {@code this}
+		 */
+		public Builder traverseCauses(boolean traverseCauses) {
+			this.traverseCauses = traverseCauses;
+			return this;
+		}
+
+		/**
+		 * Build an {@link ExceptionMatcher}.
+		 *
+		 * @return a new exception matcher
+		 */
+		public ExceptionMatcher build() {
+			return new ExceptionMatcher(buildEntries(new ArrayList<>(this.exceptionClasses), this.matchIfFound),
+					!this.matchIfFound, this.traverseCauses);
+		}
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/RetryingDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/RetryingDeserializer.java
@@ -18,13 +18,15 @@ package org.springframework.kafka.support.serializer;
 
 import java.nio.ByteBuffer;
 import java.util.Map;
+import java.util.function.Function;
 
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.jspecify.annotations.Nullable;
 
-import org.springframework.retry.RecoveryCallback;
-import org.springframework.retry.RetryOperations;
+import org.springframework.core.retry.RetryException;
+import org.springframework.core.retry.RetryOperations;
+import org.springframework.core.retry.Retryable;
 import org.springframework.util.Assert;
 
 /**
@@ -44,7 +46,7 @@ public class RetryingDeserializer<T> implements Deserializer<T> {
 	private final RetryOperations retryOperations;
 
 	@Nullable
-	private RecoveryCallback<T> recoveryCallback;
+	private Function<RetryException, T> recoveryCallback;
 
 	public RetryingDeserializer(Deserializer<T> delegate, RetryOperations retryOperations) {
 		Assert.notNull(delegate, "the 'delegate' deserializer cannot be null");
@@ -55,10 +57,11 @@ public class RetryingDeserializer<T> implements Deserializer<T> {
 
 	/**
 	 * Set a recovery callback to execute when the retries are exhausted.
-	 * @param recoveryCallback {@link RecoveryCallback} to execute
-	 * @since 3.1.2
+	 * @param recoveryCallback the recovery callback
+	 * @since 4.0
+	 * @see RetryException
 	 */
-	public void setRecoveryCallback(@Nullable RecoveryCallback<T> recoveryCallback) {
+	public void setRecoveryCallback(Function<RetryException, T> recoveryCallback) {
 		this.recoveryCallback = recoveryCallback;
 	}
 
@@ -69,22 +72,38 @@ public class RetryingDeserializer<T> implements Deserializer<T> {
 
 	@Override
 	public @Nullable T deserialize(String topic, byte[] data) {
-		return this.retryOperations.execute(context -> this.delegate.deserialize(topic, data), this.recoveryCallback);
+		return execute(() -> this.delegate.deserialize(topic, data));
 	}
 
 	@Override
 	public @Nullable T deserialize(String topic, Headers headers, byte[] data) {
-		return this.retryOperations.execute(context -> this.delegate.deserialize(topic, headers, data), this.recoveryCallback);
+		return execute(() -> this.delegate.deserialize(topic, headers, data));
 	}
 
 	@Override
 	public @Nullable T deserialize(String topic, Headers headers, ByteBuffer data) {
-		return this.retryOperations.execute(context -> this.delegate.deserialize(topic, headers, data), this.recoveryCallback);
+		return execute(() -> this.delegate.deserialize(topic, headers, data));
 	}
 
 	@Override
 	public void close() {
 		this.delegate.close();
+	}
+
+	private @Nullable T execute(Retryable<T>  retryable) {
+		try {
+			return this.retryOperations.execute(retryable);
+		}
+		catch (RetryException ex) {
+			if (this.recoveryCallback != null) {
+				return this.recoveryCallback.apply(ex);
+			}
+			Throwable cause = ex.getCause();
+			if (cause instanceof RuntimeException runtimeEx) {
+				throw runtimeEx;
+			}
+			throw new IllegalStateException(cause);
+		}
 	}
 
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/BackOffFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/BackOffFactoryTests.java
@@ -1,0 +1,285 @@
+/*
+ * Copyright 2018-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Method;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.config.EmbeddedValueResolver;
+import org.springframework.context.support.StaticApplicationContext;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.util.ReflectionUtils;
+import org.springframework.util.backoff.ExponentialBackOff;
+import org.springframework.util.backoff.FixedBackOff;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+/**
+ * Tests for {@link BackOffFactory}.
+ *
+ * @author Stephane Nicoll
+ */
+class BackOffFactoryTests {
+
+	private final BackOffFactory backOffFactory = new BackOffFactory(null);
+
+	@Test
+	void createFromAnnotationWithDefaults() {
+		assertThat(this.backOffFactory.createFromAnnotation(getAnnotation("withDefaults")))
+				.isInstanceOfSatisfying(FixedBackOff.class, (backOff) ->
+						assertThat(backOff.getInterval()).isEqualTo(1000));
+	}
+
+	@Test
+	void createFromAnnotationWithDelayOnlyOnValue() {
+		assertThat(this.backOffFactory.createFromAnnotation(getAnnotation("withDelayOnlyValue")))
+				.isInstanceOfSatisfying(FixedBackOff.class, (backOff) ->
+						assertThat(backOff.getInterval()).isEqualTo(2000));
+	}
+
+	@Test
+	void createFromAnnotationWithDelayOnlyOnAttribute() {
+		assertThat(this.backOffFactory.createFromAnnotation(getAnnotation("withDelayOnlyAttribute")))
+				.isInstanceOfSatisfying(FixedBackOff.class, (backOff) ->
+						assertThat(backOff.getInterval()).isEqualTo(2000));
+	}
+
+	@Test
+	void createFromAnnotationWithDelayValueToZero() {
+		assertThat(this.backOffFactory.createFromAnnotation(getAnnotation("withDelayValueToZero")))
+				.isInstanceOfSatisfying(FixedBackOff.class, (backOff) ->
+						assertThat(backOff.getInterval()).isEqualTo(0));
+	}
+
+	@Test
+	void createFromAnnotationWithDelayAttributeToZero() {
+		assertThat(this.backOffFactory.createFromAnnotation(getAnnotation("withDelayAttributeToZero")))
+				.isInstanceOfSatisfying(FixedBackOff.class, (backOff) ->
+						assertThat(backOff.getInterval()).isEqualTo(0));
+	}
+
+	@Test
+	void createFromAnnotationWithInvalidDelay() {
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> this.backOffFactory.createFromAnnotation(getAnnotation("withInvalidDelay")))
+				.withMessage("Invalid delay (-1ms): must be >= 0.");
+	}
+
+	@Test
+	void createFromAnnotationWithInvalidMaxDelay() {
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> this.backOffFactory.createFromAnnotation(getAnnotation("withInvalidMaxDelay")))
+				.withMessage("Invalid maxDelay (-1ms): must be greater than zero.");
+	}
+
+	@Test
+	void createFromAnnotationWithInvalidMultiplier() {
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> this.backOffFactory.createFromAnnotation(getAnnotation("withInvalidMultiplier")))
+				.withMessage("Invalid multiplier '-0.5': must be greater than or equal to 1. A multiplier of 1 is equivalent to a fixed delay.");
+	}
+
+	@Test
+	void createFromAnnotationWithInvalidJitter() {
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> this.backOffFactory.createFromAnnotation(getAnnotation("withInvalidJitter")))
+				.withMessage("Invalid jitter (-1ms): must be greater than or equal to zero.");
+	}
+
+	@Test
+	void createFromAnnotationWithAttributeValues() {
+		assertThat(this.backOffFactory.createFromAnnotation(getAnnotation("withValues")))
+				.isInstanceOfSatisfying(ExponentialBackOff.class, (backOff) -> {
+					assertThat(backOff.getInitialInterval()).isEqualTo(900);
+					assertThat(backOff.getMaxInterval()).isEqualTo(4000);
+					assertThat(backOff.getMultiplier()).isEqualTo(1.7);
+					assertThat(backOff.getJitter()).isEqualTo(500);
+				});
+	}
+
+	@Test
+	void createFromAnnotationWithDurationFormat() {
+		assertThat(this.backOffFactory.createFromAnnotation(getAnnotation("withDurationFormat")))
+				.isInstanceOfSatisfying(ExponentialBackOff.class, (backOff) -> {
+					assertThat(backOff.getInitialInterval()).isEqualTo(900);
+					assertThat(backOff.getMaxInterval()).isEqualTo(4000);
+					assertThat(backOff.getMultiplier()).isEqualTo(1.7);
+					assertThat(backOff.getJitter()).isEqualTo(500);
+				});
+	}
+
+	@Test
+	void createFromAnnotationWithDelayAndDelayString() {
+		assertThat(this.backOffFactory.createFromAnnotation(getAnnotation("withDelayAndDelayString")))
+				.isInstanceOfSatisfying(FixedBackOff.class, (backOff) ->
+						assertThat(backOff.getInterval()).isEqualTo(4000));
+	}
+
+	@Test
+	void createFromAnnotationWithMaxDelayAndMaxDelayString() {
+		assertThat(this.backOffFactory.createFromAnnotation(getAnnotation("withMaxDelayAndMaxDelayString")))
+				.isInstanceOfSatisfying(ExponentialBackOff.class, (backOff) -> {
+					assertThat(backOff.getMaxInterval()).isEqualTo(4000);
+				});
+	}
+
+	@Test
+	void createFromAnnotationWithMultiplierAndMultiplierString() {
+		assertThat(this.backOffFactory.createFromAnnotation(getAnnotation("withMultiplierAndMultiplierString")))
+				.isInstanceOfSatisfying(ExponentialBackOff.class, (backOff) -> {
+					assertThat(backOff.getMultiplier()).isEqualTo(2.5);
+				});
+	}
+
+	@Test
+	void createFromAnnotationWithJitterAndJitterString() {
+		assertThat(this.backOffFactory.createFromAnnotation(getAnnotation("withJitterAndJitterString")))
+				.isInstanceOfSatisfying(ExponentialBackOff.class, (backOff) -> {
+					assertThat(backOff.getJitter()).isEqualTo(1000);
+				});
+	}
+
+	@Test
+	void createFromAnnotationWithStringProperties() {
+		MockEnvironment environment = new MockEnvironment()
+				.withProperty("test.delay", "2s")
+				.withProperty("test.max-delay", "4s")
+				.withProperty("test.multiplier", "1.6")
+				.withProperty("test.jitter", "500");
+		assertThat(createFromAnnotation(getAnnotation("withStringProperties"), environment))
+				.isInstanceOfSatisfying(ExponentialBackOff.class, (backOff) -> {
+					assertThat(backOff.getInitialInterval()).isEqualTo(2000);
+					assertThat(backOff.getMaxInterval()).isEqualTo(4000);
+					assertThat(backOff.getMultiplier()).isEqualTo(1.6);
+					assertThat(backOff.getJitter()).isEqualTo(500);
+				});
+	}
+
+	@Test
+	void createFromAnnotationWithStringSpEL() {
+		MockEnvironment environment = new MockEnvironment()
+				.withProperty("test.jitter", "500");
+		assertThat(createFromAnnotation(getAnnotation("withStringSpEL"), environment))
+				.isInstanceOfSatisfying(ExponentialBackOff.class, (backOff) -> {
+					assertThat(backOff.getInitialInterval()).isEqualTo(2000);
+					assertThat(backOff.getMaxInterval()).isEqualTo(4000);
+					assertThat(backOff.getMultiplier()).isEqualTo(1.6);
+					assertThat(backOff.getJitter()).isEqualTo(500);
+				});
+	}
+
+	private org.springframework.util.backoff.BackOff createFromAnnotation(BackOff annotation, ConfigurableEnvironment environment) {
+		StaticApplicationContext context = new StaticApplicationContext();
+		context.setEnvironment(environment);
+		context.refresh();
+		return new BackOffFactory(new EmbeddedValueResolver(context.getBeanFactory())).createFromAnnotation(annotation);
+	}
+
+	private BackOff getAnnotation(String methodName) {
+		Method method = ReflectionUtils.findMethod(Sample.class, methodName);
+		assertThat(method).isNotNull();
+		return method.getAnnotation(TestAnnotation.class).backOff();
+	}
+
+	@SuppressWarnings("unused")
+	static class Sample {
+
+		@TestAnnotation(backOff = @BackOff)
+		void withDefaults() {
+		}
+
+		@TestAnnotation(backOff = @BackOff(2000))
+		void withDelayOnlyValue() {
+		}
+
+		@TestAnnotation(backOff = @BackOff(delay = 2000))
+		void withDelayOnlyAttribute() {
+		}
+
+		@TestAnnotation(backOff = @BackOff(0))
+		void withDelayValueToZero() {
+		}
+
+		@TestAnnotation(backOff = @BackOff(0))
+		void withDelayAttributeToZero() {
+		}
+
+		@TestAnnotation(backOff = @BackOff(-1))
+		void withInvalidDelay() {
+		}
+
+		@TestAnnotation(backOff = @BackOff(maxDelay = -1))
+		void withInvalidMaxDelay() {
+		}
+
+		@TestAnnotation(backOff = @BackOff(multiplier = -0.5))
+		void withInvalidMultiplier() {
+		}
+
+		@TestAnnotation(backOff = @BackOff(jitter = -1))
+		void withInvalidJitter() {
+		}
+
+		@TestAnnotation(backOff = @BackOff(delay = 900, maxDelay = 4000, multiplier = 1.7, jitter = 500))
+		void withValues() {
+		}
+
+		@TestAnnotation(backOff = @BackOff(delayString = "900ms", maxDelayString = "4s", multiplierString = "1.7", jitterString = "500ms"))
+		void withDurationFormat() {
+		}
+
+		@TestAnnotation(backOff = @BackOff(delay = 2000, delayString = "4s"))
+		void withDelayAndDelayString() {
+		}
+
+		@TestAnnotation(backOff = @BackOff(maxDelay = 2000, maxDelayString = "4s"))
+		void withMaxDelayAndMaxDelayString() {
+		}
+
+		@TestAnnotation(backOff = @BackOff(multiplier = 1.5, multiplierString = "2.5"))
+		void withMultiplierAndMultiplierString() {
+		}
+
+		@TestAnnotation(backOff = @BackOff(jitter = 500, jitterString = "1s"))
+		void withJitterAndJitterString() {
+		}
+
+		@TestAnnotation(backOff = @BackOff(delayString = "${test.delay}", maxDelayString = "${test.max-delay}", multiplierString = "${test.multiplier}", jitterString = "${test.jitter}"))
+		void withStringProperties() {
+		}
+
+		@TestAnnotation(backOff = @BackOff(delayString = "#{2 * 1000}", maxDelayString = "#{8000 / 2}", multiplierString = "#{0.16 * 10}", jitterString = "#{environment.getProperty('test.jitter')}"))
+		void withStringSpEL() {
+		}
+
+	}
+
+	@Target(ElementType.METHOD)
+	@Retention(RetentionPolicy.RUNTIME)
+	@interface TestAnnotation {
+
+		BackOff backOff();
+	}
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/CommonDelegatingErrorHandlerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/CommonDelegatingErrorHandlerTests.java
@@ -204,7 +204,7 @@ public class CommonDelegatingErrorHandlerTests {
 			KafkaException.class, directCauseErrorHandler
 		));
 		delegatingErrorHandler.addDelegate(IllegalStateException.class, mock(CommonErrorHandler.class));
-		assertThat(KafkaTestUtils.getPropertyValue(delegatingErrorHandler, "classifier.classified", Map.class).keySet())
+		assertThat(KafkaTestUtils.getPropertyValue(delegatingErrorHandler, "exceptionMatcher.entries", Map.class).keySet())
 				.contains(IllegalStateException.class);
 
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ErrorHandlingUtilsTest.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ErrorHandlingUtilsTest.java
@@ -31,9 +31,9 @@ import org.apache.kafka.common.TopicPartition;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.classify.BinaryExceptionClassifier;
 import org.springframework.core.log.LogAccessor;
 import org.springframework.kafka.KafkaException;
+import org.springframework.kafka.support.ExceptionMatcher;
 import org.springframework.util.backoff.BackOff;
 import org.springframework.util.backoff.FixedBackOff;
 
@@ -72,7 +72,7 @@ class ErrorHandlingUtilsTest {
 
 	private final List<RetryListener> retryListeners = new ArrayList<>();
 
-	private final BinaryExceptionClassifier classifier = BinaryExceptionClassifier.defaultClassifier();
+	private final ExceptionMatcher exceptionMatcher = ExceptionMatcher.defaultMatcher();
 
 	private final ConsumerRecords<?, ?> consumerRecords = recordsOf(
 			new ConsumerRecord<>("foo", 0, 0L, "a", "a"),
@@ -99,7 +99,7 @@ class ErrorHandlingUtilsTest {
 		ErrorHandlingUtils.retryBatch(
 				thrownException, consumerRecords, consumer, container, listener, backOff,
 				seeker, recoverer, logger, KafkaException.Level.INFO, retryListeners,
-				classifier, true
+				exceptionMatcher, true
 		);
 	}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ExceptionClassifierTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ExceptionClassifierTests.java
@@ -31,27 +31,27 @@ public class ExceptionClassifierTests {
 	void testDefault() {
 		ExceptionClassifier ec = new ExceptionClassifier() {
 		};
-		assertThat(ec.getClassifier().classify(new Exception())).isTrue();
-		assertThat(ec.getClassifier().classify(new ClassCastException())).isFalse();
+		assertThat(ec.getExceptionMatcher().match(new Exception())).isTrue();
+		assertThat(ec.getExceptionMatcher().match(new ClassCastException())).isFalse();
 		ec.removeClassification(ClassCastException.class);
-		assertThat(ec.getClassifier().classify(new ClassCastException())).isTrue();
-		assertThat(ec.getClassifier().classify(new IllegalStateException())).isTrue();
+		assertThat(ec.getExceptionMatcher().match(new ClassCastException())).isTrue();
+		assertThat(ec.getExceptionMatcher().match(new IllegalStateException())).isTrue();
 		ec.addNotRetryableExceptions(IllegalStateException.class);
-		assertThat(ec.getClassifier().classify(new IllegalStateException())).isFalse();
+		assertThat(ec.getExceptionMatcher().match(new IllegalStateException())).isFalse();
 	}
 
 	@Test
 	void testDefaultFalse() {
 		ExceptionClassifier ec = new ExceptionClassifier() {
 		};
-		assertThat(ec.getClassifier().classify(new Exception())).isTrue();
+		assertThat(ec.getExceptionMatcher().match(new Exception())).isTrue();
 		ec.defaultFalse();
-		assertThat(ec.getClassifier().classify(new Exception())).isFalse();
-		assertThat(ec.getClassifier().classify(new IllegalStateException())).isFalse();
+		assertThat(ec.getExceptionMatcher().match(new Exception())).isFalse();
+		assertThat(ec.getExceptionMatcher().match(new IllegalStateException())).isFalse();
 		ec.addRetryableExceptions(IllegalStateException.class);
-		assertThat(ec.getClassifier().classify(new IllegalStateException())).isTrue();
+		assertThat(ec.getExceptionMatcher().match(new IllegalStateException())).isTrue();
 		ec.removeClassification(IllegalStateException.class);
-		assertThat(ec.getClassifier().classify(new IllegalStateException())).isFalse();
+		assertThat(ec.getExceptionMatcher().match(new IllegalStateException())).isFalse();
 	}
 
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/AsyncCompletableFutureRetryTopicClassLevelIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/AsyncCompletableFutureRetryTopicClassLevelIntegrationTests.java
@@ -43,6 +43,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.BackOff;
 import org.springframework.kafka.annotation.DltHandler;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.annotation.KafkaHandler;
@@ -73,7 +74,6 @@ import org.springframework.messaging.converter.CompositeMessageConverter;
 import org.springframework.messaging.converter.GenericMessageConverter;
 import org.springframework.messaging.converter.SmartMessageConverter;
 import org.springframework.messaging.handler.annotation.Header;
-import org.springframework.retry.annotation.Backoff;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.test.annotation.DirtiesContext;
@@ -352,7 +352,7 @@ public class AsyncCompletableFutureRetryTopicClassLevelIntegrationTests {
 
 	@RetryableTopic(
 			attempts = "${five.attempts}",
-			backoff = @Backoff(delay = 25, maxDelay = 1000, multiplier = 1.5),
+			backoff = @BackOff(delay = 25, maxDelay = 1000, multiplier = 1.5),
 			numPartitions = "#{3}",
 			timeout = "${missing.property:100000}",
 			include = MyRetryException.class, kafkaTemplate = "${kafka.template}",
@@ -388,7 +388,7 @@ public class AsyncCompletableFutureRetryTopicClassLevelIntegrationTests {
 		}
 	}
 
-	@RetryableTopic(dltStrategy = DltStrategy.NO_DLT, attempts = "4", backoff = @Backoff(30),
+	@RetryableTopic(dltStrategy = DltStrategy.NO_DLT, attempts = "4", backoff = @BackOff(30),
 			sameIntervalTopicReuseStrategy = SameIntervalTopicReuseStrategy.MULTIPLE_TOPICS,
 			kafkaTemplate = "${kafka.template}")
 	@KafkaListener(topics = FOURTH_TOPIC, containerFactory = MAIN_TOPIC_CONTAINER_FACTORY)
@@ -432,7 +432,7 @@ public class AsyncCompletableFutureRetryTopicClassLevelIntegrationTests {
 
 	@RetryableTopic(
 			attempts = "4",
-			backoff = @Backoff(25),
+			backoff = @BackOff(25),
 			numPartitions = "2",
 			retryTopicSuffix = "-listener1",
 			dltTopicSuffix = "-listener1-dlt",
@@ -465,7 +465,7 @@ public class AsyncCompletableFutureRetryTopicClassLevelIntegrationTests {
 
 	@RetryableTopic(
 			attempts = "4",
-			backoff = @Backoff(25),
+			backoff = @BackOff(25),
 			numPartitions = "2",
 			retryTopicSuffix = "-listener2",
 			dltTopicSuffix = "-listener2-dlt",
@@ -498,7 +498,7 @@ public class AsyncCompletableFutureRetryTopicClassLevelIntegrationTests {
 
 	@RetryableTopic(
 			attempts = "4",
-			backoff = @Backoff(50),
+			backoff = @BackOff(50),
 			sameIntervalTopicReuseStrategy = SameIntervalTopicReuseStrategy.MULTIPLE_TOPICS)
 	@KafkaListener(
 			id = "manual",
@@ -530,7 +530,7 @@ public class AsyncCompletableFutureRetryTopicClassLevelIntegrationTests {
 			attempts = "3",
 			numPartitions = "3",
 			exclude = MyDontRetryException.class,
-			backoff = @Backoff(delay = 50, maxDelay = 100, multiplier = 3),
+			backoff = @BackOff(delay = 50, maxDelay = 100, multiplier = 3),
 			traversingCauses = "true",
 			kafkaTemplate = "${kafka.template}")
 	@KafkaListener(topics = NOT_RETRYABLE_EXCEPTION_TOPIC, containerFactory = MAIN_TOPIC_CONTAINER_FACTORY)
@@ -561,7 +561,7 @@ public class AsyncCompletableFutureRetryTopicClassLevelIntegrationTests {
 
 	@RetryableTopic(
 			attempts = "2",
-			backoff = @Backoff(50))
+			backoff = @BackOff(50))
 	@KafkaListener(
 			id = "reuseRetry1",
 			topics = FIRST_REUSE_RETRY_TOPIC,
@@ -592,7 +592,7 @@ public class AsyncCompletableFutureRetryTopicClassLevelIntegrationTests {
 
 	@RetryableTopic(
 			attempts = "5",
-			backoff = @Backoff(delay = 30, maxDelay = 100, multiplier = 2))
+			backoff = @BackOff(delay = 30, maxDelay = 100, multiplier = 2))
 	@KafkaListener(
 			id = "reuseRetry2",
 			topics = SECOND_REUSE_RETRY_TOPIC,
@@ -621,7 +621,7 @@ public class AsyncCompletableFutureRetryTopicClassLevelIntegrationTests {
 
 	}
 
-	@RetryableTopic(attempts = "5", backoff = @Backoff(delay = 1, maxDelay = 5, multiplier = 1.4))
+	@RetryableTopic(attempts = "5", backoff = @BackOff(delay = 1, maxDelay = 5, multiplier = 1.4))
 	@KafkaListener(id = "reuseRetry3", topics = THIRD_REUSE_RETRY_TOPIC,
 			containerFactory = "retryTopicListenerContainerFactory")
 	static class ThirdReuseRetryTopicListener {

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/AsyncMonoFutureRetryTopicClassLevelIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/AsyncMonoFutureRetryTopicClassLevelIntegrationTests.java
@@ -43,6 +43,7 @@ import reactor.core.publisher.Mono;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.BackOff;
 import org.springframework.kafka.annotation.DltHandler;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.annotation.KafkaHandler;
@@ -73,7 +74,6 @@ import org.springframework.messaging.converter.CompositeMessageConverter;
 import org.springframework.messaging.converter.GenericMessageConverter;
 import org.springframework.messaging.converter.SmartMessageConverter;
 import org.springframework.messaging.handler.annotation.Header;
-import org.springframework.retry.annotation.Backoff;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.test.annotation.DirtiesContext;
@@ -349,7 +349,7 @@ public class AsyncMonoFutureRetryTopicClassLevelIntegrationTests {
 
 	@RetryableTopic(
 			attempts = "${five.attempts}",
-			backoff = @Backoff(delay = 250, maxDelay = 1000, multiplier = 1.5),
+			backoff = @BackOff(delay = 250, maxDelay = 1000, multiplier = 1.5),
 			numPartitions = "#{3}",
 			timeout = "${missing.property:100000}",
 			include = MyRetryException.class, kafkaTemplate = "${kafka.template}",
@@ -386,7 +386,7 @@ public class AsyncMonoFutureRetryTopicClassLevelIntegrationTests {
 
 	}
 
-	@RetryableTopic(dltStrategy = DltStrategy.NO_DLT, attempts = "4", backoff = @Backoff(300),
+	@RetryableTopic(dltStrategy = DltStrategy.NO_DLT, attempts = "4", backoff = @BackOff(300),
 			sameIntervalTopicReuseStrategy = SameIntervalTopicReuseStrategy.MULTIPLE_TOPICS,
 			kafkaTemplate = "${kafka.template}")
 	@KafkaListener(topics = FOURTH_TOPIC, containerFactory = MAIN_TOPIC_CONTAINER_FACTORY)
@@ -433,7 +433,7 @@ public class AsyncMonoFutureRetryTopicClassLevelIntegrationTests {
 
 	@RetryableTopic(
 			attempts = "4",
-			backoff = @Backoff(250),
+			backoff = @BackOff(250),
 			numPartitions = "2",
 			retryTopicSuffix = "-listener1",
 			dltTopicSuffix = "-listener1-dlt",
@@ -464,7 +464,7 @@ public class AsyncMonoFutureRetryTopicClassLevelIntegrationTests {
 
 	@RetryableTopic(
 			attempts = "4",
-			backoff = @Backoff(250),
+			backoff = @BackOff(250),
 			numPartitions = "2",
 			retryTopicSuffix = "-listener2",
 			dltTopicSuffix = "-listener2-dlt",
@@ -495,7 +495,7 @@ public class AsyncMonoFutureRetryTopicClassLevelIntegrationTests {
 
 	@RetryableTopic(
 			attempts = "4",
-			backoff = @Backoff(50),
+			backoff = @BackOff(50),
 			sameIntervalTopicReuseStrategy = SameIntervalTopicReuseStrategy.MULTIPLE_TOPICS)
 	@KafkaListener(
 			id = "manual",
@@ -522,7 +522,7 @@ public class AsyncMonoFutureRetryTopicClassLevelIntegrationTests {
 			attempts = "3",
 			numPartitions = "3",
 			exclude = MyDontRetryException.class,
-			backoff = @Backoff(delay = 50, maxDelay = 100, multiplier = 3),
+			backoff = @BackOff(delay = 50, maxDelay = 100, multiplier = 3),
 			traversingCauses = "true",
 			kafkaTemplate = "${kafka.template}")
 	@KafkaListener(topics = NOT_RETRYABLE_EXCEPTION_TOPIC, containerFactory = MAIN_TOPIC_CONTAINER_FACTORY)
@@ -552,7 +552,7 @@ public class AsyncMonoFutureRetryTopicClassLevelIntegrationTests {
 
 	@RetryableTopic(
 			attempts = "2",
-			backoff = @Backoff(50))
+			backoff = @BackOff(50))
 	@KafkaListener(
 			id = "reuseRetry1",
 			topics = FIRST_REUSE_RETRY_TOPIC,
@@ -581,7 +581,7 @@ public class AsyncMonoFutureRetryTopicClassLevelIntegrationTests {
 
 	@RetryableTopic(
 			attempts = "5",
-			backoff = @Backoff(delay = 30, maxDelay = 100, multiplier = 2))
+			backoff = @BackOff(delay = 30, maxDelay = 100, multiplier = 2))
 	@KafkaListener(
 			id = "reuseRetry2",
 			topics = SECOND_REUSE_RETRY_TOPIC,
@@ -608,7 +608,7 @@ public class AsyncMonoFutureRetryTopicClassLevelIntegrationTests {
 
 	}
 
-	@RetryableTopic(attempts = "5", backoff = @Backoff(delay = 1, maxDelay = 5, multiplier = 1.4))
+	@RetryableTopic(attempts = "5", backoff = @BackOff(delay = 1, maxDelay = 5, multiplier = 1.4))
 	@KafkaListener(id = "reuseRetry3", topics = THIRD_REUSE_RETRY_TOPIC,
 			containerFactory = "retryTopicListenerContainerFactory")
 	static class ThirdReuseRetryTopicListener {

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/BackOffValuesGeneratorTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/BackOffValuesGeneratorTests.java
@@ -21,9 +21,9 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
-import org.springframework.retry.backoff.BackOffPolicy;
-import org.springframework.retry.backoff.ExponentialBackOffPolicy;
-import org.springframework.retry.backoff.NoBackOffPolicy;
+import org.springframework.util.backoff.BackOff;
+import org.springframework.util.backoff.ExponentialBackOff;
+import org.springframework.util.backoff.FixedBackOff;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -36,7 +36,7 @@ class BackOffValuesGeneratorTests {
 	@Test
 	void shouldGenerateWithDefaultValues() {
 		// Default MAX_ATTEMPTS = 3
-		// Default Policy = FixedBackoffPolicy
+		// Default BackOff = FixedBackOff with 1000ms interval
 
 		// setup
 		BackOffValuesGenerator backOffValuesGenerator = new BackOffValuesGenerator(-1, null);
@@ -53,10 +53,8 @@ class BackOffValuesGeneratorTests {
 	void shouldGenerateExponentialValues() {
 
 		// setup
-		ExponentialBackOffPolicy backOffPolicy = new ExponentialBackOffPolicy();
-		backOffPolicy.setMultiplier(2);
-		backOffPolicy.setInitialInterval(1000);
-		BackOffValuesGenerator backOffValuesGenerator = new BackOffValuesGenerator(4, backOffPolicy);
+		ExponentialBackOff backOff = new ExponentialBackOff(1000, 2);
+		BackOffValuesGenerator backOffValuesGenerator = new BackOffValuesGenerator(4, backOff);
 
 		// when
 		List<Long> backOffValues = backOffValuesGenerator.generateValues();
@@ -70,8 +68,8 @@ class BackOffValuesGeneratorTests {
 	void shouldGenerateWithNoBackOff() {
 
 		// setup
-		BackOffPolicy backOffPolicy = new NoBackOffPolicy();
-		BackOffValuesGenerator backOffValuesGenerator = new BackOffValuesGenerator(4, backOffPolicy);
+		BackOff backOff = new FixedBackOff(0);
+		BackOffValuesGenerator backOffValuesGenerator = new BackOffValuesGenerator(4, backOff);
 
 		// when
 		List<Long> backOffValues = backOffValuesGenerator.generateValues();

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DeliveryHeaderTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/DeliveryHeaderTests.java
@@ -28,6 +28,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.kafka.annotation.BackOff;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.annotation.KafkaHandler;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -44,7 +45,6 @@ import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.messaging.handler.annotation.Header;
-import org.springframework.retry.annotation.Backoff;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.test.annotation.DirtiesContext;
@@ -113,7 +113,7 @@ public class DeliveryHeaderTests {
 			return DeadLetterPublishingRecovererFactory::neverLogListenerException;
 		}
 
-		@RetryableTopic(backoff = @Backoff(maxDelay = 0))
+		@RetryableTopic(backoff = @BackOff(maxDelay = 0))
 		@KafkaListener(id = "dh1", topics = "dh1")
 		void listen(String in, @Header(KafkaHeaders.DELIVERY_ATTEMPT) int blockingAttempts,
 				@Header(name = RetryTopicHeaders.DEFAULT_HEADER_ATTEMPTS, required = false) Integer nonBlockingAttempts,
@@ -167,7 +167,7 @@ public class DeliveryHeaderTests {
 
 	}
 
-	@RetryableTopic(backoff = @Backoff(maxDelay = 0))
+	@RetryableTopic(backoff = @BackOff(maxDelay = 0))
 	@KafkaListener(id = "dhClassLevel1", topics = DH_CLASS_LEVEL_1)
 	static class RetryTopicClassLevel {
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/ExistingRetryTopicClassLevelIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/ExistingRetryTopicClassLevelIntegrationTests.java
@@ -35,6 +35,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.task.TaskExecutor;
+import org.springframework.kafka.annotation.BackOff;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.annotation.KafkaHandler;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -52,7 +53,6 @@ import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.messaging.handler.annotation.Header;
-import org.springframework.retry.annotation.Backoff;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
@@ -152,7 +152,7 @@ class ExistingRetryTopicClassLevelIntegrationTests {
 	}
 
 	@RetryableTopic(autoCreateTopics = "false", dltStrategy = DltStrategy.NO_DLT,
-			attempts = "${two.attempts}", backoff = @Backoff(0), kafkaTemplate = "kafkaTemplate")
+			attempts = "${two.attempts}", backoff = @BackOff(0), kafkaTemplate = "kafkaTemplate")
 	@KafkaListener(id = "firstTopicId", topics = MAIN_TOPIC_WITH_NO_PARTITION_INFO, containerFactory = MAIN_TOPIC_CONTAINER_FACTORY)
 	static class MainTopicListenerWithoutPartition {
 
@@ -178,7 +178,7 @@ class ExistingRetryTopicClassLevelIntegrationTests {
 	}
 
 	@RetryableTopic(autoCreateTopics = "false", numPartitions = "4", dltStrategy = DltStrategy.NO_DLT,
-			attempts = "${two.attempts}", backoff = @Backoff(0), kafkaTemplate = "kafkaTemplate")
+			attempts = "${two.attempts}", backoff = @BackOff(0), kafkaTemplate = "kafkaTemplate")
 	@KafkaListener(id = "secondTopicId", topics = MAIN_TOPIC_WITH_PARTITION_INFO, containerFactory = MAIN_TOPIC_CONTAINER_FACTORY)
 	static class MainTopicListenerWithPartition {
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/ExistingRetryTopicIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/ExistingRetryTopicIntegrationTests.java
@@ -37,6 +37,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.task.TaskExecutor;
+import org.springframework.kafka.annotation.BackOff;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.annotation.RetryableTopic;
@@ -53,7 +54,6 @@ import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.messaging.handler.annotation.Header;
-import org.springframework.retry.annotation.Backoff;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
@@ -162,7 +162,7 @@ public class ExistingRetryTopicIntegrationTests {
 		CountByPartitionContainer countByPartitionContainerWithoutPartition;
 
 		@RetryableTopic(autoCreateTopics = "false", dltStrategy = DltStrategy.NO_DLT,
-				attempts = "${two.attempts}", backoff = @Backoff(0), kafkaTemplate = "kafkaTemplate")
+				attempts = "${two.attempts}", backoff = @BackOff(0), kafkaTemplate = "kafkaTemplate")
 		@KafkaListener(id = "firstTopicId", topics = MAIN_TOPIC_WITH_NO_PARTITION_INFO, containerFactory = MAIN_TOPIC_CONTAINER_FACTORY)
 		public void listenFirst(String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic,
 								@Header(KafkaHeaders.ORIGINAL_PARTITION) String originalPartition,
@@ -182,7 +182,7 @@ public class ExistingRetryTopicIntegrationTests {
 		CountByPartitionContainer countByPartitionContainerWithPartition;
 
 		@RetryableTopic(autoCreateTopics = "false", numPartitions = "4", dltStrategy = DltStrategy.NO_DLT,
-				attempts = "${two.attempts}", backoff = @Backoff(0), kafkaTemplate = "kafkaTemplate")
+				attempts = "${two.attempts}", backoff = @BackOff(0), kafkaTemplate = "kafkaTemplate")
 		@KafkaListener(id = "secondTopicId", topics = MAIN_TOPIC_WITH_PARTITION_INFO, containerFactory = MAIN_TOPIC_CONTAINER_FACTORY)
 		public void listenSecond(String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic,
 								@Header(KafkaHeaders.ORIGINAL_PARTITION) String originalPartition,

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicClassLevelExceptionRoutingIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicClassLevelExceptionRoutingIntegrationTests.java
@@ -33,6 +33,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.BackOff;
 import org.springframework.kafka.annotation.DltHandler;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.annotation.KafkaHandler;
@@ -52,7 +53,6 @@ import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.messaging.handler.annotation.Header;
-import org.springframework.retry.annotation.Backoff;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.test.annotation.DirtiesContext;
@@ -195,7 +195,7 @@ class RetryTopicClassLevelExceptionRoutingIntegrationTests {
 	}
 
 	@RetryableTopic(exclude = ShouldRetryOnlyBlockingException.class, traversingCauses = "true",
-			backoff = @Backoff(50), kafkaTemplate = "kafkaTemplate")
+			backoff = @BackOff(50), kafkaTemplate = "kafkaTemplate")
 	@KafkaListener(topics = ONLY_RETRY_VIA_BLOCKING)
 	static class OnlyRetryBlockingListener {
 
@@ -216,7 +216,7 @@ class RetryTopicClassLevelExceptionRoutingIntegrationTests {
 		}
 	}
 
-	@RetryableTopic(backoff = @Backoff(50), kafkaTemplate = "kafkaTemplate")
+	@RetryableTopic(backoff = @BackOff(50), kafkaTemplate = "kafkaTemplate")
 	@KafkaListener(topics = USER_FATAL_EXCEPTION_TOPIC)
 	static class UserFatalTopicListener {
 
@@ -237,7 +237,7 @@ class RetryTopicClassLevelExceptionRoutingIntegrationTests {
 		}
 	}
 
-	@RetryableTopic(backoff = @Backoff(50))
+	@RetryableTopic(backoff = @BackOff(50))
 	@KafkaListener(topics = FRAMEWORK_FATAL_EXCEPTION_TOPIC)
 	static class FrameworkFatalTopicListener {
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicClassLevelIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicClassLevelIntegrationTests.java
@@ -46,6 +46,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.BackOff;
 import org.springframework.kafka.annotation.DltHandler;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.annotation.KafkaHandler;
@@ -77,7 +78,6 @@ import org.springframework.messaging.converter.CompositeMessageConverter;
 import org.springframework.messaging.converter.GenericMessageConverter;
 import org.springframework.messaging.converter.SmartMessageConverter;
 import org.springframework.messaging.handler.annotation.Header;
-import org.springframework.retry.annotation.Backoff;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.test.annotation.DirtiesContext;
@@ -338,7 +338,7 @@ class RetryTopicClassLevelIntegrationTests {
 	}
 
 	@RetryableTopic(attempts = "${five.attempts}",
-			backoff = @Backoff(delay = 250, maxDelay = 1000, multiplier = 1.5),
+			backoff = @BackOff(delay = 250, maxDelay = 1000, multiplier = 1.5),
 			numPartitions = "#{3}",
 			timeout = "${missing.property:2000}",
 			include = MyRetryException.class, kafkaTemplate = "${kafka.template}",
@@ -363,7 +363,7 @@ class RetryTopicClassLevelIntegrationTests {
 		}
 	}
 
-	@RetryableTopic(dltStrategy = DltStrategy.NO_DLT, attempts = "4", backoff = @Backoff(300),
+	@RetryableTopic(dltStrategy = DltStrategy.NO_DLT, attempts = "4", backoff = @BackOff(300),
 			sameIntervalTopicReuseStrategy = SameIntervalTopicReuseStrategy.MULTIPLE_TOPICS,
 			kafkaTemplate = "${kafka.template}")
 	@KafkaListener(topics = FOURTH_TOPIC, containerFactory = MAIN_TOPIC_CONTAINER_FACTORY)
@@ -400,7 +400,7 @@ class RetryTopicClassLevelIntegrationTests {
 	}
 
 	@RetryableTopic(attempts = "4",
-			backoff = @Backoff(250),
+			backoff = @BackOff(250),
 			numPartitions = "2",
 			retryTopicSuffix = "-listener1", dltTopicSuffix = "-listener1-dlt",
 			topicSuffixingStrategy = TopicSuffixingStrategy.SUFFIX_WITH_INDEX_VALUE,
@@ -421,7 +421,7 @@ class RetryTopicClassLevelIntegrationTests {
 	}
 
 	@RetryableTopic(attempts = "4",
-			backoff = @Backoff(250),
+			backoff = @BackOff(250),
 			numPartitions = "2",
 			retryTopicSuffix = "-listener2", dltTopicSuffix = "-listener2-dlt",
 			topicSuffixingStrategy = TopicSuffixingStrategy.SUFFIX_WITH_INDEX_VALUE,
@@ -441,7 +441,7 @@ class RetryTopicClassLevelIntegrationTests {
 
 	}
 
-	@RetryableTopic(attempts = "4", backoff = @Backoff(50),
+	@RetryableTopic(attempts = "4", backoff = @BackOff(50),
 			sameIntervalTopicReuseStrategy = SameIntervalTopicReuseStrategy.MULTIPLE_TOPICS)
 	@KafkaListener(id = "manual", topics = MANUAL_TOPIC, containerFactory = MAIN_TOPIC_CONTAINER_FACTORY)
 	static class SixthTopicDefaultDLTListener {
@@ -460,7 +460,7 @@ class RetryTopicClassLevelIntegrationTests {
 	}
 
 	@RetryableTopic(attempts = "3", numPartitions = "3", exclude = MyDontRetryException.class,
-			backoff = @Backoff(delay = 50, maxDelay = 100, multiplier = 3),
+			backoff = @BackOff(delay = 50, maxDelay = 100, multiplier = 3),
 			traversingCauses = "true", kafkaTemplate = "${kafka.template}")
 	@KafkaListener(topics = NOT_RETRYABLE_EXCEPTION_TOPIC, containerFactory = MAIN_TOPIC_CONTAINER_FACTORY)
 	static class NoRetryTopicListener {
@@ -480,7 +480,7 @@ class RetryTopicClassLevelIntegrationTests {
 		}
 	}
 
-	@RetryableTopic(attempts = "2", backoff = @Backoff(50))
+	@RetryableTopic(attempts = "2", backoff = @BackOff(50))
 	@KafkaListener(id = "reuseRetry1", topics = FIRST_REUSE_RETRY_TOPIC,
 			containerFactory = "retryTopicListenerContainerFactory")
 	static class FirstReuseRetryTopicListener {
@@ -499,7 +499,7 @@ class RetryTopicClassLevelIntegrationTests {
 
 	}
 
-	@RetryableTopic(attempts = "5", backoff = @Backoff(delay = 30, maxDelay = 100, multiplier = 2))
+	@RetryableTopic(attempts = "5", backoff = @BackOff(delay = 30, maxDelay = 100, multiplier = 2))
 	@KafkaListener(id = "reuseRetry2", topics = SECOND_REUSE_RETRY_TOPIC,
 			containerFactory = "retryTopicListenerContainerFactory")
 	static class SecondReuseRetryTopicListener {
@@ -518,7 +518,7 @@ class RetryTopicClassLevelIntegrationTests {
 
 	}
 
-	@RetryableTopic(attempts = "5", backoff = @Backoff(delay = 1, maxDelay = 5, multiplier = 1.4))
+	@RetryableTopic(attempts = "5", backoff = @BackOff(delay = 1, maxDelay = 5, multiplier = 1.4))
 	@KafkaListener(id = "reuseRetry3", topics = THIRD_REUSE_RETRY_TOPIC,
 			containerFactory = "retryTopicListenerContainerFactory")
 	static class ThirdReuseRetryTopicListener {

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationBuilderTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicConfigurationBuilderTests.java
@@ -107,6 +107,8 @@ class RetryTopicConfigurationBuilderTests {
 	}
 
 	@Test
+	@Deprecated
+	@SuppressWarnings("removal")
 	void shouldSetUniformRandomBackOff() {
 
 		// setup

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicExceptionRoutingIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicExceptionRoutingIntegrationTests.java
@@ -35,6 +35,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.BackOff;
 import org.springframework.kafka.annotation.DltHandler;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -53,7 +54,6 @@ import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.messaging.handler.annotation.Header;
-import org.springframework.retry.annotation.Backoff;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.test.annotation.DirtiesContext;
@@ -211,7 +211,7 @@ public class RetryTopicExceptionRoutingIntegrationTests {
 		CountDownLatchContainer container;
 
 		@RetryableTopic(exclude = ShouldRetryOnlyBlockingException.class, traversingCauses = "true",
-				backoff = @Backoff(50), kafkaTemplate = "kafkaTemplate")
+				backoff = @BackOff(50), kafkaTemplate = "kafkaTemplate")
 		@KafkaListener(topics = ONLY_RETRY_VIA_BLOCKING)
 		public void listenWithAnnotation(String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic) {
 			container.onlyRetryViaBlockingLatch.countDown();
@@ -233,7 +233,7 @@ public class RetryTopicExceptionRoutingIntegrationTests {
 		@Autowired
 		CountDownLatchContainer container;
 
-		@RetryableTopic(backoff = @Backoff(50), kafkaTemplate = "kafkaTemplate")
+		@RetryableTopic(backoff = @BackOff(50), kafkaTemplate = "kafkaTemplate")
 		@KafkaListener(topics = USER_FATAL_EXCEPTION_TOPIC)
 		public void listenWithAnnotation(String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic) {
 			container.fatalUserLatch.countDown();
@@ -255,7 +255,7 @@ public class RetryTopicExceptionRoutingIntegrationTests {
 		@Autowired
 		CountDownLatchContainer container;
 
-		@RetryableTopic(backoff = @Backoff(50))
+		@RetryableTopic(backoff = @BackOff(50))
 		@KafkaListener(topics = FRAMEWORK_FATAL_EXCEPTION_TOPIC)
 		public void listenWithAnnotation(String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic) {
 			container.fatalFrameworkLatch.countDown();

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicIntegrationTests.java
@@ -48,6 +48,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.BackOff;
 import org.springframework.kafka.annotation.DltHandler;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -78,7 +79,6 @@ import org.springframework.messaging.converter.CompositeMessageConverter;
 import org.springframework.messaging.converter.GenericMessageConverter;
 import org.springframework.messaging.converter.SmartMessageConverter;
 import org.springframework.messaging.handler.annotation.Header;
-import org.springframework.retry.annotation.Backoff;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.test.annotation.DirtiesContext;
@@ -354,7 +354,7 @@ public class RetryTopicIntegrationTests {
 		CountDownLatchContainer container;
 
 		@RetryableTopic(attempts = "${five.attempts}",
-				backoff = @Backoff(delay = 250, maxDelay = 1000, multiplier = 1.5),
+				backoff = @BackOff(delay = 250, maxDelay = 1000, multiplier = 1.5),
 				numPartitions = "#{3}",
 				timeout = "${missing.property:2000}",
 				include = MyRetryException.class, kafkaTemplate = "${kafka.template}",
@@ -380,7 +380,7 @@ public class RetryTopicIntegrationTests {
 		@Autowired
 		CountDownLatchContainer container;
 
-		@RetryableTopic(dltStrategy = DltStrategy.NO_DLT, attempts = "4", backoff = @Backoff(300),
+		@RetryableTopic(dltStrategy = DltStrategy.NO_DLT, attempts = "4", backoff = @BackOff(300),
 				sameIntervalTopicReuseStrategy = SameIntervalTopicReuseStrategy.MULTIPLE_TOPICS,
 				kafkaTemplate = "${kafka.template}")
 		@KafkaListener(topics = FOURTH_TOPIC, containerFactory = MAIN_TOPIC_CONTAINER_FACTORY)
@@ -404,7 +404,7 @@ public class RetryTopicIntegrationTests {
 		CountDownLatchContainer container;
 
 		@RetryableTopic(attempts = "4",
-				backoff = @Backoff(250),
+				backoff = @BackOff(250),
 				numPartitions = "2",
 				retryTopicSuffix = "-listener1", dltTopicSuffix = "-listener1-dlt",
 				topicSuffixingStrategy = TopicSuffixingStrategy.SUFFIX_WITH_INDEX_VALUE,
@@ -437,7 +437,7 @@ public class RetryTopicIntegrationTests {
 		CountDownLatchContainer container;
 
 		@RetryableTopic(attempts = "4",
-				backoff = @Backoff(250),
+				backoff = @BackOff(250),
 				numPartitions = "2",
 				retryTopicSuffix = "-listener2", dltTopicSuffix = "-listener2-dlt",
 				topicSuffixingStrategy = TopicSuffixingStrategy.SUFFIX_WITH_INDEX_VALUE,
@@ -467,7 +467,7 @@ public class RetryTopicIntegrationTests {
 		@Autowired
 		CountDownLatchContainer container;
 
-		@RetryableTopic(attempts = "4", backoff = @Backoff(50),
+		@RetryableTopic(attempts = "4", backoff = @BackOff(50),
 				sameIntervalTopicReuseStrategy = SameIntervalTopicReuseStrategy.MULTIPLE_TOPICS)
 		@KafkaListener(id = "manual", topics = MANUAL_TOPIC, containerFactory = MAIN_TOPIC_CONTAINER_FACTORY)
 		public void listenNoDlt(String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic,
@@ -486,7 +486,7 @@ public class RetryTopicIntegrationTests {
 		CountDownLatchContainer container;
 
 		@RetryableTopic(attempts = "3", numPartitions = "3", exclude = MyDontRetryException.class,
-				backoff = @Backoff(delay = 50, maxDelay = 100, multiplier = 3),
+				backoff = @BackOff(delay = 50, maxDelay = 100, multiplier = 3),
 				traversingCauses = "true", kafkaTemplate = "${kafka.template}")
 		@KafkaListener(topics = NOT_RETRYABLE_EXCEPTION_TOPIC, containerFactory = MAIN_TOPIC_CONTAINER_FACTORY)
 		public void listenWithAnnotation2(String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic) {
@@ -509,7 +509,7 @@ public class RetryTopicIntegrationTests {
 		@Autowired
 		CountDownLatchContainer container;
 
-		@RetryableTopic(attempts = "2", backoff = @Backoff(50))
+		@RetryableTopic(attempts = "2", backoff = @BackOff(50))
 		@KafkaListener(id = "reuseRetry1", topics = FIRST_REUSE_RETRY_TOPIC,
 				containerFactory = "retryTopicListenerContainerFactory")
 		public void listen1(String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic) {
@@ -528,7 +528,7 @@ public class RetryTopicIntegrationTests {
 		@Autowired
 		CountDownLatchContainer container;
 
-		@RetryableTopic(attempts = "5", backoff = @Backoff(delay = 30, maxDelay = 100, multiplier = 2))
+		@RetryableTopic(attempts = "5", backoff = @BackOff(delay = 30, maxDelay = 100, multiplier = 2))
 		@KafkaListener(id = "reuseRetry2", topics = SECOND_REUSE_RETRY_TOPIC,
 				containerFactory = "retryTopicListenerContainerFactory")
 		public void listen2(String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic) {
@@ -547,7 +547,7 @@ public class RetryTopicIntegrationTests {
 		@Autowired
 		CountDownLatchContainer container;
 
-		@RetryableTopic(attempts = "5", backoff = @Backoff(delay = 1, maxDelay = 5, multiplier = 1.4))
+		@RetryableTopic(attempts = "5", backoff = @BackOff(delay = 1, maxDelay = 5, multiplier = 1.4))
 		@KafkaListener(id = "reuseRetry3", topics = THIRD_REUSE_RETRY_TOPIC,
 				containerFactory = "retryTopicListenerContainerFactory")
 		public void listen3(String message, @Header(KafkaHeaders.RECEIVED_TOPIC) String receivedTopic) {

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicSameContainerFactoryIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryTopicSameContainerFactoryIntegrationTests.java
@@ -30,6 +30,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+import org.springframework.kafka.annotation.BackOff;
 import org.springframework.kafka.annotation.DltHandler;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.annotation.KafkaHandler;
@@ -48,7 +49,6 @@ import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.messaging.handler.annotation.Header;
-import org.springframework.retry.annotation.Backoff;
 import org.springframework.stereotype.Component;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
@@ -141,7 +141,7 @@ public class RetryTopicSameContainerFactoryIntegrationTests {
 
 		@RetryableTopic(
 				attempts = "4",
-				backoff = @Backoff(delay = 1000, multiplier = 2.0),
+				backoff = @BackOff(delay = 1000, multiplier = 2.0),
 				autoCreateTopics = "false",
 				topicSuffixingStrategy = TopicSuffixingStrategy.SUFFIX_WITH_INDEX_VALUE,
 				sameIntervalTopicReuseStrategy = SameIntervalTopicReuseStrategy.MULTIPLE_TOPICS)
@@ -160,7 +160,7 @@ public class RetryTopicSameContainerFactoryIntegrationTests {
 	@Component
 	@RetryableTopic(
 			attempts = "4",
-			backoff = @Backoff(delay = 1000, multiplier = 2.0),
+			backoff = @BackOff(delay = 1000, multiplier = 2.0),
 			autoCreateTopics = "false",
 			topicSuffixingStrategy = TopicSuffixingStrategy.SUFFIX_WITH_INDEX_VALUE,
 			sameIntervalTopicReuseStrategy = SameIntervalTopicReuseStrategy.MULTIPLE_TOPICS)

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryableTopicAnnotationProcessorTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/RetryableTopicAnnotationProcessorTests.java
@@ -33,6 +33,7 @@ import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.kafka.annotation.BackOff;
 import org.springframework.kafka.annotation.DltHandler;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.annotation.RetryableTopic;
@@ -40,7 +41,6 @@ import org.springframework.kafka.annotation.RetryableTopicAnnotationProcessor;
 import org.springframework.kafka.core.KafkaOperations;
 import org.springframework.kafka.support.EndpointHandlerMethod;
 import org.springframework.kafka.support.serializer.DeserializationException;
-import org.springframework.retry.annotation.Backoff;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.util.ReflectionUtils;
 
@@ -395,7 +395,7 @@ class RetryableTopicAnnotationProcessorTests {
 	static class RetryableTopicAnnotationFactoryWithDlt {
 
 		@KafkaListener
-		@RetryableTopic(attempts = "3", backoff = @Backoff(multiplier = 2, value = 1000),
+		@RetryableTopic(attempts = "3", backoff = @BackOff(multiplier = 2, value = 1000),
 			dltStrategy = DltStrategy.FAIL_ON_ERROR, excludeNames = "java.lang.IllegalStateException")
 		void listenWithRetry() {
 			// NoOps
@@ -408,7 +408,7 @@ class RetryableTopicAnnotationProcessorTests {
 	}
 
 	@KafkaListener
-	@RetryableTopic(attempts = "3", backoff = @Backoff(multiplier = 2, value = 1000),
+	@RetryableTopic(attempts = "3", backoff = @BackOff(multiplier = 2, value = 1000),
 			dltStrategy = DltStrategy.FAIL_ON_ERROR, excludeNames = "java.lang.IllegalStateException")
 	static class RetryableTopicClassLevelAnnotationFactoryWithDlt {
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/ExceptionMatcherTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/ExceptionMatcherTests.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright 2025-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.StreamCorruptedException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
+
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for {@link ExceptionMatcher}.
+ *
+ * @author Stephane Nicoll
+ */
+class ExceptionMatcherTests {
+
+	@Test
+	void matchWithDefaultMatcherAndException() {
+		assertThat(ExceptionMatcher.defaultMatcher().match(new IllegalStateException())).isTrue();
+	}
+
+	@Test
+	void matchWithDefaultMatcherAndError() {
+		assertThat(ExceptionMatcher.defaultMatcher().match(new OutOfMemoryError())).isFalse();
+	}
+
+	@Test
+	void matchWithDefaultMatcherAndNull() {
+		assertThat(ExceptionMatcher.defaultMatcher().match(new IllegalStateException())).isTrue();
+	}
+
+	@Test
+	void matchWithAllowList() {
+		ExceptionMatcher classifier = ExceptionMatcher.forAllowList()
+				.addAll(List.of(IOException.class, TimeoutException.class))
+				.build();
+
+		assertThat(classifier.match(new IOException())).isTrue();
+		// Should not match nested causes
+		assertThat(classifier.match(new RuntimeException(new IOException()))).isFalse();
+		assertThat(classifier.match(new StreamCorruptedException())).isTrue();
+		assertThat(classifier.match(new OutOfMemoryError())).isFalse();
+	}
+
+	@Test
+	public void matchWithAllowListAndTraversingCauses() {
+		ExceptionMatcher classifier = ExceptionMatcher.forAllowList()
+				.add(IOException.class)
+				.add(TimeoutException.class)
+				.traverseCauses(true)
+				.build();
+
+		assertThat(classifier.match(new IOException())).isTrue();
+		// Should match nested causes
+		assertThat(classifier.match(new RuntimeException(new IOException()))).isTrue();
+		assertThat(classifier.match(new StreamCorruptedException())).isTrue();
+		// Should match due to FileNotFoundException being a subclass of TimeoutException
+		assertThat(classifier.match(new FileNotFoundException())).isTrue();
+		assertThat(classifier.match(new RuntimeException())).isFalse();
+	}
+
+	@Test
+	public void matchWithDenyList() {
+		ExceptionMatcher classifier = ExceptionMatcher.forDenyList()
+				.addAll(List.of(Error.class, InterruptedException.class))
+				.build();
+
+		assertThat(classifier.match(new Throwable())).isTrue();
+		assertThat(classifier.match(new InterruptedException())).isFalse();
+		// should match due to OutOfMemoryError being a subclass of Error
+		assertThat(classifier.match(new OutOfMemoryError())).isFalse();
+		// Should match nested causes
+		assertThat(classifier.match(new RuntimeException(new InterruptedException()))).isTrue();
+	}
+
+	@Test
+	public void matchWithDenyListAndTraversingCauses() {
+		ExceptionMatcher classifier = ExceptionMatcher.forDenyList()
+				.add(Error.class)
+				.add(InterruptedException.class)
+				.traverseCauses(true)
+				.build();
+
+		assertThat(classifier.match(new Throwable())).isTrue();
+		assertThat(classifier.match(new InterruptedException())).isFalse();
+		// should retry due to traverseCauses=true
+		assertThat(classifier.match(new RuntimeException(new InterruptedException()))).isFalse();
+	}
+
+	@Test
+	void matchWithNullException() {
+		ExceptionMatcher classifier = ExceptionMatcher.forAllowList()
+				.add(Error.class).build();
+		assertThat(classifier.match(null)).isFalse();
+	}
+
+	@Test
+	public void creteWithEmptyAllowList() {
+		ExceptionMatcher classifier = new ExceptionMatcher(Collections.emptyList(), true);
+		assertThat(classifier.match(new IllegalStateException("foo"))).isFalse();
+	}
+
+	@Test
+	public void creteWithEmptyDenyList() {
+		ExceptionMatcher classifier = new ExceptionMatcher(Collections.emptyList(), false);
+		assertThat(classifier.match(new IllegalStateException("foo"))).isTrue();
+	}
+
+	@Test
+	public void createWithAllowListAndExactMatch() {
+		Collection<Class<? extends Throwable>> set = Collections.singleton(IllegalStateException.class);
+		assertThat(new ExceptionMatcher(set, true).match(new IllegalStateException("Foo"))).isTrue();
+	}
+
+	@Test
+	public void createWithAllowListAndMatchInCause() {
+		Collection<Class<? extends Throwable>> set = Collections.singleton(IllegalStateException.class);
+		ExceptionMatcher exceptionMatcher = new ExceptionMatcher(set, true);
+		exceptionMatcher.setTraverseCauses(true);
+		assertThat(exceptionMatcher.match(new RuntimeException(new IllegalStateException("Foo")))).isTrue();
+	}
+
+	@Test
+	public void createWithAllowListAndMatchInSubClassCause() {
+		Collection<Class<? extends Throwable>> set = Collections.singleton(IllegalStateException.class);
+		ExceptionMatcher exceptionMatcher = new ExceptionMatcher(set, true);
+		exceptionMatcher.setTraverseCauses(true);
+		assertThat(exceptionMatcher.match(new RuntimeException(new FooException("Foo")))).isTrue();
+	}
+
+	@Test
+	public void createWithNoMatchInSubClassUpdatesCache() {
+		ExceptionMatcher exceptionMatcher = new ExceptionMatcher(
+				Map.of(IllegalStateException.class, true, BarException.class, false), true, true);
+		assertThat(exceptionMatcher.match(new RuntimeException(new FooException("Foo", new BarException())))).isTrue();
+		assertThat(exceptionMatcher).extracting("entries")
+				.asInstanceOf(InstanceOfAssertFactories.map(Class.class, Boolean.class))
+				.containsEntry(FooException.class, true);
+	}
+
+	@SuppressWarnings("serial")
+	static class FooException extends IllegalStateException {
+
+		FooException(String s) {
+			super(s);
+		}
+
+		FooException(String s, Throwable t) {
+			super(s, t);
+		}
+
+	}
+
+	@SuppressWarnings("serial")
+	static class BarException extends RuntimeException {
+
+		BarException() {
+			super();
+		}
+
+	}
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/micrometer/ObservationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/micrometer/ObservationTests.java
@@ -71,6 +71,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.kafka.KafkaException;
+import org.springframework.kafka.annotation.BackOff;
 import org.springframework.kafka.annotation.DltHandler;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -94,7 +95,6 @@ import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.messaging.handler.annotation.SendTo;
-import org.springframework.retry.annotation.Backoff;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.test.annotation.DirtiesContext;
@@ -902,7 +902,7 @@ public class ObservationTests {
 
 		@RetryableTopic(
 				attempts = "2",
-				backoff = @Backoff(delay = 1000)
+				backoff = @BackOff(delay = 1000)
 		)
 		@KafkaListener(id = "asyncFailure", topics = OBSERVATION_ASYNC_FAILURE_TEST)
 		CompletableFuture<Void> handleAsync(ConsumerRecord<Integer, String> record) {

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/RetryingDeserializerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/RetryingDeserializerTests.java
@@ -19,6 +19,7 @@ package org.springframework.kafka.support.serializer;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.function.Function;
 
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.header.internals.RecordHeaders;
@@ -26,9 +27,8 @@ import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.utils.Utils;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.retry.RecoveryCallback;
-import org.springframework.retry.RetryContext;
-import org.springframework.retry.support.RetryTemplate;
+import org.springframework.core.retry.RetryException;
+import org.springframework.core.retry.RetryTemplate;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.any;
@@ -63,10 +63,10 @@ class RetryingDeserializerTests {
 		RetryingDeserializer<String> rdes = new RetryingDeserializer<>((s, b) -> {
 			throw new RuntimeException();
 		}, new RetryTemplate());
-		RecoveryCallback<String> recoveryCallback = mock();
+		Function<RetryException, String> recoveryCallback = mock();
 		rdes.setRecoveryCallback(recoveryCallback);
 		rdes.deserialize("my-topic", "my-data".getBytes());
-		verify(recoveryCallback).recover(any(RetryContext.class));
+		verify(recoveryCallback).apply(any(RetryException.class));
 	}
 
 	public static class Deser implements Deserializer<String> {


### PR DESCRIPTION
This commit replaces Spring Retry by the core retry support introduced in Spring Framework 7. This is a breaking change mostly in configuration that is detailed below.

The main feature in Spring Kafka is BackOffValuesGenerator that generates the required BackOff values upfront. These are then managed by the listener infrastructure and Spring Retry is no longer involved.

Moving this code from BackOffPolicy to BackOff dramatically simplifies that class as Spring Framework's core API naturally provides this information without the need of an extra infrastructure.

From a configuration standpoint, Spring Kafka relies quite heavily on Spring Retry's `@Backoff`. As there is no equivalent, the annotation has been moved to Spring Kafka proper with the following improvements:

* Harmonized name (`@BackOff` instead of `@Backoff`).
* Revisited Javadoc.
* Support for expression evaluation and `java.util.Duration` format.

The creation of a `BackOff` instance from the annotation is now isolated in `BackOffFactory` and the relevant tests have been added. `RetryTopicConfigurationBuilder` is mostly backward-compatible but `uniformRandomBackoff` has been deprecated as we feel that its name does not convey what it actually does.

`RetryingDeserializer` no longer offer a `RecoveryCallback` but an equivalent function that takes `RetryException` as an input. This contains the exceptions thrown as well as the number of retry attempts.

The use of BinaryExceptionClassifier has been replaced by the newly introduced `ExceptionMatcher` that is a copy of the original algorithm with a polished API.

With the migration done, we believe that further improvements can be made here: `@BackOff` oddly looks like Spring Framework's `@Retryable`. As a matter of a fact, the `maxAttempts` and `includes`/`excludes` from `@RetryableTopic` are touching the same concepts. One option would be to open up `@Retryable` so that it can be used in more case.

Another area of improvement is that harmonization of BackOff as a term. It is named "Backoff" in several places, including in `@RetryableTopic`, and it would be nice if the concept had the same syntax everywhere.

With Spring Retry being completely removed, this commit also removes the dependency and any further references to it.

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
