### PR TITLE
GH-3954: Add warning about @PostConstruct timing with NewTopic beans

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/sending-messages.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/sending-messages.adoc
@@ -74,15 +74,14 @@ The `execute` method provides direct access to the underlying javadoc:org.apache
 
 [NOTE]
 ====
-When sending messages from Spring components, avoid using `@PostConstruct` methods
-if you rely on automatic topic creation via `NewTopic` beans. `@PostConstruct` runs
-before the application context is fully ready, which may cause
-`UnknownTopicOrPartitionException` on clean brokers.
+When sending messages from Spring components, avoid using `@PostConstruct` methods if relying on automatic topic creation via `NewTopic` beans.
+`@PostConstruct` runs before the application context is fully ready, which may cause `UnknownTopicOrPartitionException` on clean brokers.
 
-Instead, consider:
-- Using an `ApplicationListener<ContextRefreshedEvent>` to send after the context is fully refreshed.
-- Implementing `SmartLifecycle` and starting after `KafkaAdmin`.
-- Or pre-creating topics externally.
+Instead, consider these alternatives:
+
+- Use an `ApplicationListener<ContextRefreshedEvent>` to ensure the context is fully refreshed before sending.
+- Implement `SmartLifecycle` to start after the `KafkaAdmin` bean has completed its initialization.
+- Pre-create topics externally.
 ====
 
 To use the template, you can configure a producer factory and provide it in the template's constructor.


### PR DESCRIPTION
<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->

Related Issue: #3954

Added a warning note to the topic configuration docs about `@PostConstruct` timing issues.

