### PR TITLE
Upgrade to Kafka 4.1.0 and update API usage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ ext {
 	jaywayJsonPathVersion = '2.9.0'
 	junit4Version = '4.13.2'
 	junitJupiterVersion = '5.13.4'
-	kafkaVersion = '4.0.0'
+	kafkaVersion = '4.1.0'
 	kotlinCoroutinesVersion = '1.10.2'
 	log4jVersion = '2.25.1'
 	micrometerDocsVersion = '1.0.4'

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ShareKafkaListenerIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ShareKafkaListenerIntegrationTests.java
@@ -63,8 +63,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 @DirtiesContext
 @EmbeddedKafka(topics = "share-listener-integration-test",
 		brokerProperties = {
-				"unstable.api.versions.enable=true",
-				"group.coordinator.rebalance.protocols=classic,share",
 				"share.coordinator.state.topic.replication.factor=1",
 				"share.coordinator.state.topic.min.isr=1"
 		})

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ShareKafkaMessageListenerContainerIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ShareKafkaMessageListenerContainerIntegrationTests.java
@@ -50,8 +50,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 @EmbeddedKafka(
 	topics = {"share-listener-integration-test"}, partitions = 1,
 	brokerProperties = {
-		"unstable.api.versions.enable=true",
-		"group.coordinator.rebalance.protocols=classic,share",
 		"share.coordinator.state.topic.replication.factor=1",
 		"share.coordinator.state.topic.min.isr=1"
 	}


### PR DESCRIPTION
- Bump kafkaVersion from 4.0.0 to 4.1.0 in build.gradle
- Remove broker properties no longer needed in embedded Kafka tests:

  * unstable.api.versions.enable=true
  * group.coordinator.rebalance.protocols=classic,share

- Replace AcknowledgeType.ACCEPT with commitSync() in share consumer tests
- Update SerializationIntegrationTests to use Plugin-based deserializer access


