### PR TITLE
Configure interceptors on listener container factory

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/receiving-messages/message-listener-container.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/receiving-messages/message-listener-container.adoc
@@ -22,25 +22,24 @@ IMPORTANT: If the interceptor mutates the record (by creating a new one), the `t
 
 The `CompositeRecordInterceptor` and `CompositeBatchInterceptor` can be used to invoke multiple interceptors.
 
-Starting with version 4.0, `AbstractMessageListenerContainer` exposes `getRecordInterceptor()` and `getBatchInterceptor()` as public methods.
+Starting with version 4.0, `AbstractKafkaListenerContainerFactory` and `AbstractMessageListenerContainer` exposes `getRecordInterceptor()` and `getBatchInterceptor()` as public methods.
 If the returned interceptor is an instance of `CompositeRecordInterceptor` or `CompositeBatchInterceptor`, additional `RecordInterceptor` or `BatchInterceptor` instances can be added to it even after the container instance extending `AbstractMessageListenerContainer` has been created and a `RecordInterceptor` or `BatchInterceptor` has already been configured.
 The following example shows how to do so:
 
 [source, java]
 ----
-public void configureRecordInterceptor(KafkaMessageListenerContainer<Integer, String> container) {
+public void configureRecordInterceptor(AbstractKafkaListenerContainerFactory<Integer, String> containerFactory) {
     CompositeRecordInterceptor compositeInterceptor;
 
-    RecordInterceptor<Integer, String> previousInterceptor = container.getRecordInterceptor();
+    RecordInterceptor<Integer, String> previousInterceptor = containerFactory.getRecordInterceptor();
     if (previousInterceptor instanceof CompositeRecordInterceptor interceptor) {
         compositeInterceptor = interceptor;
     } else {
         compositeInterceptor = new CompositeRecordInterceptor<>();
-        container.setRecordInterceptor(compositeInterceptor);
-    }
-
-    if (previousInterceptor != null) {
-        compositeRecordInterceptor.addRecordInterceptor(previousInterceptor);
+        containerFactory.setRecordInterceptor(compositeInterceptor);
+        if (previousInterceptor != null) {
+            compositeRecordInterceptor.addRecordInterceptor(previousInterceptor);
+        }
     }
 
     RecordInterceptor<Integer, String> recordInterceptor1 = new RecordInterceptor() {...};

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
@@ -61,6 +61,7 @@ import org.springframework.util.Assert;
  * @author Stephane Nicoll
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Christian Fredriksson
  *
  * @see AbstractMessageListenerContainer
  */
@@ -276,6 +277,15 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 	}
 
 	/**
+	 * Get the {@link RecordInterceptor} for modification, if configured.
+	 * @return the {@link RecordInterceptor}, or {@code null} if not configured
+	 * @since 4.0
+	 */
+	public @Nullable RecordInterceptor<K, V> getRecordInterceptor() {
+		return this.recordInterceptor;
+	}
+
+	/**
 	 * Set an interceptor to be called before calling the listener.
 	 * Only used with record listeners.
 	 * @param recordInterceptor the interceptor.
@@ -284,6 +294,15 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 	 */
 	public void setRecordInterceptor(RecordInterceptor<K, V> recordInterceptor) {
 		this.recordInterceptor = recordInterceptor;
+	}
+
+	/**
+	 * Get the {@link BatchInterceptor} for modification, if configured.
+	 * @return the {@link BatchInterceptor}, or {@code null} if not configured
+	 * @since 4.0
+	 */
+	public @Nullable BatchInterceptor<K, V> getBatchInterceptor() {
+		return this.batchInterceptor;
 	}
 
 	/**


### PR DESCRIPTION
This changes allows configuring interceptors on AbstractKafkaListenerContainerFactory in same way as on KafkaMessageListenerContainer, and changes the examle docs to show this instead.
I can revert the update to the docs if desired but I thought it to be more useful as an example since you normally have access to the listener container factory as a bean, but not to the listener container since it's not a bean.