### PR TITLE
Update listener observation operation tag

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/micrometer/KafkaListenerObservation.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/micrometer/KafkaListenerObservation.java
@@ -231,7 +231,7 @@ public enum KafkaListenerObservation implements ObservationDocumentation {
 			KeyValues keyValues = KeyValues.of(
 					ListenerLowCardinalityTags.LISTENER_ID.withValue(context.getListenerId()),
 					ListenerLowCardinalityTags.MESSAGING_SYSTEM.withValue("kafka"),
-					ListenerLowCardinalityTags.MESSAGING_OPERATION.withValue("receive"),
+					ListenerLowCardinalityTags.MESSAGING_OPERATION.withValue("process"),
 					ListenerLowCardinalityTags.MESSAGING_SOURCE_NAME.withValue(context.getSource()),
 					ListenerLowCardinalityTags.MESSAGING_SOURCE_KIND.withValue("topic")
 			);
@@ -269,7 +269,7 @@ public enum KafkaListenerObservation implements ObservationDocumentation {
 
 		@Override
 		public String getContextualName(KafkaRecordReceiverContext context) {
-			return context.getSource() + " receive";
+			return context.getSource() + " process";
 		}
 
 		private static @Nullable String getConsumerId(@Nullable String groupId, @Nullable String clientId) {

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/micrometer/ObservationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/micrometer/ObservationTests.java
@@ -113,6 +113,7 @@ import static org.mockito.Mockito.mock;
  * @author Christian Mergenthaler
  * @author Soby Chacko
  * @author Francois Rosiere
+ * @author Christian Fredriksson
  *
  * @since 3.0
  */
@@ -377,14 +378,14 @@ public class ObservationTests {
 								Map.entry("messaging.kafka.consumer.group", consumerGroup),
 								Map.entry("messaging.kafka.message.offset", offset),
 								Map.entry("messaging.kafka.source.partition", partition),
-								Map.entry("messaging.operation", "receive"),
+								Map.entry("messaging.operation", "process"),
 								Map.entry("messaging.source.kind", "topic"),
 								Map.entry("messaging.source.name", sourceName),
 								Map.entry("messaging.system", "kafka")));
 		if (keyValues.length > 0) {
 			Arrays.stream(keyValues).forEach(entry -> assertThat(span.getTags()).contains(entry));
 		}
-		assertThat(span.getName()).isEqualTo(sourceName + " receive");
+		assertThat(span.getName()).isEqualTo(sourceName + " process");
 		return span;
 	}
 
@@ -406,7 +407,7 @@ public class ObservationTests {
 		meterRegistryAssert.hasTimerWithNameAndTags("spring.kafka.listener",
 				KeyValues.of(
 								"messaging.kafka.consumer.group", consumerGroup,
-								"messaging.operation", "receive",
+								"messaging.operation", "process",
 								"messaging.source.kind", "topic",
 								"messaging.source.name", destName,
 								"messaging.system", "kafka",


### PR DESCRIPTION
This updates the listener observation operation tag according to latest standard.

E.g. [Open Telemetry states](https://github.com/open-telemetry/semantic-conventions/blob/v1.24.0/docs/messaging/messaging-spans.md#consumer):
> The consumer receives, processes, and settles a message. "Receiving" is the process of obtaining a message from the intermediary, **"processing" is the process of acting on the information a message contains**, "settling" is the process of notifying an intermediary that a message was processed successfully.

E.g. [Micrometer JMS follows this](https://github.com/micrometer-metrics/micrometer/blob/main/micrometer-jakarta9/src/main/java/io/micrometer/jakarta9/instrument/jms/DefaultJmsProcessObservationConvention.java#L34).
> `private static final KeyValue OPERATION_PROCESS = KeyValue.of(LowCardinalityKeyNames.OPERATION, "process");`