### PR TITLE
Add concurrency support to `ShareKafkaMessageListenerContainer`

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/kafka-queues.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/kafka-queues.adoc
@@ -107,7 +107,7 @@ factory.addListener(new ShareConsumerFactory.Listener<String, String>() {
 [[share-kafka-message-listener-container]]
 === ShareKafkaMessageListenerContainer
 
-The `ShareKafkaMessageListenerContainer` provides a simple, single-threaded container for share consumers:
+The `ShareKafkaMessageListenerContainer` provides a container for share consumers with support for concurrent processing:
 
 [source,java]
 ----
@@ -149,6 +149,145 @@ Share consumers do not support:
 * Explicit partition assignment (`TopicPartitionOffset`)
 * Topic patterns
 * Manual offset management
+====
+
+[[share-container-concurrency]]
+=== Concurrency
+
+The `ShareKafkaMessageListenerContainer` supports concurrent processing by creating multiple consumer threads within a single container.
+Each thread runs its own `ShareConsumer` instance that participates in the same share group.
+
+Unlike traditional consumer groups where concurrency involves partition distribution, share consumers leverage Kafka's record-level distribution at the broker.
+This means multiple consumer threads in the same container work together as part of the share group, with the Kafka broker distributing records across all consumer instances.
+
+==== Configuring Concurrency Programmatically
+
+[source,java]
+----
+@Bean
+public ShareKafkaMessageListenerContainer<String, String> concurrentContainer(
+        ShareConsumerFactory<String, String> shareConsumerFactory) {
+
+    ContainerProperties containerProps = new ContainerProperties("my-topic");
+    containerProps.setGroupId("my-share-group");
+
+    ShareKafkaMessageListenerContainer<String, String> container =
+        new ShareKafkaMessageListenerContainer<>(shareConsumerFactory, containerProps);
+
+    // Set concurrency to create 5 consumer threads
+    container.setConcurrency(5);
+
+    container.setupMessageListener(new MessageListener<String, String>() {
+        @Override
+        public void onMessage(ConsumerRecord<String, String> record) {
+            System.out.println("Received on " + Thread.currentThread().getName() + ": " + record.value());
+        }
+    });
+
+    return container;
+}
+----
+
+==== Configuring Concurrency via Factory
+
+You can set default concurrency at the factory level, which applies to all containers created by that factory:
+
+[source,java]
+----
+@Bean
+public ShareKafkaListenerContainerFactory<String, String> shareKafkaListenerContainerFactory(
+        ShareConsumerFactory<String, String> shareConsumerFactory) {
+
+    ShareKafkaListenerContainerFactory<String, String> factory =
+        new ShareKafkaListenerContainerFactory<>(shareConsumerFactory);
+
+    // Set default concurrency for all containers created by this factory
+    factory.setConcurrency(3);
+
+    return factory;
+}
+----
+
+==== Per-Listener Concurrency
+
+The concurrency setting can be overridden per listener using the `concurrency` attribute:
+
+[source,java]
+----
+@Component
+public class ConcurrentShareListener {
+
+    @KafkaListener(
+        topics = "high-throughput-topic",
+        containerFactory = "shareKafkaListenerContainerFactory",
+        groupId = "my-share-group",
+        concurrency = "10"  // Override factory default
+    )
+    public void listen(ConsumerRecord<String, String> record) {
+        // This listener will use 10 consumer threads
+        System.out.println("Processing: " + record.value());
+    }
+}
+----
+
+==== Concurrency Considerations
+
+* **Thread Safety**: Each consumer thread has its own `ShareConsumer` instance and manages its own acknowledgments independently
+* **Client IDs**: Each consumer thread receives a unique client ID with a numeric suffix (e.g., `myContainer-0`, `myContainer-1`, etc.)
+* **Metrics**: Metrics from all consumer threads are aggregated and accessible via `container.metrics()`
+* **Lifecycle**: All consumer threads start and stop together as a unit
+* **Work Distribution**: The Kafka broker handles record distribution across all consumer instances in the share group
+* **Explicit Acknowledgment**: Each thread independently manages acknowledgments for its records; unacknowledged records in one thread don't block other threads
+
+==== Concurrency with Explicit Acknowledgment
+
+Concurrency works seamlessly with explicit acknowledgment mode.
+Each consumer thread independently tracks and acknowledges its own records:
+
+[source,java]
+----
+@KafkaListener(
+    topics = "order-queue",
+    containerFactory = "explicitShareKafkaListenerContainerFactory",
+    groupId = "order-processors",
+    concurrency = "5"
+)
+public void processOrder(ConsumerRecord<String, String> record, ShareAcknowledgment acknowledgment) {
+    try {
+        // Process the order
+        processOrderLogic(record.value());
+        acknowledgment.acknowledge(); // ACCEPT
+    }
+    catch (RetryableException e) {
+        acknowledgment.release(); // Will be redelivered
+    }
+    catch (Exception e) {
+        acknowledgment.reject(); // Permanent failure
+    }
+}
+----
+
+[NOTE]
+====
+**Work Distribution Behavior:**
+
+With share consumers, record distribution is controlled by Kafka's share group coordinator at the broker level, not by Spring for Apache Kafka.
+The broker may assign all records to a single consumer thread at any given time, especially when:
+
+* The topic has a single partition
+* There's low message volume
+* The broker's distribution algorithm favors certain consumers
+
+This is normal behavior. The key benefit of concurrency is having multiple consumer threads *available* to the share group coordinator for distribution.
+As message volume increases or over time, you should see distribution across multiple threads.
+
+This differs from traditional `ConcurrentMessageListenerContainer` where Spring explicitly distributes partitions across threads.
+
+When using concurrency with share consumers:
+
+* Each thread polls and processes records independently
+* Acknowledgment constraints apply per-thread (one thread's unacknowledged records don't block other threads)
+* Concurrency setting must be greater than 0 and cannot be changed while the container is running
 ====
 
 [[share-annotation-driven-listeners]]
@@ -520,8 +659,7 @@ Share consumers differ from regular consumers in several key ways:
 === Current Limitations
 
 * **In preview**: This feature is in preview mode and may change in future versions
-* **Single-Threaded**: Share consumer containers currently run in single-threaded mode
 * **No Message Converters**: Message converters are not yet supported for share consumers
 * **No Batch Listeners**: Batch processing is not supported with share consumers
-* **Poll Constraints**: In explicit acknowledgment mode, unacknowledged records block subsequent polls
+* **Poll Constraints**: In explicit acknowledgment mode, unacknowledged records block subsequent polls within each consumer thread
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ShareKafkaMessageListenerContainerIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ShareKafkaMessageListenerContainerIntegrationTests.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
+import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AlterConfigOp;
 import org.apache.kafka.clients.admin.ConfigEntry;
@@ -82,6 +83,8 @@ import static org.mockito.Mockito.verify;
 		}
 )
 class ShareKafkaMessageListenerContainerIntegrationTests {
+
+	private static final LogAccessor logger = new LogAccessor(LogFactory.getLog(ShareKafkaMessageListenerContainerIntegrationTests.class));
 
 	@Test
 	void integrationTestShareKafkaMessageListenerContainer(EmbeddedKafkaBroker broker) throws Exception {
@@ -265,11 +268,12 @@ class ShareKafkaMessageListenerContainerIntegrationTests {
 		container.setBeanName("constraintTestContainer");
 		container.start();
 
-		LogAccessor logAccessor = spy(KafkaTestUtils.getPropertyValue(container, "listenerConsumer.logger",
+		// Access the first consumer from the consumers list
+		LogAccessor logAccessor = spy(KafkaTestUtils.getPropertyValue(container, "consumers[0].logger",
 				LogAccessor.class));
 
 		DirectFieldAccessor accessor = new DirectFieldAccessor(container);
-		accessor.setPropertyValue("listenerConsumer.logger", logAccessor);
+		accessor.setPropertyValue("consumers[0].logger", logAccessor);
 
 		try {
 			// Wait for first batch to be processed
@@ -343,11 +347,12 @@ class ShareKafkaMessageListenerContainerIntegrationTests {
 		container.setBeanName("partialAckTestContainer");
 		container.start();
 
-		LogAccessor logAccessor = spy(KafkaTestUtils.getPropertyValue(container, "listenerConsumer.logger",
+		// Access the first consumer from the consumers list
+		LogAccessor logAccessor = spy(KafkaTestUtils.getPropertyValue(container, "consumers[0].logger",
 				LogAccessor.class));
 
 		DirectFieldAccessor accessor = new DirectFieldAccessor(container);
-		accessor.setPropertyValue("listenerConsumer.logger", logAccessor);
+		accessor.setPropertyValue("consumers[0].logger", logAccessor);
 
 		produceTestRecords(bootstrapServers, topic, 4);
 
@@ -826,6 +831,292 @@ class ShareKafkaMessageListenerContainerIntegrationTests {
 		catch (Exception e) {
 			throw new RuntimeException("Failed to access internal acknowledgment type", e);
 		}
+	}
+
+	// ==================== Concurrency Integration Tests ====================
+
+	@Test
+	void shouldProcessRecordsWithMultipleConsumerThreads(EmbeddedKafkaBroker broker) throws Exception {
+		String topic = "share-container-concurrency-basic-test";
+		String groupId = "share-container-concurrency-basic-group";
+		String bootstrapServers = broker.getBrokersAsString();
+
+		// Create topic with multiple partitions to allow better distribution
+		broker.addTopics(topic);
+
+		setShareAutoOffsetResetEarliest(bootstrapServers, groupId);
+
+		// Produce more records than consumers to ensure distribution
+		int numRecords = 30;
+		int concurrency = 3;
+		produceTestRecords(bootstrapServers, topic, numRecords);
+
+		Map<String, Object> consumerProps = createConsumerProps(bootstrapServers, groupId, false);
+		DefaultShareConsumerFactory<String, String> factory = new DefaultShareConsumerFactory<>(consumerProps);
+
+		ContainerProperties containerProps = new ContainerProperties(topic);
+		CountDownLatch latch = new CountDownLatch(numRecords);
+		Map<String, AtomicInteger> threadCounts = new ConcurrentHashMap<>();
+		List<String> receivedValues = Collections.synchronizedList(new ArrayList<>());
+
+		containerProps.setMessageListener((MessageListener<String, String>) record -> {
+			String threadName = Thread.currentThread().getName();
+			threadCounts.computeIfAbsent(threadName, k -> new AtomicInteger()).incrementAndGet();
+			receivedValues.add(record.value());
+			latch.countDown();
+		});
+
+		ShareKafkaMessageListenerContainer<String, String> container =
+				new ShareKafkaMessageListenerContainer<>(factory, containerProps);
+		container.setBeanName("concurrencyBasicTest");
+		container.setConcurrency(concurrency);
+
+		assertThat(container.getConcurrency()).isEqualTo(concurrency);
+
+		container.start();
+
+		try {
+			// Verify all records are processed
+			assertThat(latch.await(30, TimeUnit.SECONDS))
+					.as("All %d records should be processed", numRecords)
+					.isTrue();
+
+			// Log thread distribution for debugging
+			logger.info(() -> "Thread distribution: " + threadCounts);
+
+			// Verify all records received
+			assertThat(receivedValues).hasSize(numRecords);
+
+			// Share consumers with single partition may use only one consumer at a time
+			// So we verify: at least 1 thread used, at most concurrency threads
+			assertThat(threadCounts.size())
+					.as("At least one consumer thread should process records")
+					.isGreaterThanOrEqualTo(1)
+					.isLessThanOrEqualTo(concurrency);
+
+			// Verify work was done
+			int totalProcessed = threadCounts.values().stream()
+					.mapToInt(AtomicInteger::get)
+					.sum();
+			assertThat(totalProcessed).isEqualTo(numRecords);
+		}
+		finally {
+			container.stop();
+		}
+	}
+
+	@Test
+	void shouldAggregateMetricsFromMultipleConsumers(EmbeddedKafkaBroker broker) throws Exception {
+		String topic = "share-container-concurrency-metrics-test";
+		String groupId = "share-container-concurrency-metrics-group";
+		String bootstrapServers = broker.getBrokersAsString();
+
+		broker.addTopics(topic);
+		setShareAutoOffsetResetEarliest(bootstrapServers, groupId);
+
+		int concurrency = 4;
+		Map<String, Object> consumerProps = createConsumerProps(bootstrapServers, groupId, false);
+		DefaultShareConsumerFactory<String, String> factory = new DefaultShareConsumerFactory<>(consumerProps);
+
+		ContainerProperties containerProps = new ContainerProperties(topic);
+		containerProps.setMessageListener((MessageListener<String, String>) record -> {
+			// Simple consumer
+		});
+
+		ShareKafkaMessageListenerContainer<String, String> container =
+				new ShareKafkaMessageListenerContainer<>(factory, containerProps);
+		container.setBeanName("concurrencyMetricsTest");
+		container.setConcurrency(concurrency);
+		container.start();
+
+		try {
+			// Wait for all consumers to initialize and register metrics
+			Awaitility.await()
+					.atMost(10, TimeUnit.SECONDS)
+					.untilAsserted(() -> {
+						var metrics = container.metrics();
+						assertThat(metrics)
+								.as("Metrics should be available from all %d consumers", concurrency)
+								.hasSize(concurrency);
+					});
+
+			var metrics = container.metrics();
+
+			// Verify each consumer has a unique client ID
+			assertThat(metrics.keySet())
+					.as("Each consumer should have unique client ID")
+					.hasSize(concurrency);
+
+			// Verify client IDs follow the pattern: beanName-0, beanName-1, etc.
+			for (String clientId : metrics.keySet()) {
+				assertThat(clientId)
+						.as("Client ID should contain bean name")
+						.contains("concurrencyMetricsTest");
+			}
+
+			logger.info(() -> "Client IDs from metrics: " + metrics.keySet());
+		}
+		finally {
+			container.stop();
+		}
+	}
+
+	@Test
+	void shouldHandleConcurrencyWithExplicitAcknowledgment(EmbeddedKafkaBroker broker) throws Exception {
+		String topic = "share-container-concurrency-explicit-test";
+		String groupId = "share-container-concurrency-explicit-group";
+		String bootstrapServers = broker.getBrokersAsString();
+
+		broker.addTopics(topic);
+		setShareAutoOffsetResetEarliest(bootstrapServers, groupId);
+
+		int numRecords = 15;
+		int concurrency = 3;
+		produceTestRecords(bootstrapServers, topic, numRecords);
+
+		Map<String, Object> consumerProps = createConsumerProps(bootstrapServers, groupId, true);
+		DefaultShareConsumerFactory<String, String> factory = new DefaultShareConsumerFactory<>(consumerProps);
+
+		ContainerProperties containerProps = new ContainerProperties(topic);
+		containerProps.setExplicitShareAcknowledgment(true);
+
+		CountDownLatch latch = new CountDownLatch(numRecords);
+		AtomicInteger acceptCount = new AtomicInteger();
+		AtomicInteger rejectCount = new AtomicInteger();
+		Map<String, AtomicInteger> threadCounts = new ConcurrentHashMap<>();
+
+		containerProps.setMessageListener((AcknowledgingShareConsumerAwareMessageListener<String, String>) (
+				record, acknowledgment, consumer) -> {
+			String threadName = Thread.currentThread().getName();
+			threadCounts.computeIfAbsent(threadName, k -> new AtomicInteger()).incrementAndGet();
+
+			// Reject every 5th record, accept others
+			int recordNum = Integer.parseInt(record.value().substring(5)); // "value0" -> 0
+			if (recordNum % 5 == 0) {
+				acknowledgment.reject();
+				rejectCount.incrementAndGet();
+			}
+			else {
+				acknowledgment.acknowledge();
+				acceptCount.incrementAndGet();
+			}
+			latch.countDown();
+		});
+
+		ShareKafkaMessageListenerContainer<String, String> container =
+				new ShareKafkaMessageListenerContainer<>(factory, containerProps);
+		container.setBeanName("concurrencyExplicitTest");
+		container.setConcurrency(concurrency);
+		container.start();
+
+		try {
+			assertThat(latch.await(30, TimeUnit.SECONDS))
+					.as("All records should be processed with explicit acknowledgment")
+					.isTrue();
+
+			logger.info(() -> "Thread distribution with explicit ack: " + threadCounts);
+			logger.info(() -> "Accept count: " + acceptCount.get() + ", Reject count: " + rejectCount.get());
+
+			// Verify at least one thread processed records
+			assertThat(threadCounts.size())
+					.as("At least one thread should process records in explicit mode")
+					.isGreaterThanOrEqualTo(1)
+					.isLessThanOrEqualTo(concurrency);
+
+			// Verify acknowledgments were processed correctly
+			assertThat(acceptCount.get() + rejectCount.get())
+					.as("Total acknowledgments should equal number of records")
+					.isEqualTo(numRecords);
+
+			assertThat(rejectCount.get())
+					.as("Expected number of rejections")
+					.isEqualTo(3); // Records 0, 5, 10
+		}
+		finally {
+			container.stop();
+		}
+	}
+
+	@Test
+	void shouldStopAllConsumerThreadsGracefully(EmbeddedKafkaBroker broker) throws Exception {
+		String topic = "share-container-concurrency-lifecycle-test";
+		String groupId = "share-container-concurrency-lifecycle-group";
+		String bootstrapServers = broker.getBrokersAsString();
+
+		broker.addTopics(topic);
+		setShareAutoOffsetResetEarliest(bootstrapServers, groupId);
+
+		int concurrency = 5;
+		Map<String, Object> consumerProps = createConsumerProps(bootstrapServers, groupId, false);
+		DefaultShareConsumerFactory<String, String> factory = new DefaultShareConsumerFactory<>(consumerProps);
+
+		ContainerProperties containerProps = new ContainerProperties(topic);
+		AtomicInteger processedCount = new AtomicInteger();
+
+		containerProps.setMessageListener((MessageListener<String, String>) record -> {
+			processedCount.incrementAndGet();
+		});
+
+		ShareKafkaMessageListenerContainer<String, String> container =
+				new ShareKafkaMessageListenerContainer<>(factory, containerProps);
+		container.setBeanName("concurrencyLifecycleTest");
+		container.setConcurrency(concurrency);
+
+		// Verify initial state
+		assertThat(container.isRunning()).isFalse();
+		assertThat(container.metrics()).isEmpty();
+
+		// Start container
+		container.start();
+		assertThat(container.isRunning()).isTrue();
+
+		// Wait for consumers to initialize
+		Awaitility.await()
+				.atMost(10, TimeUnit.SECONDS)
+				.untilAsserted(() -> assertThat(container.metrics()).hasSize(concurrency));
+
+		// Produce some records
+		produceTestRecords(bootstrapServers, topic, 10);
+
+		// Give some time for processing
+		Awaitility.await()
+				.atMost(10, TimeUnit.SECONDS)
+				.untilAsserted(() -> assertThat(processedCount.get()).isGreaterThan(0));
+
+		int processedBeforeStop = processedCount.get();
+		logger.info(() -> "Processed " + processedBeforeStop + " records before stop");
+
+		// Stop the container
+		container.stop();
+		assertThat(container.isRunning()).isFalse();
+
+		// Verify metrics are cleared after stop
+		Awaitility.await()
+				.atMost(5, TimeUnit.SECONDS)
+				.untilAsserted(() -> assertThat(container.metrics()).isEmpty());
+
+		// Verify container can be restarted
+		container.start();
+		assertThat(container.isRunning()).isTrue();
+
+		// Verify consumers are recreated
+		Awaitility.await()
+				.atMost(10, TimeUnit.SECONDS)
+				.untilAsserted(() -> assertThat(container.metrics()).hasSize(concurrency));
+
+		// Produce more records
+		produceTestRecords(bootstrapServers, topic, 5);
+
+		// Verify processing continues after restart
+		Awaitility.await()
+				.atMost(10, TimeUnit.SECONDS)
+				.untilAsserted(() -> assertThat(processedCount.get()).isGreaterThan(processedBeforeStop));
+
+		logger.info(() -> "Processed " + processedCount.get() + " records total after restart");
+
+		// Final stop
+		container.stop();
+		assertThat(container.isRunning()).isFalse();
 	}
 
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ShareKafkaMessageListenerContainerUnitTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ShareKafkaMessageListenerContainerUnitTests.java
@@ -90,6 +90,37 @@ public class ShareKafkaMessageListenerContainerUnitTests {
 	}
 
 	@Test
+	void shouldSetConcurrencyCorrectly() {
+		ContainerProperties containerProperties = new ContainerProperties("test-topic");
+		containerProperties.setMessageListener(messageListener);
+
+		ShareKafkaMessageListenerContainer<String, String> container =
+				new ShareKafkaMessageListenerContainer<>(shareConsumerFactory, containerProperties);
+
+		assertThat(container.getConcurrency()).isEqualTo(1); // Default is 1
+
+		container.setConcurrency(5);
+		assertThat(container.getConcurrency()).isEqualTo(5);
+	}
+
+	@Test
+	void shouldRejectInvalidConcurrency() {
+		ContainerProperties containerProperties = new ContainerProperties("test-topic");
+		containerProperties.setMessageListener(messageListener);
+
+		ShareKafkaMessageListenerContainer<String, String> container =
+				new ShareKafkaMessageListenerContainer<>(shareConsumerFactory, containerProperties);
+
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> container.setConcurrency(0))
+				.withMessageContaining("concurrency must be greater than 0");
+
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> container.setConcurrency(-1))
+				.withMessageContaining("concurrency must be greater than 0");
+	}
+
+	@Test
 	void shouldValidateListenerTypeOnStartup() {
 		// Given: A container with explicit acknowledgment mode and proper listener
 		ContainerProperties containerProperties = new ContainerProperties("test-topic");


### PR DESCRIPTION
  Share consumers (KIP-932) enable record-level load balancing where
  multiple consumers can cooperatively process from the same partitions.
  Unlike traditional consumer groups with exclusive partition ownership,
  share groups distribute work at the broker level via the share group
  coordinator.

  This commit adds native concurrency support to the existing
  `ShareKafkaMessageListenerContainer` rather than creating a separate
  `ConcurrentShareKafkaMessageListenerContainer`. This design choice
  avoids the parent/child container complexity that exists in the regular
  consumer model, since share consumers fundamentally operate differently:

  - Work distribution happens at the broker level, not at the Spring layer
  - Multiple threads simply provide more capacity for the broker to distribute records across
  - No partition ownership model to coordinate between child containers

  This approach provides:

  - Simpler architecture with a single container managing multiple threads
  - No parent/child context propagation concerns
  - Better alignment with share consumer semantics (record-level vs partition-level distribution)
  - Increased throughput for high-volume workloads
  - Better resource utilization across consumer threads

  Users can configure concurrency at three levels:
  1. Per-listener via `@KafkaListener(concurrency = N)`
  2. Factory-level default via `factory.setConcurrency(N)`
  3. Programmatically via `container.setConcurrency(N)`

  The feature works seamlessly with both implicit (auto-acknowledge) and
  explicit (manual acknowledge/release/reject) acknowledgment modes, with
  each consumer thread independently managing its own acknowledgments.
