### PR TITLE
Add factory-level container properties support to ShareKafkaListenerC…

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/kafka-queues.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/kafka-queues.adoc
@@ -442,20 +442,17 @@ public ShareConsumerFactory<String, String> explicitShareConsumerFactory() {
 [source,java]
 ----
 @Bean
-public ShareConsumerFactory<String, String> explicitShareConsumerFactory() {
-    Map<String, Object> props = new HashMap<>();
-    props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
-    props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-    props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-    props.put(ConsumerConfig.SHARE_ACKNOWLEDGEMENT_MODE_CONFIG, "explicit");
-    return new DefaultShareConsumerFactory<>(props);
-}
-
-@Bean
 public ShareKafkaListenerContainerFactory<String, String> explicitShareKafkaListenerContainerFactory(
-    ShareConsumerFactory<String, String> explicitShareConsumerFactory) {
-    // The factory will detect the explicit acknowledgment mode from the consumer factory configuration
-    return new ShareKafkaListenerContainerFactory<>(explicitShareConsumerFactory);
+    ShareConsumerFactory<String, String> shareConsumerFactory) {
+
+    ShareKafkaListenerContainerFactory<String, String> factory =
+        new ShareKafkaListenerContainerFactory<>(shareConsumerFactory);
+
+    // Configure acknowledgment mode at container factory level
+    // true means explicit acknowledgment is required
+    factory.getContainerProperties().setExplicitShareAcknowledgment(true);
+
+    return factory;
 }
 ----
 


### PR DESCRIPTION
…ontainerFactory

Enables configuration of container properties at the factory level, following the established pattern in other Spring Kafka container factories. This provides a more flexible and Spring-friendly way to configure share consumer containers, particularly for settings like explicit acknowledgment mode, without requiring configuration through Kafka client properties.

- Add `getContainerProperties()` method to allow configuration at factory level
- Copy factory-level properties to each listener container instance during creation
- Update acknowledgment mode determination to respect factory-level settings with proper precedence
- Add integration test for factory-level explicit acknowledgment configuration
- Update documentation with factory-level configuration example

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
