### PR TITLE
GH-1587: Refactor fixTxOffsets to use ConsumerRecords#nextOffsets

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -173,6 +173,7 @@ import org.springframework.util.StringUtils;
  * @author Christian Fredriksson
  * @author Timofey Barabanov
  * @author Janek Lasocki-Biczysko
+ * @author Su Ko
  */
 public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		extends AbstractMessageListenerContainer<K, V> implements ConsumerPauseResumeEventPublisher {

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/TransactionalContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/TransactionalContainerTests.java
@@ -108,6 +108,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
  * @author Wang Zhiyang
  * @author Soby Chacko
  * @author Raphael Rösch
+ * @author Su Ko
  *
  * @since 1.3
  *


### PR DESCRIPTION
Refactor fixTxOffsets to use nextOffsets API to correctly skip transactional commit markers
issue : #1587 

thanks 🙂

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
