### PR TITLE
GH:4152: Optimize ArrayList allocations in BatchMessagingMessageConverter

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/converter/BatchMessagingMessageConverter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/converter/BatchMessagingMessageConverter.java
@@ -175,17 +175,18 @@ public class BatchMessagingMessageConverter implements BatchMessageConverter {
 				new KafkaMessageHeaders(this.generateMessageId, this.generateTimestamp);
 
 		Map<String, Object> rawHeaders = kafkaMessageHeaders.getRawHeaders();
-		List<Object> payloads = new ArrayList<>();
-		List<Object> keys = new ArrayList<>();
-		List<String> topics = new ArrayList<>();
-		List<Integer> partitions = new ArrayList<>();
-		List<Long> offsets = new ArrayList<>();
-		List<String> timestampTypes = new ArrayList<>();
-		List<Long> timestamps = new ArrayList<>();
-		List<Map<String, Object>> convertedHeaders = new ArrayList<>();
-		List<Headers> natives = new ArrayList<>();
-		List<ConsumerRecord<?, ?>> raws = new ArrayList<>();
-		List<ConversionException> conversionFailures = new ArrayList<>();
+		int batchSize = records.size();
+		List<Object> payloads = new ArrayList<>(batchSize);
+		List<Object> keys = new ArrayList<>(batchSize);
+		List<String> topics = new ArrayList<>(batchSize);
+		List<Integer> partitions = new ArrayList<>(batchSize);
+		List<Long> offsets = new ArrayList<>(batchSize);
+		List<String> timestampTypes = new ArrayList<>(batchSize);
+		List<Long> timestamps = new ArrayList<>(batchSize);
+		List<Map<String, Object>> convertedHeaders = new ArrayList<>(batchSize);
+		List<Headers> natives = new ArrayList<>(batchSize);
+		List<ConsumerRecord<?, ?>> raws = new ArrayList<>(batchSize);
+		List<ConversionException> conversionFailures = new ArrayList<>(batchSize);
 
 		addToRawHeaders(rawHeaders, convertedHeaders, natives, raws, conversionFailures);
 		commonHeaders(acknowledgment, consumer, rawHeaders, keys, topics, partitions, offsets, timestampTypes,


### PR DESCRIPTION
Pre-size all ArrayList instances with batch size to eliminate internal array resizing and reduce GC pressure in high-throughput batch processing scenarios.

Fixes GH-4152
- Added `batchSize` variable to cache `records.size()`
- Pre-sized all 11 ArrayList instances with `batchSize`
issue: #4152 
<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
