### PR TITLE
fix wrong test example

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/testing.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/testing.adoc
@@ -149,7 +149,7 @@ The following example configuration creates topics called `cat` and `hat` with f
 public class MyTests {
 
     @ClassRule
-    private static EmbeddedKafkaRule embeddedKafka = new EmbeddedKafkaRule(1, false, 5, "cat", "hat");
+    public static EmbeddedKafkaRule embeddedKafka = new EmbeddedKafkaRule(1, false, 5, "cat", "hat");
 
     @Test
     public void test() {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->

`@ClassRule` must be declared as public. According to the JUnit [documentation](https://junit.org/junit4/javadoc/4.12/org/junit/ClassRule.html), only public fields are allowed for the `@ClassRule` annotation (“A field must be public”). However, in examples the field is shown as private.