### PR TITLE
GH-4170 : Add KafkaListener Validation (Allow @Topic or @TopicPartition)

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
@@ -666,10 +666,11 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 		endpoint.setMessageHandlerMethodFactory(this.messageHandlerMethodFactory);
 		endpoint.setGroupId(getEndpointGroupId(kafkaListener, endpoint.getId()));
 
-		Assert.state((topics.length > 0) ^ (tps.length > 0), "Only one of @Topic or @TopicPartition is allowed");
+		assertTopic(kafkaListener);
 		endpoint.setTopicPartitions(tps);
 		endpoint.setTopics(topics);
 		endpoint.setTopicPattern(resolvePattern(kafkaListener));
+
 		endpoint.setClientIdPrefix(resolveExpressionAsString(kafkaListener.clientIdPrefix(), "clientIdPrefix"));
 		endpoint.setListenerInfo(resolveExpressionAsBytes(kafkaListener.info(), "info"));
 		String group = kafkaListener.containerGroup();
@@ -858,6 +859,20 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 			groupId = id;
 		}
 		return groupId;
+	}
+
+	private void assertTopic(KafkaListener kafkaListener) {
+		int count = 0;
+		if (!kafkaListener.topicPattern().isEmpty()) {
+			count++;
+		}
+		if (kafkaListener.topics().length > 0) {
+			count++;
+		}
+		if (kafkaListener.topicPartitions().length > 0) {
+			count++;
+		}
+		Assert.state(count == 1, "Only one of @Topic or @TopicPartition or @TopicPattern must be provided");
 	}
 
 	private TopicPartitionOffset[] resolveTopicPartitions(KafkaListener kafkaListener) {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->

* As-is
  * When a @KafkaListener is created with both @Topic and @TopicPartition, the listener consumes messages based on @TopicPartition.
  * When @RetryableTopic is added, retry topics are managed based on @Topic.
* To-be
  * Creating a @KafkaListener with both @Topic and @TopicPartition is not allowed.
 
fixes #4170