### PR TITLE
GH-3618: Consider CommonErrorHandler for suspended functions

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
@@ -95,7 +95,7 @@ public @interface KafkaListener {
 	 * <p>Note: When provided, this value will override the group id property
 	 * in the consumer factory configuration, unless {@link #idIsGroup()}
 	 * is set to false or {@link #groupId()} is provided.
-	 * <p>SpEL {@code #{...}} and property place holders {@code ${...}} are supported.
+	 * <p>SpEL {@code #{...}} and property placeholders {@code ${...}} are supported.
 	 * @return the {@code id} for the container managing for this endpoint.
 	 * @see org.springframework.kafka.config.KafkaListenerEndpointRegistry#getListenerContainer(String)
 	 */


### PR DESCRIPTION
I think that the general and the most precise fix for the #3618 would be to just account for the `RecordMessagingMessageListenerAdapter` when applying the `callbackForAsyncFailure` in the listener container. This callback just applies the `CommonErrorHandler` that supposedly implements the retry policy. So, the same thing I guess is also applicable in the case of just `RecordMessagingMessageListenerAdapter`.