### PR TITLE
Remove unnecessary stream method

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerGroupSequencer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerGroupSequencer.java
@@ -201,7 +201,7 @@ public class ContainerGroupSequencer implements ApplicationContextAware,
 			this.currentGroup = this.iterator.next();
 			this.groups.forEach(grp -> {
 				Collection<String> ids = grp.getListenerIds();
-				ids.stream().forEach(id -> {
+				ids.forEach(id -> {
 					MessageListenerContainer container = this.registry.getListenerContainer(id);
 					if (Objects.requireNonNull(container).getContainerProperties().getIdleEventInterval() == null) {
 						container.getContainerProperties().setIdleEventInterval(this.defaultIdleEventInterval);

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DefaultDestinationTopicProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/DefaultDestinationTopicProcessor.java
@@ -46,7 +46,6 @@ public class DefaultDestinationTopicProcessor implements DestinationTopicProcess
 												Context context) {
 		context
 				.properties
-				.stream()
 				.forEach(destinationPropertiesProcessor);
 	}
 


### PR DESCRIPTION
I think we can call the `forEach` method directly without using the `stream` method.