### PR TITLE
Polish unchecked warning suppression in KafkaEvent

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/event/KafkaEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/KafkaEvent.java
@@ -29,6 +29,8 @@ public abstract class KafkaEvent extends ApplicationEvent {
 
 	private static final long serialVersionUID = 1L;
 
+	private static final String UNCHECKED = "unchecked";
+
 	private transient final Object container;
 
 	public KafkaEvent(Object source, Object container) {
@@ -47,7 +49,7 @@ public abstract class KafkaEvent extends ApplicationEvent {
 	 * @since 2.2.1
 	 * @see #getSource(Class)
 	 */
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings(UNCHECKED)
 	public <T> T getContainer(Class<T> type) {
 		Assert.isInstanceOf(type, this.container);
 		return (T) this.container;
@@ -65,7 +67,7 @@ public abstract class KafkaEvent extends ApplicationEvent {
 	 * @see #getContainer(Class)
 	 * @see #getSource()
 	 */
-	@SuppressWarnings("unchecked")
+	@SuppressWarnings(UNCHECKED)
 	public <T> T getSource(Class<T> type) {
 		Assert.isInstanceOf(type, getSource());
 		return (T) getSource();


### PR DESCRIPTION
## Summary

This PR refines the `@SuppressWarnings` usage in `KafkaEvent` by introducing a constant for the `"unchecked"` warning name:

- Adds a private static constant `UNCHECKED` in `KafkaEvent`.
- Reuses the constant in `@SuppressWarnings(UNCHECKED)` for both `getContainer(...)` and `getSource(...)`.

## Motivation

This is a small polish to avoid repeating the same warning name string literal and centralize it as a constant.  
The behavior of `KafkaEvent` remains unchanged.

## Testing

- No new tests added, behavior is unchanged.