### PR TITLE
refactor record

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistrar.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistrar.java
@@ -274,14 +274,6 @@ public class KafkaListenerEndpointRegistrar implements BeanFactoryAware, Initial
 
 	private record KafkaListenerEndpointDescriptor(KafkaListenerEndpoint endpoint,
 				@Nullable KafkaListenerContainerFactory<?> containerFactory) {
-
-		private KafkaListenerEndpointDescriptor(KafkaListenerEndpoint endpoint,
-				@Nullable KafkaListenerContainerFactory<?> containerFactory) {
-
-			this.endpoint = endpoint;
-			this.containerFactory = containerFactory;
-		}
-
 	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/EndpointCustomizer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/EndpointCustomizer.java
@@ -46,24 +46,6 @@ public interface EndpointCustomizer<T extends MethodKafkaListenerEndpoint<?, ?>>
 	 */
 	Collection<TopicNamesHolder> customizeEndpointAndCollectTopics(T listenerEndpoint);
 
-	class TopicNamesHolder {
-
-		private final String mainTopic;
-
-		private final @Nullable String customizedTopic;
-
-		TopicNamesHolder(String mainTopic, @Nullable String customizedTopic) {
-			this.mainTopic = mainTopic;
-			this.customizedTopic = customizedTopic;
-		}
-
-		String getMainTopic() {
-			return this.mainTopic;
-		}
-
-		@Nullable
-		String getCustomizedTopic() {
-			return this.customizedTopic;
-		}
+	record TopicNamesHolder(String mainTopic, @Nullable String customizedTopic) {
 	}
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/retrytopic/RetryTopicConfigurer.java
@@ -384,8 +384,8 @@ public class RetryTopicConfigurer implements BeanFactoryAware {
 				.customizeEndpointAndCollectTopics(endpoint)
 				.forEach(topicNamesHolder ->
 						this.destinationTopicProcessor
-								.registerDestinationTopic(topicNamesHolder.getMainTopic(),
-										topicNamesHolder.getCustomizedTopic(),
+								.registerDestinationTopic(topicNamesHolder.mainTopic(),
+										topicNamesHolder.customizedTopic(),
 										destinationTopicProperties, context));
 
 		registrar.registerEndpoint(endpoint, resolvedFactory);

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/EndpointCustomizerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/EndpointCustomizerFactoryTests.java
@@ -170,11 +170,11 @@ class EndpointCustomizerFactoryTests {
 		String topic1WithSuffix = topics[0] + suffix;
 		String topic2WithSuffix = topics[1] + suffix;
 		assertThat(holders).hasSize(2).element(0)
-				.matches(holder -> holder.getMainTopic().equals(topics[0])
-						&& holder.getCustomizedTopic().equals(topic1WithSuffix));
+				.matches(holder -> holder.mainTopic().equals(topics[0])
+						&& holder.customizedTopic().equals(topic1WithSuffix));
 		assertThat(holders).hasSize(2).element(1)
-				.matches(holder -> holder.getMainTopic().equals(topics[1])
-						&& holder.getCustomizedTopic().equals(topic2WithSuffix));
+				.matches(holder -> holder.mainTopic().equals(topics[1])
+						&& holder.customizedTopic().equals(topic2WithSuffix));
 
 		String testStringSuffix = testString + suffix;
 		assertThat(endpoint.getTopics()).contains(topic1WithSuffix, topic2WithSuffix);
@@ -191,11 +191,11 @@ class EndpointCustomizerFactoryTests {
 				(List<EndpointCustomizer.TopicNamesHolder>) endpointCustomizer.customizeEndpointAndCollectTopics(endpointTPO);
 
 		assertThat(holdersTPO).hasSize(2).element(0)
-				.matches(holder -> holder.getMainTopic().equals(topics[0])
-						&& holder.getCustomizedTopic().equals(topic1WithSuffix));
+				.matches(holder -> holder.mainTopic().equals(topics[0])
+						&& holder.customizedTopic().equals(topic1WithSuffix));
 		assertThat(holdersTPO).hasSize(2).element(1)
-				.matches(holder -> holder.getMainTopic().equals(topics[1])
-						&& holder.getCustomizedTopic().equals(topic2WithSuffix));
+				.matches(holder -> holder.mainTopic().equals(topics[1])
+						&& holder.customizedTopic().equals(topic2WithSuffix));
 
 		assertThat(endpointTPO.getTopics()).isEmpty();
 		TopicPartitionOffset[] topicPartitionsToAssign = endpointTPO.getTopicPartitionsToAssign();
@@ -226,8 +226,8 @@ class EndpointCustomizerFactoryTests {
 	}
 
 	private Predicate<EndpointCustomizer.TopicNamesHolder> assertMainTopic(int index) {
-		return holder -> holder.getCustomizedTopic().equals(topics[index])
-				&& holder.getMainTopic().equals(topics[index]);
+		return holder -> holder.customizedTopic().equals(topics[index])
+				&& holder.mainTopic().equals(topics[index]);
 	}
 
 	private boolean equalsTopicPartitionOffset(TopicPartitionOffset tpo1, TopicPartitionOffset tpo2) {


### PR DESCRIPTION
<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->

I deleted `KafkaListenerEndpointDescriptor`constructor as it is record.
And I also change `TopicNamesHolder` class to record, as it is same.