### PR TITLE
GH-4189 : Modify Topic Assignment Docs of @KafkaListener

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/receiving-messages/listener-annotation.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/receiving-messages/listener-annotation.adoc
@@ -83,7 +83,8 @@ public void listen(String data) {
 [[topic-partition-assignment]]
 == Topic Partition Assignment
 
-You can configure the topic for `@KafkaListener` in three ways. You must configure the topic in one of these ways.
+You can configure the topic for `@KafkaListener` in three ways.
+You must configure the topic in one of these ways.
 [source, java]
 ----
 @KafkaListener(id = "myListener", topics = "myTopic")
@@ -103,11 +104,13 @@ public void listen(String data) {
 ----
 
 
-You can simply configure the topic directly by name. In this case, you can also configure the multiple topics like `topics = {"myTopic1", myTopic2"}`.
+You can simply configure the topic directly by name.
+In this case, you can also configure the multiple topics like `topics = {"myTopic1", myTopic2"}`.
 
 You can also configure topics using topicPattern, which enables topic subscription based on a regular expression.
 
-When you configure topics using either of these ways (topic or topic pattern), Kafka automatically assigns partitions according to the consumer group. Alternatively, you can configure POJO listeners with explicit topics and partitions (and, optionally, their initial offsets).
+When you configure topics using either of these ways (topic or topic pattern), Kafka automatically assigns partitions according to the consumer group.
+Alternatively, you can configure POJO listeners with explicit topics and partitions (and, optionally, their initial offsets).
 The following example shows how to do so:
 
 [source, java]


### PR DESCRIPTION
<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->

Previously, the documentation only described manual topic partition assignment for @KafkaListener. I added information on how to configure it using by topics and topicPartitions. Thanks.

resolve: #4189