### PR TITLE
GH-4205: Allow serializing/deserializing null values in Kotlin

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JacksonJsonDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JacksonJsonDeserializer.java
@@ -65,6 +65,7 @@ import org.springframework.util.StringUtils;
  * @author Ivan Ponomarev
  * @author Omer Celik
  * @author Soby Chacko
+ * @author Trond Ziarkowski
  *
  * @since 4.0
  */
@@ -566,7 +567,7 @@ public class JacksonJsonDeserializer<T> implements Deserializer<T> {
 	}
 
 	@Override
-	public @Nullable T deserialize(String topic, Headers headers, byte[] data) {
+	public @Nullable T deserialize(String topic, Headers headers, byte @Nullable [] data) {
 		if (data == null) {
 			return null;
 		}
@@ -597,7 +598,7 @@ public class JacksonJsonDeserializer<T> implements Deserializer<T> {
 	}
 
 	@Override
-	public @Nullable T deserialize(String topic, byte[] data) {
+	public @Nullable T deserialize(String topic, byte @Nullable [] data) {
 		if (data == null) {
 			return null;
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JacksonJsonSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JacksonJsonSerializer.java
@@ -54,6 +54,7 @@ import org.springframework.util.StringUtils;
  * @author Wang Zhiyang
  * @author Omer Celik
  * @author Soby Chacko
+ * @author Trond Ziarkowski
  *
  * @since 4.0
  */
@@ -202,9 +203,8 @@ public class JacksonJsonSerializer<T> implements Serializer<T> {
 		return mappingsMap;
 	}
 
-	@SuppressWarnings("NullAway") // Dataflow analysis limitation
 	@Override
-	public byte[] serialize(String topic, Headers headers, @Nullable T data) {
+	public byte @Nullable [] serialize(String topic, Headers headers, @Nullable T data) {
 		if (data == null) {
 			return null;
 		}
@@ -214,9 +214,8 @@ public class JacksonJsonSerializer<T> implements Serializer<T> {
 		return serialize(topic, data);
 	}
 
-	@SuppressWarnings("NullAway") // Dataflow analysis limitation
 	@Override
-	public byte[] serialize(String topic, @Nullable T data) {
+	public byte @Nullable [] serialize(String topic, @Nullable T data) {
 		if (data == null) {
 			return null;
 		}

--- a/spring-kafka/src/test/kotlin/org/springframework/kafka/support/serializer/JacksonJsonDeserializerTests.kt
+++ b/spring-kafka/src/test/kotlin/org/springframework/kafka/support/serializer/JacksonJsonDeserializerTests.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support.serializer
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import tools.jackson.core.type.TypeReference
+import kotlin.text.Charsets.UTF_8
+
+/**
+ * @author Trond Ziarkowski
+ *
+ * @since 4.0.1
+ */
+class JacksonJsonDeserializerTests {
+    private val targetType = object : TypeReference<DeserializedData>() {}
+    private val deserializer = JacksonJsonDeserializer(targetType).ignoreTypeHeaders()
+
+    @Test
+    fun `Expect deserializing a non-null value to work`() {
+        val dataToDeserialize = """{"value":"test-data"}""".toByteArray(UTF_8)
+        val deserializedData = deserializer.deserialize("topic", dataToDeserialize)
+
+        assertThat(deserializedData).isEqualTo(DeserializedData("test-data"))
+    }
+
+    @Test
+    fun `Expect deserializing a null value to work`() {
+        val deserializedData = deserializer.deserialize("topic", null)
+        assertThat(deserializedData).isNull()
+    }
+
+    private data class DeserializedData(val value: String)
+
+}

--- a/spring-kafka/src/test/kotlin/org/springframework/kafka/support/serializer/JacksonJsonSerializerTests.kt
+++ b/spring-kafka/src/test/kotlin/org/springframework/kafka/support/serializer/JacksonJsonSerializerTests.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2016-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support.serializer
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import tools.jackson.core.type.TypeReference
+import kotlin.text.Charsets.UTF_8
+
+/**
+ * @author Trond Ziarkowski
+ *
+ * @since 4.0.1
+ */
+class JacksonJsonSerializerTests {
+    private val targetType = object : TypeReference<DataToSerialize>() {}
+    private val serializer = JacksonJsonSerializer(targetType).noTypeInfo()
+
+    @Test
+    fun `Expect serializing a non-null value to work`() {
+        val dataToSerialize = DataToSerialize("test-data")
+        val bytes = serializer.serialize("topic", dataToSerialize)
+
+        assertThat(bytes?.toString(UTF_8)).isEqualTo("""{"value":"test-data"}""")
+    }
+
+    @Test
+    fun `Expect serializing a null value to work`() {
+        val bytes = serializer.serialize("topic", null)
+        assertThat(bytes).isNull()
+    }
+
+    private data class DataToSerialize(val value: String)
+}


### PR DESCRIPTION
Fixes GH-4205 (https://github.com/spring-projects/spring-kafka/issues/4205)

- Replaced byte[] with byte @Nullable [] to be able to return and receive null values

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
