### PR TITLE
GH-4190: Add `DefaultJwtValidator` to runtime hints and associated test

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/aot/KafkaRuntimeHints.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/aot/KafkaRuntimeHints.java
@@ -25,6 +25,7 @@ import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.common.message.CreateTopicsRequestData.CreatableTopic;
 import org.apache.kafka.common.protocol.Message;
 import org.apache.kafka.common.security.oauthbearer.DefaultJwtRetriever;
+import org.apache.kafka.common.security.oauthbearer.DefaultJwtValidator;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.AppInfoParser.AppInfo;
 import org.apache.kafka.common.utils.ImplicitLinkedHashCollection;
@@ -90,6 +91,7 @@ public class KafkaRuntimeHints implements RuntimeHintsRegistrar {
 		Stream.of(
 						// Following Kafka classes need to be ideally part of Oracle's reachability metadata repository.
 						DefaultJwtRetriever.class,
+						DefaultJwtValidator.class,
 						Message.class,
 						ImplicitLinkedHashCollection.Element.class,
 						NewTopic.class,

--- a/spring-kafka/src/test/java/org/springframework/kafka/aot/KafkaRuntimeHintsTest.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/aot/KafkaRuntimeHintsTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.aot;
+
+import org.apache.kafka.common.security.oauthbearer.DefaultJwtValidator;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.aot.hint.MemberCategory;
+import org.springframework.aot.hint.RuntimeHints;
+import org.springframework.aot.hint.predicate.RuntimeHintsPredicates;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Wai Leong
+ * @since 4.0.1
+ */
+class KafkaRuntimeHintsTest {
+
+	@Test
+	void shouldRegisterDefaultJwtValidatorRuntimeHints() {
+		RuntimeHints hints = new RuntimeHints();
+		new KafkaRuntimeHints().registerHints(hints, getClass().getClassLoader());
+		assertThat(RuntimeHintsPredicates.reflection().onType(DefaultJwtValidator.class)
+				.withMemberCategories(
+						MemberCategory.INVOKE_DECLARED_CONSTRUCTORS,
+						MemberCategory.INVOKE_DECLARED_METHODS))
+				.accepts(hints);
+	}
+}


### PR DESCRIPTION
Closes gh-4190