### PR TITLE
GH-4210: Make sure that `@Payload` arg has a precedence

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
@@ -903,8 +903,13 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 					genericParameterType = extractGenericParameterTypFromMethodParameter(methodParameter);
 				}
 				else {
-					this.logger.debug(() -> "Ambiguous parameters for target payload for method " + method
-							+ "; no inferred type available");
+					if (methodParameter.hasParameterAnnotation(Payload.class)) {
+						genericParameterType = parameterType;
+					}
+					else {
+						this.logger.debug(() -> "Ambiguous parameters for target payload for method " + method
+								+ "; no inferred type available");
+					}
 					break;
 				}
 			}

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -1171,7 +1171,7 @@ public class EnableKafkaIntegrationTests {
 	}
 
 	@Test
-	public void testCustomMethodArgumentResovlerListener() throws InterruptedException {
+	public void testCustomMethodArgumentResolverListener() throws InterruptedException {
 		template.send("annotated39", "foo");
 		assertThat(this.listener.customMethodArgumentResolverLatch.await(30, TimeUnit.SECONDS)).isTrue();
 		assertThat(this.listener.customMethodArgument.body).isEqualTo("foo");
@@ -2516,7 +2516,9 @@ public class EnableKafkaIntegrationTests {
 		}
 
 		@KafkaListener(id = "customMethodArgumentResolver", topics = "annotated39")
-		public void customMethodArgumentResolverListener(String data, CustomMethodArgument customMethodArgument) {
+		public void customMethodArgumentResolverListener(CustomMethodArgument customMethodArgument,
+				@Payload String data) {
+
 			this.customMethodArgument = customMethodArgument;
 			this.customMethodArgumentResolverLatch.countDown();
 		}


### PR DESCRIPTION
Fixes: github.com/spring-projects/spring-kafka/issues/4210

The `MessagingMessageListenerAdapter` scanning for the payload argument may end up with an ambiguity when several matching arguments are there.

* Add a check for the presence of the `@Payload` on the argument to give it a higher priority

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
