### PR TITLE
GH-4236: Add `@Serial` to `serialVersionUID` properties

### DIFF
--- a/spring-kafka-test/src/main/java/org/springframework/kafka/test/utils/ContainerTestUtils.java
+++ b/spring-kafka-test/src/main/java/org/springframework/kafka/test/utils/ContainerTestUtils.java
@@ -16,6 +16,7 @@
 
 package org.springframework.kafka.test.utils;
 
+import java.io.Serial;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Collection;
@@ -132,6 +133,7 @@ public final class ContainerTestUtils {
 
 	private static class ContainerTestUtilsException extends RuntimeException {
 
+		@Serial
 		private static final long serialVersionUID = 1L;
 
 		ContainerTestUtilsException(String message, Throwable cause) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/NoProducerAvailableException.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/NoProducerAvailableException.java
@@ -16,6 +16,8 @@
 
 package org.springframework.kafka.core;
 
+import java.io.Serial;
+
 import org.springframework.kafka.KafkaException;
 
 /**
@@ -28,6 +30,7 @@ import org.springframework.kafka.KafkaException;
  */
 public class NoProducerAvailableException extends KafkaException {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	private final String txIdPrefix;

--- a/spring-kafka/src/main/java/org/springframework/kafka/event/ConcurrentContainerStoppedEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/ConcurrentContainerStoppedEvent.java
@@ -16,6 +16,8 @@
 
 package org.springframework.kafka.event;
 
+import java.io.Serial;
+
 /**
  * An event published when a concurrent container is stopped.
  *
@@ -25,6 +27,7 @@ package org.springframework.kafka.event;
  */
 public class ConcurrentContainerStoppedEvent extends KafkaEvent {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	private final ConsumerStoppedEvent.Reason reason;

--- a/spring-kafka/src/main/java/org/springframework/kafka/event/ConsumerFailedToStartEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/ConsumerFailedToStartEvent.java
@@ -16,6 +16,8 @@
 
 package org.springframework.kafka.event;
 
+import java.io.Serial;
+
 /**
  * An event published when a consumer fails to start.
  *
@@ -25,6 +27,7 @@ package org.springframework.kafka.event;
  */
 public class ConsumerFailedToStartEvent extends KafkaEvent {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/event/ConsumerPartitionPausedEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/ConsumerPartitionPausedEvent.java
@@ -16,6 +16,8 @@
 
 package org.springframework.kafka.event;
 
+import java.io.Serial;
+
 import org.apache.kafka.common.TopicPartition;
 
 /**
@@ -28,6 +30,7 @@ import org.apache.kafka.common.TopicPartition;
  */
 public class ConsumerPartitionPausedEvent extends KafkaEvent {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	private final TopicPartition partition;

--- a/spring-kafka/src/main/java/org/springframework/kafka/event/ConsumerPartitionResumedEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/ConsumerPartitionResumedEvent.java
@@ -16,6 +16,8 @@
 
 package org.springframework.kafka.event;
 
+import java.io.Serial;
+
 import org.apache.kafka.common.TopicPartition;
 
 /**
@@ -27,6 +29,7 @@ import org.apache.kafka.common.TopicPartition;
  */
 public class ConsumerPartitionResumedEvent extends KafkaEvent {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	private final TopicPartition partition;

--- a/spring-kafka/src/main/java/org/springframework/kafka/event/ConsumerPausedEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/ConsumerPausedEvent.java
@@ -16,6 +16,7 @@
 
 package org.springframework.kafka.event;
 
+import java.io.Serial;
 import java.util.Collection;
 
 import org.apache.kafka.common.TopicPartition;
@@ -30,6 +31,7 @@ import org.jspecify.annotations.Nullable;
  */
 public class ConsumerPausedEvent extends KafkaEvent {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	private final @Nullable String reason;

--- a/spring-kafka/src/main/java/org/springframework/kafka/event/ConsumerResumedEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/ConsumerResumedEvent.java
@@ -16,6 +16,7 @@
 
 package org.springframework.kafka.event;
 
+import java.io.Serial;
 import java.util.Collection;
 
 import org.apache.kafka.common.TopicPartition;
@@ -29,6 +30,7 @@ import org.apache.kafka.common.TopicPartition;
  */
 public class ConsumerResumedEvent extends KafkaEvent {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	private transient Collection<TopicPartition> partitions;

--- a/spring-kafka/src/main/java/org/springframework/kafka/event/ConsumerRetryAuthEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/ConsumerRetryAuthEvent.java
@@ -16,6 +16,8 @@
 
 package org.springframework.kafka.event;
 
+import java.io.Serial;
+
 /**
  * An event published when authentication or authorization of a consumer fails and
  * is being retried. Contains the reason for this event.
@@ -26,6 +28,7 @@ package org.springframework.kafka.event;
  */
 public class ConsumerRetryAuthEvent extends KafkaEvent {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/event/ConsumerRetryAuthSuccessfulEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/ConsumerRetryAuthSuccessfulEvent.java
@@ -16,6 +16,8 @@
 
 package org.springframework.kafka.event;
 
+import java.io.Serial;
+
 /**
  * An event published when authentication or authorization has been retried successfully.
  *
@@ -25,6 +27,7 @@ package org.springframework.kafka.event;
  */
 public class ConsumerRetryAuthSuccessfulEvent extends KafkaEvent {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/event/ConsumerStartedEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/ConsumerStartedEvent.java
@@ -16,6 +16,8 @@
 
 package org.springframework.kafka.event;
 
+import java.io.Serial;
+
 /**
  * An event published when a consumer has started.
  *
@@ -25,6 +27,7 @@ package org.springframework.kafka.event;
  */
 public class ConsumerStartedEvent extends KafkaEvent {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/event/ConsumerStartingEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/ConsumerStartingEvent.java
@@ -16,6 +16,8 @@
 
 package org.springframework.kafka.event;
 
+import java.io.Serial;
+
 /**
  * An event published when a consumer is initializing.
  *
@@ -25,6 +27,7 @@ package org.springframework.kafka.event;
  */
 public class ConsumerStartingEvent extends KafkaEvent {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/event/ConsumerStoppedEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/ConsumerStoppedEvent.java
@@ -16,6 +16,8 @@
 
 package org.springframework.kafka.event;
 
+import java.io.Serial;
+
 /**
  * An event published when a consumer is stopped. While it is best practice to use
  * stateless listeners, you can consume this event to clean up any thread-based resources
@@ -30,6 +32,7 @@ package org.springframework.kafka.event;
  */
 public class ConsumerStoppedEvent extends KafkaEvent {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/event/ConsumerStoppingEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/ConsumerStoppingEvent.java
@@ -16,6 +16,7 @@
 
 package org.springframework.kafka.event;
 
+import java.io.Serial;
 import java.util.Collection;
 
 import org.apache.kafka.clients.consumer.Consumer;
@@ -34,6 +35,7 @@ import org.jspecify.annotations.Nullable;
  */
 public class ConsumerStoppingEvent extends KafkaEvent {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	private transient final Consumer<?, ?> consumer;

--- a/spring-kafka/src/main/java/org/springframework/kafka/event/ContainerStoppedEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/ContainerStoppedEvent.java
@@ -16,6 +16,8 @@
 
 package org.springframework.kafka.event;
 
+import java.io.Serial;
+
 /**
  * An event published when a container is stopped.
  *
@@ -25,6 +27,7 @@ package org.springframework.kafka.event;
  */
 public class ContainerStoppedEvent extends KafkaEvent {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/event/KafkaEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/KafkaEvent.java
@@ -16,6 +16,8 @@
 
 package org.springframework.kafka.event;
 
+import java.io.Serial;
+
 import org.springframework.context.ApplicationEvent;
 import org.springframework.util.Assert;
 
@@ -27,6 +29,7 @@ import org.springframework.util.Assert;
  */
 public abstract class KafkaEvent extends ApplicationEvent {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	private static final String UNCHECKED = "unchecked";

--- a/spring-kafka/src/main/java/org/springframework/kafka/event/ListenerContainerIdleEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/ListenerContainerIdleEvent.java
@@ -16,6 +16,7 @@
 
 package org.springframework.kafka.event;
 
+import java.io.Serial;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -34,6 +35,7 @@ import org.jspecify.annotations.Nullable;
  */
 public class ListenerContainerIdleEvent extends KafkaEvent {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	private final long idleTime;

--- a/spring-kafka/src/main/java/org/springframework/kafka/event/ListenerContainerNoLongerIdleEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/ListenerContainerNoLongerIdleEvent.java
@@ -16,6 +16,7 @@
 
 package org.springframework.kafka.event;
 
+import java.io.Serial;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -34,6 +35,7 @@ import org.jspecify.annotations.Nullable;
  */
 public class ListenerContainerNoLongerIdleEvent extends KafkaEvent {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	private final long idleTime;

--- a/spring-kafka/src/main/java/org/springframework/kafka/event/ListenerContainerPartitionIdleEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/ListenerContainerPartitionIdleEvent.java
@@ -16,6 +16,8 @@
 
 package org.springframework.kafka.event;
 
+import java.io.Serial;
+
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.common.TopicPartition;
 
@@ -29,6 +31,7 @@ import org.apache.kafka.common.TopicPartition;
  */
 public class ListenerContainerPartitionIdleEvent extends KafkaEvent {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	private final long idleTime;

--- a/spring-kafka/src/main/java/org/springframework/kafka/event/ListenerContainerPartitionNoLongerIdleEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/ListenerContainerPartitionNoLongerIdleEvent.java
@@ -16,6 +16,8 @@
 
 package org.springframework.kafka.event;
 
+import java.io.Serial;
+
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.common.TopicPartition;
 
@@ -29,6 +31,7 @@ import org.apache.kafka.common.TopicPartition;
  */
 public class ListenerContainerPartitionNoLongerIdleEvent extends KafkaEvent {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	private final long idleTime;

--- a/spring-kafka/src/main/java/org/springframework/kafka/event/NonResponsiveConsumerEvent.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/event/NonResponsiveConsumerEvent.java
@@ -16,6 +16,7 @@
 
 package org.springframework.kafka.event;
 
+import java.io.Serial;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -35,6 +36,7 @@ import org.jspecify.annotations.Nullable;
  */
 public class NonResponsiveConsumerEvent extends KafkaEvent {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	private final long timeSinceLastPoll;

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/BatchListenerFailedException.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/BatchListenerFailedException.java
@@ -16,6 +16,8 @@
 
 package org.springframework.kafka.listener;
 
+import java.io.Serial;
+
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.jspecify.annotations.Nullable;
 
@@ -32,6 +34,7 @@ import org.springframework.kafka.KafkaException;
  */
 public class BatchListenerFailedException extends KafkaException {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	private final int index;

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaBackoffException.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaBackoffException.java
@@ -16,6 +16,8 @@
 
 package org.springframework.kafka.listener;
 
+import java.io.Serial;
+
 import org.apache.kafka.common.TopicPartition;
 
 import org.springframework.kafka.KafkaException;
@@ -28,6 +30,7 @@ import org.springframework.kafka.KafkaException;
  */
 public class KafkaBackoffException extends KafkaException {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	private final String listenerId;

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/TimestampedException.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/TimestampedException.java
@@ -16,6 +16,7 @@
 
 package org.springframework.kafka.listener;
 
+import java.io.Serial;
 import java.time.Instant;
 
 import org.springframework.kafka.KafkaException;
@@ -29,6 +30,7 @@ import org.springframework.kafka.KafkaException;
  */
 public class TimestampedException extends KafkaException {
 
+	@Serial
 	private static final long serialVersionUID = -2544217643924234282L;
 
 	private final long timestamp;

--- a/spring-kafka/src/main/java/org/springframework/kafka/requestreply/KafkaReplyTimeoutException.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/requestreply/KafkaReplyTimeoutException.java
@@ -16,6 +16,8 @@
 
 package org.springframework.kafka.requestreply;
 
+import java.io.Serial;
+
 import org.springframework.kafka.KafkaException;
 
 /**
@@ -27,6 +29,7 @@ import org.springframework.kafka.KafkaException;
  */
 public class KafkaReplyTimeoutException extends KafkaException {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	public KafkaReplyTimeoutException(String message) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/JacksonMimeTypeModule.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/JacksonMimeTypeModule.java
@@ -17,6 +17,7 @@
 package org.springframework.kafka.support;
 
 import java.io.IOException;
+import java.io.Serial;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonSerializer;
@@ -37,6 +38,7 @@ import org.springframework.util.MimeType;
 @Deprecated(forRemoval = true, since = "4.0")
 public final class JacksonMimeTypeModule extends SimpleModule {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	public JacksonMimeTypeModule() {

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/MimeTypeJacksonModule.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/MimeTypeJacksonModule.java
@@ -16,6 +16,8 @@
 
 package org.springframework.kafka.support;
 
+import java.io.Serial;
+
 import tools.jackson.core.JsonGenerator;
 import tools.jackson.databind.SerializationContext;
 import tools.jackson.databind.ValueSerializer;
@@ -33,6 +35,7 @@ import org.springframework.util.MimeType;
  */
 public final class MimeTypeJacksonModule extends SimpleModule {
 
+	@Serial
 	private static final long serialVersionUID = 1L;
 
 	public MimeTypeJacksonModule() {


### PR DESCRIPTION
As mentioned in GH-4326, while reviewing the Spring Kafka codebase, I noticed that the `@Serial` annotation was used only in the ConcurrentContainerStoppedEvent class.
After reviewing the related code, I could not find a specific reason for this class to differ from other similar Serializable classes, and removing the annotation does not appear to introduce any issues.
For the sake of consistency with the existing serialization style, this PR removes the `@Serial` annotation.
This is my first contribution to an open-source project, so please feel free to point out anything that could be improved.

Thank you for taking the time to review this PR.

**Related Issue**
Closes #4236