### PR TITLE
Fix formatting in `transactions.adoc`

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/transactions.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/transactions.adoc
@@ -136,7 +136,7 @@ public static class Config {
 
 }
 ----
-When setting `maxCache` to 5, `transactional.id` is `my.txid.`++`{0-4}`+.
+When setting `maxCache` to 5, `transactional.id` is `my.txid.`+`{0-4}`.
 
 IMPORTANT: When using `KafkaTransactionManager` with the `ConcurrentMessageListenerContainer` and enabling `maxCache`, it is necessary to set `maxCache` to a value greater than or equal to `concurrency`.
 If a `MessageListenerContainer` is unable to acquire a `transactional.id` suffix, it will throw a `NoProducerAvailableException`.


### PR DESCRIPTION
Reference
https://docs.spring.io/spring-kafka/reference/4.1-SNAPSHOT/kafka/transactions.html

Current:
<img width="1137" height="55" alt="image" src="https://github.com/user-attachments/assets/537cfc54-5e99-43b7-bcce-0ffdfb03774f" />


After:
<img width="1232" height="95" alt="image" src="https://github.com/user-attachments/assets/bbb4004e-b8fd-44b6-a975-4a28a6402917" />
