### PR TITLE
GH-4273: Fix `ConcurrentModificationException` in `getAssignedPartiti…

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -282,10 +282,14 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		ListenerConsumer partitionsListenerConsumer = this.listenerConsumer;
 		if (partitionsListenerConsumer != null) {
 			if (partitionsListenerConsumer.definedPartitions != null) {
-				return Collections.unmodifiableCollection(partitionsListenerConsumer.definedPartitions.keySet());
+				synchronized (partitionsListenerConsumer.definedPartitions) {
+					return List.copyOf(partitionsListenerConsumer.definedPartitions.keySet());
+				}
 			}
 			else if (partitionsListenerConsumer.assignedPartitions != null) {
-				return Collections.unmodifiableCollection(partitionsListenerConsumer.assignedPartitions);
+				synchronized (partitionsListenerConsumer.assignedPartitions) {
+					return List.copyOf(partitionsListenerConsumer.assignedPartitions);
+				}
 			}
 		}
 		return null;
@@ -1980,7 +1984,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 				this.commonErrorHandler.clearThreadState();
 			}
 			if (this.consumerSeekAwareListener != null) {
-				this.consumerSeekAwareListener.onPartitionsRevoked(partitions);
+				this.consumerSeekAwareListener.onPartitionsRevoked(Collections.emptyList());
 				this.consumerSeekAwareListener.unregisterSeekCallback();
 			}
 			this.logger.info(() -> this.consumerGroupId + ": Consumer stopped");


### PR DESCRIPTION
…ons()`

Fixes https://github.com/spring-projects/spring-kafka/issues/4273

The previous fix (GH-3726) wrapped `definedPartitions` and `assignedPartitions` with `Collections.synchronizedMap/Set`, but this only synchronizes individual operations. Per Java documentation, manual synchronization is required when iterating over synchronized collection views.

The method was returning unmodifiable views of these collections, which callers would then iterate outside any synchronization. When partitions were reassigned concurrently (e.g., during rebalance), the iteration would fail with `ConcurrentModificationException`.

The fix synchronizes on the underlying collection while creating a snapshot copy. This ensures the iteration (during copy) is protected, and callers receive an independent snapshot safe to use without holding any locks.

Additionally, `wrapUp()` now explicitly passes an empty collection to `onPartitionsRevoked()` during shutdown. Previously, this accidentally worked because the mutable view would become empty after `unsubscribe()` cleared the underlying collection. Since `getAssignedPartitions()` now returns a snapshot, we must explicitly pass an empty collection to preserve the shutdown signal semantics. The actual partition cleanup already occurs via the rebalance listener during `unsubscribe()`.
