### PR TITLE
Upgrade to Apache Kafka 4.2.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ ext {
 	jaywayJsonPathVersion = '2.9.0'
 	junit4Version = '4.13.2'
 	junitJupiterVersion = '6.0.3'
-	kafkaVersion = '4.1.1'
+	kafkaVersion = '4.2.0'
 	kotlinCoroutinesVersion = '1.10.2'
 	log4jVersion = '2.25.3'
 	micrometerDocsVersion = '1.0.4'

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/StreamsBuilderFactoryBean.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/StreamsBuilderFactoryBean.java
@@ -24,6 +24,7 @@ import java.util.Properties;
 import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.commons.logging.LogFactory;
+import org.apache.kafka.streams.CloseOptions;
 import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
@@ -399,9 +400,11 @@ public class StreamsBuilderFactoryBean extends AbstractFactoryBean<StreamsBuilde
 			if (this.running) {
 				try {
 					if (this.kafkaStreams != null) {
-						this.kafkaStreams.close(new KafkaStreams.CloseOptions()
-								.timeout(this.closeTimeout)
-								.leaveGroup(this.leaveGroupOnClose)
+						this.kafkaStreams.close(
+								CloseOptions.timeout(this.closeTimeout)
+										.withGroupMembershipOperation(this.leaveGroupOnClose
+												? CloseOptions.GroupMembershipOperation.LEAVE_GROUP
+												: CloseOptions.GroupMembershipOperation.REMAIN_IN_GROUP)
 						);
 						if (this.cleanupConfig.cleanupOnStop()) {
 							this.kafkaStreams.cleanUp();

--- a/spring-kafka/src/test/java/org/springframework/kafka/config/KafkaStreamsCustomizerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/config/KafkaStreamsCustomizerTests.java
@@ -61,6 +61,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Artem Bilan
  * @author Almog Gavra
  * @author Sanghyeok An
+ * @author Soby Chacko
  *
  * @since 2.1.5
  */
@@ -236,9 +237,9 @@ public class KafkaStreamsCustomizerTests {
 		}
 
 		@Override
-		public DeserializationHandlerResponse handle(ErrorHandlerContext context, ConsumerRecord<byte[], byte[]> record,
+		public Response handleError(ErrorHandlerContext context, ConsumerRecord<byte[], byte[]> record,
 				Exception exception) {
-			return null;
+			return Response.fail();
 		}
 
 	}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ShareKafkaListenerIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ShareKafkaListenerIntegrationTests.java
@@ -151,7 +151,7 @@ class ShareKafkaListenerIntegrationTests {
 		kafkaTemplate.send(topic, "ack-consumer-aware-message");
 
 		// Wait for processing
-		assertThat(AckShareConsumerAwareTestListener.latch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(AckShareConsumerAwareTestListener.latch.await(30, TimeUnit.SECONDS)).isTrue();
 		assertThat(AckShareConsumerAwareTestListener.received.get()).isEqualTo("ack-consumer-aware-message");
 		assertThat(AckShareConsumerAwareTestListener.consumerReceived.get()).isNotNull();
 		assertThat(AckShareConsumerAwareTestListener.acknowledgmentReceived.get()).isNotNull();

--- a/spring-kafka/src/test/java/org/springframework/kafka/streams/RecoveringDeserializationExceptionHandlerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/streams/RecoveringDeserializationExceptionHandlerTests.java
@@ -33,7 +33,8 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.errors.DeserializationExceptionHandler.DeserializationHandlerResponse;
+import org.apache.kafka.streams.errors.DeserializationExceptionHandler.Response;
+import org.apache.kafka.streams.errors.DeserializationExceptionHandler.Result;
 import org.apache.kafka.streams.errors.ErrorHandlerContext;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.processor.WallclockTimestampExtractor;
@@ -94,10 +95,10 @@ public class RecoveringDeserializationExceptionHandlerTests {
 				Recoverer.class.getName());
 		handler.configure(configs);
 		assertThat(KafkaTestUtils.getPropertyValue(handler, "recoverer")).isInstanceOf(Recoverer.class);
-		assertThat(handler.handle((ErrorHandlerContext) null, new ConsumerRecord<>("foo", 0, 0, null, null),
-				new IllegalArgumentException())).isEqualTo(DeserializationHandlerResponse.CONTINUE);
-		assertThat(handler.handle((ErrorHandlerContext) null, new ConsumerRecord<>("foo", 0, 0, null, null),
-				new IllegalStateException())).isEqualTo(DeserializationHandlerResponse.FAIL);
+		assertThat(handler.handleError((ErrorHandlerContext) null, new ConsumerRecord<>("foo", 0, 0, null, null),
+				new IllegalArgumentException())).extracting(Response::result).isEqualTo(Result.RESUME);
+		assertThat(handler.handleError((ErrorHandlerContext) null, new ConsumerRecord<>("foo", 0, 0, null, null),
+				new IllegalStateException())).extracting(Response::result).isEqualTo(Result.FAIL);
 	}
 
 	@Test
@@ -107,10 +108,10 @@ public class RecoveringDeserializationExceptionHandlerTests {
 		configs.put(RecoveringDeserializationExceptionHandler.KSTREAM_DESERIALIZATION_RECOVERER, Recoverer.class);
 		handler.configure(configs);
 		assertThat(KafkaTestUtils.getPropertyValue(handler, "recoverer")).isInstanceOf(Recoverer.class);
-		assertThat(handler.handle((ErrorHandlerContext) null, new ConsumerRecord<>("foo", 0, 0, null, null),
-				new IllegalArgumentException())).isEqualTo(DeserializationHandlerResponse.CONTINUE);
-		assertThat(handler.handle((ErrorHandlerContext) null, new ConsumerRecord<>("foo", 0, 0, null, null),
-				new IllegalStateException())).isEqualTo(DeserializationHandlerResponse.FAIL);
+		assertThat(handler.handleError((ErrorHandlerContext) null, new ConsumerRecord<>("foo", 0, 0, null, null),
+				new IllegalArgumentException())).extracting(Response::result).isEqualTo(Result.RESUME);
+		assertThat(handler.handleError((ErrorHandlerContext) null, new ConsumerRecord<>("foo", 0, 0, null, null),
+				new IllegalStateException())).extracting(Response::result).isEqualTo(Result.FAIL);
 	}
 
 	@Test
@@ -121,17 +122,17 @@ public class RecoveringDeserializationExceptionHandlerTests {
 		configs.put(RecoveringDeserializationExceptionHandler.KSTREAM_DESERIALIZATION_RECOVERER, rec);
 		handler.configure(configs);
 		assertThat(KafkaTestUtils.getPropertyValue(handler, "recoverer")).isSameAs(rec);
-		assertThat(handler.handle((ErrorHandlerContext) null, new ConsumerRecord<>("foo", 0, 0, null, null),
-				new IllegalArgumentException())).isEqualTo(DeserializationHandlerResponse.CONTINUE);
-		assertThat(handler.handle((ErrorHandlerContext) null, new ConsumerRecord<>("foo", 0, 0, null, null),
-				new IllegalStateException())).isEqualTo(DeserializationHandlerResponse.FAIL);
+		assertThat(handler.handleError((ErrorHandlerContext) null, new ConsumerRecord<>("foo", 0, 0, null, null),
+				new IllegalArgumentException())).extracting(Response::result).isEqualTo(Result.RESUME);
+		assertThat(handler.handleError((ErrorHandlerContext) null, new ConsumerRecord<>("foo", 0, 0, null, null),
+				new IllegalStateException())).extracting(Response::result).isEqualTo(Result.FAIL);
 	}
 
 	@Test
 	void withNoRecoverer() {
 		RecoveringDeserializationExceptionHandler handler = new RecoveringDeserializationExceptionHandler();
-		assertThat(handler.handle((ErrorHandlerContext) null, new ConsumerRecord<>("foo", 0, 0, null, null),
-				new IllegalArgumentException())).isEqualTo(DeserializationHandlerResponse.FAIL);
+		assertThat(handler.handleError((ErrorHandlerContext) null, new ConsumerRecord<>("foo", 0, 0, null, null),
+				new IllegalArgumentException())).extracting(Response::result).isEqualTo(Result.FAIL);
 	}
 
 	@Test


### PR DESCRIPTION
  - Replace deprecated `KafkaStreams.CloseOptions` with top-level `CloseOptions` API using `GroupMembershipOperation` enum
  - Add new `handleError()` override in `RecoveringDeserializationExceptionHandler` returning `Response`
  - Deprecate `handle()` for removal in favor of `handleError()`
  - Update `RecoveringDeserializationExceptionHandlerTests` and `KafkaStreamsCustomizerTests` for new API
  - Increase share consumer listener test timeout for Kafka 4.2.0 group coordination timing