### PR TITLE
GH-4303: Allow @KafkaListener with no topic specification for programmatic resolution

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
@@ -150,6 +150,7 @@ import org.springframework.validation.Validator;
  * @author Soby Chacko
  * @author Omer Celik
  * @author Go BeomJun
+ * @author Maxim Ceban
  *
  * @see KafkaListener
  * @see KafkaListenerErrorHandler

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessorTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessorTests.java
@@ -41,6 +41,7 @@ import static org.mockito.Mockito.mock;
 
 /**
  * @author Sanghyeok An
+ * @author Maxim Ceban
  *
  * @since 4.0.0
  */


### PR DESCRIPTION
## Summary

The `assertTopic` validation introduced in GH-4170 / PR #4172 requires exactly one of `topics`/`topicPartitions`/`topicPattern` to be set (`count == 1`). This breaks a valid use case where a meta-annotated `@KafkaListener` intentionally omits all topic specifications because the custom `KafkaListenerContainerFactory` resolves topics programmatically in `createListenerContainer()`.

This PR changes the validation from `count == 1` to `count <= 1` so that:
- **Multiple topic specifications** (`count > 1`) are still rejected with `IllegalStateException`
- **No topic specification** (`count == 0`) is permitted, allowing container factories to resolve topics at runtime

## Use Case

A common pattern for custom annotation-driven listeners:

```java
@Target(ElementType.METHOD)
@Retention(RetentionPolicy.RUNTIME)
@KafkaListener(containerFactory = "myFactory")
@interface MyCustomKafkaListener {
}
```

With a custom container factory that resolves topics programmatically:

```java
public class TopicResolvingContainerFactory extends ConcurrentKafkaListenerContainerFactory<String, Object> {

    @Override
    public ConcurrentMessageListenerContainer<String, Object> createListenerContainer(
            KafkaListenerEndpoint endpoint) {
        if (endpoint instanceof AbstractKafkaListenerEndpoint<?, ?> akle) {
            akle.setTopics("programmatically-resolved-topic");
        }
        return super.createListenerContainer(endpoint);
    }
}
```

Before GH-4170, this worked because no validation existed. After GH-4170, the `count == 1` check rejects `count == 0`, throwing:
```
IllegalStateException: Only one of @Topic or @TopicPartition or @TopicPattern must be provided
```

## Changes

- **`KafkaListenerAnnotationBeanPostProcessor.java`**: Changed `Assert.state(count == 1, ...)` to `Assert.state(count <= 1, ...)`
- **`KafkaListenerAnnotationBeanPostProcessorTests.java`**: Added two tests:
  - `shouldRejectMultipleTopicSpecifications` — verifies that specifying both `topics` and `topicPattern` still fails
  - `shouldAllowNoTopicSpecificationForProgrammaticResolution` — verifies that a meta-annotated `@KafkaListener` with no topics works when a custom container factory resolves topics programmatically

Fixes: #4303