### PR TITLE
GH-4306: Stop listener observations for filtered records

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -112,6 +112,7 @@ import org.springframework.kafka.listener.ContainerProperties.AckMode;
 import org.springframework.kafka.listener.ContainerProperties.AssignmentCommitOption;
 import org.springframework.kafka.listener.ContainerProperties.EOSMode;
 import org.springframework.kafka.listener.adapter.AsyncRepliesAware;
+import org.springframework.kafka.listener.adapter.FilteringMessageListenerAdapter;
 import org.springframework.kafka.listener.adapter.KafkaBackoffAwareMessageListenerAdapter;
 import org.springframework.kafka.listener.adapter.RecordMessagingMessageListenerAdapter;
 import org.springframework.kafka.support.Acknowledgment;
@@ -175,6 +176,7 @@ import org.springframework.util.StringUtils;
  * @author Janek Lasocki-Biczysko
  * @author Hyoungjune Kim
  * @author Su Ko
+ * @author Jinhui Kim
  */
 public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		extends AbstractMessageListenerContainer<K, V> implements ConsumerPauseResumeEventPublisher {
@@ -995,9 +997,22 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 
 		private void setupObservationRegistry(ObservationRegistry observationRegistry) {
 			if (this.listener != null) {
-				MessageListener<?, ?> target = unwrapDelegateIfAny(this.listener);
+				List<FilteringMessageListenerAdapter<?, ?>> filteringAdapters = new ArrayList<>();
+				MessageListener<?, ?> target = this.listener;
+				while (target instanceof DelegatingMessageListener<?> delegatingMessageListener) {
+					if (target instanceof FilteringMessageListenerAdapter<?, ?> filteringAdapter) {
+						filteringAdapters.add(filteringAdapter);
+					}
+					if (delegatingMessageListener.getDelegate() instanceof MessageListener<?, ?> delegate) {
+						target = delegate;
+					}
+					else {
+						break;
+					}
+				}
 				if (RecordMessagingMessageListenerAdapter.class.equals(target.getClass())) {
 					((RecordMessagingMessageListenerAdapter<?, ?>) target).setObservationRegistry(observationRegistry);
+					filteringAdapters.forEach(adapter -> adapter.setObservationRegistry(observationRegistry));
 					this.isListenerAdapterObservationAware = true;
 				}
 			}
@@ -3590,13 +3605,6 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 
 		private OffsetAndMetadata createOffsetAndMetadata(long offset) {
 			return this.offsetAndMetadataProvider.provide(this.listenerMetadata, offset);
-		}
-
-		private static MessageListener<?, ?> unwrapDelegateIfAny(MessageListener<?, ?> listener) {
-			if (listener instanceof DelegatingMessageListener<?> delegatingMessageListener) {
-				return (MessageListener<?, ?>) delegatingMessageListener.getDelegate();
-			}
-			return listener;
 		}
 
 		private final class ConsumerAcknowledgment implements Acknowledgment {

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/FilteringMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/FilteringMessageListenerAdapter.java
@@ -16,6 +16,8 @@
 
 package org.springframework.kafka.listener.adapter;
 
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.jspecify.annotations.Nullable;
@@ -23,6 +25,7 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.kafka.listener.AcknowledgingConsumerAwareMessageListener;
 import org.springframework.kafka.listener.MessageListener;
 import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.util.Assert;
 
 /**
  * A {@link MessageListener} adapter that implements filter logic
@@ -32,6 +35,7 @@ import org.springframework.kafka.support.Acknowledgment;
  * @param <V> the value type.
  *
  * @author Gary Russell
+ * @author Jinhui Kim
  *
  */
 public class FilteringMessageListenerAdapter<K, V>
@@ -39,6 +43,8 @@ public class FilteringMessageListenerAdapter<K, V>
 		implements AcknowledgingConsumerAwareMessageListener<K, V> {
 
 	private final boolean ackDiscarded;
+
+	private ObservationRegistry observationRegistry = ObservationRegistry.NOOP;
 
 	/**
 	 * Create an instance with the supplied strategy and delegate listener.
@@ -64,6 +70,16 @@ public class FilteringMessageListenerAdapter<K, V>
 		this.ackDiscarded = ackDiscarded;
 	}
 
+	/**
+	 * Set the {@link ObservationRegistry} to stop observations for filtered records.
+	 * @param observationRegistry the observation registry.
+	 * @since 4.0.4
+	 */
+	public void setObservationRegistry(ObservationRegistry observationRegistry) {
+		Assert.notNull(observationRegistry, "'observationRegistry' must not be null");
+		this.observationRegistry = observationRegistry;
+	}
+
 	@Override
 	public void onMessage(ConsumerRecord<K, V> consumerRecord, @Nullable Acknowledgment acknowledgment,
 			@Nullable Consumer<?, ?> consumer) {
@@ -78,6 +94,14 @@ public class FilteringMessageListenerAdapter<K, V>
 		}
 		else {
 			ackFilteredIfNecessary(acknowledgment);
+			stopCurrentObservation();
+		}
+	}
+
+	private void stopCurrentObservation() {
+		Observation currentObservation = this.observationRegistry.getCurrentObservation();
+		if (currentObservation != null) {
+			currentObservation.stop();
 		}
 	}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/micrometer/MicrometerMetricsTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/micrometer/MicrometerMetricsTests.java
@@ -18,11 +18,14 @@ package org.springframework.kafka.support.micrometer;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.observation.DefaultMeterObservationHandler;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationHandler;
 import io.micrometer.observation.ObservationRegistry;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.jupiter.api.Test;
@@ -39,6 +42,7 @@ import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.listener.adapter.RecordFilterStrategy;
 import org.springframework.kafka.test.EmbeddedKafkaBroker;
 import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
@@ -51,14 +55,21 @@ import static org.awaitility.Awaitility.await;
 /**
  * @author Soby Chacko
  * @author Hyoungjune Kim
+ * @author Jinhui Kim
  * @since 3.2.7
  */
 @SpringJUnitConfig
-@EmbeddedKafka(topics = { MicrometerMetricsTests.METRICS_TEST_TOPIC }, partitions = 1)
+@EmbeddedKafka(topics = { MicrometerMetricsTests.METRICS_TEST_TOPIC, MicrometerMetricsTests.FILTERED_METRICS_TEST_TOPIC,
+		MicrometerMetricsTests.FILTERED_RETRY_METRICS_TEST_TOPIC },
+		partitions = 1)
 @DirtiesContext
 public class MicrometerMetricsTests {
 
 	public final static String METRICS_TEST_TOPIC = "metrics.test.topic";
+
+	public final static String FILTERED_METRICS_TEST_TOPIC = "metrics.filtered.test.topic";
+
+	public final static String FILTERED_RETRY_METRICS_TEST_TOPIC = "metrics.filtered.retry.test.topic";
 
 	@Test
 	void verifyMetricsWithoutObservation(@Autowired MetricsListener listener,
@@ -118,6 +129,43 @@ public class MicrometerMetricsTests {
 		});
 	}
 
+	@Test
+	void verifyFilteredRecordStopsObservation(@Autowired FilteredObservationListener filteredObservationListener,
+			@Autowired TestObservationHandler observationHandler,
+			@Autowired KafkaTemplate<Integer, String> template)
+			throws Exception {
+
+		observationHandler.clear();
+		template.send(FILTERED_METRICS_TEST_TOPIC, "test").get(10, TimeUnit.SECONDS);
+
+		await().untilAsserted(() -> {
+			assertThat(observationHandler.getStartedObservations()).isGreaterThan(0);
+			assertThat(observationHandler.getStoppedObservations())
+					.isEqualTo(observationHandler.getStartedObservations());
+		});
+
+		assertThat(filteredObservationListener.latch.await(1, TimeUnit.SECONDS)).isFalse();
+	}
+
+	@Test
+	void verifyFilteredRetryableRecordStopsObservation(
+			@Autowired RetryFilteredObservationListener retryFilteredObservationListener,
+			@Autowired TestObservationHandler observationHandler,
+			@Autowired KafkaTemplate<Integer, String> template)
+			throws Exception {
+
+		observationHandler.clear();
+		template.send(FILTERED_RETRY_METRICS_TEST_TOPIC, "test").get(10, TimeUnit.SECONDS);
+
+		await().untilAsserted(() -> {
+			assertThat(observationHandler.getStartedObservations()).isGreaterThan(0);
+			assertThat(observationHandler.getStoppedObservations())
+					.isEqualTo(observationHandler.getStartedObservations());
+		});
+
+		assertThat(retryFilteredObservationListener.latch.await(1, TimeUnit.SECONDS)).isFalse();
+	}
+
 	@Configuration
 	@EnableKafka
 	static class Config {
@@ -173,6 +221,17 @@ public class MicrometerMetricsTests {
 		}
 
 		@Bean
+		ConcurrentKafkaListenerContainerFactory<Integer, String> filteredObservationListenerContainerFactory(
+				ConsumerFactory<Integer, String> cf, ObservationRegistry observationRegistry) {
+			ConcurrentKafkaListenerContainerFactory<Integer, String> factory =
+					new ConcurrentKafkaListenerContainerFactory<>();
+			factory.setConsumerFactory(cf);
+			factory.getContainerProperties().setObservationEnabled(true);
+			factory.getContainerProperties().setObservationRegistry(observationRegistry);
+			return factory;
+		}
+
+		@Bean
 		MetricsListener metricsListener() {
 			return new MetricsListener();
 		}
@@ -193,10 +252,31 @@ public class MicrometerMetricsTests {
 		}
 
 		@Bean
-		ObservationRegistry observationRegistry(MeterRegistry meterRegistry) {
+		RetryFilteredObservationListener retryFilteredObservationListener() {
+			return new RetryFilteredObservationListener();
+		}
+
+		@Bean
+		FilteredObservationListener filteredObservationListener() {
+			return new FilteredObservationListener();
+		}
+
+		@Bean
+		TestObservationHandler testObservationHandler() {
+			return new TestObservationHandler();
+		}
+
+		@Bean
+		RecordFilterStrategy<Integer, String> alwaysTrueFilter() {
+			return record -> true;
+		}
+
+		@Bean
+		ObservationRegistry observationRegistry(MeterRegistry meterRegistry, TestObservationHandler testObservationHandler) {
 			ObservationRegistry observationRegistry = ObservationRegistry.create();
 			observationRegistry.observationConfig()
-					.observationHandler(new DefaultMeterObservationHandler(meterRegistry));
+					.observationHandler(new DefaultMeterObservationHandler(meterRegistry))
+					.observationHandler(testObservationHandler);
 			return observationRegistry;
 		}
 
@@ -250,5 +330,73 @@ public class MicrometerMetricsTests {
 
 	}
 
-}
+	static class FilteredObservationListener {
 
+		final CountDownLatch latch = new CountDownLatch(1);
+
+		@KafkaListener(id = "filteredObservationTest",
+				topics = FILTERED_METRICS_TEST_TOPIC,
+				containerFactory = "filteredObservationListenerContainerFactory",
+				filter = "alwaysTrueFilter")
+		void listen(ConsumerRecord<Integer, String> in) {
+			latch.countDown();
+		}
+
+	}
+
+	static class RetryFilteredObservationListener {
+
+		final CountDownLatch latch = new CountDownLatch(1);
+
+		@RetryableTopic(attempts = "1")
+		@KafkaListener(id = "retryFilteredObservationTest",
+				topics = FILTERED_RETRY_METRICS_TEST_TOPIC,
+				containerFactory = "retryBackOffObservationListenerContainerFactory",
+				filter = "alwaysTrueFilter")
+		void listen(ConsumerRecord<Integer, String> in) {
+			latch.countDown();
+		}
+
+	}
+
+	static class TestObservationHandler implements ObservationHandler<Observation.Context> {
+
+		private final AtomicInteger startedObservations = new AtomicInteger();
+
+		private final AtomicInteger stoppedObservations = new AtomicInteger();
+
+		@Override
+		public void onStart(Observation.Context context) {
+			if (context instanceof KafkaRecordReceiverContext) {
+				this.startedObservations.incrementAndGet();
+			}
+		}
+
+		@Override
+		public void onStop(Observation.Context context) {
+			if (context instanceof KafkaRecordReceiverContext) {
+				this.stoppedObservations.incrementAndGet();
+			}
+		}
+
+		@Override
+		public boolean supportsContext(Observation.Context context) {
+			return true;
+		}
+
+		int getStartedObservations() {
+			return this.startedObservations.get();
+		}
+
+		int getStoppedObservations() {
+			return this.stoppedObservations.get();
+		}
+
+		void clear() {
+			this.startedObservations.set(0);
+			this.stoppedObservations.set(0);
+		}
+
+	}
+
+}


### PR DESCRIPTION
Fixes #4306

## Problem

When observation is enabled for record listeners, the container starts an observation per record.
For adapter-aware listeners, the container expects the delegate adapter to stop it.

With `FilteringMessageListenerAdapter`, filtered records do not call delegate `onMessage()`.
In that path, the observation could remain active and leak.

## Changes

- Added `ObservationRegistry` support to `FilteringMessageListenerAdapter`.
- Explicitly stop the current observation when a record is filtered out.
- Updated `KafkaMessageListenerContainer` observation setup to propagate `ObservationRegistry`
  through delegating filtering listener chains.

## Tests

- Added filtered-record observation test:
  `verifyFilteredRecordStopsObservation`
- Added retry + filter + observation combination test:
  `verifyFilteredRetryableRecordStopsObservation`
- Verified `MicrometerMetricsTests` passes.

## Notes

The fix is intentionally scoped to the filtered-record short-circuit path to avoid changing
the existing async/reply observation lifecycle behavior.
