### PR TITLE
GH-4337: Fix compilation warnings

### DIFF
--- a/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaSaslHandlerClassloadingTest.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaSaslHandlerClassloadingTest.java
@@ -140,7 +140,10 @@ class KafkaSaslHandlerClassloadingTest {
 	/**
 	 * Marker exception to exit producer creation after capturing classloader.
 	 */
+	@SuppressWarnings("serial")
 	static class TestAbortedException extends RuntimeException {
+
+		private static final long serialVersionUID = 1L;
 	}
 
 	/**

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/CommitOnAssignmentTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/CommitOnAssignmentTests.java
@@ -196,7 +196,7 @@ public class CommitOnAssignmentTests {
 				this.closeLatch.countDown();
 				return null;
 			}).given(consumer).close();
-			willReturn(new ConsumerGroupMetadata("")).given(consumer).groupMetadata();
+			willReturn(mock(ConsumerGroupMetadata.class)).given(consumer).groupMetadata();
 			return consumer;
 		}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/DefaultAfterRollbackProcessorTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/DefaultAfterRollbackProcessorTests.java
@@ -79,7 +79,7 @@ public class DefaultAfterRollbackProcessorTests {
 		IllegalStateException illegalState = new IllegalStateException();
 		@SuppressWarnings("unchecked")
 		Consumer<String, String> consumer = mock(Consumer.class);
-		given(consumer.groupMetadata()).willReturn(new ConsumerGroupMetadata("foo"));
+		given(consumer.groupMetadata()).willReturn(mock(ConsumerGroupMetadata.class));
 		MessageListenerContainer container = mock(MessageListenerContainer.class);
 		given(container.getContainerProperties()).willReturn(new ContainerProperties("foo"));
 		processor.process(records, consumer, container, illegalState, true, EOSMode.V2);
@@ -130,7 +130,7 @@ public class DefaultAfterRollbackProcessorTests {
 		IllegalStateException illegalState = new IllegalStateException();
 		@SuppressWarnings("unchecked")
 		Consumer<String, String> consumer = mock(Consumer.class);
-		given(consumer.groupMetadata()).willReturn(new ConsumerGroupMetadata("foo"));
+		given(consumer.groupMetadata()).willReturn(mock(ConsumerGroupMetadata.class));
 		MessageListenerContainer container = mock(MessageListenerContainer.class);
 		given(container.isRunning()).willReturn(true);
 		processor.processBatch(consumerRecords, records, consumer, container, illegalState, false, EOSMode.V2);

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/DefaultErrorHandlerNoSeeksBatchListenerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/DefaultErrorHandlerNoSeeksBatchListenerTests.java
@@ -218,7 +218,7 @@ public class DefaultErrorHandlerNoSeeksBatchListenerTests {
 				this.closeLatch.countDown();
 				return null;
 			}).given(consumer).close();
-			willReturn(new ConsumerGroupMetadata(CONTAINER_ID)).given(consumer).groupMetadata();
+			willReturn(mock(ConsumerGroupMetadata.class)).given(consumer).groupMetadata();
 			return consumer;
 		}
 
@@ -250,7 +250,7 @@ public class DefaultErrorHandlerNoSeeksBatchListenerTests {
 						return new ConsumerRecords(Collections.emptyMap(), Map.of());
 				}
 			}).given(consumer).poll(any());
-			willReturn(new ConsumerGroupMetadata(CONTAINER_ID_2)).given(consumer).groupMetadata();
+			willReturn(mock(ConsumerGroupMetadata.class)).given(consumer).groupMetadata();
 			return consumer;
 		}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/DefaultErrorHandlerSeekAfterCommitExceptionBatchListenerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/DefaultErrorHandlerSeekAfterCommitExceptionBatchListenerTests.java
@@ -200,7 +200,7 @@ public class DefaultErrorHandlerSeekAfterCommitExceptionBatchListenerTests {
 				this.closeLatch.countDown();
 				return null;
 			}).given(consumer).close();
-			willReturn(new ConsumerGroupMetadata(CONTAINER_ID)).given(consumer).groupMetadata();
+			willReturn(mock(ConsumerGroupMetadata.class)).given(consumer).groupMetadata();
 			return consumer;
 		}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentOnErrorBatchModeTXTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentOnErrorBatchModeTXTests.java
@@ -236,7 +236,7 @@ public class SeekToCurrentOnErrorBatchModeTXTests {
 				this.closeLatch.countDown();
 				return null;
 			}).given(consumer).close();
-			willReturn(new ConsumerGroupMetadata(CONTAINER_ID)).given(consumer).groupMetadata();
+			willReturn(mock(ConsumerGroupMetadata.class)).given(consumer).groupMetadata();
 			return consumer;
 		}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentOnErrorRecordModeTXTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/SeekToCurrentOnErrorRecordModeTXTests.java
@@ -237,7 +237,7 @@ public class SeekToCurrentOnErrorRecordModeTXTests {
 				this.closeLatch.countDown();
 				return null;
 			}).given(consumer).close();
-			willReturn(new ConsumerGroupMetadata(CONTAINER_ID)).given(consumer).groupMetadata();
+			willReturn(mock(ConsumerGroupMetadata.class)).given(consumer).groupMetadata();
 			return consumer;
 		}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/SubBatchPerPartitionTxRollbackTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/SubBatchPerPartitionTxRollbackTests.java
@@ -210,7 +210,7 @@ public class SubBatchPerPartitionTxRollbackTests {
 				this.closeLatch.countDown();
 				return null;
 			}).given(consumer).close();
-			willReturn(new ConsumerGroupMetadata(CONTAINER_ID)).given(consumer).groupMetadata();
+			willReturn(mock(ConsumerGroupMetadata.class)).given(consumer).groupMetadata();
 			return consumer;
 		}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/SubBatchPerPartitionTxTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/SubBatchPerPartitionTxTests.java
@@ -196,7 +196,7 @@ public class SubBatchPerPartitionTxTests {
 				this.closeLatch.countDown();
 				return null;
 			}).given(consumer).close();
-			willReturn(new ConsumerGroupMetadata(CONTAINER_ID)).given(consumer).groupMetadata();
+			willReturn(mock(ConsumerGroupMetadata.class)).given(consumer).groupMetadata();
 			return consumer;
 		}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/TransactionalContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/TransactionalContainerTests.java
@@ -244,7 +244,7 @@ public class TransactionalContainerTests {
 		props.setAssignmentCommitOption(AssignmentCommitOption.ALWAYS);
 		props.setEosMode(eosMode);
 		props.setStopContainerWhenFenced(stopWhenFenced);
-		ConsumerGroupMetadata consumerGroupMetadata = new ConsumerGroupMetadata("group");
+		ConsumerGroupMetadata consumerGroupMetadata = mock(ConsumerGroupMetadata.class);
 		given(consumer.groupMetadata()).willReturn(consumerGroupMetadata);
 		final KafkaTemplate template = new KafkaTemplate(pf);
 		if (AckMode.MANUAL_IMMEDIATE.equals(ackMode)) {


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-kafka/issues/4337

Fix test compile warnings: use mocks for ConsumerGroupMetadata, add serialVersionUID

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
