### PR TITLE
GH-4328: Expose native Kafka Streams DLQ configuration

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/streams.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/streams.adoc
@@ -297,16 +297,31 @@ Spring Integration automatically provides an implementation using its `GatewayPr
 It also requires a `MessagingMessageConverter` to convert the key, value and metadata (including headers) to/from a Spring Messaging `Message<?>`.
 See {spring-integration-url}/kafka.html#streams-integration[Calling a Spring Integration Flow from a `KStream`] for more information.
 
+[[recovery-strategies]]
+== Recovery Strategies
+
+The framework provides the following exception handlers, which follow the same recovery strategies:
+
+- xref:streams.adoc#streams-deser-recovery[`RecoveringDeserializationExceptionHandler`]
+- xref:streams.adoc#streams-processing-recovery[`RecoveringProcessingExceptionHandler`]
+- xref:streams.adoc#streams-production-recovery[`RecoveringProductionExceptionHandler`]
+
+The recovery strategies are as follows, by priority order:
+
+- If a xref:streams.adoc#dead-letter-destination-resolver[`KafkaStreamsDeadLetterDestinationResolver`] is defined, resume the stream and forward the failed record to the resolved topic-partition using the native Kafka Streams DLQ.
+- If xref:streams.adoc#dead-letter-queue-topic-name-property[`errors.dead.letter.queue.topic.name`] is defined and set to a topic name, resume the stream and forward the failed record to that topic using the native Kafka Streams DLQ.
+- If a `ConsumerRecordRecoverer` implementation is defined, invoke it and resume the stream without producing dead-letter records, as handling is delegated to the `ConsumerRecordRecoverer`. For example, the provided xref:streams.adoc#dead-letter-publishing-recoverer[`DeadLetterPublishingRecoverer`] implementation can be used.
+- Fail the stream without producing dead-letter records.
+
+When a dead-letter record is published to a dead-letter topic, whether through the native Kafka Streams DLQ or via a `ConsumerRecordRecoverer` implementation, the record is enriched with the xref:kafka/annotation-error-handling.adoc#dead-letters[Spring for Apache Kafka DLT headers].
+
 [[streams-deser-recovery]]
 == Recovery from Deserialization Exceptions
 
-Version 2.3 introduced the `RecoveringDeserializationExceptionHandler` which can take some action when a deserialization exception occurs.
-Refer to the Kafka documentation about `DeserializationExceptionHandler`, of which the `RecoveringDeserializationExceptionHandler` is an implementation.
-The `RecoveringDeserializationExceptionHandler` is configured with a `ConsumerRecordRecoverer` implementation.
-The framework provides the `DeadLetterPublishingRecoverer` which sends the failed record to a dead-letter topic.
-See xref:kafka/annotation-error-handling.adoc#dead-letters[Publishing Dead-letter Records] for more information about this recoverer.
+Version 2.3 introduced the `RecoveringDeserializationExceptionHandler`, which can take some action when a deserialization exception occurs.
+It implements the `DeserializationExceptionHandler` interface (refer to the Kafka documentation for details) and follows the xref:streams.adoc#recovery-strategies[Spring for Apache Kafka recovery strategies].
 
-To configure the recoverer, add the following properties to your streams configuration:
+To configure the `RecoveringDeserializationExceptionHandler`, add the following property to your streams configuration:
 
 [source, java]
 ----
@@ -314,9 +329,71 @@ To configure the recoverer, add the following properties to your streams configu
 public KafkaStreamsConfiguration kStreamsConfigs() {
     Map<String, Object> props = new HashMap<>();
     ...
-    props.put(StreamsConfig.DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG,
+    props.put(StreamsConfig.DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG,
             RecoveringDeserializationExceptionHandler.class);
-    props.put(RecoveringDeserializationExceptionHandler.KSTREAM_DESERIALIZATION_RECOVERER, recoverer());
+    ...
+    return new KafkaStreamsConfiguration(props);
+}
+----
+
+[[streams-processing-recovery]]
+== Recovery from Processing Exceptions
+
+Version 4.1 introduces the `RecoveringProcessingExceptionHandler`, which can take some action when an exception occurs during stream processing.
+It implements the `ProcessingExceptionHandler` interface (refer to the Kafka documentation for details), introduced by https://cwiki.apache.org/confluence/display/KAFKA/KIP-1033%3A+Add+Kafka+Streams+exception+handler+for+exceptions+occurring+during+processing[KIP-1033]
+and follows the xref:streams.adoc#recovery-strategies[Spring for Apache Kafka recovery strategies].
+
+To enable the `RecoveringProcessingExceptionHandler`, add the following property to your streams configuration:
+
+[source, java]
+----
+@Bean(name = KafkaStreamsDefaultConfiguration.DEFAULT_STREAMS_CONFIG_BEAN_NAME)
+public KafkaStreamsConfiguration kStreamsConfigs() {
+    Map<String, Object> props = new HashMap<>();
+    ...
+    props.put(StreamsConfig.PROCESSING_EXCEPTION_HANDLER_CLASS_CONFIG,
+            RecoveringProcessingExceptionHandler.class);
+    ...
+}
+----
+
+[[streams-production-recovery]]
+== Recovery from Production Exceptions
+
+Version 4.1 introduces the `RecoveringProductionExceptionHandler`, which can take some action when an exception occurs during record production or serialization.
+It implements the `ProductionExceptionHandler` interface (refer to the Kafka documentation for details) and follows the xref:streams.adoc#recovery-strategies[Spring for Apache Kafka recovery strategies].
+
+To configure the `RecoveringProductionExceptionHandler`, add the following property to your streams configuration:
+
+[source, java]
+----
+@Bean(name = KafkaStreamsDefaultConfiguration.DEFAULT_STREAMS_CONFIG_BEAN_NAME)
+public KafkaStreamsConfiguration kStreamsConfigs() {
+    Map<String, Object> props = new HashMap<>();
+    ...
+    props.put(StreamsConfig.PRODUCTION_EXCEPTION_HANDLER_CLASS_CONFIG,
+            RecoveringProductionExceptionHandler.class);
+    ...
+}
+----
+
+[[dead-letter-publishing-recoverer]]
+== Dead Letter Publishing Recoverer
+
+The framework provides the `DeadLetterPublishingRecoverer`, which sends the failed record to a dead-letter topic.
+See xref:kafka/annotation-error-handling.adoc#dead-letters[Publishing Dead-letter records] for more information about this recoverer.
+
+To configure the recoverer for an exception handler, add the following properties to your streams configuration:
+
+[source, java]
+----
+@Bean(name = KafkaStreamsDefaultConfiguration.DEFAULT_STREAMS_CONFIG_BEAN_NAME)
+public KafkaStreamsConfiguration kStreamsConfigs() {
+    Map<String, Object> props = new HashMap<>();
+    ...
+    props.put(StreamsConfig.DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG,
+            RecoveringDeserializationExceptionHandler.class);
+    props.put(RecoveringDeserializationExceptionHandler.RECOVERER, recoverer());
     ...
     return new KafkaStreamsConfiguration(props);
 }
@@ -329,6 +406,60 @@ public DeadLetterPublishingRecoverer recoverer() {
 ----
 
 Of course, the `recoverer()` bean can be your own implementation of `ConsumerRecordRecoverer`.
+
+[[dead-letter-destination-resolver]]
+== Dead Letter Destination Resolver
+
+A bean of type `KafkaStreamsDeadLetterDestinationResolver` can be defined to activate native DLQ routing in the exception handlers.
+
+It determines the DLQ topic name and partition resolution logic to use, based on the error handler context, the input record of the failed processor, and the exception thrown:
+
+[source, java]
+----
+@Bean
+public KafkaStreamsDeadLetterDestinationResolver resolver() {
+    return (context, record, ex) -> {
+        if (ex instanceof FooException) return new TopicPartition("dlqTopic1", -1);
+        if (record instanceof Foo) return new TopicPartition("dlqTopic2", -1);
+        if (context.processorNodeId().equals("processor-1")) return new TopicPartition("dlqTopic3", -1);
+        return new TopicPartition("defaultDlqTopic", -1);
+    };
+}
+----
+
+A negative partition number indicates that the partition will be determined by the default partitioner.
+
+The `KafkaStreamsDeadLetterDestinationResolver` can then be injected into the exception handlers as follows:
+
+[source, java]
+----
+@Bean(name = KafkaStreamsDefaultConfiguration.DEFAULT_STREAMS_CONFIG_BEAN_NAME)
+public KafkaStreamsConfiguration kStreamsConfigs() {
+    Map<String, Object> props = new HashMap<>();
+    ...
+    props.put(StreamsConfig.PROCESSING_EXCEPTION_HANDLER_CLASS_CONFIG,
+            RecoveringProcessingExceptionHandler.class);
+    props.put(RecoveringProcessingExceptionHandler.DLQ_DESTINATION_RESOLVER, resolver());
+    ...
+    return new KafkaStreamsConfiguration(props);
+}
+----
+
+[[dead-letter-queue-topic-name-property]]
+== Dead Letter Queue Topic Name Property
+
+The Kafka Streams property `errors.dead.letter.queue.topic.name` can be defined and set to a topic name to activate native DLQ routing in the exception handlers.
+This directly specifies the DLQ topic to which the enabled exception handlers will route all failed records.
+
+Alternatively, this can be set programmatically through the `StreamsBuilderFactoryBean`:
+
+[source, java]
+----
+@Bean
+public StreamsBuilderFactoryBeanConfigurer streamsBuilderFactoryBeanConfigurer() {
+    return sfb -> sfb.setDeadLetterTopicName("deadLetterQueueTopic");
+}
+----
 
 [[kafka-streams-iq-support]]
 == Interactive Query Support

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -36,3 +36,20 @@ See xref:kafka/kafka-queues.adoc#share-acknowledgment-api[ShareAcknowledgment AP
 
 The default value of `sameIntervalTopicReuseStrategy` in `RetryTopicConfigurationBuilder` has been changed from `MULTIPLE_TOPICS` to `SINGLE_TOPIC` to align with the `@RetryableTopic` annotation default.
 See xref:retrytopic/topic-naming.adoc[Topic Naming] for more information.
+
+[[x41-kafka-streams-native-dlq]]
+=== Kafka Streams Native DLQ Support
+
+Spring for Apache Kafka now provides exception handlers that support Kafka Streams DLQ (KIP-1034, Kafka 4.2):
+
+- xref:streams.adoc#streams-deser-recovery[`RecoveringDeserializationExceptionHandler`] (updated).
+- xref:streams.adoc#streams-processing-recovery[`RecoveringProcessingExceptionHandler`] (new).
+- xref:streams.adoc#streams-production-recovery[`RecoveringProductionExceptionHandler`] (new).
+
+The provided exception handlers support multiple Kafka Streams DLQ enabling strategies and dead-letter topic resolution options:
+
+- The Kafka Streams property xref:streams.adoc#dead-letter-queue-topic-name-property[`errors.dead.letter.queue.topic.name`].
+- An implementation of the new xref:streams.adoc#dead-letter-destination-resolver[`KafkaStreamsDeadLetterDestinationResolver`] functional interface for dynamic resolution.
+- The `setDeadLetterTopicName()` method of the xref:streams.adoc#dead-letter-queue-topic-name-property[`StreamsBuilderFactoryBean`].
+
+`RecoveringDeserializationExceptionHandler.KSTREAM_DESERIALIZATION_RECOVERER` has been deprecated in favor of `RecoveringDeserializationExceptionHandler.RECOVERER` to align with the new handlers properties.

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/StreamsBuilderFactoryBean.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/StreamsBuilderFactoryBean.java
@@ -105,6 +105,8 @@ public class StreamsBuilderFactoryBean extends AbstractFactoryBean<StreamsBuilde
 
 	private @Nullable StreamsUncaughtExceptionHandler streamsUncaughtExceptionHandler;
 
+	private @Nullable String deadLetterTopicName;
+
 	private boolean autoStartup = true;
 
 	private int phase = Integer.MAX_VALUE - 1000; // NOSONAR magic #
@@ -161,6 +163,24 @@ public class StreamsBuilderFactoryBean extends AbstractFactoryBean<StreamsBuilde
 	@Override
 	public synchronized void setBeanName(String name) {
 		this.beanName = name;
+	}
+
+	/**
+	 * Set the dead letter topic name.
+	 * @param deadLetterTopicName the dead letter topic name.
+	 * @since 4.1.0
+	 */
+	public void setDeadLetterTopicName(String deadLetterTopicName) {
+		this.deadLetterTopicName = deadLetterTopicName;
+	}
+
+	/**
+	 * Get the dead letter topic name.
+	 * @return the dead letter topic name.
+	 * @since 4.1.0
+	 */
+	public @Nullable String getDeadLetterTopicName() {
+		return this.deadLetterTopicName;
 	}
 
 	/**
@@ -365,6 +385,9 @@ public class StreamsBuilderFactoryBean extends AbstractFactoryBean<StreamsBuilde
 				try {
 					Assert.state(this.properties != null,
 							"streams configuration properties must not be null");
+					if (this.deadLetterTopicName != null) {
+						this.properties.put(StreamsConfig.ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG, this.deadLetterTopicName);
+					}
 					this.kafkaStreams = this.kafkaStreamsCustomizer.initKafkaStreams(
 							this.topology, this.properties, this.clientSupplier
 					);

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterPublishingRecoverer.java
@@ -16,13 +16,9 @@
 
 package org.springframework.kafka.listener;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.Collections;
-import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -74,9 +70,6 @@ import org.springframework.util.ObjectUtils;
  */
 public class DeadLetterPublishingRecoverer extends ExceptionClassifier implements ConsumerAwareRecordRecoverer {
 
-	private static final BiFunction<ConsumerRecord<?, ?>, Exception, @Nullable Headers> DEFAULT_HEADERS_FUNCTION =
-			(rec, ex) -> null;
-
 	protected final LogAccessor logger = new LogAccessor(LogFactory.getLog(getClass())); // NOSONAR
 
 	private static final BiFunction<ConsumerRecord<?, ?>, Exception, @Nullable TopicPartition>
@@ -88,17 +81,19 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 
 	private final boolean transactional;
 
+	/**
+	 * Manages the creation of dead-letter record headers. Previously encapsulated
+	 * in {@link DeadLetterPublishingRecoverer}, DLT header creation is now delegated to
+	 * the dedicated {@link DeadLetterRecordManager} class so it can be leveraged by any
+	 * {@link org.springframework.kafka.streams.AbstractRecoveringExceptionHandler} implementation.
+	 * @since 4.1.0
+	 * @see org.springframework.kafka.listener.DeadLetterRecordManager
+	 */
+	private final DeadLetterRecordManager deadLetterRecordManager = new DeadLetterRecordManager();
+
 	private final BiFunction<ConsumerRecord<?, ?>, Exception, @Nullable TopicPartition> destinationResolver;
 
 	private final Function<ProducerRecord<?, ?>, ? extends @Nullable KafkaOperations<?, ?>> templateResolver;
-
-	private final EnumSet<HeaderNames.HeadersToAdd> whichHeaders = EnumSet.allOf(HeaderNames.HeadersToAdd.class);
-
-	private @Nullable HeaderNames headerNames;
-
-	private boolean retainExceptionHeader;
-
-	private BiFunction<ConsumerRecord<?, ?>, Exception, @Nullable Headers> headersFunction = DEFAULT_HEADERS_FUNCTION;
 
 	private boolean verifyPartition = true;
 
@@ -106,39 +101,15 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 
 	private Duration waitForSendResultTimeout = Duration.ofSeconds(THIRTY);
 
-	private boolean appendOriginalHeaders = true;
-
 	private boolean failIfSendResultIsError = true;
 
 	private boolean throwIfNoDestinationReturned = false;
 
 	private long timeoutBuffer = Duration.ofSeconds(FIVE).toMillis();
 
-	private boolean stripPreviousExceptionHeaders = true;
-
 	private boolean skipSameTopicFatalExceptions = true;
 
 	private boolean logRecoveryRecord = false;
-
-	private ExceptionHeadersCreator exceptionHeadersCreator = this::addExceptionInfoHeaders;
-
-	private Supplier<HeaderNames> headerNamesSupplier = () -> HeaderNames.Builder
-			.original()
-			.offsetHeader(KafkaHeaders.DLT_ORIGINAL_OFFSET)
-			.timestampHeader(KafkaHeaders.DLT_ORIGINAL_TIMESTAMP)
-			.timestampTypeHeader(KafkaHeaders.DLT_ORIGINAL_TIMESTAMP_TYPE)
-			.topicHeader(KafkaHeaders.DLT_ORIGINAL_TOPIC)
-			.partitionHeader(KafkaHeaders.DLT_ORIGINAL_PARTITION)
-			.consumerGroupHeader(KafkaHeaders.DLT_ORIGINAL_CONSUMER_GROUP)
-			.exception()
-			.keyExceptionFqcn(KafkaHeaders.DLT_KEY_EXCEPTION_FQCN)
-			.exceptionFqcn(KafkaHeaders.DLT_EXCEPTION_FQCN)
-			.exceptionCauseFqcn(KafkaHeaders.DLT_EXCEPTION_CAUSE_FQCN)
-			.keyExceptionMessage(KafkaHeaders.DLT_KEY_EXCEPTION_MESSAGE)
-			.exceptionMessage(KafkaHeaders.DLT_EXCEPTION_MESSAGE)
-			.keyExceptionStacktrace(KafkaHeaders.DLT_KEY_EXCEPTION_STACKTRACE)
-			.exceptionStacktrace(KafkaHeaders.DLT_EXCEPTION_STACKTRACE)
-			.build();
 
 	/**
 	 * Create an instance with the provided template and a default destination resolving
@@ -266,7 +237,7 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 	 * @since 2.5
 	 */
 	public void setRetainExceptionHeader(boolean retainExceptionHeader) {
-		this.retainExceptionHeader = retainExceptionHeader;
+		this.deadLetterRecordManager.setRetainExceptionHeader(retainExceptionHeader);
 	}
 
 	/**
@@ -280,11 +251,11 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 	 */
 	public void setHeadersFunction(BiFunction<ConsumerRecord<?, ?>, Exception, @Nullable Headers> headersFunction) {
 		Assert.notNull(headersFunction, "'headersFunction' cannot be null");
-		if (!this.headersFunction.equals(DEFAULT_HEADERS_FUNCTION)) {
-			this.logger.warn(() -> "Replacing custom headers function: " + this.headersFunction
+		if (!this.deadLetterRecordManager.isDefaultHeadersFunction()) {
+			this.logger.warn(() -> "Replacing custom headers function: " + this.deadLetterRecordManager.getHeadersFunction()
 					+ ", consider using addHeadersFunction() if you need multiple functions");
 		}
-		this.headersFunction = headersFunction;
+		this.deadLetterRecordManager.setHeadersFunction(headersFunction);
 	}
 
 	/**
@@ -319,7 +290,7 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 	 * @since 2.7.9
 	 */
 	public void setAppendOriginalHeaders(boolean appendOriginalHeaders) {
-		this.appendOriginalHeaders = appendOriginalHeaders;
+		this.deadLetterRecordManager.setAppendOriginalHeaders(appendOriginalHeaders);
 	}
 
 	/**
@@ -397,7 +368,7 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 	 * @since 2.7.9
 	 */
 	public void setStripPreviousExceptionHeaders(boolean stripPreviousExceptionHeaders) {
-		this.stripPreviousExceptionHeaders = stripPreviousExceptionHeaders;
+		this.deadLetterRecordManager.setStripPreviousExceptionHeaders(stripPreviousExceptionHeaders);
 	}
 
 	/**
@@ -428,7 +399,7 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 	 */
 	public void setExceptionHeadersCreator(ExceptionHeadersCreator headersCreator) {
 		Assert.notNull(headersCreator, "'headersCreator' cannot be null");
-		this.exceptionHeadersCreator = headersCreator;
+		this.deadLetterRecordManager.setExceptionHeadersCreator(headersCreator);
 	}
 
 	/**
@@ -449,7 +420,7 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 		Assert.notNull(headers, "'headers' cannot be null");
 		Assert.noNullElements(headers, "'headers' cannot include null elements");
 		for (HeaderNames.HeadersToAdd header : headers) {
-			this.whichHeaders.remove(header);
+			this.deadLetterRecordManager.removeHeaderToAdd(header);
 		}
 	}
 
@@ -461,7 +432,7 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 	public void includeHeader(HeaderNames.HeadersToAdd... headers) {
 		Assert.notNull(headers, "'headers' cannot be null");
 		Assert.noNullElements(headers, "'headers' cannot include null elements");
-		Collections.addAll(this.whichHeaders, headers);
+		this.deadLetterRecordManager.addAllToHeaders(headers);
 	}
 
 	/**
@@ -477,12 +448,12 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 	 */
 	public void addHeadersFunction(BiFunction<ConsumerRecord<?, ?>, Exception, @Nullable Headers> headersFunction) {
 		Assert.notNull(headersFunction, "'headersFunction' cannot be null");
-		if (this.headersFunction.equals(DEFAULT_HEADERS_FUNCTION)) {
-			this.headersFunction = headersFunction;
+		if (this.deadLetterRecordManager.isDefaultHeadersFunction()) {
+			this.deadLetterRecordManager.setHeadersFunction(headersFunction);
 		}
 		else {
-			BiFunction<ConsumerRecord<?, ?>, Exception, @Nullable Headers> toCompose = this.headersFunction;
-			this.headersFunction = (rec, ex) -> {
+			BiFunction<ConsumerRecord<?, ?>, Exception, @Nullable Headers> toCompose = this.deadLetterRecordManager.getHeadersFunction();
+			this.deadLetterRecordManager.setHeadersFunction((rec, ex) -> {
 				Headers headers1 = toCompose.apply(rec, ex);
 				if (headers1 == null) {
 					headers1 = new RecordHeaders();
@@ -498,7 +469,7 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 					headers2.forEach(headers1::add); // NOSONAR, never null here
 				}
 				return headers1;
-			};
+			});
 		}
 	}
 
@@ -531,35 +502,11 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 		DeserializationException kDeserEx = SerializationUtils.getExceptionFromHeader(record,
 				KafkaUtils.KEY_DESERIALIZER_EXCEPTION_HEADER, this.logger);
 		Headers headers = new RecordHeaders(record.headers().toArray());
-		addAndEnhanceHeaders(record, exception, vDeserEx, kDeserEx, headers);
+		this.deadLetterRecordManager.addAndEnhanceHeaders(record, exception, vDeserEx, kDeserEx, headers);
 		ProducerRecord<Object, Object> outRecord = createProducerRecord(record, tp, headers,
 				kDeserEx == null ? null : kDeserEx.getData(), vDeserEx == null ? null : vDeserEx.getData());
 		KafkaOperations<?, ?> kafkaTemplate = this.templateResolver.apply(outRecord);
 		sendOrThrow(outRecord, (KafkaOperations<Object, Object>) kafkaTemplate, record);
-	}
-
-	private void addAndEnhanceHeaders(ConsumerRecord<?, ?> record, Exception exception,
-			@Nullable DeserializationException vDeserEx, @Nullable DeserializationException kDeserEx, Headers headers) {
-
-		if (this.headerNames == null) {
-			this.headerNames = this.headerNamesSupplier.get();
-		}
-		if (kDeserEx != null) {
-			if (!this.retainExceptionHeader) {
-				headers.remove(KafkaUtils.KEY_DESERIALIZER_EXCEPTION_HEADER);
-			}
-			this.exceptionHeadersCreator.create(headers, kDeserEx, true, this.headerNames);
-		}
-		if (vDeserEx != null) {
-			if (!this.retainExceptionHeader) {
-				headers.remove(KafkaUtils.VALUE_DESERIALIZER_EXCEPTION_HEADER);
-			}
-			this.exceptionHeadersCreator.create(headers, vDeserEx, false, this.headerNames);
-		}
-		if (kDeserEx == null && vDeserEx == null) {
-			this.exceptionHeadersCreator.create(headers, exception, false, this.headerNames);
-		}
-		enhanceHeaders(headers, record, exception); // NOSONAR headers are never null
 	}
 
 	private void sendOrThrow(ProducerRecord<Object, Object> outRecord,
@@ -767,115 +714,6 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 		return Duration.ofSeconds(THIRTY);
 	}
 
-	private void enhanceHeaders(Headers kafkaHeaders, ConsumerRecord<?, ?> record, Exception exception) {
-		maybeAddOriginalHeaders(kafkaHeaders, record, exception);
-		Headers headers = this.headersFunction.apply(record, exception);
-		if (headers != null) {
-			headers.forEach(header -> {
-				if (header instanceof SingleRecordHeader) {
-					kafkaHeaders.remove(header.key());
-				}
-				kafkaHeaders.add(header);
-			});
-		}
-	}
-
-	private void maybeAddOriginalHeaders(Headers kafkaHeaders, ConsumerRecord<?, ?> record, Exception ex) {
-		maybeAddHeader(kafkaHeaders, Objects.requireNonNull(this.headerNames).original.topicHeader,
-				() -> record.topic().getBytes(StandardCharsets.UTF_8), HeaderNames.HeadersToAdd.TOPIC);
-		maybeAddHeader(kafkaHeaders, this.headerNames.original.partitionHeader,
-				() -> ByteBuffer.allocate(Integer.BYTES).putInt(record.partition()).array(),
-				HeaderNames.HeadersToAdd.PARTITION);
-		maybeAddHeader(kafkaHeaders, this.headerNames.original.offsetHeader,
-				() -> ByteBuffer.allocate(Long.BYTES).putLong(record.offset()).array(),
-				HeaderNames.HeadersToAdd.OFFSET);
-		maybeAddHeader(kafkaHeaders, this.headerNames.original.timestampHeader,
-				() -> ByteBuffer.allocate(Long.BYTES).putLong(record.timestamp()).array(), HeaderNames.HeadersToAdd.TS);
-		maybeAddHeader(kafkaHeaders, this.headerNames.original.timestampTypeHeader,
-				() -> record.timestampType().toString().getBytes(StandardCharsets.UTF_8),
-				HeaderNames.HeadersToAdd.TS_TYPE);
-		if (ex instanceof ListenerExecutionFailedException) {
-			String consumerGroup = ((ListenerExecutionFailedException) ex).getGroupId();
-			if (consumerGroup != null) {
-				maybeAddHeader(kafkaHeaders, this.headerNames.original.consumerGroup,
-						() -> consumerGroup.getBytes(StandardCharsets.UTF_8), HeaderNames.HeadersToAdd.GROUP);
-			}
-		}
-	}
-
-	private void maybeAddHeader(Headers kafkaHeaders, String header, Supplier<byte[]> valueSupplier,
-			HeaderNames.HeadersToAdd hta) {
-
-		if (this.whichHeaders.contains(hta)
-				&& (this.appendOriginalHeaders || kafkaHeaders.lastHeader(header) == null)) {
-			kafkaHeaders.add(header, valueSupplier.get());
-		}
-	}
-
-	private void addExceptionInfoHeaders(Headers kafkaHeaders, Exception exception, boolean isKey,
-			HeaderNames names) {
-
-		appendOrReplace(kafkaHeaders,
-				isKey ? names.exceptionInfo.keyExceptionFqcn : names.exceptionInfo.exceptionFqcn,
-				() -> exception.getClass().getName().getBytes(StandardCharsets.UTF_8),
-				HeaderNames.HeadersToAdd.EXCEPTION);
-		Exception cause = ErrorHandlingUtils.findRootCause(exception);
-		if (cause != null) {
-			appendOrReplace(kafkaHeaders,
-					names.exceptionInfo.exceptionCauseFqcn,
-					() -> cause.getClass().getName().getBytes(StandardCharsets.UTF_8),
-					HeaderNames.HeadersToAdd.EX_CAUSE);
-		}
-		String message = buildMessage(exception, cause);
-		if (message != null) {
-			appendOrReplace(kafkaHeaders,
-					isKey ? names.exceptionInfo.keyExceptionMessage : names.exceptionInfo.exceptionMessage,
-					() -> message.getBytes(StandardCharsets.UTF_8),
-					HeaderNames.HeadersToAdd.EX_MSG);
-		}
-		appendOrReplace(kafkaHeaders,
-				isKey ? names.exceptionInfo.keyExceptionStacktrace : names.exceptionInfo.exceptionStacktrace,
-				() -> getStackTraceAsString(exception).getBytes(StandardCharsets.UTF_8),
-				HeaderNames.HeadersToAdd.EX_STACKTRACE);
-	}
-
-	private @Nullable String buildMessage(Exception exception, @Nullable Throwable cause) {
-		String message = exception.getMessage();
-		if (!exception.equals(cause)) {
-			if (message != null) {
-				message = message + "; ";
-			}
-			String causeMsg = Objects.requireNonNull(cause).getMessage();
-			if (causeMsg != null) {
-				if (message != null) {
-					message = message + causeMsg;
-				}
-				else {
-					message = causeMsg;
-				}
-			}
-		}
-		return message;
-	}
-
-	private void appendOrReplace(Headers headers, String header, Supplier<byte[]> valueSupplier,
-			HeaderNames.HeadersToAdd hta) {
-
-		if (this.whichHeaders.contains(hta)) {
-			if (this.stripPreviousExceptionHeaders) {
-				headers.remove(header);
-			}
-			headers.add(header, valueSupplier.get());
-		}
-	}
-
-	private String getStackTraceAsString(Throwable cause) {
-		StringWriter stringWriter = new StringWriter();
-		PrintWriter printWriter = new PrintWriter(stringWriter, true);
-		cause.printStackTrace(printWriter);
-		return stringWriter.getBuffer().toString();
-	}
-
 	/**
 	 * Set a {@link Supplier} for {@link HeaderNames}.
 	 * @param supplier the supplier.
@@ -884,7 +722,7 @@ public class DeadLetterPublishingRecoverer extends ExceptionClassifier implement
 	 */
 	public void setHeaderNamesSupplier(Supplier<HeaderNames> supplier) {
 		Assert.notNull(supplier, "'HeaderNames supplier cannot be null");
-		this.headerNamesSupplier = supplier;
+		this.deadLetterRecordManager.setHeaderNamesSupplier(supplier);
 	}
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterRecordManager.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/DeadLetterRecordManager.java
@@ -1,0 +1,361 @@
+/*
+ * Copyright 2018-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Objects;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+
+import org.apache.commons.logging.LogFactory;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.core.log.LogAccessor;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.kafka.support.KafkaUtils;
+import org.springframework.kafka.support.serializer.DeserializationException;
+import org.springframework.kafka.support.serializer.SerializationUtils;
+import org.springframework.util.Assert;
+
+/**
+ * Manage the creation of headers for records published to a DLT by a {@link DeadLetterPublishingRecoverer}
+ * or a {@link org.springframework.kafka.streams.AbstractRecoveringExceptionHandler} implementation.
+ *
+ * @author Loïc Greffier
+ * @since 4.1.0
+ */
+public class DeadLetterRecordManager {
+
+	private static final BiFunction<ConsumerRecord<?, ?>, Exception, @Nullable Headers> DEFAULT_HEADERS_FUNCTION =
+			(rec, ex) -> null;
+
+	protected final LogAccessor logger = new LogAccessor(LogFactory.getLog(getClass())); // NOSONAR
+
+	private final EnumSet<DeadLetterPublishingRecoverer.HeaderNames.HeadersToAdd> whichHeaders = EnumSet.allOf(DeadLetterPublishingRecoverer.HeaderNames.HeadersToAdd.class);
+
+	private DeadLetterPublishingRecoverer.@org.jspecify.annotations.Nullable HeaderNames headerNames;
+
+	private boolean retainExceptionHeader;
+
+	private BiFunction<ConsumerRecord<?, ?>, Exception, @Nullable Headers> headersFunction = DEFAULT_HEADERS_FUNCTION;
+
+	private boolean appendOriginalHeaders = true;
+
+	private boolean stripPreviousExceptionHeaders = true;
+
+	private DeadLetterPublishingRecoverer.ExceptionHeadersCreator exceptionHeadersCreator = this::addExceptionInfoHeaders;
+
+	private Supplier<DeadLetterPublishingRecoverer.HeaderNames> headerNamesSupplier = () -> DeadLetterPublishingRecoverer.HeaderNames.Builder
+			.original()
+			.offsetHeader(KafkaHeaders.DLT_ORIGINAL_OFFSET)
+			.timestampHeader(KafkaHeaders.DLT_ORIGINAL_TIMESTAMP)
+			.timestampTypeHeader(KafkaHeaders.DLT_ORIGINAL_TIMESTAMP_TYPE)
+			.topicHeader(KafkaHeaders.DLT_ORIGINAL_TOPIC)
+			.partitionHeader(KafkaHeaders.DLT_ORIGINAL_PARTITION)
+			.consumerGroupHeader(KafkaHeaders.DLT_ORIGINAL_CONSUMER_GROUP)
+			.exception()
+			.keyExceptionFqcn(KafkaHeaders.DLT_KEY_EXCEPTION_FQCN)
+			.exceptionFqcn(KafkaHeaders.DLT_EXCEPTION_FQCN)
+			.exceptionCauseFqcn(KafkaHeaders.DLT_EXCEPTION_CAUSE_FQCN)
+			.keyExceptionMessage(KafkaHeaders.DLT_KEY_EXCEPTION_MESSAGE)
+			.exceptionMessage(KafkaHeaders.DLT_EXCEPTION_MESSAGE)
+			.keyExceptionStacktrace(KafkaHeaders.DLT_KEY_EXCEPTION_STACKTRACE)
+			.exceptionStacktrace(KafkaHeaders.DLT_EXCEPTION_STACKTRACE)
+			.build();
+
+	public DeadLetterRecordManager() { }
+
+	/**
+	 * Enriches headers with deserialization exception information and metadata, then creates a producer record for dead letter publishing.
+	 * @param record the consumer record
+	 * @param exception the exception that triggered the dead letter publishing
+	 * @param topicPartition the target topic and partition
+	 * @param sourceRawKey the raw key bytes of the source record that triggers the exception
+	 * @param sourceRawValue the raw value bytes of the source record that triggers the exception
+	 * @return a producer record
+	 * @since 4.1.0
+	 */
+	public ProducerRecord<byte[], byte[]> enrichHeadersAndCreateProducerRecord(ConsumerRecord<?, ?> record, Exception exception, TopicPartition topicPartition, byte[] sourceRawKey, byte[] sourceRawValue) {
+		DeserializationException vDeserEx = SerializationUtils.getExceptionFromHeader(record,
+				KafkaUtils.VALUE_DESERIALIZER_EXCEPTION_HEADER, this.logger);
+		DeserializationException kDeserEx = SerializationUtils.getExceptionFromHeader(record,
+				KafkaUtils.KEY_DESERIALIZER_EXCEPTION_HEADER, this.logger);
+		Headers headers = new RecordHeaders(record.headers().toArray());
+		addAndEnhanceHeaders(record, exception, vDeserEx, kDeserEx, headers);
+		return new ProducerRecord<>(topicPartition.topic(),
+				topicPartition.partition() < 0 ? null : topicPartition.partition(),
+				sourceRawKey,
+				sourceRawValue, headers);
+	}
+
+	/**
+	 * Adds and enriches headers with deserialization exception information, original record metadata, and custom headers.
+	 * @param record the consumer record
+	 * @param exception the exception that triggered the dead letter publishing
+	 * @param vDeserEx the value deserialization exception, if any occurred during deserialization
+	 * @param kDeserEx the key deserialization exception, if any occurred during deserialization
+	 * @param headers the headers to be enriched
+	 */
+	public void addAndEnhanceHeaders(ConsumerRecord<?, ?> record, Exception exception, @Nullable DeserializationException vDeserEx, @Nullable DeserializationException kDeserEx, Headers headers) {
+		if (this.headerNames == null) {
+			this.headerNames = this.headerNamesSupplier.get();
+		}
+		if (kDeserEx != null) {
+			if (!this.retainExceptionHeader) {
+				headers.remove(KafkaUtils.KEY_DESERIALIZER_EXCEPTION_HEADER);
+			}
+			this.exceptionHeadersCreator.create(headers, kDeserEx, true, this.headerNames);
+		}
+		if (vDeserEx != null) {
+			if (!this.retainExceptionHeader) {
+				headers.remove(KafkaUtils.VALUE_DESERIALIZER_EXCEPTION_HEADER);
+			}
+			this.exceptionHeadersCreator.create(headers, vDeserEx, false, this.headerNames);
+		}
+		if (kDeserEx == null && vDeserEx == null) {
+			this.exceptionHeadersCreator.create(headers, exception, false, this.headerNames);
+		}
+		enhanceHeaders(headers, record, exception); // NOSONAR headers are never null
+	}
+
+	private void enhanceHeaders(Headers kafkaHeaders, ConsumerRecord<?, ?> record, Exception exception) {
+		maybeAddOriginalHeaders(kafkaHeaders, record, exception);
+		Headers headers = this.headersFunction.apply(record, exception);
+		if (headers != null) {
+			headers.forEach(header -> {
+				if (header instanceof DeadLetterPublishingRecoverer.SingleRecordHeader) {
+					kafkaHeaders.remove(header.key());
+				}
+				kafkaHeaders.add(header);
+			});
+		}
+	}
+
+	private void maybeAddOriginalHeaders(Headers kafkaHeaders, ConsumerRecord<?, ?> record, Exception ex) {
+		maybeAddHeader(kafkaHeaders, Objects.requireNonNull(this.headerNames).getOriginal().topicHeader,
+				() -> record.topic().getBytes(StandardCharsets.UTF_8), DeadLetterPublishingRecoverer.HeaderNames.HeadersToAdd.TOPIC);
+		maybeAddHeader(kafkaHeaders, this.headerNames.getOriginal().partitionHeader,
+				() -> ByteBuffer.allocate(Integer.BYTES).putInt(record.partition()).array(),
+				DeadLetterPublishingRecoverer.HeaderNames.HeadersToAdd.PARTITION);
+		maybeAddHeader(kafkaHeaders, this.headerNames.getOriginal().offsetHeader,
+				() -> ByteBuffer.allocate(Long.BYTES).putLong(record.offset()).array(),
+				DeadLetterPublishingRecoverer.HeaderNames.HeadersToAdd.OFFSET);
+		maybeAddHeader(kafkaHeaders, this.headerNames.getOriginal().timestampHeader,
+				() -> ByteBuffer.allocate(Long.BYTES).putLong(record.timestamp()).array(), DeadLetterPublishingRecoverer.HeaderNames.HeadersToAdd.TS);
+		maybeAddHeader(kafkaHeaders, this.headerNames.getOriginal().timestampTypeHeader,
+				() -> record.timestampType().toString().getBytes(StandardCharsets.UTF_8),
+				DeadLetterPublishingRecoverer.HeaderNames.HeadersToAdd.TS_TYPE);
+		if (ex instanceof ListenerExecutionFailedException) {
+			String consumerGroup = ((ListenerExecutionFailedException) ex).getGroupId();
+			if (consumerGroup != null) {
+				maybeAddHeader(kafkaHeaders, this.headerNames.getOriginal().consumerGroup,
+						() -> consumerGroup.getBytes(StandardCharsets.UTF_8), DeadLetterPublishingRecoverer.HeaderNames.HeadersToAdd.GROUP);
+			}
+		}
+	}
+
+	private void maybeAddHeader(Headers kafkaHeaders, String header, Supplier<byte[]> valueSupplier, DeadLetterPublishingRecoverer.HeaderNames.HeadersToAdd hta) {
+
+		if (this.whichHeaders.contains(hta)
+				&& (this.appendOriginalHeaders || kafkaHeaders.lastHeader(header) == null)) {
+			kafkaHeaders.add(header, valueSupplier.get());
+		}
+	}
+
+	private void addExceptionInfoHeaders(Headers kafkaHeaders, Exception exception, boolean isKey, DeadLetterPublishingRecoverer.HeaderNames names) {
+
+		appendOrReplace(kafkaHeaders,
+				isKey ? names.getExceptionInfo().keyExceptionFqcn : names.getExceptionInfo().exceptionFqcn,
+				() -> exception.getClass().getName().getBytes(StandardCharsets.UTF_8),
+				DeadLetterPublishingRecoverer.HeaderNames.HeadersToAdd.EXCEPTION);
+		Exception cause = ErrorHandlingUtils.findRootCause(exception);
+		if (cause != null) {
+			appendOrReplace(kafkaHeaders,
+					names.getExceptionInfo().exceptionCauseFqcn,
+					() -> cause.getClass().getName().getBytes(StandardCharsets.UTF_8),
+					DeadLetterPublishingRecoverer.HeaderNames.HeadersToAdd.EX_CAUSE);
+		}
+		String message = buildMessage(exception, cause);
+		if (message != null) {
+			appendOrReplace(kafkaHeaders,
+					isKey ? names.getExceptionInfo().keyExceptionMessage : names.getExceptionInfo().exceptionMessage,
+					() -> message.getBytes(StandardCharsets.UTF_8),
+					DeadLetterPublishingRecoverer.HeaderNames.HeadersToAdd.EX_MSG);
+		}
+		appendOrReplace(kafkaHeaders,
+				isKey ? names.getExceptionInfo().keyExceptionStacktrace : names.getExceptionInfo().exceptionStacktrace,
+				() -> getStackTraceAsString(exception).getBytes(StandardCharsets.UTF_8),
+				DeadLetterPublishingRecoverer.HeaderNames.HeadersToAdd.EX_STACKTRACE);
+	}
+
+	private void appendOrReplace(Headers headers, String header, Supplier<byte[]> valueSupplier, DeadLetterPublishingRecoverer.HeaderNames.HeadersToAdd hta) {
+
+		if (this.whichHeaders.contains(hta)) {
+			if (this.stripPreviousExceptionHeaders) {
+				headers.remove(header);
+			}
+			headers.add(header, valueSupplier.get());
+		}
+	}
+
+	private @Nullable String buildMessage(Exception exception, @Nullable Throwable cause) {
+		String message = exception.getMessage();
+		if (!exception.equals(cause)) {
+			if (message != null) {
+				message = message + "; ";
+			}
+			String causeMsg = Objects.requireNonNull(cause).getMessage();
+			if (causeMsg != null) {
+				if (message != null) {
+					message = message + causeMsg;
+				}
+				else {
+					message = causeMsg;
+				}
+			}
+		}
+		return message;
+	}
+
+	private String getStackTraceAsString(Throwable cause) {
+		StringWriter stringWriter = new StringWriter();
+		PrintWriter printWriter = new PrintWriter(stringWriter, true);
+		cause.printStackTrace(printWriter);
+		return stringWriter.getBuffer().toString();
+	}
+
+	/**
+	 * Set a {@link Supplier} for {@link DeadLetterPublishingRecoverer.HeaderNames}.
+	 * @param supplier the supplier.
+	 * @since 4.1.0
+	 */
+	public void setHeaderNamesSupplier(Supplier<DeadLetterPublishingRecoverer.HeaderNames> supplier) {
+		Assert.notNull(supplier, "'DeadLetterPublishingRecoverer.HeaderNames' supplier cannot be null");
+		this.headerNamesSupplier = supplier;
+	}
+
+	/**
+	 * Set to true to retain a Java serialized {@link DeserializationException} header. By
+	 * default, such headers are removed from the published record, unless both key and
+	 * value deserialization exceptions occur, in which case, the DLT_* headers are
+	 * created from the value exception and the key exception header is retained.
+	 * @param retainExceptionHeader true to retain the exception header.
+	 * @since 4.1.0
+	 */
+	public void setRetainExceptionHeader(boolean retainExceptionHeader) {
+		this.retainExceptionHeader = retainExceptionHeader;
+	}
+
+	/**
+	 * Set a {@link DeadLetterPublishingRecoverer.ExceptionHeadersCreator} implementation to completely take over
+	 * setting the exception headers in the output record. Disables all headers that are
+	 * set by default.
+	 * @param headersCreator the creator.
+	 * @since 4.1.0
+	 */
+	public void setExceptionHeadersCreator(DeadLetterPublishingRecoverer.ExceptionHeadersCreator headersCreator) {
+		Assert.notNull(headersCreator, "'headersCreator' cannot be null");
+		this.exceptionHeadersCreator = headersCreator;
+	}
+
+	/**
+	 * Set a function which will be called to obtain additional headers to add to the
+	 * published record. If a {@link Header} returned is an instance of
+	 * {@link DeadLetterPublishingRecoverer.SingleRecordHeader}, then that header will replace any existing header of
+	 * that name, rather than being appended as a new value.
+	 * @param headersFunction the headers function.
+	 * @since 4.1.0
+	 */
+	public void setHeadersFunction(BiFunction<ConsumerRecord<?, ?>, Exception, @Nullable Headers> headersFunction) {
+		Assert.notNull(headersFunction, "'headersFunction' cannot be null");
+		if (!this.headersFunction.equals(DEFAULT_HEADERS_FUNCTION)) {
+			this.logger.warn(() -> "Replacing custom headers function: " + this.headersFunction
+					+ ", consider using addHeadersFunction() if you need multiple functions");
+		}
+		this.headersFunction = headersFunction;
+	}
+
+	/**
+	 * Set to false if you don't want to append the current "original" headers (topic,
+	 * partition, etc.) if they are already present. When false, only the first "original"
+	 * headers are retained.
+	 * @param appendOriginalHeaders set to false not to replace.
+	 * @since 4.1.0
+	 */
+	public void setAppendOriginalHeaders(boolean appendOriginalHeaders) {
+		this.appendOriginalHeaders = appendOriginalHeaders;
+	}
+
+	/**
+	 * Set to {@code false} to retain previous exception headers as well as headers for the
+	 * current exception. Default is true, which means only the current headers are
+	 * retained; setting it to false this can cause a growth in record size when a record
+	 * is republished many times.
+	 * @param stripPreviousExceptionHeaders false to retain all.
+	 * @since 4.1.0
+	 */
+	public void setStripPreviousExceptionHeaders(boolean stripPreviousExceptionHeaders) {
+		this.stripPreviousExceptionHeaders = stripPreviousExceptionHeaders;
+	}
+
+	/**
+	 * Is the headers function the default one.
+	 * @return true if it is, false otherwise.
+	 * @since 4.1.0
+	 */
+	public boolean isDefaultHeadersFunction() {
+		return this.headersFunction.equals(DEFAULT_HEADERS_FUNCTION);
+	}
+
+	/**
+	 * Return the headers function.
+	 * @return the headers function
+	 * @since 4.1.0
+	 */
+	public BiFunction<ConsumerRecord<?, ?>, Exception, @Nullable Headers> getHeadersFunction() {
+		return this.headersFunction;
+	}
+
+	/**
+	 * Remove a header from the set of headers to be added to the published record.
+	 * @param header the header to exclude
+	 * @since 4.1.0
+	 */
+	public void removeHeaderToAdd(DeadLetterPublishingRecoverer.HeaderNames.HeadersToAdd header) {
+		this.whichHeaders.remove(header);
+	}
+
+	/**
+	 * Add all headers to be added to the published record.
+	 * @param headers the headers to include
+	 * @since 4.1.0
+	 */
+	public void addAllToHeaders(DeadLetterPublishingRecoverer.HeaderNames.HeadersToAdd... headers) {
+		Collections.addAll(this.whichHeaders, headers);
+	}
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/streams/AbstractRecoveringExceptionHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/streams/AbstractRecoveringExceptionHandler.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2019-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.streams;
+
+import java.lang.reflect.Constructor;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.errors.ErrorHandlerContext;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.kafka.listener.ConsumerRecordRecoverer;
+import org.springframework.kafka.listener.DeadLetterRecordManager;
+import org.springframework.util.ClassUtils;
+
+/**
+ * Abstract base class for recovering Kafka Streams exception handlers.
+ *
+ * @param <R> the handler-specific response type
+ * @author Loïc Greffier
+ * @since 4.1
+ */
+public abstract class AbstractRecoveringExceptionHandler<R> {
+
+	private static final Log LOGGER = LogFactory.getLog(AbstractRecoveringExceptionHandler.class);
+
+	protected final DeadLetterRecordManager deadLetterRecordManager = new DeadLetterRecordManager();
+
+	protected @Nullable ConsumerRecordRecoverer recoverer;
+
+	protected @Nullable KafkaStreamsDeadLetterDestinationResolver destinationResolver;
+
+	protected @Nullable String deadLetterTopic;
+
+	protected AbstractRecoveringExceptionHandler() {
+	}
+
+	protected AbstractRecoveringExceptionHandler(ConsumerRecordRecoverer recoverer) {
+		this.recoverer = recoverer;
+	}
+
+	/**
+	 * Handles errors using a prioritized recovery strategy.
+	 * <ol>
+	 *     <li>Resume the stream by forwarding to the topic-partition resolved by {@link KafkaStreamsDeadLetterDestinationResolver} via the native Kafka Streams DLQ.</li>
+	 *     <li>Resume the stream by forwarding to the {@code errors.dead.letter.queue.topic.name} topic via the native Kafka Streams DLQ.</li>
+	 *     <li>Delegate the recovery logic and dead-letter record sending to the {@link ConsumerRecordRecoverer}. Resume with no dead-letter records, as it is expected to be handled by the {@link ConsumerRecordRecoverer}.</li>
+	 *     <li>Fail the stream with no dead-letter records.</li>
+	 * </ol>
+	 * @param context the error handler context
+	 * @param record the consumer record that caused the error
+	 * @param exception the exception that occurred
+	 * @return a handler-specific response
+	 */
+	protected R handleErrorCommon(ErrorHandlerContext context, ConsumerRecord<?, ?> record, Exception exception) {
+		if (this.destinationResolver != null) {
+			TopicPartition tp = this.destinationResolver.resolve(context, record, exception);
+			ProducerRecord<byte[], byte[]> outRecord = this.deadLetterRecordManager.enrichHeadersAndCreateProducerRecord(
+					record, exception, tp, context.sourceRawKey(), context.sourceRawValue());
+			return resume(Collections.singletonList(outRecord));
+		}
+
+		if (this.deadLetterTopic != null) {
+			ProducerRecord<byte[], byte[]> outRecord = this.deadLetterRecordManager.enrichHeadersAndCreateProducerRecord(
+					record, exception, new TopicPartition(this.deadLetterTopic, -1), context.sourceRawKey(), context.sourceRawValue());
+			return resume(Collections.singletonList(outRecord));
+		}
+
+		if (this.recoverer == null) {
+			return fail();
+		}
+		try {
+			this.recoverer.accept(record, exception);
+			return resume(Collections.emptyList());
+		}
+		catch (RuntimeException e) {
+			LOGGER.error("Recoverer threw an exception; recovery failed", e);
+			return fail();
+		}
+	}
+
+	/**
+	 * Configure common attributes.
+	 * @param configs the configuration map
+	 * @param destinationResolverKey the property key for the native DLQ destination resolver
+	 * @param recovererKey the property key for the recoverer
+	 * @param legacyRecovererKey the legacy property key for the recoverer, used as fallback if recovererKey is not defined
+	 */
+	protected void configureCommon(Map<String, ?> configs, String destinationResolverKey,
+			String recovererKey, @Nullable String legacyRecovererKey) {
+
+		if (configs.get(StreamsConfig.ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG) != null) {
+			this.deadLetterTopic = String.valueOf(configs.get(StreamsConfig.ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG));
+		}
+
+		if (configs.containsKey(destinationResolverKey)) {
+			Object configValue = configs.get(destinationResolverKey);
+			if (configValue instanceof KafkaStreamsDeadLetterDestinationResolver) {
+				this.destinationResolver = (KafkaStreamsDeadLetterDestinationResolver) configValue;
+			}
+			else if (configValue instanceof String) {
+				this.destinationResolver = fromString(configValue, KafkaStreamsDeadLetterDestinationResolver.class);
+			}
+			else if (configValue instanceof Class) {
+				this.destinationResolver = fromClass(configValue, KafkaStreamsDeadLetterDestinationResolver.class);
+			}
+			else {
+				LOGGER.error("Unknown property type for " + destinationResolverKey
+						+ "; failed operations cannot be resolved to a DLT destination");
+			}
+		}
+
+		String effectiveRecovererKey = configs.containsKey(recovererKey)
+				? recovererKey
+				: legacyRecovererKey;
+
+		if (effectiveRecovererKey != null && configs.containsKey(effectiveRecovererKey)) {
+			Object configValue = configs.get(effectiveRecovererKey);
+			if (configValue instanceof ConsumerRecordRecoverer) {
+				this.recoverer = (ConsumerRecordRecoverer) configValue;
+			}
+			else if (configValue instanceof String) {
+				this.recoverer = fromString(configValue, ConsumerRecordRecoverer.class);
+			}
+			else if (configValue instanceof Class) {
+				this.recoverer = fromClass(configValue, ConsumerRecordRecoverer.class);
+			}
+			else {
+				LOGGER.error("Unknown property type for " + effectiveRecovererKey
+						+ "; failed operations cannot be recovered");
+			}
+		}
+	}
+
+	private <T> @Nullable T fromString(Object configValue, Class<T> targetType) throws LinkageError {
+		try {
+			Class<?> clazz = ClassUtils.forName((String) configValue,
+					AbstractRecoveringExceptionHandler.class.getClassLoader());
+			Constructor<?> constructor = clazz.getConstructor();
+			return targetType.cast(constructor.newInstance());
+		}
+		catch (Exception e) {
+			LOGGER.error("Failed to instantiate " + targetType.getSimpleName() + " from class name " + configValue, e);
+			return null;
+		}
+	}
+
+	private <T> @Nullable T fromClass(Object configValue, Class<T> targetType) {
+		try {
+			Class<?> clazz = (Class<?>) configValue;
+			Constructor<?> constructor = clazz.getConstructor();
+			return targetType.cast(constructor.newInstance());
+		}
+		catch (Exception e) {
+			LOGGER.error("Failed to instantiate " + targetType.getSimpleName() + " from class " + ((Class<?>) configValue).getName(), e);
+			return null;
+		}
+	}
+
+	/**
+	 * Create a response indicating that processing should fail.
+	 * @return a handler-specific fail response
+	 */
+	protected abstract R fail();
+
+	/**
+	 * Create a response indicating that processing should resume.
+	 * @param deadLetterRecords The list of dead letter records to forward to DLQ
+	 * @return a handler-specific resume response
+	 */
+	protected abstract R resume(List<ProducerRecord<byte[], byte[]>> deadLetterRecords);
+}
+

--- a/spring-kafka/src/main/java/org/springframework/kafka/streams/KafkaStreamsDeadLetterDestinationResolver.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/streams/KafkaStreamsDeadLetterDestinationResolver.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.streams;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.streams.errors.ErrorHandlerContext;
+
+/**
+ * Interface for resolving the dead-letter topic destination of a failed record handled by
+ * either {@link RecoveringDeserializationExceptionHandler},
+ * {@link RecoveringProcessingExceptionHandler}, or {@link RecoveringProductionExceptionHandler}
+ * through the native Kafka Streams DLQ.
+ *
+ * @author Loïc Greffier
+ * @since 4.1
+ */
+@FunctionalInterface
+public interface KafkaStreamsDeadLetterDestinationResolver {
+	/**
+	 * Resolves the topic-partition to which a dead-letter record should be sent.
+	 * Use a negative partition number to let the partitioner determine the partition.
+	 *
+	 * @param errorHandlerContext the error handler context
+	 * @param record the input record of the failed processor
+	 * @param exception the exception
+	 * @return the topic-partition to which the failed record should be sent
+	 */
+	TopicPartition resolve(ErrorHandlerContext errorHandlerContext, ConsumerRecord<?, ?> record, Exception exception);
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/streams/RecoveringDeserializationExceptionHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/streams/RecoveringDeserializationExceptionHandler.java
@@ -16,44 +16,51 @@
 
 package org.springframework.kafka.streams;
 
-import java.lang.reflect.Constructor;
+import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.streams.errors.DeserializationExceptionHandler;
 import org.apache.kafka.streams.errors.ErrorHandlerContext;
-import org.jspecify.annotations.Nullable;
 
 import org.springframework.kafka.listener.ConsumerRecordRecoverer;
-import org.springframework.util.ClassUtils;
 
 /**
- * A {@link DeserializationExceptionHandler} that calls a {@link ConsumerRecordRecoverer}.
- * and continues.
+ * A {@link DeserializationExceptionHandler} that calls a {@link ConsumerRecordRecoverer}
+ * or uses the native Kafka Streams DLQ and continues.
  *
  * @author Gary Russell
  * @author Soby Chacko
  * @since 2.3
  *
  */
-public class RecoveringDeserializationExceptionHandler implements DeserializationExceptionHandler {
+public class RecoveringDeserializationExceptionHandler
+		extends AbstractRecoveringExceptionHandler<DeserializationExceptionHandler.Response>
+		implements DeserializationExceptionHandler {
+
+	/**
+	 * Property name for configuring the recoverer using properties.
+	 * @deprecated Since 4.1 in favor of {@link #RECOVERER}.
+	 */
+	@Deprecated(since = "4.1", forRemoval = true)
+	public static final String KSTREAM_DESERIALIZATION_RECOVERER = "spring.deserialization.recoverer";
 
 	/**
 	 * Property name for configuring the recoverer using properties.
 	 */
-	public static final String KSTREAM_DESERIALIZATION_RECOVERER = "spring.deserialization.recoverer";
+	public static final String RECOVERER = "spring.kafka.streams.deserialization.exception.handler.recoverer";
 
-	private static final Log LOGGER = LogFactory.getLog(RecoveringDeserializationExceptionHandler.class);
-
-	private @Nullable ConsumerRecordRecoverer recoverer;
+	/**
+	 * Property name for configuring the native DLQ destination resolver.
+	 */
+	public static final String DLQ_DESTINATION_RESOLVER = "spring.kafka.streams.deserialization.exception.handler.dlq.destination.resolver";
 
 	public RecoveringDeserializationExceptionHandler() {
 	}
 
 	public RecoveringDeserializationExceptionHandler(ConsumerRecordRecoverer recoverer) {
-		this.recoverer = recoverer;
+		super(recoverer);
 	}
 
 	/**
@@ -72,70 +79,37 @@ public class RecoveringDeserializationExceptionHandler implements Deserializatio
 				: DeserializationHandlerResponse.FAIL;
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public Response handleError(ErrorHandlerContext context, ConsumerRecord<byte[], byte[]> record,
 			Exception exception) {
-
-		if (this.recoverer == null) {
-			return Response.fail();
-		}
-		try {
-			this.recoverer.accept(record, exception);
-			return Response.resume();
-		}
-		catch (RuntimeException e) {
-			LOGGER.error("Recoverer threw an exception; recovery failed", e);
-			return Response.fail();
-		}
+		return handleErrorCommon(context, record, exception);
 	}
 
+	/**
+	 * {@inheritDoc}
+	 */
 	@Override
 	public void configure(Map<String, ?> configs) {
-		if (configs.containsKey(KSTREAM_DESERIALIZATION_RECOVERER)) {
-			Object configValue = configs.get(KSTREAM_DESERIALIZATION_RECOVERER);
-			if (configValue instanceof ConsumerRecordRecoverer) {
-				this.recoverer = (ConsumerRecordRecoverer) configValue;
-			}
-			else if (configValue instanceof String) {
-				fromString(configValue);
-			}
-			else if (configValue instanceof Class) {
-				fromClass(configValue);
-			}
-			else {
-				LOGGER.error("Unknown property type for " + KSTREAM_DESERIALIZATION_RECOVERER
-						+ "; failed deserializations cannot be recovered");
-			}
-		}
-
+		configureCommon(configs, DLQ_DESTINATION_RESOLVER, RECOVERER, KSTREAM_DESERIALIZATION_RECOVERER);
 	}
 
-	private void fromString(Object configValue) throws LinkageError {
-		try {
-			@SuppressWarnings("unchecked")
-			Class<? extends ConsumerRecordRecoverer> clazz =
-					(Class<? extends ConsumerRecordRecoverer>) ClassUtils
-						.forName((String) configValue,
-									RecoveringDeserializationExceptionHandler.class.getClassLoader());
-			Constructor<? extends ConsumerRecordRecoverer> constructor = clazz.getConstructor();
-			this.recoverer = constructor.newInstance();
-		}
-		catch (Exception e) {
-			LOGGER.error("Failed to instantiate recoverer, failed deserializations cannot be recovered", e);
-		}
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	protected Response fail() {
+		return Response.fail();
 	}
 
-	private void fromClass(Object configValue) {
-		try {
-			@SuppressWarnings("unchecked")
-			Class<? extends ConsumerRecordRecoverer> clazz =
-				(Class<? extends ConsumerRecordRecoverer>) configValue;
-			Constructor<? extends ConsumerRecordRecoverer> constructor = clazz.getConstructor();
-			this.recoverer = constructor.newInstance();
-		}
-		catch (Exception e) {
-			LOGGER.error("Failed to instantiate recoverer, failed deserializations cannot be recovered", e);
-		}
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	protected Response resume(List<ProducerRecord<byte[], byte[]>> deadLetterRecords) {
+		return Response.resume(deadLetterRecords);
 	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/streams/RecoveringProcessingExceptionHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/streams/RecoveringProcessingExceptionHandler.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2019-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.streams;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.streams.errors.ErrorHandlerContext;
+import org.apache.kafka.streams.errors.ProcessingExceptionHandler;
+import org.apache.kafka.streams.processor.api.Record;
+
+import org.springframework.kafka.listener.ConsumerRecordRecoverer;
+
+/**
+ * A {@link ProcessingExceptionHandler} that calls a {@link ConsumerRecordRecoverer}
+ * or uses the native Kafka Streams DLQ and continues.
+ *
+ * @author Loïc Greffier
+ * @since 4.1
+ */
+public class RecoveringProcessingExceptionHandler
+		extends AbstractRecoveringExceptionHandler<ProcessingExceptionHandler.Response>
+		implements ProcessingExceptionHandler {
+
+	/**
+	 * Property name for configuring the recoverer using properties.
+	 */
+	public static final String RECOVERER = "spring.kafka.streams.processing.exception.handler.recoverer";
+
+	/**
+	 * Property name for configuring the native DLQ destination resolver.
+	 */
+	public static final String DLQ_DESTINATION_RESOLVER = "spring.kafka.streams.processing.exception.handler.dlq.destination.resolver";
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Response handleError(ErrorHandlerContext context, Record<?, ?> record, Exception exception) {
+		ConsumerRecord<?, ?> consumerSourceRecord = new ConsumerRecord<>(
+				context.topic(),
+				context.partition(),
+				context.offset(),
+				context.timestamp(),
+				TimestampType.NO_TIMESTAMP_TYPE,
+				context.sourceRawKey().length,
+				context.sourceRawValue().length,
+				context.sourceRawKey(),
+				context.sourceRawValue(),
+				context.headers(),
+				Optional.empty(),
+				Optional.empty());
+
+		return handleErrorCommon(context, consumerSourceRecord, exception);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void configure(Map<String, ?> configs) {
+		configureCommon(configs, DLQ_DESTINATION_RESOLVER, RECOVERER, null);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	protected Response fail() {
+		return Response.fail();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	protected Response resume(List<ProducerRecord<byte[], byte[]>> deadLetterRecords) {
+		return Response.resume(deadLetterRecords);
+	}
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/streams/RecoveringProductionExceptionHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/streams/RecoveringProductionExceptionHandler.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2019-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.streams;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.streams.errors.ErrorHandlerContext;
+import org.apache.kafka.streams.errors.ProductionExceptionHandler;
+
+import org.springframework.kafka.listener.ConsumerRecordRecoverer;
+
+/**
+ * A {@link ProductionExceptionHandler} that calls a {@link ConsumerRecordRecoverer}
+ * or uses the native Kafka Streams DLQ and continues.
+ *
+ * @author Loïc Greffier
+ * @since 4.1
+ */
+public class RecoveringProductionExceptionHandler
+		extends AbstractRecoveringExceptionHandler<ProductionExceptionHandler.Response>
+		implements ProductionExceptionHandler {
+
+	/**
+	 * Property name for configuring the recoverer using properties.
+	 */
+	public static final String RECOVERER = "spring.kafka.streams.production.exception.handler.recoverer";
+
+	/**
+	 * Property name for configuring the native DLQ destination resolver.
+	 */
+	public static final String DLQ_DESTINATION_RESOLVER = "spring.kafka.streams.production.exception.handler.dlq.destination.resolver";
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public Response handleError(ErrorHandlerContext context, ProducerRecord<byte[], byte[]> record, Exception exception) {
+		return handleErrorCommon(context, buildConsumerSourceRecord(context), exception);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@SuppressWarnings("rawtypes")
+	@Override
+	public Response handleSerializationError(ErrorHandlerContext context, ProducerRecord record, Exception exception, SerializationExceptionOrigin origin) {
+		return handleErrorCommon(context, buildConsumerSourceRecord(context), exception);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void configure(Map<String, ?> configs) {
+		configureCommon(configs, DLQ_DESTINATION_RESOLVER, RECOVERER, null);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	protected Response fail() {
+		return Response.fail();
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	protected Response resume(List<ProducerRecord<byte[], byte[]>> deadLetterRecords) {
+		return Response.resume(deadLetterRecords);
+	}
+
+	private ConsumerRecord<?, ?> buildConsumerSourceRecord(ErrorHandlerContext context) {
+		return new ConsumerRecord<>(
+				context.topic(),
+				context.partition(),
+				context.offset(),
+				context.timestamp(),
+				TimestampType.NO_TIMESTAMP_TYPE,
+				context.sourceRawKey().length,
+				context.sourceRawValue().length,
+				context.sourceRawKey(),
+				context.sourceRawValue(),
+				context.headers(),
+				Optional.empty(),
+				Optional.empty());
+	}
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/streams/AbstractRecoveringExceptionHandlerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/streams/AbstractRecoveringExceptionHandlerTests.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2019-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.streams;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.errors.ErrorHandlerContext;
+import org.jspecify.annotations.NonNull;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.kafka.listener.ConsumerRecordRecoverer;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Abstract base test class for {@link RecoveringDeserializationExceptionHandlerTests},
+ * {@link RecoveringProcessingExceptionHandlerTests} and {@link RecoveringProductionExceptionHandlerTests} implementations.
+ *
+ * @param <H> the handler type
+ * @param <R> the handler-specific response type
+ * @author Loïc Greffier
+ * @since 4.1
+ */
+abstract class AbstractRecoveringExceptionHandlerTests<H, R> {
+
+	private final String recovererPropertyKey;
+
+	private final String destinationResolverPropertyKey;
+
+	protected AbstractRecoveringExceptionHandlerTests(String recovererPropertyKey,
+			String destinationResolverPropertyKey) {
+		this.recovererPropertyKey = recovererPropertyKey;
+		this.destinationResolverPropertyKey = destinationResolverPropertyKey;
+	}
+
+	protected abstract H createHandler(Map<String, Object> configs);
+
+	protected abstract R handleError(H handler, ErrorHandlerContext context, Exception exception);
+
+	protected abstract void assertResponseShouldResume(R response);
+
+	protected abstract void assertResponseShouldFail(R response);
+
+	protected abstract void assertResponseShouldContainDeadLetterRecords(R response,
+			ProducerRecord<byte[], byte[]> expectedRecord);
+
+	protected ErrorHandlerContext createMockContext() {
+		ErrorHandlerContext context = mock(ErrorHandlerContext.class);
+		given(context.topic()).willReturn("foo");
+		given(context.partition()).willReturn(0);
+		given(context.offset()).willReturn(0L);
+		given(context.timestamp()).willReturn(0L);
+		given(context.sourceRawKey()).willReturn(new byte[0]);
+		given(context.sourceRawValue()).willReturn(new byte[0]);
+		given(context.headers()).willReturn(new RecordHeaders());
+		return context;
+	}
+
+	@Test
+	void withRecovererAsStringProperty() {
+		Map<String, Object> configs = new HashMap<>();
+		configs.put(this.recovererPropertyKey, Recoverer.class.getName());
+		H handler = createHandler(configs);
+		assertThat(KafkaTestUtils.getPropertyValue(handler, "recoverer")).isInstanceOf(Recoverer.class);
+		assertResponseShouldResume(handleError(handler, createMockContext(), new IllegalArgumentException()));
+		assertResponseShouldFail(handleError(handler, createMockContext(), new IllegalStateException()));
+	}
+
+	@Test
+	void withRecovererAsClassProperty() {
+		Map<String, Object> configs = new HashMap<>();
+		configs.put(this.recovererPropertyKey, Recoverer.class);
+		H handler = createHandler(configs);
+		assertThat(KafkaTestUtils.getPropertyValue(handler, "recoverer")).isInstanceOf(Recoverer.class);
+		assertResponseShouldResume(handleError(handler, createMockContext(), new IllegalArgumentException()));
+		assertResponseShouldFail(handleError(handler, createMockContext(), new IllegalStateException()));
+	}
+
+	@Test
+	void withRecovererAsObjectProperty() {
+		Map<String, Object> configs = new HashMap<>();
+		Recoverer rec = new Recoverer();
+		configs.put(this.recovererPropertyKey, rec);
+		H handler = createHandler(configs);
+		assertThat(KafkaTestUtils.getPropertyValue(handler, "recoverer")).isSameAs(rec);
+		assertResponseShouldResume(handleError(handler, createMockContext(), new IllegalArgumentException()));
+		assertResponseShouldFail(handleError(handler, createMockContext(), new IllegalStateException()));
+	}
+
+	@Test
+	void withNoRecoverer() {
+		H handler = createHandler(new HashMap<>());
+		assertResponseShouldFail(handleError(handler, createMockContext(), new IllegalArgumentException()));
+	}
+
+	@Test
+	void withDestinationResolverAsStringProperty() {
+		Map<String, Object> configs = new HashMap<>();
+		configs.put(this.destinationResolverPropertyKey, KafkaStreamsDlqDestinationResolver.class.getName());
+		H handler = createHandler(configs);
+		ErrorHandlerContext context = createMockContext();
+		R result = handleError(handler, context, new IllegalArgumentException());
+		assertThat(KafkaTestUtils.getPropertyValue(handler, "destinationResolver"))
+				.isInstanceOf(KafkaStreamsDlqDestinationResolver.class);
+		assertResponseShouldResume(result);
+		assertResponseShouldContainDeadLetterRecords(result,
+				new ProducerRecord<>("foo", 1, new byte[0], new byte[0]));
+	}
+
+	@Test
+	void withDestinationResolverAsClassProperty() {
+		Map<String, Object> configs = new HashMap<>();
+		configs.put(this.destinationResolverPropertyKey, KafkaStreamsDlqDestinationResolver.class);
+		H handler = createHandler(configs);
+		ErrorHandlerContext context = createMockContext();
+		R result = handleError(handler, context, new IllegalArgumentException());
+		assertThat(KafkaTestUtils.getPropertyValue(handler, "destinationResolver"))
+				.isInstanceOf(KafkaStreamsDlqDestinationResolver.class);
+		assertResponseShouldResume(result);
+		assertResponseShouldContainDeadLetterRecords(result,
+				new ProducerRecord<>("foo", 1, new byte[0], new byte[0]));
+	}
+
+	@Test
+	void withDestinationResolverAsObjectProperty() {
+		Map<String, Object> configs = new HashMap<>();
+		KafkaStreamsDlqDestinationResolver resolver = new KafkaStreamsDlqDestinationResolver();
+		configs.put(this.destinationResolverPropertyKey, resolver);
+		H handler = createHandler(configs);
+		ErrorHandlerContext context = createMockContext();
+		R result = handleError(handler, context, new IllegalArgumentException());
+		assertThat(KafkaTestUtils.getPropertyValue(handler, "destinationResolver")).isSameAs(resolver);
+		assertResponseShouldResume(result);
+		assertResponseShouldContainDeadLetterRecords(result,
+				new ProducerRecord<>("foo", 1, new byte[0], new byte[0]));
+	}
+
+	@Test
+	void withDeadLetterQueueTopic() {
+		Map<String, Object> configs = new HashMap<>();
+		configs.put(StreamsConfig.ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG, "foo");
+		H handler = createHandler(configs);
+		ErrorHandlerContext context = createMockContext();
+		R result = handleError(handler, context, new IllegalArgumentException());
+		assertResponseShouldResume(result);
+		assertResponseShouldContainDeadLetterRecords(result,
+				new ProducerRecord<>("foo", null, new byte[0], new byte[0]));
+	}
+
+	@Test
+	void withNullDeadLetterQueueTopicShouldFail() {
+		Map<String, Object> configs = new HashMap<>();
+		configs.put(StreamsConfig.ERRORS_DEAD_LETTER_QUEUE_TOPIC_NAME_CONFIG, null);
+		H handler = createHandler(configs);
+		assertResponseShouldFail(handleError(handler, createMockContext(), new IllegalArgumentException()));
+	}
+
+	public static class Recoverer implements ConsumerRecordRecoverer {
+
+		@Override
+		public void accept(ConsumerRecord<?, ?> record, Exception exception) {
+			if (exception instanceof IllegalStateException) {
+				throw new IllegalStateException("recovery failed test");
+			}
+		}
+
+	}
+
+	public static class KafkaStreamsDlqDestinationResolver implements KafkaStreamsDeadLetterDestinationResolver {
+
+		@Override
+		public @NonNull TopicPartition resolve(@NonNull ErrorHandlerContext errorHandlerContext, @NonNull ConsumerRecord<?, ?> record, @NonNull Exception exception) {
+			return new TopicPartition("foo", 1);
+		}
+
+	}
+
+}
+

--- a/spring-kafka/src/test/java/org/springframework/kafka/streams/RecoveringDeserializationExceptionHandlerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/streams/RecoveringDeserializationExceptionHandlerTests.java
@@ -24,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
@@ -33,8 +34,7 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
-import org.apache.kafka.streams.errors.DeserializationExceptionHandler.Response;
-import org.apache.kafka.streams.errors.DeserializationExceptionHandler.Result;
+import org.apache.kafka.streams.errors.DeserializationExceptionHandler;
 import org.apache.kafka.streams.errors.ErrorHandlerContext;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.processor.WallclockTimestampExtractor;
@@ -58,7 +58,6 @@ import org.springframework.kafka.core.KafkaOperations;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
-import org.springframework.kafka.listener.ConsumerRecordRecoverer;
 import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.test.EmbeddedKafkaBroker;
@@ -79,7 +78,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringJUnitConfig
 @DirtiesContext
 @EmbeddedKafka(partitions = 1, topics = { "recoverer1", "recoverer2", "recovererDLQ" })
-public class RecoveringDeserializationExceptionHandlerTests {
+public class RecoveringDeserializationExceptionHandlerTests
+		extends AbstractRecoveringExceptionHandlerTests<RecoveringDeserializationExceptionHandler,
+		DeserializationExceptionHandler.Response> {
 
 	@Autowired
 	private KafkaOperations<byte[], byte[]> kafkaTemplate;
@@ -87,52 +88,87 @@ public class RecoveringDeserializationExceptionHandlerTests {
 	@Autowired
 	private CompletableFuture<ConsumerRecord<byte[], byte[]>> resultFuture;
 
-	@Test
-	void viaStringProperty() {
+	RecoveringDeserializationExceptionHandlerTests() {
+		super(RecoveringDeserializationExceptionHandler.RECOVERER,
+				RecoveringDeserializationExceptionHandler.DLQ_DESTINATION_RESOLVER);
+	}
+
+	@Override
+	protected RecoveringDeserializationExceptionHandler createHandler(Map<String, Object> configs) {
 		RecoveringDeserializationExceptionHandler handler = new RecoveringDeserializationExceptionHandler();
-		Map<String, Object> configs = new HashMap<String, Object>();
-		configs.put(RecoveringDeserializationExceptionHandler.KSTREAM_DESERIALIZATION_RECOVERER,
-				Recoverer.class.getName());
 		handler.configure(configs);
-		assertThat(KafkaTestUtils.getPropertyValue(handler, "recoverer")).isInstanceOf(Recoverer.class);
-		assertThat(handler.handleError((ErrorHandlerContext) null, new ConsumerRecord<>("foo", 0, 0, null, null),
-				new IllegalArgumentException())).extracting(Response::result).isEqualTo(Result.RESUME);
-		assertThat(handler.handleError((ErrorHandlerContext) null, new ConsumerRecord<>("foo", 0, 0, null, null),
-				new IllegalStateException())).extracting(Response::result).isEqualTo(Result.FAIL);
+		return handler;
+	}
+
+	@Override
+	protected DeserializationExceptionHandler.Response handleError(
+			RecoveringDeserializationExceptionHandler handler, ErrorHandlerContext context, Exception exception) {
+		return handler.handleError(context,
+				new ConsumerRecord<>(context.topic(), context.partition(), context.offset(), null, null), exception);
+	}
+
+	@Override
+	protected void assertResponseShouldResume(DeserializationExceptionHandler.Response response) {
+		assertThat(response.result()).isEqualTo(DeserializationExceptionHandler.Result.RESUME);
+	}
+
+	@Override
+	protected void assertResponseShouldFail(DeserializationExceptionHandler.Response response) {
+		assertThat(response.result()).isEqualTo(DeserializationExceptionHandler.Result.FAIL);
+	}
+
+	@Override
+	protected void assertResponseShouldContainDeadLetterRecords(
+			DeserializationExceptionHandler.Response response, ProducerRecord<byte[], byte[]> expectedRecord) {
+		assertThat(response.deadLetterQueueRecords()).hasSize(1).first()
+				.satisfies(record -> {
+					assertThat(record.topic()).isEqualTo(expectedRecord.topic());
+					assertThat(record.partition()).isEqualTo(expectedRecord.partition());
+					assertThat(record.key()).isEqualTo(expectedRecord.key());
+					assertThat(record.value()).isEqualTo(expectedRecord.value());
+					assertThat(record.headers().lastHeader(KafkaHeaders.DLT_EXCEPTION_FQCN)).isNotNull();
+					assertThat(record.headers().lastHeader(KafkaHeaders.DLT_EXCEPTION_CAUSE_FQCN)).isNotNull();
+					assertThat(record.headers().lastHeader(KafkaHeaders.DLT_EXCEPTION_STACKTRACE)).isNotNull();
+					assertThat(record.headers().lastHeader(KafkaHeaders.DLT_ORIGINAL_TOPIC)).isNotNull();
+					assertThat(record.headers().lastHeader(KafkaHeaders.DLT_ORIGINAL_PARTITION)).isNotNull();
+					assertThat(record.headers().lastHeader(KafkaHeaders.DLT_ORIGINAL_OFFSET)).isNotNull();
+					assertThat(record.headers().lastHeader(KafkaHeaders.DLT_ORIGINAL_TIMESTAMP)).isNotNull();
+					assertThat(record.headers().lastHeader(KafkaHeaders.DLT_ORIGINAL_TIMESTAMP_TYPE)).isNotNull();
+				});
 	}
 
 	@Test
-	void viaClassProperty() {
-		RecoveringDeserializationExceptionHandler handler = new RecoveringDeserializationExceptionHandler();
-		Map<String, Object> configs = new HashMap<String, Object>();
+	@SuppressWarnings("removal")
+	void withLegacyRecovererKeyAsStringProperty() {
+		Map<String, Object> configs = new HashMap<>();
+		configs.put(RecoveringDeserializationExceptionHandler.KSTREAM_DESERIALIZATION_RECOVERER, Recoverer.class.getName());
+		RecoveringDeserializationExceptionHandler handler = createHandler(configs);
+		assertThat(KafkaTestUtils.getPropertyValue(handler, "recoverer")).isInstanceOf(Recoverer.class);
+		assertResponseShouldResume(handleError(handler, createMockContext(), new IllegalArgumentException()));
+		assertResponseShouldFail(handleError(handler, createMockContext(), new IllegalStateException()));
+	}
+
+	@Test
+	@SuppressWarnings("removal")
+	void withLegacyRecovererKeyAsClassProperty() {
+		Map<String, Object> configs = new HashMap<>();
 		configs.put(RecoveringDeserializationExceptionHandler.KSTREAM_DESERIALIZATION_RECOVERER, Recoverer.class);
-		handler.configure(configs);
+		RecoveringDeserializationExceptionHandler handler = createHandler(configs);
 		assertThat(KafkaTestUtils.getPropertyValue(handler, "recoverer")).isInstanceOf(Recoverer.class);
-		assertThat(handler.handleError((ErrorHandlerContext) null, new ConsumerRecord<>("foo", 0, 0, null, null),
-				new IllegalArgumentException())).extracting(Response::result).isEqualTo(Result.RESUME);
-		assertThat(handler.handleError((ErrorHandlerContext) null, new ConsumerRecord<>("foo", 0, 0, null, null),
-				new IllegalStateException())).extracting(Response::result).isEqualTo(Result.FAIL);
+		assertResponseShouldResume(handleError(handler, createMockContext(), new IllegalArgumentException()));
+		assertResponseShouldFail(handleError(handler, createMockContext(), new IllegalStateException()));
 	}
 
 	@Test
-	void viaObjectProperty() {
-		RecoveringDeserializationExceptionHandler handler = new RecoveringDeserializationExceptionHandler();
+	@SuppressWarnings("removal")
+	void withLegacyRecovererKeyAsObjectProperty() {
 		Map<String, Object> configs = new HashMap<>();
 		Recoverer rec = new Recoverer();
 		configs.put(RecoveringDeserializationExceptionHandler.KSTREAM_DESERIALIZATION_RECOVERER, rec);
-		handler.configure(configs);
+		RecoveringDeserializationExceptionHandler handler = createHandler(configs);
 		assertThat(KafkaTestUtils.getPropertyValue(handler, "recoverer")).isSameAs(rec);
-		assertThat(handler.handleError((ErrorHandlerContext) null, new ConsumerRecord<>("foo", 0, 0, null, null),
-				new IllegalArgumentException())).extracting(Response::result).isEqualTo(Result.RESUME);
-		assertThat(handler.handleError((ErrorHandlerContext) null, new ConsumerRecord<>("foo", 0, 0, null, null),
-				new IllegalStateException())).extracting(Response::result).isEqualTo(Result.FAIL);
-	}
-
-	@Test
-	void withNoRecoverer() {
-		RecoveringDeserializationExceptionHandler handler = new RecoveringDeserializationExceptionHandler();
-		assertThat(handler.handleError((ErrorHandlerContext) null, new ConsumerRecord<>("foo", 0, 0, null, null),
-				new IllegalArgumentException())).extracting(Response::result).isEqualTo(Result.FAIL);
+		assertResponseShouldResume(handleError(handler, createMockContext(), new IllegalArgumentException()));
+		assertResponseShouldFail(handleError(handler, createMockContext(), new IllegalStateException()));
 	}
 
 	@Test
@@ -145,17 +181,6 @@ public class RecoveringDeserializationExceptionHandlerTests {
 		assertThat(record.headers().lastHeader(KafkaHeaders.DLT_EXCEPTION_STACKTRACE)).isNotNull();
 	}
 
-	public static class Recoverer implements ConsumerRecordRecoverer {
-
-		@Override
-		public void accept(ConsumerRecord<?, ?> record, Exception exception) {
-			if (exception instanceof IllegalStateException) {
-				throw new IllegalStateException("recovery failed test");
-			}
-		}
-
-	}
-
 	@Configuration
 	@EnableKafka
 	@EnableKafkaStreams
@@ -163,9 +188,6 @@ public class RecoveringDeserializationExceptionHandlerTests {
 
 		@Value("${" + EmbeddedKafkaBroker.SPRING_EMBEDDED_KAFKA_BROKERS + "}")
 		private String brokerAddresses;
-
-		@Value("${streaming.topic.two}")
-		private String streamingTopic2;
 
 		@Bean
 		public ProducerFactory<byte[], byte[]> producerFactory() {
@@ -197,7 +219,7 @@ public class RecoveringDeserializationExceptionHandlerTests {
 			props.put(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, "100");
 			props.put(StreamsConfig.DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG,
 					RecoveringDeserializationExceptionHandler.class);
-			props.put(RecoveringDeserializationExceptionHandler.KSTREAM_DESERIALIZATION_RECOVERER, recoverer());
+			props.put(RecoveringDeserializationExceptionHandler.RECOVERER, recoverer());
 			return new KafkaStreamsConfiguration(props);
 		}
 
@@ -216,7 +238,8 @@ public class RecoveringDeserializationExceptionHandlerTests {
 
 		@Bean
 		public Map<String, Object> consumerConfigs() {
-			Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(this.brokerAddresses, "recovererGroup", false);
+			Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(this.brokerAddresses, "recovererGroup",
+					false);
 			consumerProps.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
 			consumerProps.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class);
 			return consumerProps;
@@ -229,7 +252,7 @@ public class RecoveringDeserializationExceptionHandlerTests {
 
 		@Bean
 		public KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<byte[], byte[]>>
-					kafkaListenerContainerFactory() {
+				kafkaListenerContainerFactory() {
 
 			ConcurrentKafkaListenerContainerFactory<byte[], byte[]> factory =
 					new ConcurrentKafkaListenerContainerFactory<>();

--- a/spring-kafka/src/test/java/org/springframework/kafka/streams/RecoveringProcessingExceptionHandlerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/streams/RecoveringProcessingExceptionHandlerTests.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.streams;
+
+import java.util.Map;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.streams.errors.ErrorHandlerContext;
+import org.apache.kafka.streams.errors.ProcessingExceptionHandler;
+import org.apache.kafka.streams.processor.api.Record;
+
+import org.springframework.kafka.support.KafkaHeaders;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Loïc Greffier
+ * @since 4.1
+ */
+class RecoveringProcessingExceptionHandlerTests
+		extends AbstractRecoveringExceptionHandlerTests<RecoveringProcessingExceptionHandler,
+		ProcessingExceptionHandler.Response> {
+
+	RecoveringProcessingExceptionHandlerTests() {
+		super(RecoveringProcessingExceptionHandler.RECOVERER,
+				RecoveringProcessingExceptionHandler.DLQ_DESTINATION_RESOLVER);
+	}
+
+	@Override
+	protected RecoveringProcessingExceptionHandler createHandler(Map<String, Object> configs) {
+		RecoveringProcessingExceptionHandler handler = new RecoveringProcessingExceptionHandler();
+		handler.configure(configs);
+		return handler;
+	}
+
+	@Override
+	protected ProcessingExceptionHandler.Response handleError(
+			RecoveringProcessingExceptionHandler handler, ErrorHandlerContext context, Exception exception) {
+		return handler.handleError(context,
+				new Record<>(context.sourceRawKey(), context.sourceRawValue(), context.timestamp()), exception);
+	}
+
+	@Override
+	protected void assertResponseShouldResume(ProcessingExceptionHandler.Response response) {
+		assertThat(response.result()).isEqualTo(ProcessingExceptionHandler.Result.RESUME);
+	}
+
+	@Override
+	protected void assertResponseShouldFail(ProcessingExceptionHandler.Response response) {
+		assertThat(response.result()).isEqualTo(ProcessingExceptionHandler.Result.FAIL);
+	}
+
+	@Override
+	protected void assertResponseShouldContainDeadLetterRecords(
+			ProcessingExceptionHandler.Response response, ProducerRecord<byte[], byte[]> expectedRecord) {
+		assertThat(response.deadLetterQueueRecords()).hasSize(1).first()
+				.satisfies(record -> {
+					assertThat(record.topic()).isEqualTo(expectedRecord.topic());
+					assertThat(record.partition()).isEqualTo(expectedRecord.partition());
+					assertThat(record.key()).isEqualTo(expectedRecord.key());
+					assertThat(record.value()).isEqualTo(expectedRecord.value());
+					assertThat(record.headers().lastHeader(KafkaHeaders.DLT_EXCEPTION_STACKTRACE)).isNotNull();
+					assertThat(record.headers().lastHeader(KafkaHeaders.DLT_EXCEPTION_STACKTRACE).value()).isNotNull();
+				});
+	}
+
+}
+

--- a/spring-kafka/src/test/java/org/springframework/kafka/streams/RecoveringProductionExceptionHandlerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/streams/RecoveringProductionExceptionHandlerTests.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2019-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.streams;
+
+import java.util.Map;
+
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.streams.errors.ErrorHandlerContext;
+import org.apache.kafka.streams.errors.ProductionExceptionHandler;
+
+import org.springframework.kafka.support.KafkaHeaders;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Loïc Greffier
+ * @since 4.1
+ */
+class RecoveringProductionExceptionHandlerTests
+		extends AbstractRecoveringExceptionHandlerTests<RecoveringProductionExceptionHandler,
+		ProductionExceptionHandler.Response> {
+
+	RecoveringProductionExceptionHandlerTests() {
+		super(RecoveringProductionExceptionHandler.RECOVERER,
+				RecoveringProductionExceptionHandler.DLQ_DESTINATION_RESOLVER);
+	}
+
+	@Override
+	protected RecoveringProductionExceptionHandler createHandler(Map<String, Object> configs) {
+		RecoveringProductionExceptionHandler handler = new RecoveringProductionExceptionHandler();
+		handler.configure(configs);
+		return handler;
+	}
+
+	@Override
+	protected ProductionExceptionHandler.Response handleError(
+			RecoveringProductionExceptionHandler handler, ErrorHandlerContext context, Exception exception) {
+		return handler.handleError(context,
+				new ProducerRecord<>(context.topic(), context.partition(), context.sourceRawKey(),
+						context.sourceRawValue()),
+				exception);
+	}
+
+	@Override
+	protected void assertResponseShouldResume(ProductionExceptionHandler.Response response) {
+		assertThat(response.result()).isEqualTo(ProductionExceptionHandler.Result.RESUME);
+	}
+
+	@Override
+	protected void assertResponseShouldFail(ProductionExceptionHandler.Response response) {
+		assertThat(response.result()).isEqualTo(ProductionExceptionHandler.Result.FAIL);
+	}
+
+	@Override
+	protected void assertResponseShouldContainDeadLetterRecords(
+			ProductionExceptionHandler.Response response, ProducerRecord<byte[], byte[]> expectedRecord) {
+		assertThat(response.deadLetterQueueRecords()).hasSize(1).first()
+				.satisfies(record -> {
+					assertThat(record.topic()).isEqualTo(expectedRecord.topic());
+					assertThat(record.partition()).isEqualTo(expectedRecord.partition());
+					assertThat(record.key()).isEqualTo(expectedRecord.key());
+					assertThat(record.value()).isEqualTo(expectedRecord.value());
+					assertThat(record.headers().lastHeader(KafkaHeaders.DLT_EXCEPTION_STACKTRACE)).isNotNull();
+					assertThat(record.headers().lastHeader(KafkaHeaders.DLT_EXCEPTION_STACKTRACE).value()).isNotNull();
+				});
+	}
+
+}
+


### PR DESCRIPTION
The PR addresses the 4 points mentioned in issue #4328:

- Make the `RecoveringDeserializationExceptionHandler` leverage the new Kafka Streams native DLQ introduced by [KIP-1034](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1034%3A+Dead+letter+queue+in+Kafka+Streams).
- Introduce a new `NativeDeadLetterDestinationResolver` as an alternative to resolve the Kafka Streams native DLQ destination.
- Make the Kafka Streams native DLQ use the Spring Kafka DLT headers.
- Introduce new `RecoveringProcessingExceptionHandler` and `RecoveringProductionExceptionHandler`.

To answer these points:

- New **DeadLetterRecordManager** class. I've introduced a new `DeadLetterRecordManager` class as a common place to build DLT headers, so the utilities for building headers can be leveraged by both the `DeadLetterPublishingRecoverer` and exception handlers. I preferred this over a static utility class because of the number of parameters. One instance per handler and for the `DeadLetterPublishingRecoverer`.

- New `RecoveringProcessingExceptionHandler` and `RecoveringProductionExceptionHandler` implementations with the same recovery logic as `RecoveringDeserializationExceptionHandler`. I've introduced a new `AbstractRecoveringExceptionHandler` that holds the commons for all handlers.

- New **NativeDeadLetterDestinationResolver** interface. Allow users to define a native DLQ routing logic based on 3 given parameters: the `ErrorHandlerContext`, the source record as `ConsumerRecord` and the exception. All handlers leverage it. For now, it is loaded in the same way as the `DeadLetterPublishingRecoverer` was.

- I’ve updated the tests to cover the 3 recovering handler implementations. I introduced an `AbstractRecoveringExceptionHandlerTests` class that contains commons tests. Child classes override some methods to create the corresponding handler and assert the related handling response.

Concerns:

- The `HeaderNames` class is still located within the `DeadLetterPublishingRecoverer` class. It might be better to move it to `DeadLetterRecordManager`, but this would be a breaking change.

Closes #4328