### PR TITLE
GH-4355 Add @Nullable for ProducerFactory & ConsumerFactory interfaces

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/ConsumerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/ConsumerFactory.java
@@ -34,7 +34,7 @@ import org.jspecify.annotations.Nullable;
  * @author Gary Russell
  * @author Artem Bilan
  */
-public interface ConsumerFactory<K, V> {
+public interface ConsumerFactory<K, V extends @Nullable Object> {
 
 	/**
 	 * Create a consumer with the group id and client id as configured in the properties.

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/ProducerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/ProducerFactory.java
@@ -36,7 +36,7 @@ import org.jspecify.annotations.Nullable;
  * @author Thomas Strauß
  * @author  Kwon YongHyun
  */
-public interface ProducerFactory<K, V> {
+public interface ProducerFactory<K, V extends @Nullable Object> {
 
 	/**
 	 * The default close timeout duration as 30 seconds.


### PR DESCRIPTION
Fix issue for KafkaRecords null not being allowed for kotlin due to missing JSpecify `@Nullable` 
