### PR TITLE
GH-4369: Pass explicit acknowledgment mode as consumer override property

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultShareConsumerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultShareConsumerFactory.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
@@ -138,22 +139,43 @@ public class DefaultShareConsumerFactory<K, V> extends KafkaResourceFactory
 	 */
 	@Override
 	public ShareConsumer<K, V> createShareConsumer(@Nullable String groupId, @Nullable String clientId) {
-		return createRawConsumer(groupId, clientId);
+		return createRawConsumer(groupId, clientId, null);
+	}
+
+	/**
+	 * Create a share consumer with the provided group id, client id, and additional property overrides.
+	 * @param groupId the group id (maybe null).
+	 * @param clientId the client id.
+	 * @param overrideProperties additional properties to apply (maybe null).
+	 * @return the share consumer.
+	 */
+	@Override
+	public ShareConsumer<K, V> createShareConsumer(@Nullable String groupId,
+			@Nullable String clientId,
+			@Nullable Properties overrideProperties) {
+		return createRawConsumer(groupId, clientId, overrideProperties);
 	}
 
 	/**
 	 * Actually create the consumer.
 	 * @param groupId the group id (maybe null).
 	 * @param clientId the client id.
+	 * @param overrideProperties additional properties to apply (maybe null).
 	 * @return the share consumer.
 	 */
-	protected ShareConsumer<K, V> createRawConsumer(@Nullable String groupId, @Nullable String clientId) {
+	protected ShareConsumer<K, V> createRawConsumer(
+			@Nullable String groupId,
+			@Nullable String clientId,
+			@Nullable Properties overrideProperties) {
 		Map<String, Object> consumerProperties = new HashMap<>(this.configs);
 		if (groupId != null) {
 			consumerProperties.put("group.id", groupId);
 		}
 		if (clientId != null) {
 			consumerProperties.put("client.id", clientId);
+		}
+		if (overrideProperties != null) {
+			overrideProperties.forEach((k, v) -> consumerProperties.put((String) k, v));
 		}
 		return new ExtendedShareConsumer(consumerProperties);
 	}

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/ShareConsumerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/ShareConsumerFactory.java
@@ -19,6 +19,7 @@ package org.springframework.kafka.core;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 import org.apache.kafka.clients.consumer.ShareConsumer;
 import org.apache.kafka.common.serialization.Deserializer;
@@ -42,6 +43,21 @@ public interface ShareConsumerFactory<K, V> {
 	 * @return the share consumer.
 	 */
 	ShareConsumer<K, V> createShareConsumer(@Nullable String groupId, @Nullable String clientId);
+
+	/**
+	 * Create a share consumer with the provided group id, client id,
+	 * and additional property overrides.
+	 * These overrides take precedence over the factory's default configuration.
+	 * @param groupId the group id (maybe null).
+	 * @param clientId the client id.
+	 * @param overrideProperties additional properties to apply (maybe null).
+	 * @return the share consumer.
+	 */
+	default ShareConsumer<K, V> createShareConsumer(@Nullable String groupId,
+			@Nullable String clientId,
+			@Nullable Properties overrideProperties) {
+		return createShareConsumer(groupId, clientId);
+	}
 
 	/**
 	 * Return an unmodifiable reference to the configuration map for this factory.

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ShareKafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ShareKafkaMessageListenerContainer.java
@@ -22,6 +22,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -300,26 +302,30 @@ public class ShareKafkaMessageListenerContainer<K, V>
 		private final long ackTimeoutMs;
 
 		ShareListenerConsumer(GenericMessageListener<?> listener, String consumerClientId) {
-			this.consumer = ShareKafkaMessageListenerContainer.this.shareConsumerFactory.createShareConsumer(
-					ShareKafkaMessageListenerContainer.this.getGroupId(),
-					consumerClientId);
 
-			this.genericListener = listener;
-			this.clientId = consumerClientId;
 			ContainerProperties containerProperties = getContainerProperties();
 
-			// Configure acknowledgment mode
+			// Configure acknowledgment mode before factory
 			this.isExplicitMode = containerProperties.isExplicitShareAcknowledgment();
 			this.ackTimeoutMs = containerProperties.getShareAcknowledgmentTimeout().toMillis();
 
-			// Configure consumer properties based on acknowledgment mode
+			// add properties to configure consumer for explicit acknowledgment mode if needed
+			Properties overrides = null;
 			if (this.isExplicitMode) {
-				// Apply explicit mode configuration to consumer
-				// Note: This should ideally be done during consumer creation in the factory
+				overrides = new Properties();
+				overrides.put("share.acknowledgement.mode", "explicit");
 				this.logger.info("Share consumer configured for explicit acknowledgment mode");
 			}
 
-			this.consumer.subscribe(Arrays.asList(containerProperties.getTopics()));
+			this.consumer = ShareKafkaMessageListenerContainer.this.shareConsumerFactory.createShareConsumer(
+					ShareKafkaMessageListenerContainer.this.getGroupId(),
+					consumerClientId,
+					overrides);
+
+			this.genericListener = listener;
+			this.clientId = consumerClientId;
+
+			this.consumer.subscribe(Arrays.asList(Objects.requireNonNull(containerProperties.getTopics())));
 		}
 
 		@Nullable

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultShareConsumerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultShareConsumerFactoryTests.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -124,6 +125,35 @@ class DefaultShareConsumerFactoryTests {
 		configs.put("value.deserializer", StringDeserializer.class);
 		DefaultShareConsumerFactory<String, String> factory = new DefaultShareConsumerFactory<>(configs);
 		ShareConsumer<String, String> shareConsumer = factory.createShareConsumer("group", "myapp-client-id");
+		assertThat(shareConsumer).isNotNull();
+	}
+
+	@Test
+	void shouldCreateShareConsumerWithOverrideProperties() {
+		Map<String, Object> configs = new HashMap<>();
+		configs.put("bootstrap.servers", "localhost:9092");
+		configs.put("key.deserializer", StringDeserializer.class);
+		configs.put("value.deserializer", StringDeserializer.class);
+		DefaultShareConsumerFactory<String, String> factory = new DefaultShareConsumerFactory<>(configs);
+
+		Properties overrides = new Properties();
+		overrides.put("share.acknowledgement.mode", "explicit");
+
+		ShareConsumer<String, String> shareConsumer =
+				factory.createShareConsumer("group", "myapp-client-id", overrides);
+		assertThat(shareConsumer).isNotNull();
+	}
+
+	@Test
+	void shouldCreateShareConsumerWithNullOverrideProperties() {
+		Map<String, Object> configs = new HashMap<>();
+		configs.put("bootstrap.servers", "localhost:9092");
+		configs.put("key.deserializer", StringDeserializer.class);
+		configs.put("value.deserializer", StringDeserializer.class);
+		DefaultShareConsumerFactory<String, String> factory = new DefaultShareConsumerFactory<>(configs);
+
+		ShareConsumer<String, String> shareConsumer =
+				factory.createShareConsumer("group", "myapp-client-id", null);
 		assertThat(shareConsumer).isNotNull();
 	}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ShareKafkaMessageListenerContainerIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ShareKafkaMessageListenerContainerIntegrationTests.java
@@ -145,7 +145,7 @@ class ShareKafkaMessageListenerContainerIntegrationTests {
 		setShareAutoOffsetResetEarliest(bootstrapServers, groupId);
 		produceTestRecords(bootstrapServers, topic, 3);
 
-		Map<String, Object> consumerProps = createConsumerProps(bootstrapServers, groupId, true);
+		Map<String, Object> consumerProps = createConsumerProps(bootstrapServers, groupId);
 		DefaultShareConsumerFactory<String, String> factory = new DefaultShareConsumerFactory<>(consumerProps);
 
 		ContainerProperties containerProps = new ContainerProperties(topic);
@@ -195,7 +195,7 @@ class ShareKafkaMessageListenerContainerIntegrationTests {
 		setShareAutoOffsetResetEarliest(bootstrapServers, groupId);
 		produceTestRecords(bootstrapServers, topic, 3);
 
-		Map<String, Object> consumerProps = createConsumerProps(bootstrapServers, groupId, false);
+		Map<String, Object> consumerProps = createConsumerProps(bootstrapServers, groupId);
 		DefaultShareConsumerFactory<String, String> factory = new DefaultShareConsumerFactory<>(consumerProps);
 
 		ContainerProperties containerProps = new ContainerProperties(topic);
@@ -237,7 +237,7 @@ class ShareKafkaMessageListenerContainerIntegrationTests {
 		setShareAutoOffsetResetEarliest(bootstrapServers, groupId);
 		produceTestRecords(bootstrapServers, topic, 3);
 
-		Map<String, Object> consumerProps = createConsumerProps(bootstrapServers, groupId, true);
+		Map<String, Object> consumerProps = createConsumerProps(bootstrapServers, groupId);
 		DefaultShareConsumerFactory<String, String> factory = new DefaultShareConsumerFactory<>(consumerProps);
 
 		ContainerProperties containerProps = new ContainerProperties(topic);
@@ -317,7 +317,7 @@ class ShareKafkaMessageListenerContainerIntegrationTests {
 
 		setShareAutoOffsetResetEarliest(bootstrapServers, groupId);
 
-		Map<String, Object> consumerProps = createConsumerProps(bootstrapServers, groupId, true);
+		Map<String, Object> consumerProps = createConsumerProps(bootstrapServers, groupId);
 		DefaultShareConsumerFactory<String, String> factory = new DefaultShareConsumerFactory<>(consumerProps);
 
 		ContainerProperties containerProps = new ContainerProperties(topic);
@@ -408,7 +408,7 @@ class ShareKafkaMessageListenerContainerIntegrationTests {
 		setShareAutoOffsetResetEarliest(bootstrapServers, groupId);
 		produceTestRecords(bootstrapServers, topic, 5);
 
-		Map<String, Object> consumerProps = createConsumerProps(bootstrapServers, groupId, true);
+		Map<String, Object> consumerProps = createConsumerProps(bootstrapServers, groupId);
 		DefaultShareConsumerFactory<String, String> factory = new DefaultShareConsumerFactory<>(consumerProps);
 
 		ContainerProperties containerProps = new ContainerProperties(topic);
@@ -459,7 +459,7 @@ class ShareKafkaMessageListenerContainerIntegrationTests {
 		setShareAutoOffsetResetEarliest(bootstrapServers, groupId);
 		produceTestRecords(bootstrapServers, topic, 1);
 
-		Map<String, Object> consumerProps = createConsumerProps(bootstrapServers, groupId, true);
+		Map<String, Object> consumerProps = createConsumerProps(bootstrapServers, groupId);
 		DefaultShareConsumerFactory<String, String> factory = new DefaultShareConsumerFactory<>(consumerProps);
 
 		ContainerProperties containerProps = new ContainerProperties(topic);
@@ -516,7 +516,7 @@ class ShareKafkaMessageListenerContainerIntegrationTests {
 			producer.send(new ProducerRecord<>(topic, "good", goodRecordValue.getBytes(StandardCharsets.UTF_8))).get();
 		}
 
-		Map<String, Object> consumerProps = createConsumerProps(bootstrapServers, groupId, false);
+		Map<String, Object> consumerProps = createConsumerProps(bootstrapServers, groupId);
 		DefaultShareConsumerFactory<String, String> factory = new DefaultShareConsumerFactory<>(consumerProps);
 
 		CountDownLatch twoGoodRecordsLatch = new CountDownLatch(2);
@@ -555,7 +555,7 @@ class ShareKafkaMessageListenerContainerIntegrationTests {
 			producer.send(new ProducerRecord<>(topic, "reject", "reject-value")).get();
 		}
 
-		Map<String, Object> consumerProps = createConsumerProps(bootstrapServers, groupId, true);
+		Map<String, Object> consumerProps = createConsumerProps(bootstrapServers, groupId);
 		DefaultShareConsumerFactory<String, String> factory = new DefaultShareConsumerFactory<>(consumerProps);
 
 		ContainerProperties containerProps = new ContainerProperties(topic);
@@ -627,7 +627,7 @@ class ShareKafkaMessageListenerContainerIntegrationTests {
 		setShareAutoOffsetResetEarliest(bootstrapServers, groupId);
 		produceTestRecords(bootstrapServers, topic, 1);
 
-		Map<String, Object> consumerProps = createConsumerProps(bootstrapServers, groupId, false);
+		Map<String, Object> consumerProps = createConsumerProps(bootstrapServers, groupId);
 		DefaultShareConsumerFactory<String, String> factory = new DefaultShareConsumerFactory<>(consumerProps);
 
 		// Test 1: Basic MessageListener
@@ -648,7 +648,7 @@ class ShareKafkaMessageListenerContainerIntegrationTests {
 
 		setShareAutoOffsetResetEarliest(bootstrapServers, groupId);
 
-		Map<String, Object> consumerProps = createConsumerProps(bootstrapServers, groupId, true);
+		Map<String, Object> consumerProps = createConsumerProps(bootstrapServers, groupId);
 		DefaultShareConsumerFactory<String, String> factory = new DefaultShareConsumerFactory<>(consumerProps);
 
 		ContainerProperties containerProps = new ContainerProperties(topic);
@@ -703,7 +703,7 @@ class ShareKafkaMessageListenerContainerIntegrationTests {
 		setShareAutoOffsetResetEarliest(bootstrapServers, groupId);
 		produceTestRecords(bootstrapServers, topic, 1);
 
-		Map<String, Object> consumerProps = createConsumerProps(bootstrapServers, groupId, true);
+		Map<String, Object> consumerProps = createConsumerProps(bootstrapServers, groupId);
 		DefaultShareConsumerFactory<String, String> factory = new DefaultShareConsumerFactory<>(consumerProps);
 
 		ContainerProperties containerProps = new ContainerProperties(topic);
@@ -775,7 +775,7 @@ class ShareKafkaMessageListenerContainerIntegrationTests {
 		setShareAutoOffsetResetEarliest(bootstrapServers, groupId);
 		produceTestRecords(bootstrapServers, topic, 1);
 
-		Map<String, Object> consumerProps = createConsumerProps(bootstrapServers, groupId, true);
+		Map<String, Object> consumerProps = createConsumerProps(bootstrapServers, groupId);
 		DefaultShareConsumerFactory<String, String> factory = new DefaultShareConsumerFactory<>(consumerProps);
 
 		ContainerProperties containerProps = new ContainerProperties(topic);
@@ -823,7 +823,7 @@ class ShareKafkaMessageListenerContainerIntegrationTests {
 		setShareAutoOffsetResetEarliest(bootstrapServers, groupId);
 		produceTestRecords(bootstrapServers, topic, 1);
 
-		Map<String, Object> consumerProps = createConsumerProps(bootstrapServers, groupId, true);
+		Map<String, Object> consumerProps = createConsumerProps(bootstrapServers, groupId);
 		DefaultShareConsumerFactory<String, String> factory = new DefaultShareConsumerFactory<>(consumerProps);
 
 		ContainerProperties containerProps = new ContainerProperties(topic);
@@ -956,15 +956,12 @@ class ShareKafkaMessageListenerContainerIntegrationTests {
 	}
 
 	// Utility methods
-	private static Map<String, Object> createConsumerProps(String bootstrapServers, String groupId, boolean explicit) {
+	private static Map<String, Object> createConsumerProps(String bootstrapServers, String groupId) {
 		Map<String, Object> props = new HashMap<>();
 		props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
 		props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
 		props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
 		props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-		if (explicit) {
-			props.put("share.acknowledgement.mode", "explicit");
-		}
 		return props;
 	}
 
@@ -1042,7 +1039,7 @@ class ShareKafkaMessageListenerContainerIntegrationTests {
 		int concurrency = 3;
 		produceTestRecords(bootstrapServers, topic, numRecords);
 
-		Map<String, Object> consumerProps = createConsumerProps(bootstrapServers, groupId, false);
+		Map<String, Object> consumerProps = createConsumerProps(bootstrapServers, groupId);
 		DefaultShareConsumerFactory<String, String> factory = new DefaultShareConsumerFactory<>(consumerProps);
 
 		ContainerProperties containerProps = new ContainerProperties(topic);
@@ -1083,7 +1080,7 @@ class ShareKafkaMessageListenerContainerIntegrationTests {
 		setShareAutoOffsetResetEarliest(bootstrapServers, groupId);
 
 		int concurrency = 4;
-		Map<String, Object> consumerProps = createConsumerProps(bootstrapServers, groupId, false);
+		Map<String, Object> consumerProps = createConsumerProps(bootstrapServers, groupId);
 		DefaultShareConsumerFactory<String, String> factory = new DefaultShareConsumerFactory<>(consumerProps);
 
 		ContainerProperties containerProps = new ContainerProperties(topic);
@@ -1140,7 +1137,7 @@ class ShareKafkaMessageListenerContainerIntegrationTests {
 		int concurrency = 3;
 		produceTestRecords(bootstrapServers, topic, numRecords);
 
-		Map<String, Object> consumerProps = createConsumerProps(bootstrapServers, groupId, true);
+		Map<String, Object> consumerProps = createConsumerProps(bootstrapServers, groupId);
 		DefaultShareConsumerFactory<String, String> factory = new DefaultShareConsumerFactory<>(consumerProps);
 
 		ContainerProperties containerProps = new ContainerProperties(topic);
@@ -1199,7 +1196,7 @@ class ShareKafkaMessageListenerContainerIntegrationTests {
 		setShareAutoOffsetResetEarliest(bootstrapServers, groupId);
 
 		int concurrency = 5;
-		Map<String, Object> consumerProps = createConsumerProps(bootstrapServers, groupId, false);
+		Map<String, Object> consumerProps = createConsumerProps(bootstrapServers, groupId);
 		DefaultShareConsumerFactory<String, String> factory = new DefaultShareConsumerFactory<>(consumerProps);
 
 		ContainerProperties containerProps = new ContainerProperties(topic);


### PR DESCRIPTION
  Fixes #4369
  When "setExplicitShareAcknowledgment(true)" is set on the container properties, the "share.acknowledgement.mode=explicit" property is now passed to the consumer factory via a new "createShareConsumer" overload that accepts override properties, instead of relying on the user to set it manually in the factory configuration.

  Signed-off-by: Maxwell Balla <ballamaxwell7@gmail.com>

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
