### PR TITLE
Await share consumer startup before returning

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ShareKafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ShareKafkaMessageListenerContainer.java
@@ -26,6 +26,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.kafka.clients.consumer.AcknowledgeType;
@@ -242,11 +243,24 @@ public class ShareKafkaMessageListenerContainer<K, V>
 		}
 
 		setRunning(true);
+		this.startLatch = new CountDownLatch(this.concurrency);
 
 		for (ShareListenerConsumer consumer : builtConsumers) {
 			this.consumers.add(consumer);
 			CompletableFuture<Void> future = CompletableFuture.runAsync(consumer, consumerExecutor);
 			this.consumerFutures.add(future);
+		}
+		try {
+			if (!this.startLatch.await(containerProperties.getConsumerStartTimeout().toMillis(),
+					TimeUnit.MILLISECONDS)) {
+
+				this.logger.error("Consumer thread failed to start - does the configured task executor "
+						+ "have enough threads to support all containers and concurrency?");
+				publishConsumerFailedToStart();
+			}
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
 		}
 	}
 
@@ -323,6 +337,13 @@ public class ShareKafkaMessageListenerContainer<K, V>
 		ApplicationEventPublisher publisher = getApplicationEventPublisher();
 		if (publisher != null) {
 			publisher.publishEvent(new ConsumerStartedEvent(this, this));
+		}
+	}
+
+	private void publishConsumerFailedToStart() {
+		ApplicationEventPublisher publisher = getApplicationEventPublisher();
+		if (publisher != null) {
+			publisher.publishEvent(new ConsumerFailedToStartEvent(this, this));
 		}
 	}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ShareKafkaMessageListenerContainerUnitTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ShareKafkaMessageListenerContainerUnitTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.kafka.listener;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -48,6 +49,7 @@ import org.springframework.kafka.event.ConsumerStoppedEvent;
 import org.springframework.kafka.event.ConsumerStoppedEvent.Reason;
 import org.springframework.kafka.event.ShareConsumerStoppingEvent;
 import org.springframework.kafka.listener.ContainerProperties.ShareAckMode;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -364,6 +366,44 @@ public class ShareKafkaMessageListenerContainerUnitTests {
 	}
 
 	@Test
+	void shouldAwaitConsumerThreadStartup() {
+		ContainerProperties containerProperties = new ContainerProperties("test-topic");
+		containerProperties.setMessageListener(messageListener);
+		containerProperties.setConsumerStartTimeout(Duration.ofSeconds(5));
+		containerProperties.setListenerTaskExecutor(task -> new Thread(() -> {
+			try {
+				Thread.sleep(200);
+			}
+			catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+			}
+			task.run();
+		}).start());
+
+		@SuppressWarnings("unchecked")
+		ShareConsumer<String, String> consumer = mock(ShareConsumer.class);
+		given(this.shareConsumerFactory.createShareConsumer(any(), eq("startupWaitContainer"), any()))
+				.willReturn(consumer);
+		given(consumer.poll(Duration.ofMillis(1000)))
+				.willReturn(new ConsumerRecords<>(Collections.emptyMap(), Map.of()));
+
+		ShareKafkaMessageListenerContainer<String, String> container =
+				new ShareKafkaMessageListenerContainer<>(this.shareConsumerFactory, containerProperties);
+		container.setBeanName("startupWaitContainer");
+
+		long start = System.nanoTime();
+		container.start();
+		long elapsed = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - start);
+
+		try {
+			assertThat(elapsed).isGreaterThanOrEqualTo(150L);
+		}
+		finally {
+			container.stop();
+		}
+	}
+
+	@Test
 	void shouldDefaultToNoAcknowledgementCommitCallback() {
 		ContainerProperties containerProperties = new ContainerProperties("test-topic");
 		containerProperties.setMessageListener(messageListener);
@@ -653,5 +693,50 @@ public class ShareKafkaMessageListenerContainerUnitTests {
 				.isThrownBy(container::start)
 				.withMessage("failed to create consumer");
 		assertThat(failedEvent.get()).isNotNull();
+	}
+
+	@Test
+	void shouldPublishFailedToStartWhenNotAllConsumersStartWithinTimeout() throws InterruptedException {
+		ContainerProperties containerProperties = new ContainerProperties("test-topic");
+		containerProperties.setMessageListener(messageListener);
+		containerProperties.setConsumerStartTimeout(Duration.ofMillis(50));
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setCorePoolSize(1);
+		executor.setMaxPoolSize(1);
+		executor.afterPropertiesSet();
+		containerProperties.setListenerTaskExecutor(executor);
+
+		@SuppressWarnings("unchecked")
+		ShareConsumer<String, String> firstConsumer = mock(ShareConsumer.class);
+		@SuppressWarnings("unchecked")
+		ShareConsumer<String, String> secondConsumer = mock(ShareConsumer.class);
+		given(this.shareConsumerFactory.createShareConsumer(any(), eq("failedStartContainer-0"), any()))
+				.willReturn(firstConsumer);
+		given(this.shareConsumerFactory.createShareConsumer(any(), eq("failedStartContainer-1"), any()))
+				.willReturn(secondConsumer);
+		willAnswer(invocation -> {
+			Thread.sleep(200);
+			return new ConsumerRecords<>(Collections.emptyMap(), Map.of());
+		}).given(firstConsumer).poll(Duration.ofMillis(1000));
+
+		ShareKafkaMessageListenerContainer<String, String> container =
+				new ShareKafkaMessageListenerContainer<>(this.shareConsumerFactory, containerProperties);
+		container.setBeanName("failedStartContainer");
+		container.setConcurrency(2);
+		CountDownLatch failedToStartLatch = new CountDownLatch(1);
+		container.setApplicationEventPublisher(event -> {
+			if (event instanceof ConsumerFailedToStartEvent) {
+				failedToStartLatch.countDown();
+			}
+		});
+
+		try {
+			container.start();
+			assertThat(failedToStartLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		}
+		finally {
+			container.stop();
+			executor.destroy();
+		}
 	}
 }


### PR DESCRIPTION
Fixes #4357

## Summary
- wait for all share consumer threads to signal startup before returning from doStart()
- publish ConsumerFailedToStartEvent when all consumers do not start within consumerStartTimeout
- add unit tests covering startup waiting and failed startup event publication

## Testing
- ./gradlew :spring-kafka:test --tests org.springframework.kafka.listener.ShareKafkaMessageListenerContainerUnitTests
