### PR TITLE
Fix immutability StreamsBuilderFactory properties

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaStreamsConfiguration.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaStreamsConfiguration.java
@@ -55,7 +55,7 @@ public class KafkaStreamsConfiguration {
 			props.putAll(this.configs);
 			this.properties = props;
 		}
-		return this.properties;
+		return (Properties) this.properties.clone();
 	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/StreamsBuilderFactoryBean.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/StreamsBuilderFactoryBean.java
@@ -190,12 +190,12 @@ public class StreamsBuilderFactoryBean extends AbstractFactoryBean<StreamsBuilde
 	 */
 	public void setStreamsConfiguration(Properties streamsConfig) {
 		Assert.notNull(streamsConfig, STREAMS_CONFIG_MUST_NOT_BE_NULL);
-		this.properties = streamsConfig;
+		this.properties = (Properties) streamsConfig.clone();
 	}
 
 	@Nullable
 	public Properties getStreamsConfiguration() {
-		return this.properties; // NOSONAR - inconsistent synchronization
+		return (Properties) this.properties.clone(); // NOSONAR - inconsistent synchronization
 	}
 
 	public void setClientSupplier(KafkaClientSupplier clientSupplier) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/StreamsBuilderFactoryBean.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/StreamsBuilderFactoryBean.java
@@ -195,7 +195,7 @@ public class StreamsBuilderFactoryBean extends AbstractFactoryBean<StreamsBuilde
 
 	@Nullable
 	public Properties getStreamsConfiguration() {
-		return (Properties) this.properties.clone(); // NOSONAR - inconsistent synchronization
+		return (Properties) this.properties.clone();
 	}
 
 	public void setClientSupplier(KafkaClientSupplier clientSupplier) {


### PR DESCRIPTION
Fix immuable object sharing across `StreamsBuilderFactoryBean`


As discussed https://github.com/spring-projects/spring-kafka/pull/4373#discussion_r3011957331, This PR ensures that `StreamsBuilderFactoryBean`  & `KafkaStreamsConfiguration` always sends a new copy of properties, ensuring immutablility.
