### PR TITLE
GH-4380: Add AcknowledgementCommitCallback support for async share co…

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
@@ -28,6 +28,7 @@ import java.util.regex.Pattern;
 
 import io.micrometer.observation.ObservationRegistry;
 import org.aopalliance.aop.Advice;
+import org.apache.kafka.clients.consumer.AcknowledgementCommitCallback;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.jspecify.annotations.Nullable;
 
@@ -351,6 +352,8 @@ public class ContainerProperties extends ConsumerProperties {
 	private ShareAckMode shareAckMode = ShareAckMode.EXPLICIT; // default: container-managed explicit mode
 
 	private boolean syncShareCommits = true;
+
+	private @Nullable AcknowledgementCommitCallback acknowledgementCommitCallback;
 
 	private Duration shareAcknowledgmentTimeout = Duration.ofSeconds(30); // Align with Kafka's share.record.lock.duration.ms default
 
@@ -1197,6 +1200,28 @@ public class ContainerProperties extends ConsumerProperties {
 	 */
 	public boolean isSyncShareCommits() {
 		return this.syncShareCommits;
+	}
+
+	/**
+	 * Set the callback to be invoked when acknowledgement commits complete.
+	 * <p>This is particularly useful when {@link #setSyncShareCommits(boolean) syncShareCommits}
+	 * is {@code false} (async mode) to get visibility into commit success or failure.
+	 * <p>If not set and async commits are enabled, a default callback that logs failures will be used.
+	 * @param acknowledgementCommitCallback the callback, or null to use the default.
+	 * @since 4.1
+	 * @see AcknowledgementCommitCallback
+	 */
+	public void setAcknowledgementCommitCallback(AcknowledgementCommitCallback acknowledgementCommitCallback) {
+		this.acknowledgementCommitCallback = acknowledgementCommitCallback;
+	}
+
+	/**
+	 * Get the acknowledgement commit callback.
+	 * @return the callback, or null if not set.
+	 * @since 4.1
+	 */
+	public @Nullable AcknowledgementCommitCallback getAcknowledgementCommitCallback() {
+		return this.acknowledgementCommitCallback;
 	}
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ShareKafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ShareKafkaMessageListenerContainer.java
@@ -29,6 +29,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.kafka.clients.consumer.AcknowledgeType;
+import org.apache.kafka.clients.consumer.AcknowledgementCommitCallback;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -77,6 +78,7 @@ import org.springframework.util.Assert;
  * <li>Poll-level acknowledgment constraints in {@link ContainerProperties.ShareAckMode#MANUAL} mode</li>
  * <li>Integration with Spring's {@code @KafkaListener} annotation</li>
  * <li>Configurable concurrency for increased throughput</li>
+ * <li>Sync or async commit modes with optional {@link AcknowledgementCommitCallback} for async commit visibility</li>
  * </ul>
  * <p>
  * <strong>Acknowledgment Modes:</strong>
@@ -341,6 +343,20 @@ public class ShareKafkaMessageListenerContainer<K, V>
 				this.consumer = ShareKafkaMessageListenerContainer.this.shareConsumerFactory.createShareConsumer(
 						groupId, consumerClientId,
 						Map.of(ConsumerConfig.SHARE_ACKNOWLEDGEMENT_MODE_CONFIG, ShareAcknowledgementMode.EXPLICIT.name()));
+			}
+
+			// Register acknowledgement commit callback
+			AcknowledgementCommitCallback callback = containerProperties.getAcknowledgementCommitCallback();
+			if (callback != null) {
+				this.consumer.setAcknowledgementCommitCallback(callback);
+			}
+			else if (!this.syncShareCommits) {
+				// Default callback for async mode: log failures
+				this.consumer.setAcknowledgementCommitCallback((offsets, exception) -> {
+					if (exception != null) {
+						this.logger.error(exception, () -> "Async acknowledgement commit failed for offsets: " + offsets);
+					}
+				});
 			}
 
 			this.consumer.subscribe(Arrays.asList(containerProperties.getTopics()));

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ShareKafkaMessageListenerContainerIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ShareKafkaMessageListenerContainerIntegrationTests.java
@@ -79,7 +79,8 @@ import static org.mockito.Mockito.verify;
 				"share-container-lifecycle-test",
 				"share-container-recoverer-release-test",
 				"share-container-deser-error-test",
-				"share-container-async-commit-test"
+				"share-container-async-commit-test",
+				"share-container-async-callback-test"
 		},
 		partitions = 1,
 		brokerProperties = {
@@ -1319,5 +1320,48 @@ class ShareKafkaMessageListenerContainerIntegrationTests {
 				.untilAsserted(() -> assertThat(redeliveryCount.get()).isZero());
 
 		restartContainer.stop();
+	}
+
+	@Test
+	void shouldInvokeAcknowledgementCommitCallbackOnAsyncCommit(EmbeddedKafkaBroker broker) throws Exception {
+		final String topic = "share-container-async-callback-test";
+		final String groupId = "asyncCallbackGroup";
+		String bootstrapServers = broker.getBrokersAsString();
+
+		produceTestRecords(bootstrapServers, topic, 3);
+		setShareAutoOffsetResetEarliest(bootstrapServers, groupId);
+
+		var consumerProps = new HashMap<String, Object>();
+		consumerProps.put("bootstrap.servers", bootstrapServers);
+		consumerProps.put("key.deserializer", StringDeserializer.class);
+		consumerProps.put("value.deserializer", StringDeserializer.class);
+		consumerProps.put("group.id", groupId);
+
+		DefaultShareConsumerFactory<String, String> consumerFactory = new DefaultShareConsumerFactory<>(consumerProps);
+
+		CountDownLatch messageLatch = new CountDownLatch(3);
+		CountDownLatch callbackLatch = new CountDownLatch(1);
+		AtomicReference<Exception> callbackError = new AtomicReference<>();
+
+		ContainerProperties containerProps = new ContainerProperties(topic);
+		containerProps.setSyncShareCommits(false);
+		containerProps.setAcknowledgementCommitCallback((offsets, exception) -> {
+			if (exception != null) {
+				callbackError.set(exception);
+			}
+			callbackLatch.countDown();
+		});
+		containerProps.setMessageListener((MessageListener<String, String>) record -> messageLatch.countDown());
+
+		ShareKafkaMessageListenerContainer<String, String> container =
+				new ShareKafkaMessageListenerContainer<>(consumerFactory, containerProps);
+		container.setBeanName("asyncCallbackTestContainer");
+		container.start();
+
+		assertThat(messageLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(callbackLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(callbackError.get()).isNull();
+
+		container.stop();
 	}
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ShareKafkaMessageListenerContainerUnitTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ShareKafkaMessageListenerContainerUnitTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.kafka.listener;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -23,6 +24,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.kafka.clients.consumer.AcknowledgeType;
+import org.apache.kafka.clients.consumer.AcknowledgementCommitCallback;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -349,6 +351,117 @@ public class ShareKafkaMessageListenerContainerUnitTests {
 
 		verify(mockConsumer).commitAsync();
 		verify(mockConsumer, never()).commitSync();
+	}
+
+	@Test
+	void shouldDefaultToNoAcknowledgementCommitCallback() {
+		ContainerProperties containerProperties = new ContainerProperties("test-topic");
+		containerProperties.setMessageListener(messageListener);
+
+		assertThat(containerProperties.getAcknowledgementCommitCallback()).isNull();
+	}
+
+	@Test
+	void shouldStoreCustomAcknowledgementCommitCallback() {
+		ContainerProperties containerProperties = new ContainerProperties("test-topic");
+		AcknowledgementCommitCallback customCallback = (offsets, exception) -> { };
+		containerProperties.setAcknowledgementCommitCallback(customCallback);
+
+		assertThat(containerProperties.getAcknowledgementCommitCallback()).isSameAs(customCallback);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void shouldRegisterCustomCallbackOnShareConsumer() throws Exception {
+		ShareConsumerFactory<String, String> mockFactory = mock(ShareConsumerFactory.class);
+		given(mockFactory.getConfigurationProperties()).willReturn(Map.of());
+
+		ShareConsumer<String, String> mockConsumer = mock(ShareConsumer.class);
+		given(mockFactory.createShareConsumer(any(), any(), any())).willReturn(mockConsumer);
+
+		CountDownLatch callbackRegistered = new CountDownLatch(1);
+		AcknowledgementCommitCallback customCallback = (offsets, exception) -> { };
+
+		// Signal when callback is set on the consumer
+		lenient().doAnswer(invocation -> {
+			callbackRegistered.countDown();
+			return null;
+		}).when(mockConsumer).setAcknowledgementCommitCallback(any());
+
+		ContainerProperties containerProperties = new ContainerProperties("test-topic");
+		containerProperties.setSyncShareCommits(false);
+		containerProperties.setAcknowledgementCommitCallback(customCallback);
+		containerProperties.setMessageListener(messageListener);
+
+		ShareKafkaMessageListenerContainer<String, String> container =
+				new ShareKafkaMessageListenerContainer<>(mockFactory, containerProperties);
+		container.setBeanName("customCallbackContainer");
+		container.start();
+		assertThat(callbackRegistered.await(5, TimeUnit.SECONDS)).isTrue();
+		container.stop();
+
+		verify(mockConsumer).setAcknowledgementCommitCallback(customCallback);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void shouldRegisterDefaultLoggingCallbackWhenAsyncAndNoCustomCallback() throws Exception {
+		ShareConsumerFactory<String, String> mockFactory = mock(ShareConsumerFactory.class);
+		given(mockFactory.getConfigurationProperties()).willReturn(Map.of());
+
+		ShareConsumer<String, String> mockConsumer = mock(ShareConsumer.class);
+		given(mockFactory.createShareConsumer(any(), any(), any())).willReturn(mockConsumer);
+
+		CountDownLatch callbackRegistered = new CountDownLatch(1);
+		lenient().doAnswer(invocation -> {
+			callbackRegistered.countDown();
+			return null;
+		}).when(mockConsumer).setAcknowledgementCommitCallback(any());
+
+		ContainerProperties containerProperties = new ContainerProperties("test-topic");
+		containerProperties.setSyncShareCommits(false);
+		containerProperties.setMessageListener(messageListener);
+
+		ShareKafkaMessageListenerContainer<String, String> container =
+				new ShareKafkaMessageListenerContainer<>(mockFactory, containerProperties);
+		container.setBeanName("defaultCallbackContainer");
+		container.start();
+
+		assertThat(callbackRegistered.await(5, TimeUnit.SECONDS)).isTrue();
+
+		container.stop();
+
+		verify(mockConsumer).setAcknowledgementCommitCallback(any(AcknowledgementCommitCallback.class));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void shouldNotRegisterCallbackWhenSyncCommits() throws Exception {
+		ShareConsumerFactory<String, String> mockFactory = mock(ShareConsumerFactory.class);
+		given(mockFactory.getConfigurationProperties()).willReturn(Map.of());
+
+		ShareConsumer<String, String> mockConsumer = mock(ShareConsumer.class);
+		given(mockFactory.createShareConsumer(any(), any(), any())).willReturn(mockConsumer);
+
+		CountDownLatch subscribed = new CountDownLatch(1);
+		lenient().doAnswer(invocation -> {
+			subscribed.countDown();
+			return null;
+		}).when(mockConsumer).subscribe(any(Collection.class));
+
+		ContainerProperties containerProperties = new ContainerProperties("test-topic");
+		containerProperties.setMessageListener(messageListener);
+
+		ShareKafkaMessageListenerContainer<String, String> container =
+				new ShareKafkaMessageListenerContainer<>(mockFactory, containerProperties);
+		container.setBeanName("noCallbackSyncContainer");
+		container.start();
+
+		assertThat(subscribed.await(5, TimeUnit.SECONDS)).isTrue();
+
+		container.stop();
+
+		verify(mockConsumer, never()).setAcknowledgementCommitCallback(any());
 	}
 
 }


### PR DESCRIPTION
Fixes #4380

Following up on #4379 (async commit option), this PR adds
AcknowledgementCommitCallback support to the share consumer container.

When `syncShareCommits=false`, a default callback is registered that logs
commit failures. Users can provide a custom callback via
`ContainerProperties.setAcknowledgementCommitCallback()` for custom error
handling.

Changes:
- `ContainerProperties`: added `acknowledgementCommitCallback` field with setter/getter
- `ShareKafkaMessageListenerContainer`: register the callback on the `ShareConsumer`
  before `subscribe()`, with a default logging callback for async mode

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
