### PR TITLE
Fixes gh-4384: Ensure non-string override properties are consistent

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
@@ -398,16 +398,17 @@ public class DefaultKafkaConsumerFactory<K, V> extends KafkaResourceFactory
 						&& !ConsumerConfig.CLIENT_ID_CONFIG.equals(key)
 						&& !ConsumerConfig.GROUP_ID_CONFIG.equals(key)) {
 
-					Object value;
+					Object value = entry.getValue();
 
-					if (properties.getProperty(key) != null) {
-						value = properties.getProperty(key);
+					if (value != null) {
+						modifiedConfigs.put(key, value);
 					}
 					else {
-						value = entry.getValue();
+						String stringValue = properties.getProperty(key);
+						if (stringValue != null) {
+							modifiedConfigs.put(key, stringValue);
+						}
 					}
-
-					modifiedConfigs.put(key, value);
 				}
 			}
 			checkInaccessible(properties, modifiedConfigs);

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
@@ -368,13 +367,14 @@ public class DefaultKafkaConsumerFactory<K, V> extends KafkaResourceFactory
 		boolean shouldModifyClientId = (this.configs.containsKey(ConsumerConfig.CLIENT_ID_CONFIG)
 				&& StringUtils.hasText(clientIdSuffix)) || overrideClientIdPrefix;
 		if (groupId == null
-				&& (properties == null || properties.stringPropertyNames().isEmpty())
+				&& properties == null
 				&& !shouldModifyClientId) {
+
 			return createKafkaConsumer(new HashMap<>(this.configs));
 		}
 		else {
-			return createConsumerWithAdjustedProperties(groupId, clientIdPrefix, properties, overrideClientIdPrefix,
-					clientIdSuffix, shouldModifyClientId);
+			return createConsumerWithAdjustedProperties(groupId, clientIdPrefix, properties,
+					overrideClientIdPrefix, clientIdSuffix, shouldModifyClientId);
 		}
 	}
 
@@ -392,18 +392,16 @@ public class DefaultKafkaConsumerFactory<K, V> extends KafkaResourceFactory
 							: modifiedConfigs.get(ConsumerConfig.CLIENT_ID_CONFIG)) + clientIdSuffix);
 		}
 		if (properties != null) {
-			Set<String> stringPropertyNames = properties.stringPropertyNames();  // to get any nested default Properties
-			stringPropertyNames
-					.stream()
-					.filter(name -> !name.equals(ConsumerConfig.CLIENT_ID_CONFIG)
-							&& !name.equals(ConsumerConfig.GROUP_ID_CONFIG))
-					.forEach(name -> modifiedConfigs.put(name, properties.getProperty(name)));
-			properties.entrySet().stream()
-					.filter(entry -> !entry.getKey().equals(ConsumerConfig.CLIENT_ID_CONFIG)
-							&& !entry.getKey().equals(ConsumerConfig.GROUP_ID_CONFIG)
-							&& !stringPropertyNames.contains(entry.getKey())
-							&& entry.getKey() instanceof String)
-					.forEach(entry -> modifiedConfigs.put((String) entry.getKey(), entry.getValue()));
+			for (Map.Entry<Object, Object> entry : properties.entrySet()) {
+				Object key = entry.getKey();
+
+				if (key instanceof String
+						&& !key.equals(ConsumerConfig.CLIENT_ID_CONFIG)
+						&& !key.equals(ConsumerConfig.GROUP_ID_CONFIG)) {
+
+					modifiedConfigs.put((String) key, entry.getValue());
+				}
+			}
 			checkInaccessible(properties, modifiedConfigs);
 		}
 		return createKafkaConsumer(modifiedConfigs);

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
@@ -393,13 +393,21 @@ public class DefaultKafkaConsumerFactory<K, V> extends KafkaResourceFactory
 		}
 		if (properties != null) {
 			for (Map.Entry<Object, Object> entry : properties.entrySet()) {
-				Object key = entry.getKey();
 
-				if (key instanceof String
-						&& !key.equals(ConsumerConfig.CLIENT_ID_CONFIG)
-						&& !key.equals(ConsumerConfig.GROUP_ID_CONFIG)) {
+				if (entry.getKey() instanceof String key
+						&& !ConsumerConfig.CLIENT_ID_CONFIG.equals(key)
+						&& !ConsumerConfig.GROUP_ID_CONFIG.equals(key)) {
 
-					modifiedConfigs.put((String) key, entry.getValue());
+					Object value;
+
+					if (properties.getProperty(key) != null) {
+						value = properties.getProperty(key);
+					}
+					else {
+						value = entry.getValue();
+					}
+
+					modifiedConfigs.put(key, value);
 				}
 			}
 			checkInaccessible(properties, modifiedConfigs);

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/DefaultKafkaConsumerFactory.java
@@ -367,7 +367,7 @@ public class DefaultKafkaConsumerFactory<K, V> extends KafkaResourceFactory
 		boolean shouldModifyClientId = (this.configs.containsKey(ConsumerConfig.CLIENT_ID_CONFIG)
 				&& StringUtils.hasText(clientIdSuffix)) || overrideClientIdPrefix;
 		if (groupId == null
-				&& properties == null
+				&& (properties == null || properties.isEmpty())
 				&& !shouldModifyClientId) {
 
 			return createKafkaConsumer(new HashMap<>(this.configs));
@@ -400,14 +400,12 @@ public class DefaultKafkaConsumerFactory<K, V> extends KafkaResourceFactory
 
 					Object value = entry.getValue();
 
+					if (value == null) {
+						value = properties.getProperty(key);
+					}
+
 					if (value != null) {
 						modifiedConfigs.put(key, value);
-					}
-					else {
-						String stringValue = properties.getProperty(key);
-						if (stringValue != null) {
-							modifiedConfigs.put(key, stringValue);
-						}
 					}
 				}
 			}

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
@@ -88,14 +88,16 @@ public class DefaultKafkaConsumerFactoryTests {
 	@Test
 	public void testProvidedDeserializerInstancesAreShared() {
 		ConsumerFactory<String, String> target = new DefaultKafkaConsumerFactory<>(Collections.emptyMap(),
-				new StringDeserializer() { }, null);
+				new StringDeserializer() {
+				}, null);
 		assertThat(target.getKeyDeserializer()).isSameAs(target.getKeyDeserializer());
 	}
 
 	@Test
 	public void testSupplierProvidedDeserializersAreNotShared() {
 		ConsumerFactory<String, String> target = new DefaultKafkaConsumerFactory<>(Collections.emptyMap(),
-				() -> new StringDeserializer() { }, null);
+				() -> new StringDeserializer() {
+				}, null);
 		assertThat(target.getKeyDeserializer()).isNotSameAs(target.getKeyDeserializer());
 	}
 
@@ -117,19 +119,19 @@ public class DefaultKafkaConsumerFactoryTests {
 	}
 
 	@Test
-	void testNonStringOverridePropertyApplied() {
-		Map<String, Object> originalConfig =
-				Collections.singletonMap(ConsumerConfig.GROUP_ID_CONFIG, "original");
+	void testIntegerOverrideApplied() {
+		Map<String, Object> configs = new HashMap<>();
+		configs.put(ConsumerConfig.GROUP_ID_CONFIG, "test");
 
 		Properties overrides = new Properties();
 		overrides.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 2);
 
-		final Map<String, Object> captured = new HashMap<>();
+		Map<String, Object> captured = new HashMap<>();
 
 		DefaultKafkaConsumerFactory<String, String> factory =
-				new DefaultKafkaConsumerFactory<>(originalConfig) {
+				new DefaultKafkaConsumerFactory<>(configs) {
 					@Override
-					protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
+					protected Consumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
 						captured.putAll(configProps);
 						return null;
 					}
@@ -141,19 +143,20 @@ public class DefaultKafkaConsumerFactoryTests {
 	}
 
 	@Test
-	void testIntegerOverrideConvertedToString() {
-		Map<String, Object> originalConfig =
-				Collections.singletonMap(ConsumerConfig.GROUP_ID_CONFIG, "original");
+	void testMixedTypeOverridesApplied() {
+		Map<String, Object> configs = new HashMap<>();
+		configs.put(ConsumerConfig.GROUP_ID_CONFIG, "test");
 
 		Properties overrides = new Properties();
 		overrides.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 2);
+		overrides.setProperty("foo", "bar");
 
-		final Map<String, Object> captured = new HashMap<>();
+		Map<String, Object> captured = new HashMap<>();
 
 		DefaultKafkaConsumerFactory<String, String> factory =
-				new DefaultKafkaConsumerFactory<>(originalConfig) {
+				new DefaultKafkaConsumerFactory<>(configs) {
 					@Override
-					protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
+					protected Consumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
 						captured.putAll(configProps);
 						return null;
 					}
@@ -161,33 +164,10 @@ public class DefaultKafkaConsumerFactoryTests {
 
 		factory.createConsumer(null, null, null, overrides);
 
-		assertThat(captured.get(ConsumerConfig.MAX_POLL_RECORDS_CONFIG))
-				.isEqualTo(2);
-	}
-
-	@Test
-	void testMixedTypeOverridePropertiesApplied() {
-		Map<String, Object> originalConfig =
-				Collections.singletonMap(ConsumerConfig.GROUP_ID_CONFIG, "original");
-
-		Properties overrides = new Properties();
-		overrides.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 2);
-		overrides.put("additional", "property");
-
-		final Map<String, Object> captured = new HashMap<>();
-
-		DefaultKafkaConsumerFactory<String, String> factory =
-				new DefaultKafkaConsumerFactory<>(originalConfig) {
-					@Override
-					protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
-						captured.putAll(configProps);
-						return null;
-					}
-				};
-
-		factory.createConsumer(null, null, null, overrides);
-
-		assertThat(captured.get(ConsumerConfig.MAX_POLL_RECORDS_CONFIG)).isEqualTo(2);
+		assertThat(captured)
+				.containsEntry(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 2)
+				.containsEntry("foo", "bar")
+				.containsEntry(ConsumerConfig.GROUP_ID_CONFIG, "test");
 	}
 
 	@Test
@@ -474,8 +454,7 @@ public class DefaultKafkaConsumerFactoryTests {
 			assertThat(KafkaTestUtils.getPropertyValue(pfTx, "cache", Map.class)).hasSize(1);
 			assertThat(pfTx.getCache()).hasSize(1);
 			assertThat(KafkaTestUtils.getPropertyValue(container, "listenerConsumer.consumer")).isSameAs(wrapped.get());
-		}
-		finally {
+		} finally {
 			container.stop();
 			pf.destroy();
 			pfTx.destroy();
@@ -527,17 +506,16 @@ public class DefaultKafkaConsumerFactoryTests {
 			assertThat(KafkaTestUtils.getPropertyValue(suffixStrategy, "suffixCache", Map.class)).hasSize(1);
 			//  1 tm tx producer and 1 templateTx tx producer
 			assertThat(KafkaTestUtils.getPropertyValue(container, "listenerConsumer.consumer")).isSameAs(wrapped.get());
-		}
-		finally {
+		} finally {
 			container.stop();
 			pf.destroy();
 			pfTx.destroy();
 		}
 	}
 
-	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@SuppressWarnings({"rawtypes", "unchecked"})
 	@ParameterizedTest
-	@ValueSource(booleans = { true, false })
+	@ValueSource(booleans = {true, false})
 	void listener(boolean closeWithTimeout) {
 		Map<String, Object> consumerConfig = KafkaTestUtils.consumerProps(this.embeddedKafka, "txCache1Group", false);
 		consumerConfig.put(ConsumerConfig.CLIENT_ID_CONFIG, "foo-0");
@@ -566,14 +544,13 @@ public class DefaultKafkaConsumerFactoryTests {
 		assertThat(removals).isEmpty();
 		if (closeWithTimeout) {
 			consumer.close(CloseOptions.timeout(Duration.ofSeconds(10)));
-		}
-		else {
+		} else {
 			consumer.close();
 		}
 		assertThat(removals).hasSize(1);
 	}
 
-	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@SuppressWarnings({"rawtypes", "unchecked"})
 	@Test
 	void configDeserializer() {
 		Deserializer key = mock(Deserializer.class);
@@ -601,5 +578,4 @@ public class DefaultKafkaConsumerFactoryTests {
 	public static class Config {
 
 	}
-
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
@@ -141,6 +141,31 @@ public class DefaultKafkaConsumerFactoryTests {
 	}
 
 	@Test
+	void testIntegerOverrideConvertedToString() {
+		Map<String, Object> originalConfig =
+				Collections.singletonMap(ConsumerConfig.GROUP_ID_CONFIG, "original");
+
+		Properties overrides = new Properties();
+		overrides.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 2);
+
+		final Map<String, Object> captured = new HashMap<>();
+
+		DefaultKafkaConsumerFactory<String, String> factory =
+				new DefaultKafkaConsumerFactory<>(originalConfig) {
+					@Override
+					protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
+						captured.putAll(configProps);
+						return null;
+					}
+				};
+
+		factory.createConsumer(null, null, null, overrides);
+
+		assertThat(captured.get(ConsumerConfig.MAX_POLL_RECORDS_CONFIG))
+				.isEqualTo(2);
+	}
+
+	@Test
 	void testMixedTypeOverridePropertiesApplied() {
 		Map<String, Object> originalConfig =
 				Collections.singletonMap(ConsumerConfig.GROUP_ID_CONFIG, "original");

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
@@ -73,10 +73,10 @@ import static org.mockito.Mockito.verify;
  *
  * @since 1.0.6
  */
-@EmbeddedKafka(topics = {"txCache1", "txCache2", "txCacheSendFromListener"},
+@EmbeddedKafka(topics = { "txCache1", "txCache2", "txCacheSendFromListener" },
 		brokerProperties = {
 				"transaction.state.log.replication.factor=1",
-				"transaction.state.log.min.isr=1"}
+				"transaction.state.log.min.isr=1" }
 )
 @SpringJUnitConfig
 @DirtiesContext
@@ -88,17 +88,71 @@ public class DefaultKafkaConsumerFactoryTests {
 	@Test
 	public void testProvidedDeserializerInstancesAreShared() {
 		ConsumerFactory<String, String> target = new DefaultKafkaConsumerFactory<>(Collections.emptyMap(),
-				new StringDeserializer() {
-				}, null);
+				new StringDeserializer() { }, null);
 		assertThat(target.getKeyDeserializer()).isSameAs(target.getKeyDeserializer());
 	}
 
 	@Test
 	public void testSupplierProvidedDeserializersAreNotShared() {
 		ConsumerFactory<String, String> target = new DefaultKafkaConsumerFactory<>(Collections.emptyMap(),
-				() -> new StringDeserializer() {
-				}, null);
+				() -> new StringDeserializer() { }, null);
 		assertThat(target.getKeyDeserializer()).isNotSameAs(target.getKeyDeserializer());
+	}
+
+	@Test
+	public void testMixedTypeOverridesApplied() {
+		Map<String, Object> configs = KafkaTestUtils.consumerProps(this.embeddedKafka, "testGroup", false);
+
+		Properties overrides = new Properties();
+		overrides.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 2);
+		overrides.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+		AtomicReference<ConsumerConfig> capturedConfig = new AtomicReference<>();
+
+		DefaultKafkaConsumerFactory<String, String> factory =
+				new DefaultKafkaConsumerFactory<String, String>(configs) {
+
+					@Override
+					protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
+						capturedConfig.set(new ConsumerConfig(configProps));
+						return mock(KafkaConsumer.class);
+					}
+				};
+
+		factory.createConsumer(null, null, null, overrides);
+
+		ConsumerConfig consumerConfig = capturedConfig.get();
+
+		assertThat(consumerConfig.getInt(ConsumerConfig.MAX_POLL_RECORDS_CONFIG)).isEqualTo(2);
+		assertThat(consumerConfig.getString(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)).isEqualTo("earliest");
+	}
+
+	@Test
+	public void testIntegerAndStringOverridesTogether() {
+		Map<String, Object> configs = KafkaTestUtils.consumerProps(this.embeddedKafka, "testGroup", false);
+
+		Properties overrides = new Properties();
+		overrides.setProperty(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, "5");
+		overrides.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+		AtomicReference<ConsumerConfig> capturedConfig = new AtomicReference<>();
+
+		DefaultKafkaConsumerFactory<String, String> factory =
+				new DefaultKafkaConsumerFactory<String, String>(configs) {
+
+					@Override
+					protected Consumer<String, String> createRawConsumer(Map<String, Object> configProps) {
+						capturedConfig.set(new ConsumerConfig(configProps));
+						return mock(Consumer.class);
+					}
+				};
+
+		factory.createConsumer(null, null, null, overrides);
+
+		ConsumerConfig consumerConfig = capturedConfig.get();
+
+		assertThat(consumerConfig.getInt(ConsumerConfig.MAX_POLL_RECORDS_CONFIG)).isEqualTo(5);
+		assertThat(consumerConfig.getString(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)).isEqualTo("earliest");
 	}
 
 	@Test
@@ -116,65 +170,6 @@ public class DefaultKafkaConsumerFactoryTests {
 				};
 		target.createConsumer(null, null, null, null);
 		assertThat(configPassedToKafkaConsumer).isEqualTo(originalConfig);
-	}
-
-	@Test
-	void testMixedTypeOverridesApplied() {
-		Map<String, Object> configs = KafkaTestUtils.consumerProps(this.embeddedKafka, "testGroup", false);
-
-		Properties overrides = new Properties();
-		overrides.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 2);
-		overrides.setProperty("some.property", "value");
-
-		AtomicReference<ConsumerConfig> capturedConfig = new AtomicReference<>();
-
-		DefaultKafkaConsumerFactory<String, String> factory =
-				new DefaultKafkaConsumerFactory<>(configs) {
-
-					@Override
-					protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
-						capturedConfig.set(new ConsumerConfig(configProps));
-						return mock(KafkaConsumer.class);
-					}
-
-				};
-
-		factory.createConsumer(null, null, null, overrides);
-
-		ConsumerConfig consumerConfig = capturedConfig.get();
-
-		assertThat(consumerConfig.getInt(ConsumerConfig.MAX_POLL_RECORDS_CONFIG)).isEqualTo(2);
-		assertThat(consumerConfig.getString("some.property")).isEqualTo("value");
-	}
-
-	@Test
-	void testIntegerAndStringOverridesTogether() {
-		Map<String, Object> configs = new HashMap<>();
-		configs.put(ConsumerConfig.GROUP_ID_CONFIG, "test");
-
-		Properties overrides = new Properties();
-		overrides.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 5);
-		overrides.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-
-		AtomicReference<ConsumerConfig> capturedConfig = new AtomicReference<>();
-
-		DefaultKafkaConsumerFactory<String, String> factory =
-				new DefaultKafkaConsumerFactory<>(configs) {
-
-					@Override
-					protected Consumer<String, String> createRawConsumer(Map<String, Object> configProps) {
-						capturedConfig.set(new ConsumerConfig(configProps));
-						return mock(Consumer.class);
-					}
-
-				};
-
-		factory.createConsumer(null, null, null, overrides);
-
-		ConsumerConfig consumerConfig = capturedConfig.get();
-
-		assertThat(consumerConfig.getInt(ConsumerConfig.MAX_POLL_RECORDS_CONFIG)).isEqualTo(5);
-		assertThat(consumerConfig.getString(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)).isEqualTo("earliest");
 	}
 
 	@Test
@@ -414,6 +409,7 @@ public class DefaultKafkaConsumerFactoryTests {
 						configPassedToKafkaConsumer.putAll(configProps);
 						return null;
 					}
+
 				};
 		target.createConsumer(null, null, null, overrides);
 		assertThat(configPassedToKafkaConsumer.get(ConsumerConfig.MAX_POLL_RECORDS_CONFIG)).isEqualTo("2");
@@ -511,6 +507,7 @@ public class DefaultKafkaConsumerFactoryTests {
 			assertThat(KafkaTestUtils.getPropertyValue(pfTx, "cache", Map.class)).hasSize(1);
 			assertThat(pfTx.getCache()).hasSize(1);
 			assertThat(KafkaTestUtils.getPropertyValue(suffixStrategy, "suffixCache", Map.class)).hasSize(1);
+			//  1 tm tx producer and 1 templateTx tx producer
 			assertThat(KafkaTestUtils.getPropertyValue(container, "listenerConsumer.consumer")).isSameAs(wrapped.get());
 		}
 		finally {
@@ -520,9 +517,9 @@ public class DefaultKafkaConsumerFactoryTests {
 		}
 	}
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@ParameterizedTest
-	@ValueSource(booleans = {true, false})
+	@ValueSource(booleans = { true, false })
 	void listener(boolean closeWithTimeout) {
 		Map<String, Object> consumerConfig = KafkaTestUtils.consumerProps(this.embeddedKafka, "txCache1Group", false);
 		consumerConfig.put(ConsumerConfig.CLIENT_ID_CONFIG, "foo-0");
@@ -543,7 +540,6 @@ public class DefaultKafkaConsumerFactoryTests {
 			}
 
 		});
-
 		cf.setBeanName("cf");
 
 		Consumer consumer = cf.createConsumer();
@@ -559,7 +555,7 @@ public class DefaultKafkaConsumerFactoryTests {
 		assertThat(removals).hasSize(1);
 	}
 
-	@SuppressWarnings({"rawtypes", "unchecked"})
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Test
 	void configDeserializer() {
 		Deserializer key = mock(Deserializer.class);
@@ -587,4 +583,5 @@ public class DefaultKafkaConsumerFactoryTests {
 	public static class Config {
 
 	}
+
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
@@ -119,46 +119,26 @@ public class DefaultKafkaConsumerFactoryTests {
 	}
 
 	@Test
-	void testIntegerOverrideApplied() {
-		Map<String, Object> configs = new HashMap<>();
-		configs.put(ConsumerConfig.GROUP_ID_CONFIG, "test");
-
-		Properties overrides = new Properties();
-		overrides.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 2);
-
-		Map<String, Object> captured = new HashMap<>();
-
-		DefaultKafkaConsumerFactory<String, String> factory =
-				new DefaultKafkaConsumerFactory<>(configs) {
-					@Override
-					protected Consumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
-						captured.putAll(configProps);
-						return null;
-					}
-				};
-
-		factory.createConsumer(null, null, null, overrides);
-
-		assertThat(captured.get(ConsumerConfig.MAX_POLL_RECORDS_CONFIG)).isEqualTo(2);
-	}
-
-	@Test
 	void testMixedTypeOverridesApplied() {
-		Map<String, Object> configs = new HashMap<>();
-		configs.put(ConsumerConfig.GROUP_ID_CONFIG, "test");
+		Map<String, Object> configs = KafkaTestUtils.consumerProps(
+				this.embeddedKafka,
+				"testGroup",
+				false
+		);
 
 		Properties overrides = new Properties();
 		overrides.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 2);
-		overrides.setProperty("foo", "bar");
+		overrides.setProperty("some.property", "value");
 
 		Map<String, Object> captured = new HashMap<>();
 
 		DefaultKafkaConsumerFactory<String, String> factory =
 				new DefaultKafkaConsumerFactory<>(configs) {
+
 					@Override
-					protected Consumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
+					protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
 						captured.putAll(configProps);
-						return null;
+						return mock(KafkaConsumer.class);
 					}
 				};
 
@@ -166,8 +146,33 @@ public class DefaultKafkaConsumerFactoryTests {
 
 		assertThat(captured)
 				.containsEntry(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 2)
-				.containsEntry("foo", "bar")
-				.containsEntry(ConsumerConfig.GROUP_ID_CONFIG, "test");
+				.containsEntry("some.property", "value");
+	}
+
+	@Test
+	void testIntegerAndStringOverridesTogether() {
+		Map<String, Object> configs = new HashMap<>();
+		configs.put(ConsumerConfig.GROUP_ID_CONFIG, "test");
+
+		Properties overrides = new Properties();
+		overrides.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 5);
+		overrides.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+		DefaultKafkaConsumerFactory<String, String> factory =
+				new DefaultKafkaConsumerFactory<>(configs) {
+
+					@Override
+					protected Consumer<String, String> createRawConsumer(Map<String, Object> configProps) {
+
+						assertThat(configProps)
+								.containsEntry(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 5)
+								.containsEntry(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+						return mock(Consumer.class);
+					}
+				};
+
+		factory.createConsumer(null, null, null, overrides);
 	}
 
 	@Test
@@ -407,7 +412,6 @@ public class DefaultKafkaConsumerFactoryTests {
 						configPassedToKafkaConsumer.putAll(configProps);
 						return null;
 					}
-
 				};
 		target.createConsumer(null, null, null, overrides);
 		assertThat(configPassedToKafkaConsumer.get(ConsumerConfig.MAX_POLL_RECORDS_CONFIG)).isEqualTo("2");
@@ -454,7 +458,8 @@ public class DefaultKafkaConsumerFactoryTests {
 			assertThat(KafkaTestUtils.getPropertyValue(pfTx, "cache", Map.class)).hasSize(1);
 			assertThat(pfTx.getCache()).hasSize(1);
 			assertThat(KafkaTestUtils.getPropertyValue(container, "listenerConsumer.consumer")).isSameAs(wrapped.get());
-		} finally {
+		}
+		finally {
 			container.stop();
 			pf.destroy();
 			pfTx.destroy();
@@ -504,9 +509,9 @@ public class DefaultKafkaConsumerFactoryTests {
 			assertThat(KafkaTestUtils.getPropertyValue(pfTx, "cache", Map.class)).hasSize(1);
 			assertThat(pfTx.getCache()).hasSize(1);
 			assertThat(KafkaTestUtils.getPropertyValue(suffixStrategy, "suffixCache", Map.class)).hasSize(1);
-			//  1 tm tx producer and 1 templateTx tx producer
 			assertThat(KafkaTestUtils.getPropertyValue(container, "listenerConsumer.consumer")).isSameAs(wrapped.get());
-		} finally {
+		}
+		finally {
 			container.stop();
 			pf.destroy();
 			pfTx.destroy();
@@ -536,6 +541,7 @@ public class DefaultKafkaConsumerFactoryTests {
 			}
 
 		});
+
 		cf.setBeanName("cf");
 
 		Consumer consumer = cf.createConsumer();
@@ -544,7 +550,8 @@ public class DefaultKafkaConsumerFactoryTests {
 		assertThat(removals).isEmpty();
 		if (closeWithTimeout) {
 			consumer.close(CloseOptions.timeout(Duration.ofSeconds(10)));
-		} else {
+		}
+		else {
 			consumer.close();
 		}
 		assertThat(removals).hasSize(1);

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
@@ -73,10 +73,10 @@ import static org.mockito.Mockito.verify;
  *
  * @since 1.0.6
  */
-@EmbeddedKafka(topics = { "txCache1", "txCache2", "txCacheSendFromListener" },
+@EmbeddedKafka(topics = {"txCache1", "txCache2", "txCacheSendFromListener"},
 		brokerProperties = {
 				"transaction.state.log.replication.factor=1",
-				"transaction.state.log.min.isr=1" }
+				"transaction.state.log.min.isr=1"}
 )
 @SpringJUnitConfig
 @DirtiesContext
@@ -120,33 +120,31 @@ public class DefaultKafkaConsumerFactoryTests {
 
 	@Test
 	void testMixedTypeOverridesApplied() {
-		Map<String, Object> configs = KafkaTestUtils.consumerProps(
-				this.embeddedKafka,
-				"testGroup",
-				false
-		);
+		Map<String, Object> configs = KafkaTestUtils.consumerProps(this.embeddedKafka, "testGroup", false);
 
 		Properties overrides = new Properties();
 		overrides.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 2);
 		overrides.setProperty("some.property", "value");
 
-		Map<String, Object> captured = new HashMap<>();
+		AtomicReference<ConsumerConfig> capturedConfig = new AtomicReference<>();
 
 		DefaultKafkaConsumerFactory<String, String> factory =
 				new DefaultKafkaConsumerFactory<>(configs) {
 
 					@Override
 					protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
-						captured.putAll(configProps);
+						capturedConfig.set(new ConsumerConfig(configProps));
 						return mock(KafkaConsumer.class);
 					}
+
 				};
 
 		factory.createConsumer(null, null, null, overrides);
 
-		assertThat(captured)
-				.containsEntry(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 2)
-				.containsEntry("some.property", "value");
+		ConsumerConfig consumerConfig = capturedConfig.get();
+
+		assertThat(consumerConfig.getInt(ConsumerConfig.MAX_POLL_RECORDS_CONFIG)).isEqualTo(2);
+		assertThat(consumerConfig.getString("some.property")).isEqualTo("value");
 	}
 
 	@Test
@@ -158,21 +156,25 @@ public class DefaultKafkaConsumerFactoryTests {
 		overrides.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 5);
 		overrides.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
 
+		AtomicReference<ConsumerConfig> capturedConfig = new AtomicReference<>();
+
 		DefaultKafkaConsumerFactory<String, String> factory =
 				new DefaultKafkaConsumerFactory<>(configs) {
 
 					@Override
 					protected Consumer<String, String> createRawConsumer(Map<String, Object> configProps) {
-
-						assertThat(configProps)
-								.containsEntry(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 5)
-								.containsEntry(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
-
+						capturedConfig.set(new ConsumerConfig(configProps));
 						return mock(Consumer.class);
 					}
+
 				};
 
 		factory.createConsumer(null, null, null, overrides);
+
+		ConsumerConfig consumerConfig = capturedConfig.get();
+
+		assertThat(consumerConfig.getInt(ConsumerConfig.MAX_POLL_RECORDS_CONFIG)).isEqualTo(5);
+		assertThat(consumerConfig.getString(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG)).isEqualTo("earliest");
 	}
 
 	@Test

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
@@ -117,6 +117,55 @@ public class DefaultKafkaConsumerFactoryTests {
 	}
 
 	@Test
+	void testNonStringOverridePropertyApplied() {
+		Map<String, Object> originalConfig =
+				Collections.singletonMap(ConsumerConfig.GROUP_ID_CONFIG, "original");
+
+		Properties overrides = new Properties();
+		overrides.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 2);
+
+		final Map<String, Object> captured = new HashMap<>();
+
+		DefaultKafkaConsumerFactory<String, String> factory =
+				new DefaultKafkaConsumerFactory<>(originalConfig) {
+					@Override
+					protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
+						captured.putAll(configProps);
+						return null;
+					}
+				};
+
+		factory.createConsumer(null, null, null, overrides);
+
+		assertThat(captured.get(ConsumerConfig.MAX_POLL_RECORDS_CONFIG)).isEqualTo(2);
+	}
+
+	@Test
+	void testMixedTypeOverridePropertiesApplied() {
+		Map<String, Object> originalConfig =
+				Collections.singletonMap(ConsumerConfig.GROUP_ID_CONFIG, "original");
+
+		Properties overrides = new Properties();
+		overrides.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 2);
+		overrides.put("additional", "property");
+
+		final Map<String, Object> captured = new HashMap<>();
+
+		DefaultKafkaConsumerFactory<String, String> factory =
+				new DefaultKafkaConsumerFactory<>(originalConfig) {
+					@Override
+					protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
+						captured.putAll(configProps);
+						return null;
+					}
+				};
+
+		factory.createConsumer(null, null, null, overrides);
+
+		assertThat(captured.get(ConsumerConfig.MAX_POLL_RECORDS_CONFIG)).isEqualTo(2);
+	}
+
+	@Test
 	public void testBootstrapServersSupplier() {
 		Map<String, Object> originalConfig = Collections.emptyMap();
 		final Map<String, Object> configPassedToKafkaConsumer = new HashMap<>();


### PR DESCRIPTION
Problem

DefaultKafkaConsumerFactory uses Properties#stringPropertyNames() when merging override properties, which ignores non-string values. This leads to inconsistent behavior when override properties contain non-string values (e.g. integers).

Solution

Updated the merge logic in createConsumerWithAdjustedProperties to iterate over all entries in the Properties object, ensuring all values (including non-string) are consistently applied.

The existing branching logic is preserved to avoid any behavioral regression.

Result
Consistent handling of override properties regardless of value type
No impact on existing lifecycle behavior
Testing

Added tests to verify:

Non-string override properties are applied correctly
Mixed-type properties behave consistently

All existing tests pass.