### PR TITLE
Fix backoff recovery in multi-partition batch listener containers

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/AfterRollbackProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/AfterRollbackProcessor.java
@@ -21,6 +21,7 @@ import java.util.List;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
 
 import org.springframework.kafka.listener.ContainerProperties.EOSMode;
 
@@ -91,6 +92,14 @@ public interface AfterRollbackProcessor<K, V> {
 	 * @since 2.2
 	 */
 	default void clearThreadState() {
+	}
+
+	/**
+	 * Optional method to clear state for the specified topic/partition.
+	 * @param topicPartition the topic/partition.
+	 * @since 4.1
+	 */
+	default void clearTopicPartitionState(TopicPartition topicPartition) {
 	}
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonErrorHandler.java
@@ -166,6 +166,14 @@ public interface CommonErrorHandler extends DeliveryAttemptAware {
 	}
 
 	/**
+	 * Optional method to clear state for the specified topic/partition.
+	 * @param topicPartition the topic/partition.
+	 * @since 4.1
+	 */
+	default void clearTopicPartitionState(TopicPartition topicPartition) {
+	}
+
+	/**
 	 * Return true if the offset should be committed for a handled error (no exception
 	 * thrown).
 	 * @return true to commit.

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/DefaultAfterRollbackProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/DefaultAfterRollbackProcessor.java
@@ -250,6 +250,11 @@ public class DefaultAfterRollbackProcessor<K, V> extends FailedRecordProcessor
 		this.lastIntervals.remove(currentThread);
 	}
 
+	@Override
+	public void clearTopicPartitionState(TopicPartition topicPartition) {
+		super.clearTopicPartition(topicPartition);
+	}
+
 	private static OffsetAndMetadata createOffsetAndMetadata(@Nullable MessageListenerContainer container, long offset) {
 		if (container == null) {
 			return new OffsetAndMetadata(offset);

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/DefaultErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/DefaultErrorHandler.java
@@ -207,4 +207,9 @@ public class DefaultErrorHandler extends FailedBatchProcessor implements CommonE
 		getFallbackBatchHandler().onPartitionsAssigned(consumer, partitions, publishPause);
 	}
 
+	@Override
+	public void clearTopicPartitionState(TopicPartition topicPartition) {
+		super.clearTopicPartition(topicPartition);
+	}
+
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordProcessor.java
@@ -22,6 +22,7 @@ import java.util.function.BiFunction;
 
 import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.core.log.LogAccessor;
@@ -177,6 +178,15 @@ public abstract class FailedRecordProcessor extends ExceptionClassifier implemen
 
 	public void clearThreadState() {
 		this.failureTracker.clearThreadState();
+	}
+
+	/**
+	 * Clear the state for the specified topic/partition.
+	 * @param topicPartition the topic/partition.
+	 * @since 4.1
+	 */
+	public void clearTopicPartition(TopicPartition topicPartition) {
+		this.failureTracker.clearTopicPartition(topicPartition);
 	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordTracker.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordTracker.java
@@ -246,6 +246,16 @@ class FailedRecordTracker implements RecoveryStrategy {
 		this.failures.remove(Thread.currentThread());
 	}
 
+	void clearTopicPartition(TopicPartition topicPartition) {
+		Map<TopicPartition, FailedRecord> map = this.failures.get(Thread.currentThread());
+		if (map != null) {
+			map.remove(topicPartition);
+			if (map.isEmpty()) {
+				this.failures.remove(Thread.currentThread());
+			}
+		}
+	}
+
 	ConsumerAwareRecordRecoverer getRecoverer() {
 		return this.recoverer;
 	}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -2360,9 +2360,9 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 				if (this.batchFailed) {
 					this.batchFailed = false;
 					if (this.commonErrorHandler != null) {
-						this.commonErrorHandler.clearThreadState();
+						records.partitions().forEach(this.commonErrorHandler::clearTopicPartitionState);
 					}
-					getAfterRollbackProcessor().clearThreadState();
+					records.partitions().forEach(getAfterRollbackProcessor()::clearTopicPartitionState);
 				}
 				if (!this.autoCommit && !this.isRecordAck) {
 					processCommits();

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/DefaultAfterRollbackProcessorTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/DefaultAfterRollbackProcessorTests.java
@@ -176,4 +176,16 @@ public class DefaultAfterRollbackProcessorTests {
 		assertThat(System.currentTimeMillis() >= t1 + 200).isTrue();
 	}
 
+	@Test
+	void testClearTopicPartitionState() {
+		DefaultAfterRollbackProcessor<String, String> processor = new DefaultAfterRollbackProcessor<>();
+		TopicPartition tp = new TopicPartition("test-topic", 0);
+
+		// Verify that clearTopicPartitionState can be called without throwing an exception
+		processor.clearTopicPartitionState(tp);
+
+		// Verify that clearThreadState still works as expected
+		processor.clearThreadState();
+	}
+
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/MultiPartitionBackoffTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/MultiPartitionBackoffTests.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import java.util.List;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.kafka.support.TopicPartitionOffset;
+import org.springframework.util.backoff.FixedBackOff;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Tests for partition-specific state clearing in multi-partition environments.
+ * @since 4.1
+ */
+public class MultiPartitionBackoffTests {
+
+	@Test
+	void testErrorHandlerClearTopicPartitionState() {
+		DefaultErrorHandler errorHandler = new DefaultErrorHandler(new FixedBackOff(1000L, 10));
+		ConsumerRecord<String, String> record0 = new ConsumerRecord<>("foo", 0, 0L, "foo", "bar");
+		ConsumerRecord<String, String> record1 = new ConsumerRecord<>("foo", 1, 0L, "foo", "bar");
+		Consumer<?, ?> consumer = mock(Consumer.class);
+		MessageListenerContainer container = mock(MessageListenerContainer.class);
+
+		// Fail partition 0
+		errorHandler.handleOne(new RuntimeException(), record0, consumer, container);
+		// Fail partition 1
+		errorHandler.handleOne(new RuntimeException(), record1, consumer, container);
+
+		assertThat(errorHandler.deliveryAttempt(new TopicPartitionOffset("foo", 0, 0L))).isEqualTo(2);
+		assertThat(errorHandler.deliveryAttempt(new TopicPartitionOffset("foo", 1, 0L))).isEqualTo(2);
+
+		// Clear only partition 1
+		errorHandler.clearTopicPartitionState(new TopicPartition("foo", 1));
+
+		assertThat(errorHandler.deliveryAttempt(new TopicPartitionOffset("foo", 0, 0L))).isEqualTo(2); // Still 2
+		assertThat(errorHandler.deliveryAttempt(new TopicPartitionOffset("foo", 1, 0L))).isEqualTo(1); // Reset to 1
+
+		// Clear thread state
+		errorHandler.clearThreadState();
+		assertThat(errorHandler.deliveryAttempt(new TopicPartitionOffset("foo", 0, 0L))).isEqualTo(1);
+	}
+
+	@Test
+	void testAfterRollbackProcessorClearTopicPartitionState() {
+		DefaultAfterRollbackProcessor<String, String> processor = new DefaultAfterRollbackProcessor<>(new FixedBackOff(1000L, 10));
+		ConsumerRecord<String, String> record0 = new ConsumerRecord<>("foo", 0, 0L, "foo", "bar");
+		ConsumerRecord<String, String> record1 = new ConsumerRecord<>("foo", 1, 0L, "foo", "bar");
+		@SuppressWarnings("unchecked")
+		Consumer<String, String> consumer = mock(Consumer.class);
+		MessageListenerContainer container = mock(MessageListenerContainer.class);
+		given(container.getContainerProperties()).willReturn(new ContainerProperties("foo"));
+
+		// Use process to simulate failure and tracking
+		processor.process(List.of(record0), consumer, container, new RuntimeException(), true, ContainerProperties.EOSMode.V2);
+		processor.process(List.of(record1), consumer, container, new RuntimeException(), true, ContainerProperties.EOSMode.V2);
+
+		assertThat(processor.deliveryAttempt(new TopicPartitionOffset("foo", 0, 0L))).isEqualTo(2);
+		assertThat(processor.deliveryAttempt(new TopicPartitionOffset("foo", 1, 0L))).isEqualTo(2);
+
+		// Clear only partition 0
+		processor.clearTopicPartitionState(new TopicPartition("foo", 0));
+
+		assertThat(processor.deliveryAttempt(new TopicPartitionOffset("foo", 0, 0L))).isEqualTo(1);
+		assertThat(processor.deliveryAttempt(new TopicPartitionOffset("foo", 1, 0L))).isEqualTo(2);
+
+		// Clear thread state
+		processor.clearThreadState();
+		assertThat(processor.deliveryAttempt(new TopicPartitionOffset("foo", 1, 0L))).isEqualTo(1);
+	}
+
+}


### PR DESCRIPTION
Fixes #4371

Problem:
Backoff breaks recovery on batching listener container in multi-partition environments. When a batch from partition A fails and starts backoff, a subsequent successful batch from partition B would clear the backoff state for ALL partitions, preventing partition A from completing its backoff cycle and being sent to DLQ.

Solution:
- Added [clearTopicPartitionState(TopicPartition)](cci:1://file:///d:/Projects/spring-kafka/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonErrorHandler.java:167:1-175:2) method to [CommonErrorHandler](cci:2://file:///d:/Projects/spring-kafka/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonErrorHandler.java:38:0-206:1) interface
- Added [clearTopicPartitionState(TopicPartition)](cci:1://file:///d:/Projects/spring-kafka/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonErrorHandler.java:167:1-175:2) method to [AfterRollbackProcessor](cci:2://file:///d:/Projects/spring-kafka/spring-kafka/src/main/java/org/springframework/kafka/listener/AfterRollbackProcessor.java:42:0-120:1) interface
- Implemented topic-partition-specific state clearing in [FailedRecordTracker](cci:2://file:///d:/Projects/spring-kafka/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordTracker.java:48:0-322:1)
- Implemented topic-partition-specific state clearing in [DefaultAfterRollbackProcessor](cci:2://file:///d:/Projects/spring-kafka/spring-kafka/src/main/java/org/springframework/kafka/listener/DefaultAfterRollbackProcessor.java:59:0-278:1)
- Updated [doInvokeBatchListener](cci:1://file:///d:/Projects/spring-kafka/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java:2348:2-2399:3) to clear state per partition instead of thread-wide clearing

This allows each partition to maintain its own backoff state independently, enabling proper backoff recovery in multi-partition environments.