### PR TITLE
GH-4377: Fix `asyncReplies` calculation for container

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/DelegatingMessageListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/DelegatingMessageListener.java
@@ -16,22 +16,34 @@
 
 package org.springframework.kafka.listener;
 
+import org.springframework.kafka.listener.adapter.AsyncRepliesAware;
+
 /**
  * Classes implementing this interface allow containers to determine the type of the
  * ultimate listener.
+ * <p>
+ * This interface also implements {@link AsyncRepliesAware} contract delegating to the {@link #getDelegate()},
+ * respectivelly.
  *
  * @param <T> the type received by the listener.
  *
  * @author Gary Russell
+ * @author Artem Bilan
+ *
  * @since 2.0
  *
  */
-public interface DelegatingMessageListener<T> {
+public interface DelegatingMessageListener<T> extends AsyncRepliesAware {
 
 	/**
 	 * Return the delegate.
 	 * @return the delegate.
 	 */
 	T getDelegate();
+
+	@Override
+	default boolean isAsyncReplies() {
+		return getDelegate() instanceof AsyncRepliesAware asyncRepliesAware && asyncRepliesAware.isAsyncReplies();
+	}
 
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/AsyncCompletableFutureRetryTopicScenarioTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/AsyncCompletableFutureRetryTopicScenarioTests.java
@@ -43,7 +43,6 @@ import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.listener.ContainerProperties;
-import org.springframework.kafka.listener.ContainerProperties.AckMode;
 import org.springframework.kafka.listener.KafkaListenerErrorHandler;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.test.EmbeddedKafkaBroker;
@@ -1323,7 +1322,7 @@ public class AsyncCompletableFutureRetryTopicScenarioTests {
 	}
 
 	@EnableKafka
-	@Configuration
+	@Configuration(proxyBeanMethods = false)
 	static class KafkaConsumerConfig {
 
 		@Autowired
@@ -1342,7 +1341,7 @@ public class AsyncCompletableFutureRetryTopicScenarioTests {
 		ConcurrentKafkaListenerContainerFactory<String, String> retryTopicListenerContainerFactory(
 				ConsumerFactory<String, String> consumerFactory) {
 
-			ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+			var factory = new ConcurrentKafkaListenerContainerFactory<String, String>();
 			ContainerProperties props = factory.getContainerProperties();
 			props.setIdleEventInterval(100L);
 			props.setPollTimeout(50L);
@@ -1358,15 +1357,9 @@ public class AsyncCompletableFutureRetryTopicScenarioTests {
 		ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory(
 				ConsumerFactory<String, String> consumerFactory) {
 
-			ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+			var factory = new ConcurrentKafkaListenerContainerFactory<String, String>();
 			factory.setConsumerFactory(consumerFactory);
 			factory.setConcurrency(1);
-			factory.setContainerCustomizer(container -> {
-				if (container.getListenerId().startsWith("manual")) {
-					container.getContainerProperties().setAckMode(AckMode.MANUAL);
-					container.getContainerProperties().setAsyncAcks(true);
-				}
-			});
 			return factory;
 		}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/AsyncMonoRetryTopicScenarioTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/AsyncMonoRetryTopicScenarioTests.java
@@ -455,7 +455,7 @@ public class AsyncMonoRetryTopicScenarioTests {
 	}
 
 	@EnableKafka
-	@Configuration
+	@Configuration(proxyBeanMethods = false)
 	static class KafkaConsumerConfig {
 
 		@Autowired
@@ -474,7 +474,7 @@ public class AsyncMonoRetryTopicScenarioTests {
 		ConcurrentKafkaListenerContainerFactory<String, String> retryTopicListenerContainerFactory(
 				ConsumerFactory<String, String> consumerFactory) {
 
-			ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+			var factory = new ConcurrentKafkaListenerContainerFactory<String, String>();
 			ContainerProperties props = factory.getContainerProperties();
 			props.setIdleEventInterval(100L);
 			props.setPollTimeout(50L);
@@ -490,15 +490,9 @@ public class AsyncMonoRetryTopicScenarioTests {
 		ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory(
 				ConsumerFactory<String, String> consumerFactory) {
 
-			ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+			var factory = new ConcurrentKafkaListenerContainerFactory<String, String>();
 			factory.setConsumerFactory(consumerFactory);
 			factory.setConcurrency(1);
-			factory.setContainerCustomizer(container -> {
-				if (container.getListenerId().startsWith("manual")) {
-					container.getContainerProperties().setAckMode(AckMode.MANUAL);
-					container.getContainerProperties().setAsyncAcks(true);
-				}
-			});
 			return factory;
 		}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/AsyncMonoRetryTopicScenarioTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/retrytopic/AsyncMonoRetryTopicScenarioTests.java
@@ -41,7 +41,6 @@ import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.listener.ContainerProperties;
-import org.springframework.kafka.listener.ContainerProperties.AckMode;
 import org.springframework.kafka.listener.KafkaListenerErrorHandler;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.test.EmbeddedKafkaBroker;


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-kafka/issues/4377

The `KafkaMessageListenerContainer.ListenerConsumer` determines its `asyncReplies` against `listener instanceof AsyncRepliesAware`.
However, in case of retryable topics configuration, or just `factory.setRecordFilterStrategy()`, the provided `listener` is going to be wrapped with a `DelegatingMessageListener` or even stack of them, e.g., in case of retryable topics and record filtering combination

* Implement `AsyncRepliesAware` contract on the `DelegatingMessageListener` with simple delegation to the `getDelegate()`
* There is not need in new tests, and modification of existing configuration, based on `CompletableFuture` and `Mono`, is enough to prove that new feature works as expected. Previously those tests enforced `AckMode.MANUAL` and `asyncAcks` through configuration to work out `asyncReplies` behavior. With the fix we got them through fallback according to the `isAsyncReplies()` state of the ultimate listener

The `AsyncRepliesAware` contract goes down in the history to the `3.3.x` version. Therefore, applying this fix into that branch feels legit. Moreover, it is not a breaking change due to the `default` methods feature in Java internfaces.

NOTE: The `asyncAcks` still needed to be

**Auto-cherry-pick to `4.0.x` & `3.3.x`**

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
