### PR TITLE
Improve description of messageListener in container properties documentation

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/container-props.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/container-props.adoc
@@ -138,7 +138,7 @@ The default executor creates threads named `<name>-C-n`; with the `KafkaMessageL
 
 |[[messageListener]]<<messageListener,`messageListener`>>
 |`null`
-|The message listener.
+|The message listener that processes records consumed from Kafka topics.
 
 |[[micrometerEnabled]]<<micrometerEnabled,`micrometerEnabled`>>
 |`true`


### PR DESCRIPTION
Improve clarity of the messageListener property description by specifying that it processes records consumed from Kafka topics.