### PR TITLE
Fix NPE in StreamsBuilderFactoryBean when Properties are null

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/config/StreamsBuilderFactoryBean.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/StreamsBuilderFactoryBean.java
@@ -198,7 +198,7 @@ public class StreamsBuilderFactoryBean extends AbstractFactoryBean<StreamsBuilde
 
 	@Nullable
 	public Properties getStreamsConfiguration() {
-		return (Properties) this.properties.clone();
+		return this.properties != null ? (Properties) this.properties.clone() : null;
 	}
 
 	public void setClientSupplier(KafkaClientSupplier clientSupplier) {

--- a/spring-kafka/src/test/java/org/springframework/kafka/streams/KafkaStreamsInteractiveQueryServiceTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/streams/KafkaStreamsInteractiveQueryServiceTests.java
@@ -159,6 +159,15 @@ class KafkaStreamsInteractiveQueryServiceTests {
 	}
 
 	@Test
+	void currentHostInfoWithNoProperties() {
+		StreamsBuilderFactoryBean sbfb = new StreamsBuilderFactoryBean();
+		sbfb.setAutoStartup(false);
+		KafkaStreamsInteractiveQueryService iqs = new KafkaStreamsInteractiveQueryService(sbfb);
+		HostInfo currentKafkaStreamsApplicationHostInfo = iqs.getCurrentKafkaStreamsApplicationHostInfo();
+		assertThat(currentKafkaStreamsApplicationHostInfo).isNull();
+	}
+
+	@Test
 	void hostInfoForKeyAndStore() throws Exception {
 		ensureKafkaStreamsProcessorIsUpAndRunning();
 


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-kafka/issues/4434

- Added null pointer check before clone in StreamsBuilderFactoryBean.getStreamsConfiguration
- Added test case to check NPE for KafkaStreamsInteractiveQueryService
