### PR TITLE
make the method setBackOffFunction work for the batch processing as well (backport to the branch 3.3.x)

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ErrorHandlingUtils.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ErrorHandlingUtils.java
@@ -78,17 +78,51 @@ public final class ErrorHandlingUtils {
 	 * @param logLevel the log level.
 	 * @param retryListeners the retry listeners.
 	 * @param classifier the exception classifier.
-	 * @param reClassifyOnExceptionChange true to reset the state if a different exception
+	 * @param reClassifyOnExceptionChange true to reclassify the exception if a different exception
 	 * is thrown during retry.
 	 * @since 2.9.7
+	 * @deprecated in favor of the other retryBatch method that allows more control over the retry process
 	 */
+	@Deprecated
 	public static void retryBatch(Exception thrownException, ConsumerRecords<?, ?> records, Consumer<?, ?> consumer,
 			MessageListenerContainer container, Runnable invokeListener, BackOff backOff,
 			CommonErrorHandler seeker, BiConsumer<ConsumerRecords<?, ?>, Exception> recoverer, LogAccessor logger,
 			KafkaException.Level logLevel, List<RetryListener> retryListeners, BinaryExceptionClassifier classifier,
 			boolean reClassifyOnExceptionChange) {
+		retryBatch(thrownException, records, consumer, container, invokeListener, backOff.start(), seeker, recoverer,
+				logger, logLevel, retryListeners, classifier, reClassifyOnExceptionChange, false);
+	}
 
-		BackOffExecution execution = backOff.start();
+	/**
+	 * Retry a complete batch by pausing the consumer and then, in a loop, poll the
+	 * consumer, wait for the next back off, then call the listener. When retries are
+	 * exhausted, call the recoverer with the {@link ConsumerRecords}.
+	 * @param thrownException the exception.
+	 * @param records the records.
+	 * @param consumer the consumer.
+	 * @param container the container.
+	 * @param invokeListener the {@link Runnable} to run (call the listener).
+	 * @param execution the backOff execution to use for the retries.
+	 * @param seeker the common error handler that re-seeks the entire batch.
+	 * @param recoverer the recoverer.
+	 * @param logger the logger.
+	 * @param logLevel the log level.
+	 * @param retryListeners the retry listeners.
+	 * @param classifier the exception classifier.
+	 * @param reClassifyOnExceptionChange true to reclassify the exception if a different exception
+	 * is thrown during retry.
+	 * @param resetStateOnExceptionChange true to if a different exception thrown during retry should end this method.
+	 * @return a new exception if resetStateOnExceptionChange was true and a different exception has occurred
+	 * 	 (retry with a possibly different BackOffExecution is expected if non-null is returned)
+     * @since 3.3.16
+	 */
+	@Nullable
+	public static Exception retryBatch(Exception thrownException, ConsumerRecords<?, ?> records, Consumer<?, ?> consumer,
+			MessageListenerContainer container, Runnable invokeListener, BackOffExecution execution,
+			CommonErrorHandler seeker, BiConsumer<ConsumerRecords<?, ?>, Exception> recoverer, LogAccessor logger,
+			KafkaException.Level logLevel, List<RetryListener> retryListeners, BinaryExceptionClassifier classifier,
+			boolean reClassifyOnExceptionChange, boolean resetStateOnExceptionChange) {
+
 		long nextBackOff = execution.nextBackOff();
 		String failed = null;
 		Set<TopicPartition> assignment = consumer.assignment();
@@ -147,7 +181,7 @@ public final class ErrorHandlingUtils {
 				}
 				try {
 					invokeListener.run();
-					return;
+					return null;
 				}
 				catch (Exception ex) {
 					listen(retryListeners, records, ex, attempt++);
@@ -162,6 +196,9 @@ public final class ErrorHandlingUtils {
 							&& !classifier.classify(newException)) {
 
 						break;
+					}
+					if (resetStateOnExceptionChange && !newException.getClass().equals(lastException.getClass())) {
+						return newException;
 					}
 				}
 				nextBackOff = execution.nextBackOff();
@@ -184,6 +221,7 @@ public final class ErrorHandlingUtils {
 				consumerPauseResumeEventPublisher.publishConsumerResumedEvent(assignment2);
 			}
 		}
+		return null;
 	} // NOSONAR NCSS line count
 
 	private static void listen(List<RetryListener> listeners, ConsumerRecords<?, ?> records,

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedBatchProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedBatchProcessor.java
@@ -84,6 +84,9 @@ public abstract class FailedBatchProcessor extends FailedRecordProcessor {
 
 		super(recoverer, backOff, backOffHandler);
 		this.fallbackBatchHandler = fallbackHandler;
+		if (this.fallbackBatchHandler instanceof FallbackBatchErrorHandler handler) {
+			handler.setFailureTracker(getFailureTracker());
+		}
 	}
 
 	@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedBatchProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedBatchProcessor.java
@@ -107,16 +107,24 @@ public abstract class FailedBatchProcessor extends FailedRecordProcessor {
 
 	/**
 	 * Set to {@code false} to not reclassify the exception if different from the previous
-	 * failure. If the changed exception is classified as retryable, the existing back off
-	 * sequence is used; a new sequence is not started. Default true. Only applies when
-	 * the fallback batch error handler (for exceptions other than
-	 * {@link BatchListenerFailedException}) is the default.
+	 * failure. Default true. If the changed exception is classified as retryable, the existing
+	 * back off sequence is used if resetStateOnExceptionChange is false; a new sequence is started
+	 * if resetStateOnExceptionChange is true. Only applies when the fallback batch error handler
+	 * (for exceptions other than {@link BatchListenerFailedException}) is the default.
 	 * @param reclassifyOnExceptionChange false to not reclassify.
 	 * @since 2.9.7
 	 */
 	public void setReclassifyOnExceptionChange(boolean reclassifyOnExceptionChange) {
 		if (this.fallbackBatchHandler instanceof FallbackBatchErrorHandler handler) {
 			handler.setReclassifyOnExceptionChange(reclassifyOnExceptionChange);
+		}
+	}
+
+	@Override
+	public void setResetStateOnExceptionChange(boolean resetStateOnExceptionChange) {
+		super.setResetStateOnExceptionChange(resetStateOnExceptionChange);
+		if (this.fallbackBatchHandler instanceof FallbackBatchErrorHandler handler) {
+			handler.setResetStateOnExceptionChange(resetStateOnExceptionChange);
 		}
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordTracker.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordTracker.java
@@ -213,7 +213,7 @@ class FailedRecordTracker implements RecoveryStrategy {
 		return failedRecord;
 	}
 
-	private BackOff determineBackOff(ConsumerRecord<?, ?> record, Exception exception) {
+	BackOff determineBackOff(ConsumerRecord<?, ?> record, Exception exception) {
 		if (this.backOffFunction == null) {
 			return this.backOff;
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FallbackBatchErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FallbackBatchErrorHandler.java
@@ -36,6 +36,7 @@ import org.springframework.kafka.KafkaException;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.backoff.BackOff;
+import org.springframework.util.backoff.BackOffExecution;
 import org.springframework.util.backoff.FixedBackOff;
 
 /**
@@ -67,6 +68,8 @@ class FallbackBatchErrorHandler extends ExceptionClassifier implements CommonErr
 	private boolean ackAfterHandle = true;
 
 	private boolean reclassifyOnExceptionChange = true;
+
+	private boolean resetStateOnExceptionChange = false;
 
 	private FailedRecordTracker failureTracker;
 
@@ -132,13 +135,26 @@ class FallbackBatchErrorHandler extends ExceptionClassifier implements CommonErr
 
 	/**
 	 * Set to false to not reclassify the exception if different from the previous
-	 * failure. If the changed exception is classified as retryable, the existing back off
-	 * sequence is used; a new sequence is not started. Default true.
+	 * failure. Default true. If the changed exception is classified as retryable, the
+	 * existing back off sequence is used when resetStateOnExceptionChange is set to
+	 * false; a new sequence is started when resetStateOnExceptionChange is set to true.
 	 * @param reclassifyOnExceptionChange false to not reclassify.
 	 * @since 2.9.7
 	 */
 	public void setReclassifyOnExceptionChange(boolean reclassifyOnExceptionChange) {
 		this.reclassifyOnExceptionChange = reclassifyOnExceptionChange;
+	}
+
+	/**
+	 * Set to false to keep the same back off sequence even when the exception changes
+	 * in subsequent retries. Default false. If set to true, a new sequence is started
+	 * when the exception changes.
+	 * @param resetStateOnExceptionChange true to start a new back off sequence
+	 * when the exception changes in subsequent retries
+	 * @since 3.3.16
+	 */
+	public void setResetStateOnExceptionChange(boolean resetStateOnExceptionChange) {
+		this.resetStateOnExceptionChange = resetStateOnExceptionChange;
 	}
 
 	void setFailureTracker(FailedRecordTracker failedRecordTracker) {
@@ -155,11 +171,17 @@ class FallbackBatchErrorHandler extends ExceptionClassifier implements CommonErr
 		}
 		this.retrying.put(Thread.currentThread(), true);
 		try {
-			BackOff backOffToUse = this.failureTracker == null ? this.backOff :
-					this.failureTracker.determineBackOff(records.iterator().next(), thrownException);
-			ErrorHandlingUtils.retryBatch(thrownException, records, consumer, container, invokeListener, backOffToUse,
-					this.seeker, this.recoverer, this.logger, getLogLevel(), this.retryListeners, getClassifier(),
-					this.reclassifyOnExceptionChange);
+			BackOffExecution backOffExecution = null;
+			while (thrownException != null) {
+				BackOff backOffToUse = this.failureTracker == null ? this.backOff :
+						this.failureTracker.determineBackOff(records.iterator().next(), thrownException);
+				if (backOffExecution == null || this.resetStateOnExceptionChange) {
+					backOffExecution = backOffToUse.start();
+				}
+				thrownException = ErrorHandlingUtils.retryBatch(thrownException, records, consumer, container, invokeListener,
+						backOffExecution, this.seeker, this.recoverer, this.logger, getLogLevel(), this.retryListeners,
+						getClassifier(), this.reclassifyOnExceptionChange, this.resetStateOnExceptionChange);
+			}
 		}
 		finally {
 			this.retrying.remove(Thread.currentThread());

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FallbackBatchErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FallbackBatchErrorHandler.java
@@ -68,6 +68,8 @@ class FallbackBatchErrorHandler extends ExceptionClassifier implements CommonErr
 
 	private boolean reclassifyOnExceptionChange = true;
 
+	private FailedRecordTracker failureTracker;
+
 	/**
 	 * Construct an instance with a default {@link FixedBackOff} (unlimited attempts with
 	 * a 5 second back off).
@@ -139,6 +141,10 @@ class FallbackBatchErrorHandler extends ExceptionClassifier implements CommonErr
 		this.reclassifyOnExceptionChange = reclassifyOnExceptionChange;
 	}
 
+	void setFailureTracker(FailedRecordTracker failedRecordTracker) {
+		this.failureTracker = failedRecordTracker;
+	}
+
 	@Override
 	public void handleBatch(Exception thrownException, @Nullable ConsumerRecords<?, ?> records,
 			Consumer<?, ?> consumer, MessageListenerContainer container, Runnable invokeListener) {
@@ -149,7 +155,9 @@ class FallbackBatchErrorHandler extends ExceptionClassifier implements CommonErr
 		}
 		this.retrying.put(Thread.currentThread(), true);
 		try {
-			ErrorHandlingUtils.retryBatch(thrownException, records, consumer, container, invokeListener, this.backOff,
+			BackOff backOffToUse = this.failureTracker == null ? this.backOff :
+					this.failureTracker.determineBackOff(records.iterator().next(), thrownException);
+			ErrorHandlingUtils.retryBatch(thrownException, records, consumer, container, invokeListener, backOffToUse,
 					this.seeker, this.recoverer, this.logger, getLogLevel(), this.retryListeners, getClassifier(),
 					this.reclassifyOnExceptionChange);
 		}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ErrorHandlingUtilsTest.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ErrorHandlingUtilsTest.java
@@ -97,9 +97,9 @@ class ErrorHandlingUtilsTest {
 
 	private void doRetries() {
 		ErrorHandlingUtils.retryBatch(
-				thrownException, consumerRecords, consumer, container, listener, backOff,
+				thrownException, consumerRecords, consumer, container, listener, backOff.start(),
 				seeker, recoverer, logger, KafkaException.Level.INFO, retryListeners,
-				classifier, true
+				classifier, true, false
 		);
 	}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/FallbackBatchErrorHandlerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/FallbackBatchErrorHandlerTests.java
@@ -287,6 +287,30 @@ public class FallbackBatchErrorHandlerTests {
 		assertThat(retries.get()).isEqualTo(3);
 	}
 
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Test
+	void reclassifyResetBackOffOnExceptionChange() {
+		AtomicReference<Exception> thrown = new AtomicReference<>();
+		DefaultErrorHandler eh = new DefaultErrorHandler((cr, ex) ->  {
+			thrown.set(ex);
+		}, new FixedBackOff(0L, 3));
+		eh.setResetStateOnExceptionChange(true);
+		ConsumerRecords records = new ConsumerRecords(
+				Map.of(new TopicPartition("foo", 0), List.of(new ConsumerRecord("foo", 0, 0L, null, "bar"))));
+		MessageListenerContainer container = mock(MessageListenerContainer.class);
+		given(container.isRunning()).willReturn(true);
+		AtomicInteger retries = new AtomicInteger();
+		eh.handleBatch(new IllegalStateException(), records, mock(Consumer.class), container,
+				() -> {
+					retries.incrementAndGet();
+					throw new ListenerExecutionFailedException("", new IllegalArgumentException());
+				});
+		assertThat(thrown.get()).isInstanceOf(ListenerExecutionFailedException.class)
+				.extracting("cause")
+				.isInstanceOf(IllegalArgumentException.class);
+		assertThat(retries.get()).isEqualTo(4);
+	}
+
 	private boolean getRetryingFieldValue(FallbackBatchErrorHandler errorHandler) {
 		Field field = ReflectionUtils.findField(FallbackBatchErrorHandler.class, "retrying");
 		ReflectionUtils.makeAccessible(field);


### PR DESCRIPTION
The method setBackOffFunction of FailedRecordProcessor and its descendants (FailedBatchProcessor and DefaultErrorHandler) is useful for classifying the exceptions thrown from the application code (listeners). However, I find it very surprising that this method does not work when processing the messages in batches (the supplied backOffFunction is never called there). Please review my attempt to make it work for the batch processing as well.