### PR TITLE
GH-4444: Fix COUNT_TIME ack mode ignoring the time condition

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -3249,10 +3249,10 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			if (this.isCountAck) {
 				countAcks();
 			}
-			else if (this.isTimeAck) {
+			if (this.isTimeAck) {
 				timedAcks();
 			}
-			else if (!this.isManualImmediateAck) {
+			else if (!this.isCountAck && !this.isManualImmediateAck) {
 				commitIfNecessary();
 				this.count = 0;
 			}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
@@ -523,6 +523,52 @@ public class KafkaMessageListenerContainerTests {
 		verify(consumer.get(), times(2)).commitSync(anyMap(), any());
 	}
 
+	@SuppressWarnings("unchecked")
+	@Test
+	void testCountTimeAckModeCommitsOnTimeExpiry() throws Exception {
+		ConsumerFactory<Integer, String> cf = mock(ConsumerFactory.class);
+		Consumer<Integer, String> consumer = mock(Consumer.class);
+		given(cf.createConsumer(eq("grp"), eq("clientId"), isNull(), any())).willReturn(consumer);
+
+		final Map<TopicPartition, List<ConsumerRecord<Integer, String>>> records = new HashMap<>();
+		records.put(new TopicPartition("foo", 0), List.of(
+				new ConsumerRecord<>("foo", 0, 0L, 1, "foo"),
+				new ConsumerRecord<>("foo", 0, 1L, 1, "bar")));
+		ConsumerRecords<Integer, String> consumerRecords = new ConsumerRecords<>(records, Map.of());
+
+		// Each poll sleeps briefly so the ackTime elapses across a few poll cycles
+		given(consumer.poll(any(Duration.class))).willAnswer(i -> {
+			Thread.sleep(100);
+			return consumerRecords;
+		});
+
+		TopicPartitionOffset[] topicPartitions = new TopicPartitionOffset[] {
+				new TopicPartitionOffset("foo", 0) };
+		ContainerProperties containerProps = new ContainerProperties(topicPartitions);
+		containerProps.setGroupId("grp");
+		containerProps.setClientId("clientId");
+		containerProps.setAckMode(AckMode.COUNT_TIME);
+		containerProps.setAckCount(1000);  // never reached — only 2 records per poll
+		containerProps.setAckTime(300);    // fires after ~3 polls (3 * 100 ms)
+		containerProps.setMissingTopicsFatal(false);
+		containerProps.setMessageListener((MessageListener<Integer, String>) message -> { });
+
+		CountDownLatch commitLatch = new CountDownLatch(1);
+		willAnswer(i -> {
+			records.clear();  // stop feeding records after the first time-based commit
+			commitLatch.countDown();
+			return null;
+		}).given(consumer).commitSync(anyMap(), any());
+
+		KafkaMessageListenerContainer<Integer, String> container =
+				new KafkaMessageListenerContainer<>(cf, containerProps);
+		container.start();
+		assertThat(commitLatch.await(10, TimeUnit.SECONDS))
+				.as("COUNT_TIME ack mode must commit when ackTime elapses even if ackCount is not reached")
+				.isTrue();
+		container.stop();
+	}
+
 	@Test
 	public void testRecordAck() throws Exception {
 		logger.info("Start record ack");


### PR DESCRIPTION
## Summary

Fixes #4444.

In `KafkaMessageListenerContainer.processCommits()`, the `if-else if` structure caused `timedAcks()` to be unreachable for `COUNT_TIME` ack mode.

For `COUNT_TIME`, both `isCountAck` and `isTimeAck` are `true`. Because of the `else if`, `timedAcks()` was dead code — only the count threshold was ever checked, meaning the time component of `COUNT_TIME` was silently ignored.

### Root cause

```java
// BEFORE — timedAcks() unreachable for COUNT_TIME
if (this.isCountAck) {
    countAcks();
}
else if (this.isTimeAck) {   // never reached when isCountAck == true
    timedAcks();
}
```

### Fix

Split into two independent `if` checks so both conditions are evaluated for `COUNT_TIME`:

```java
if (this.isCountAck) {
    countAcks();
}
if (this.isTimeAck) {
    timedAcks();
}
else if (!this.isCountAck && !this.isManualImmediateAck) {
    commitIfNecessary();
    this.count = 0;
}
```

**No double-commit risk**: when `countAcks()` fires it resets `last = now`, so the subsequent `timedAcks()` call sees `elapsed ≈ 0` and skips committing again. All other ack modes (`COUNT`, `TIME`, `RECORD`, `BATCH`, `MANUAL`, `MANUAL_IMMEDIATE`) are unaffected.

## Tests

Added `testCountTimeAckModeCommitsOnTimeExpiry` to `KafkaMessageListenerContainerTests` — a mock-based test that configures `COUNT_TIME` with a large `ackCount` (1000, never reached by 2 records/poll) and a small `ackTime` (300 ms), then asserts that `commitSync` is called within 10 s, exercising the previously broken time-based commit path.