### PR TITLE
make the method setBackOffFunction work for the batch processing as well

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -89,3 +89,10 @@ The `StreamsBuilderFactoryBean` now supports configuring the `groupProtocol` pro
 This allows you to explicitly manage whether the underlying Kafka Streams consumers rely on the `classic` protocol or opt into the newer `streams` group protocol (KIP-1071: Server-side rebalance for Streams).
 
 See xref:streams.adoc#streams-config[Configuration] in the Kafka Streams documentation for more details.
+
+[[x41-back-off-function]]
+=== BackOffFunction Support In FailedBatchProcessor
+
+`FailedBatchProcessor` now supports setting `BackOffFunction` and `resetStateOnExceptionChange` for the batch message processing the same way as `FailedRecordProcessor` already does for single message processing. This enables using xref:kafka/annotation-error-handling.adoc#default-eh[DefaultErrorHandler] for consistent classification of the exceptions for both single and batch message processing.
+
+Please note that to keep backward compatibility, the default value for `resetStateOnExceptionChange` is `false` for `FailedBatchProcessor`, which is different from `FailedRecordProcessor`. If you want to have the same behavior for both, you need to call `setResetStateOnExceptionChange(true)` on your `FailedBatchProcessor` instance.

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ErrorHandlingUtils.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ErrorHandlingUtils.java
@@ -112,7 +112,7 @@ public final class ErrorHandlingUtils {
 	 * @param exceptionMatcher the exception matcher.
 	 * @param reClassifyOnExceptionChange true to reclassify the exception if a different exception
 	 * is thrown during retry.
-	 * @param resetStateOnExceptionChange true to if a different exception thrown during retry should end this method.
+	 * @param resetStateOnExceptionChange true if a different exception thrown during retry should end this method.
 	 * @return a new exception if resetStateOnExceptionChange was true and a different exception has occurred
 	 * 	 (retry with a possibly different BackOffExecution is expected if non-null is returned)
      * @since 4.1.0

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ErrorHandlingUtils.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ErrorHandlingUtils.java
@@ -79,17 +79,51 @@ public final class ErrorHandlingUtils {
 	 * @param logLevel the log level.
 	 * @param retryListeners the retry listeners.
 	 * @param exceptionMatcher the exception matcher.
-	 * @param reClassifyOnExceptionChange true to reset the state if a different exception
+	 * @param reClassifyOnExceptionChange true to reclassify the exception if a different exception
 	 * is thrown during retry.
 	 * @since 2.9.7
+	 * @deprecated in favor of the other retryBatch method that allows more control over the retry process
 	 */
+	@Deprecated
 	public static void retryBatch(Exception thrownException, ConsumerRecords<?, ?> records, Consumer<?, ?> consumer,
 			MessageListenerContainer container, Runnable invokeListener, BackOff backOff,
 			CommonErrorHandler seeker, BiConsumer<ConsumerRecords<?, ?>, Exception> recoverer, LogAccessor logger,
 			KafkaException.Level logLevel, List<RetryListener> retryListeners, ExceptionMatcher exceptionMatcher,
 			boolean reClassifyOnExceptionChange) {
+		retryBatch(thrownException, records, consumer, container, invokeListener, backOff.start(), seeker, recoverer,
+				logger, logLevel, retryListeners, exceptionMatcher, reClassifyOnExceptionChange, false);
+	}
 
-		BackOffExecution execution = backOff.start();
+	/**
+	 * Retry a complete batch by pausing the consumer and then, in a loop, poll the
+	 * consumer, wait for the next back off, then call the listener. When retries are
+	 * exhausted, call the recoverer with the {@link ConsumerRecords}.
+	 * @param thrownException the exception.
+	 * @param records the records.
+	 * @param consumer the consumer.
+	 * @param container the container.
+	 * @param invokeListener the {@link Runnable} to run (call the listener).
+	 * @param execution the backOff execution to use for the retries.
+	 * @param seeker the common error handler that re-seeks the entire batch.
+	 * @param recoverer the recoverer.
+	 * @param logger the logger.
+	 * @param logLevel the log level.
+	 * @param retryListeners the retry listeners.
+	 * @param exceptionMatcher the exception matcher.
+	 * @param reClassifyOnExceptionChange true to reclassify the exception if a different exception
+	 * is thrown during retry.
+	 * @param resetStateOnExceptionChange true to if a different exception thrown during retry should end this method.
+	 * @return a new exception if resetStateOnExceptionChange was true and a different exception has occurred
+	 * 	 (retry with a possibly different BackOffExecution is expected if non-null is returned)
+     * @since 4.1.0
+	 */
+	@Nullable
+	public static Exception retryBatch(Exception thrownException, ConsumerRecords<?, ?> records, Consumer<?, ?> consumer,
+			MessageListenerContainer container, Runnable invokeListener, BackOffExecution execution,
+			CommonErrorHandler seeker, BiConsumer<ConsumerRecords<?, ?>, Exception> recoverer, LogAccessor logger,
+			KafkaException.Level logLevel, List<RetryListener> retryListeners, ExceptionMatcher exceptionMatcher,
+			boolean reClassifyOnExceptionChange, boolean resetStateOnExceptionChange) {
+
 		long nextBackOff = execution.nextBackOff();
 		String failed = null;
 		Set<TopicPartition> assignment = consumer.assignment();
@@ -148,7 +182,7 @@ public final class ErrorHandlingUtils {
 				}
 				try {
 					invokeListener.run();
-					return;
+					return null;
 				}
 				catch (Exception ex) {
 					listen(retryListeners, records, ex, attempt++);
@@ -164,6 +198,10 @@ public final class ErrorHandlingUtils {
 							&& !exceptionMatcher.match(newException)) {
 
 						break;
+					}
+					if (resetStateOnExceptionChange && !Objects.requireNonNull(newException).getClass()
+							.equals(Objects.requireNonNull(lastException).getClass())) {
+						return newException;
 					}
 				}
 				nextBackOff = execution.nextBackOff();
@@ -186,6 +224,7 @@ public final class ErrorHandlingUtils {
 				consumerPauseResumeEventPublisher.publishConsumerResumedEvent(assignment2);
 			}
 		}
+		return null;
 	} // NOSONAR NCSS line count
 
 	private static void listen(List<RetryListener> listeners, ConsumerRecords<?, ?> records,

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedBatchProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedBatchProcessor.java
@@ -79,11 +79,15 @@ public abstract class FailedBatchProcessor extends FailedRecordProcessor {
 	 * @param fallbackHandler the fallback handler.
 	 * @since 2.9
 	 */
+	@SuppressWarnings("this-escape") // geFailureTracker() returns an already initialized final field
 	public FailedBatchProcessor(@Nullable BiConsumer<ConsumerRecord<?, ?>, Exception> recoverer, BackOff backOff,
 			@Nullable BackOffHandler backOffHandler, CommonErrorHandler fallbackHandler) {
 
 		super(recoverer, backOff, backOffHandler);
 		this.fallbackBatchHandler = fallbackHandler;
+		if (this.fallbackBatchHandler instanceof FallbackBatchErrorHandler handler) {
+			handler.setFailureTracker(getFailureTracker());
+		}
 	}
 
 	@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedBatchProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedBatchProcessor.java
@@ -79,7 +79,7 @@ public abstract class FailedBatchProcessor extends FailedRecordProcessor {
 	 * @param fallbackHandler the fallback handler.
 	 * @since 2.9
 	 */
-	@SuppressWarnings("this-escape") // geFailureTracker() returns an already initialized final field
+	@SuppressWarnings("this-escape") // getFailureTracker() returns an already initialized final field
 	public FailedBatchProcessor(@Nullable BiConsumer<ConsumerRecord<?, ?>, Exception> recoverer, BackOff backOff,
 			@Nullable BackOffHandler backOffHandler, CommonErrorHandler fallbackHandler) {
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedBatchProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedBatchProcessor.java
@@ -108,16 +108,24 @@ public abstract class FailedBatchProcessor extends FailedRecordProcessor {
 
 	/**
 	 * Set to {@code false} to not reclassify the exception if different from the previous
-	 * failure. If the changed exception is classified as retryable, the existing back off
-	 * sequence is used; a new sequence is not started. Default true. Only applies when
-	 * the fallback batch error handler (for exceptions other than
-	 * {@link BatchListenerFailedException}) is the default.
+	 * failure. Default true. If the changed exception is classified as retryable, the existing
+	 * back off sequence is used if resetStateOnExceptionChange is false; a new sequence is started
+	 * if resetStateOnExceptionChange is true. Only applies when the fallback batch error handler
+	 * (for exceptions other than {@link BatchListenerFailedException}) is the default.
 	 * @param reclassifyOnExceptionChange false to not reclassify.
 	 * @since 2.9.7
 	 */
 	public void setReclassifyOnExceptionChange(boolean reclassifyOnExceptionChange) {
 		if (this.fallbackBatchHandler instanceof FallbackBatchErrorHandler handler) {
 			handler.setReclassifyOnExceptionChange(reclassifyOnExceptionChange);
+		}
+	}
+
+	@Override
+	public void setResetStateOnExceptionChange(boolean resetStateOnExceptionChange) {
+		super.setResetStateOnExceptionChange(resetStateOnExceptionChange);
+		if (this.fallbackBatchHandler instanceof FallbackBatchErrorHandler handler) {
+			handler.setResetStateOnExceptionChange(resetStateOnExceptionChange);
 		}
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordProcessor.java
@@ -41,7 +41,7 @@ public abstract class FailedRecordProcessor extends ExceptionClassifier implemen
 
 	private static final BackOff NO_RETRIES_OR_DELAY_BACKOFF = new FixedBackOff(0L, 0L);
 
-	private final BiFunction<ConsumerRecord<?, ?>, @Nullable Exception, BackOff> noRetriesForClassified =
+	private final BiFunction<ConsumerRecord<?, ?>, @Nullable Exception, @Nullable BackOff> noRetriesForClassified =
 			(rec, ex) -> {
 				Exception theEx = ErrorHandlingUtils.unwrapIfNeeded(ex);
 				if (!getExceptionMatcher().match(theEx) || theEx instanceof KafkaBackoffException) {

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordProcessor.java
@@ -56,7 +56,7 @@ public abstract class FailedRecordProcessor extends ExceptionClassifier implemen
 
 	private boolean commitRecovered;
 
-	private BiFunction<ConsumerRecord<?, ?>, Exception, BackOff> userBackOffFunction = (rec, ex) -> null;
+	private BiFunction<ConsumerRecord<?, ?>, Exception, @Nullable BackOff> userBackOffFunction = (rec, ex) -> null;
 
 	private boolean seekAfterError = true;
 
@@ -94,7 +94,7 @@ public abstract class FailedRecordProcessor extends ExceptionClassifier implemen
 	 * @param backOffFunction the function.
 	 * @since 2.6
 	 */
-	public void setBackOffFunction(BiFunction<ConsumerRecord<?, ?>, Exception, BackOff> backOffFunction) {
+	public void setBackOffFunction(BiFunction<ConsumerRecord<?, ?>, Exception, @Nullable BackOff> backOffFunction) {
 		Assert.notNull(backOffFunction, "'backOffFunction' cannot be null");
 		this.userBackOffFunction = backOffFunction;
 	}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordTracker.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordTracker.java
@@ -58,7 +58,7 @@ class FailedRecordTracker implements RecoveryStrategy {
 
 	private final BackOff backOff;
 
-	private @Nullable BiFunction<ConsumerRecord<?, ?>, @Nullable Exception, BackOff> backOffFunction;
+	private @Nullable BiFunction<ConsumerRecord<?, ?>, @Nullable Exception, @Nullable BackOff> backOffFunction;
 
 	private final BackOffHandler backOffHandler;
 
@@ -113,7 +113,7 @@ class FailedRecordTracker implements RecoveryStrategy {
 	 * @param backOffFunction the function.
 	 * @since 2.6
 	 */
-	public void setBackOffFunction(@Nullable BiFunction<ConsumerRecord<?, ?>, @Nullable Exception, BackOff> backOffFunction) {
+	public void setBackOffFunction(@Nullable BiFunction<ConsumerRecord<?, ?>, @Nullable Exception, @Nullable BackOff> backOffFunction) {
 		this.backOffFunction = backOffFunction;
 	}
 
@@ -215,7 +215,7 @@ class FailedRecordTracker implements RecoveryStrategy {
 		return failedRecord;
 	}
 
-	private BackOff determineBackOff(ConsumerRecord<?, ?> record, @Nullable Exception exception) {
+	BackOff determineBackOff(ConsumerRecord<?, ?> record, @Nullable Exception exception) {
 		if (this.backOffFunction == null) {
 			return this.backOff;
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FallbackBatchErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FallbackBatchErrorHandler.java
@@ -68,6 +68,8 @@ class FallbackBatchErrorHandler extends ExceptionClassifier implements CommonErr
 
 	private boolean reclassifyOnExceptionChange = true;
 
+	private @Nullable FailedRecordTracker failureTracker;
+
 	/**
 	 * Construct an instance with a default {@link FixedBackOff} (unlimited attempts with
 	 * a 5 second back off).
@@ -139,6 +141,10 @@ class FallbackBatchErrorHandler extends ExceptionClassifier implements CommonErr
 		this.reclassifyOnExceptionChange = reclassifyOnExceptionChange;
 	}
 
+	void setFailureTracker(FailedRecordTracker failedRecordTracker) {
+		this.failureTracker = failedRecordTracker;
+	}
+
 	@Override
 	public void handleBatch(Exception thrownException, @Nullable ConsumerRecords<?, ?> records,
 			Consumer<?, ?> consumer, MessageListenerContainer container, Runnable invokeListener) {
@@ -149,7 +155,9 @@ class FallbackBatchErrorHandler extends ExceptionClassifier implements CommonErr
 		}
 		this.retrying.put(Thread.currentThread(), true);
 		try {
-			ErrorHandlingUtils.retryBatch(thrownException, records, consumer, container, invokeListener, this.backOff,
+			BackOff backOffToUse = this.failureTracker == null ? this.backOff :
+					this.failureTracker.determineBackOff(records.iterator().next(), thrownException);
+			ErrorHandlingUtils.retryBatch(thrownException, records, consumer, container, invokeListener, backOffToUse,
 					this.seeker, this.recoverer, this.logger, getLogLevel(), this.retryListeners, getExceptionMatcher(),
 					this.reclassifyOnExceptionChange);
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FallbackBatchErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FallbackBatchErrorHandler.java
@@ -36,6 +36,7 @@ import org.springframework.core.log.LogAccessor;
 import org.springframework.kafka.KafkaException;
 import org.springframework.util.Assert;
 import org.springframework.util.backoff.BackOff;
+import org.springframework.util.backoff.BackOffExecution;
 import org.springframework.util.backoff.FixedBackOff;
 
 /**
@@ -67,6 +68,8 @@ class FallbackBatchErrorHandler extends ExceptionClassifier implements CommonErr
 	private boolean ackAfterHandle = true;
 
 	private boolean reclassifyOnExceptionChange = true;
+
+	private boolean resetStateOnExceptionChange = false;
 
 	private @Nullable FailedRecordTracker failureTracker;
 
@@ -132,13 +135,26 @@ class FallbackBatchErrorHandler extends ExceptionClassifier implements CommonErr
 
 	/**
 	 * Set to false to not reclassify the exception if different from the previous
-	 * failure. If the changed exception is classified as retryable, the existing back off
-	 * sequence is used; a new sequence is not started. Default true.
+	 * failure. Default true. If the changed exception is classified as retryable, the
+	 * existing back off sequence is used when resetStateOnExceptionChange is set to
+	 * false; a new sequence is started when resetStateOnExceptionChange is set to true.
 	 * @param reclassifyOnExceptionChange false to not reclassify.
 	 * @since 2.9.7
 	 */
 	public void setReclassifyOnExceptionChange(boolean reclassifyOnExceptionChange) {
 		this.reclassifyOnExceptionChange = reclassifyOnExceptionChange;
+	}
+
+	/**
+	 * Set to false to keep the same back off sequence even when the exception changes
+	 * in subsequent retries. Default false. If set to true, a new sequence is started
+	 * when the exception changes.
+	 * @param resetStateOnExceptionChange true to start a new back off sequence
+	 * when the exception changes in subsequent retries
+	 * @since 4.1.0
+	 */
+	public void setResetStateOnExceptionChange(boolean resetStateOnExceptionChange) {
+		this.resetStateOnExceptionChange = resetStateOnExceptionChange;
 	}
 
 	void setFailureTracker(FailedRecordTracker failedRecordTracker) {
@@ -155,11 +171,17 @@ class FallbackBatchErrorHandler extends ExceptionClassifier implements CommonErr
 		}
 		this.retrying.put(Thread.currentThread(), true);
 		try {
-			BackOff backOffToUse = this.failureTracker == null ? this.backOff :
-					this.failureTracker.determineBackOff(records.iterator().next(), thrownException);
-			ErrorHandlingUtils.retryBatch(thrownException, records, consumer, container, invokeListener, backOffToUse,
-					this.seeker, this.recoverer, this.logger, getLogLevel(), this.retryListeners, getExceptionMatcher(),
-					this.reclassifyOnExceptionChange);
+			BackOffExecution backOffExecution = null;
+			while (thrownException != null) {
+				if (backOffExecution == null || this.resetStateOnExceptionChange) {
+					BackOff backOffToUse = this.failureTracker == null ? this.backOff :
+							this.failureTracker.determineBackOff(records.iterator().next(), thrownException);
+					backOffExecution = backOffToUse.start();
+				}
+				thrownException = ErrorHandlingUtils.retryBatch(thrownException, records, consumer, container, invokeListener,
+						backOffExecution, this.seeker, this.recoverer, this.logger, getLogLevel(), this.retryListeners,
+						getExceptionMatcher(), this.reclassifyOnExceptionChange, this.resetStateOnExceptionChange);
+			}
 		}
 		finally {
 			this.retrying.remove(Thread.currentThread());

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ErrorHandlingUtilsTest.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ErrorHandlingUtilsTest.java
@@ -97,9 +97,9 @@ class ErrorHandlingUtilsTest {
 
 	private void doRetries() {
 		ErrorHandlingUtils.retryBatch(
-				thrownException, consumerRecords, consumer, container, listener, backOff,
+				thrownException, consumerRecords, consumer, container, listener, backOff.start(),
 				seeker, recoverer, logger, KafkaException.Level.INFO, retryListeners,
-				exceptionMatcher, true
+				exceptionMatcher, true, false
 		);
 	}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/FallbackBatchErrorHandlerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/FallbackBatchErrorHandlerTests.java
@@ -289,7 +289,6 @@ public class FallbackBatchErrorHandlerTests {
 		assertThat(retries.get()).isEqualTo(3);
 	}
 
-	@SuppressWarnings({ "unchecked", "rawtypes" })
 	@Test
 	void reclassifyResetBackOffOnExceptionChange() {
 		AtomicReference<Exception> thrown = new AtomicReference<>();
@@ -297,9 +296,9 @@ public class FallbackBatchErrorHandlerTests {
 			thrown.set(ex);
 		}, new FixedBackOff(0L, 3));
 		eh.setResetStateOnExceptionChange(true);
-		ConsumerRecords records = new ConsumerRecords(
+		ConsumerRecords<String, String> records = new ConsumerRecords<>(
 				Map.of(new TopicPartition("foo", 0),
-						List.of(new ConsumerRecord("foo", 0, 0L, null, "bar"))), Map.of());
+						List.of(new ConsumerRecord<>("foo", 0, 0L, null, "bar"))), Map.of());
 		MessageListenerContainer container = mock(MessageListenerContainer.class);
 		given(container.isRunning()).willReturn(true);
 		AtomicInteger retries = new AtomicInteger();
@@ -312,6 +311,46 @@ public class FallbackBatchErrorHandlerTests {
 				.extracting("cause")
 				.isInstanceOf(IllegalArgumentException.class);
 		assertThat(retries.get()).isEqualTo(4);
+	}
+
+	@Test
+	void usingBackOffFunction() {
+		AtomicReference<Exception> thrown = new AtomicReference<>();
+		DefaultErrorHandler eh = new DefaultErrorHandler((cr, ex) ->  {
+			thrown.set(ex);
+		}, new FixedBackOff(0L, 2));
+		eh.setBackOffFunction((cr, ex) -> ex instanceof UnsupportedOperationException ?
+				new FixedBackOff(0L, 1) : null);
+		ConsumerRecords<String, String> records = new ConsumerRecords<>(
+				Map.of(new TopicPartition("foo", 0),
+						List.of(new ConsumerRecord<>("foo", 0, 0L, null, "bar"))), Map.of());
+		MessageListenerContainer container = mock(MessageListenerContainer.class);
+		given(container.isRunning()).willReturn(true);
+
+		// first thrown exception is UnsupportedOperationException, so BackOffFunction should cause 1 retry
+		AtomicInteger retries = new AtomicInteger();
+		eh.handleBatch(new UnsupportedOperationException(), records, mock(Consumer.class), container,
+				() -> {
+					retries.incrementAndGet();
+					throw new ListenerExecutionFailedException("", new IllegalArgumentException());
+				});
+		assertThat(thrown.get()).isInstanceOf(ListenerExecutionFailedException.class)
+				.extracting("cause")
+				.isInstanceOf(IllegalArgumentException.class);
+		assertThat(retries.get()).isEqualTo(1);
+
+		// first thrown exception is IllegalArgumentException, so BackOffFunction should return null
+		// which means that DefaultErrorHandler should use its the default FixedBackOff with 2 retries
+		retries.set(0);
+		eh.handleBatch(new IllegalArgumentException(), records, mock(Consumer.class), container,
+				() -> {
+					retries.incrementAndGet();
+					throw new ListenerExecutionFailedException("", new IllegalArgumentException());
+				});
+		assertThat(thrown.get()).isInstanceOf(ListenerExecutionFailedException.class)
+				.extracting("cause")
+				.isInstanceOf(IllegalArgumentException.class);
+		assertThat(retries.get()).isEqualTo(2);
 	}
 
 	private boolean getRetryingFieldValue(FallbackBatchErrorHandler errorHandler) {

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/FallbackBatchErrorHandlerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/FallbackBatchErrorHandlerTests.java
@@ -289,6 +289,31 @@ public class FallbackBatchErrorHandlerTests {
 		assertThat(retries.get()).isEqualTo(3);
 	}
 
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	@Test
+	void reclassifyResetBackOffOnExceptionChange() {
+		AtomicReference<Exception> thrown = new AtomicReference<>();
+		DefaultErrorHandler eh = new DefaultErrorHandler((cr, ex) ->  {
+			thrown.set(ex);
+		}, new FixedBackOff(0L, 3));
+		eh.setResetStateOnExceptionChange(true);
+		ConsumerRecords records = new ConsumerRecords(
+				Map.of(new TopicPartition("foo", 0),
+						List.of(new ConsumerRecord("foo", 0, 0L, null, "bar"))), Map.of());
+		MessageListenerContainer container = mock(MessageListenerContainer.class);
+		given(container.isRunning()).willReturn(true);
+		AtomicInteger retries = new AtomicInteger();
+		eh.handleBatch(new IllegalStateException(), records, mock(Consumer.class), container,
+				() -> {
+					retries.incrementAndGet();
+					throw new ListenerExecutionFailedException("", new IllegalArgumentException());
+				});
+		assertThat(thrown.get()).isInstanceOf(ListenerExecutionFailedException.class)
+				.extracting("cause")
+				.isInstanceOf(IllegalArgumentException.class);
+		assertThat(retries.get()).isEqualTo(4);
+	}
+
 	private boolean getRetryingFieldValue(FallbackBatchErrorHandler errorHandler) {
 		Field field = ReflectionUtils.findField(FallbackBatchErrorHandler.class, "retrying");
 		ReflectionUtils.makeAccessible(field);


### PR DESCRIPTION
The method setBackOffFunction of FailedRecordProcessor and its descendants (FailedBatchProcessor and DefaultErrorHandler) is useful for classifying the exceptions thrown from the application code (listeners). However, I find it very surprising that this method does not work when processing the messages in batches (the supplied backOffFunction is never called there). Please review my attempt to make it work for the batch processing as well.