### PR TITLE
GH-4436: Improve Javadoc on BatchListenerFailedException and FailedBatchProcessor

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/BatchListenerFailedException.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/BatchListenerFailedException.java
@@ -24,13 +24,36 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.kafka.KafkaException;
 
 /**
- * An exception thrown by user code to inform the framework which record in a batch has
- * failed.
+ * An exception thrown by a batch listener to indicate which record in the batch
+ * failed. The framework will commit the offsets of all records <em>before</em>
+ * the failed record and seek the remaining records (starting from the failed one)
+ * for redelivery.
  *
- * @author Gary Russell
+ * <p><strong>Important contract:</strong> throwing this exception carries an
+ * implicit assertion that every record before the indicated index (or before
+ * the provided {@link org.apache.kafka.clients.consumer.ConsumerRecord}) has
+ * been <em>fully and irreversibly</em> processed. The framework commits those
+ * preceding offsets immediately; they will not be redelivered.
+ *
+ * <p>This exception is <strong>not</strong> appropriate when:
+ * <ul>
+ *   <li>records are processed in parallel (e.g. using virtual threads or an
+ *       executor), because preceding records may still be in-flight when the
+ *       exception is thrown;</li>
+ *   <li>processing involves multiple steps (e.g. transform then produce to an
+ *       output topic), because earlier records may have completed only some
+ *       steps;</li>
+ *   <li>the listener is transactional and a full rollback is required on any
+ *       failure.</li>
+ * </ul>
+ * In those cases, throw a plain {@link RuntimeException} instead so that the
+ * entire batch is redelivered.
+ *
+ * @author Aditya Pal
  * @author Wang Zhiyang
  * @since 2.5
- *
+ * @see org.springframework.kafka.listener.DefaultErrorHandler
+ * @see org.springframework.kafka.listener.FailedBatchProcessor
  */
 public class BatchListenerFailedException extends KafkaException {
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedBatchProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedBatchProcessor.java
@@ -40,18 +40,29 @@ import org.springframework.kafka.support.KafkaUtils;
 import org.springframework.util.backoff.BackOff;
 
 /**
- * Subclass of {@link FailedRecordProcessor} that can process (and recover) a batch. If
- * the listener throws a {@link BatchListenerFailedException}, the offsets prior to the
- * failed record are committed and the remaining records have seeks performed. When the
- * retries are exhausted, the failed record is sent to the recoverer instead of being
- * included in the seeks. If other exceptions are thrown, the fallback handler takes the processing.
+ * Subclass of {@link FailedRecordProcessor} that can process (and recover) a
+ * batch. If the listener throws a {@link BatchListenerFailedException}, the
+ * offsets prior to the failed record are committed and the remaining records
+ * (starting from the failed one) are re-sought for redelivery. When retries
+ * are exhausted, the failed record is sent to the recoverer instead of being
+ * included in the seeks. Any other exception type is delegated to the fallback
+ * handler.
  *
- * @author Gary Russell
+ * <p><strong>Note:</strong> committing offsets for preceding records assumes
+ * those records were fully and irreversibly processed before the exception was
+ * thrown. Batch listeners that process records in parallel, use multi-step
+ * pipelines, or run inside a transaction should throw a plain
+ * {@link RuntimeException} instead of {@link BatchListenerFailedException} if
+ * they cannot guarantee that invariant — doing so causes the full batch to be
+ * redelivered rather than silently skipping records whose side effects may not
+ * have completed.
+ *
+ * @author Aditya Pal
  * @author Francois Rosiere
  * @author Wang Zhiyang
  * @author Artem Bilan
  * @since 2.8
- *
+ * @see BatchListenerFailedException
  */
 public abstract class FailedBatchProcessor extends FailedRecordProcessor {
 


### PR DESCRIPTION

Fixes GH-4436 (https://github.com/spring-projects/spring-kafka/issues/4436)

* Clarify that throwing BatchListenerFailedException asserts all preceding records were fully and irreversibly processed before the failed index
* Warn against use in parallel, multi-step, or transactional batch listeners
* Add matching warning to FailedBatchProcessor class-level Javadoc

