### PR TITLE
make the method setBackOffFunction work for the batch processing as well (backport to the branch 3.3.x)

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ErrorHandlingUtils.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ErrorHandlingUtils.java
@@ -51,6 +51,7 @@ import org.springframework.util.backoff.BackOffExecution;
  * @author Antonio Tomac
  * @author Wang Zhiyang
  * @author Sanghyeok An
+ * @author Leos Bitto
  *
  * @since 2.8
  *
@@ -78,7 +79,7 @@ public final class ErrorHandlingUtils {
 	 * @param logLevel the log level.
 	 * @param retryListeners the retry listeners.
 	 * @param classifier the exception classifier.
-	 * @param reClassifyOnExceptionChange true to reset the state if a different exception
+	 * @param reClassifyOnExceptionChange true to reclassify the exception if a different exception
 	 * is thrown during retry.
 	 * @since 2.9.7
 	 */
@@ -87,8 +88,40 @@ public final class ErrorHandlingUtils {
 			CommonErrorHandler seeker, BiConsumer<ConsumerRecords<?, ?>, Exception> recoverer, LogAccessor logger,
 			KafkaException.Level logLevel, List<RetryListener> retryListeners, BinaryExceptionClassifier classifier,
 			boolean reClassifyOnExceptionChange) {
+		retryBatch(thrownException, records, consumer, container, invokeListener, backOff.start(), seeker, recoverer,
+				logger, logLevel, retryListeners, classifier, reClassifyOnExceptionChange, false);
+	}
 
-		BackOffExecution execution = backOff.start();
+	/**
+	 * Retry a complete batch by pausing the consumer and then, in a loop, poll the
+	 * consumer, wait for the next back off, then call the listener. When retries are
+	 * exhausted, call the recoverer with the {@link ConsumerRecords}.
+	 * @param thrownException the exception.
+	 * @param records the records.
+	 * @param consumer the consumer.
+	 * @param container the container.
+	 * @param invokeListener the {@link Runnable} to run (call the listener).
+	 * @param execution the backOff execution to use for the retries.
+	 * @param seeker the common error handler that re-seeks the entire batch.
+	 * @param recoverer the recoverer.
+	 * @param logger the logger.
+	 * @param logLevel the log level.
+	 * @param retryListeners the retry listeners.
+	 * @param classifier the exception classifier.
+	 * @param reClassifyOnExceptionChange true to reclassify the exception if a different exception
+	 * is thrown during retry.
+	 * @param resetStateOnExceptionChange true if a different exception thrown during retry should end this method.
+	 * @return a new exception if resetStateOnExceptionChange was true and a different exception has occurred
+	 * (retry with a possibly different BackOffExecution is expected if non-null is returned)
+	 * @since 4.0.7
+	 */
+	@Nullable
+	public static Exception retryBatch(Exception thrownException, ConsumerRecords<?, ?> records, Consumer<?, ?> consumer,
+			MessageListenerContainer container, Runnable invokeListener, BackOffExecution execution,
+			CommonErrorHandler seeker, BiConsumer<ConsumerRecords<?, ?>, Exception> recoverer, LogAccessor logger,
+			KafkaException.Level logLevel, List<RetryListener> retryListeners, BinaryExceptionClassifier classifier,
+			boolean reClassifyOnExceptionChange, boolean resetStateOnExceptionChange) {
+
 		long nextBackOff = execution.nextBackOff();
 		String failed = null;
 		Set<TopicPartition> assignment = consumer.assignment();
@@ -147,7 +180,7 @@ public final class ErrorHandlingUtils {
 				}
 				try {
 					invokeListener.run();
-					return;
+					return null;
 				}
 				catch (Exception ex) {
 					listen(retryListeners, records, ex, attempt++);
@@ -162,6 +195,9 @@ public final class ErrorHandlingUtils {
 							&& !classifier.classify(newException)) {
 
 						break;
+					}
+					if (resetStateOnExceptionChange && !newException.getClass().equals(lastException.getClass())) {
+						return newException;
 					}
 				}
 				nextBackOff = execution.nextBackOff();
@@ -184,6 +220,7 @@ public final class ErrorHandlingUtils {
 				consumerPauseResumeEventPublisher.publishConsumerResumedEvent(assignment2);
 			}
 		}
+		return null;
 	} // NOSONAR NCSS line count
 
 	private static void listen(List<RetryListener> listeners, ConsumerRecords<?, ?> records,

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ErrorHandlingUtils.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ErrorHandlingUtils.java
@@ -113,7 +113,7 @@ public final class ErrorHandlingUtils {
 	 * @param resetStateOnExceptionChange true if a different exception thrown during retry should end this method.
 	 * @return a new exception if resetStateOnExceptionChange was true and a different exception has occurred
 	 * (retry with a possibly different BackOffExecution is expected if non-null is returned)
-	 * @since 4.0.7
+	 * @since 3.3.16, 4.0.6
 	 */
 	@Nullable
 	public static Exception retryBatch(Exception thrownException, ConsumerRecords<?, ?> records, Consumer<?, ?> consumer,

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedBatchProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedBatchProcessor.java
@@ -50,6 +50,7 @@ import org.springframework.util.backoff.BackOff;
  * @author Francois Rosiere
  * @author Wang Zhiyang
  * @author Artem Bilan
+ * @author Leos Bitto
  * @since 2.8
  *
  */
@@ -79,11 +80,15 @@ public abstract class FailedBatchProcessor extends FailedRecordProcessor {
 	 * @param fallbackHandler the fallback handler.
 	 * @since 2.9
 	 */
+	@SuppressWarnings("this-escape") // getFailureTracker() returns an already initialized final field
 	public FailedBatchProcessor(@Nullable BiConsumer<ConsumerRecord<?, ?>, Exception> recoverer, BackOff backOff,
 			@Nullable BackOffHandler backOffHandler, CommonErrorHandler fallbackHandler) {
 
 		super(recoverer, backOff, backOffHandler);
 		this.fallbackBatchHandler = fallbackHandler;
+		if (this.fallbackBatchHandler instanceof FallbackBatchErrorHandler handler) {
+			handler.setFailureTracker(getFailureTracker());
+		}
 	}
 
 	@Override
@@ -104,16 +109,24 @@ public abstract class FailedBatchProcessor extends FailedRecordProcessor {
 
 	/**
 	 * Set to {@code false} to not reclassify the exception if different from the previous
-	 * failure. If the changed exception is classified as retryable, the existing back off
-	 * sequence is used; a new sequence is not started. Default true. Only applies when
-	 * the fallback batch error handler (for exceptions other than
-	 * {@link BatchListenerFailedException}) is the default.
+	 * failure. Default true. If the changed exception is classified as retryable, the existing
+	 * back off sequence is used if resetStateOnExceptionChange is false; a new sequence is started
+	 * if resetStateOnExceptionChange is true. Only applies when the fallback batch error handler
+	 * (for exceptions other than {@link BatchListenerFailedException}) is the default.
 	 * @param reclassifyOnExceptionChange false to not reclassify.
 	 * @since 2.9.7
 	 */
 	public void setReclassifyOnExceptionChange(boolean reclassifyOnExceptionChange) {
 		if (this.fallbackBatchHandler instanceof FallbackBatchErrorHandler handler) {
 			handler.setReclassifyOnExceptionChange(reclassifyOnExceptionChange);
+		}
+	}
+
+	@Override
+	public void setResetStateOnExceptionChange(boolean resetStateOnExceptionChange) {
+		super.setResetStateOnExceptionChange(resetStateOnExceptionChange);
+		if (this.fallbackBatchHandler instanceof FallbackBatchErrorHandler handler) {
+			handler.setResetStateOnExceptionChange(resetStateOnExceptionChange);
 		}
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordTracker.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordTracker.java
@@ -213,7 +213,7 @@ class FailedRecordTracker implements RecoveryStrategy {
 		return failedRecord;
 	}
 
-	private BackOff determineBackOff(ConsumerRecord<?, ?> record, Exception exception) {
+	BackOff determineBackOff(ConsumerRecord<?, ?> record, Exception exception) {
 		if (this.backOffFunction == null) {
 			return this.backOff;
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FallbackBatchErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FallbackBatchErrorHandler.java
@@ -36,6 +36,7 @@ import org.springframework.kafka.KafkaException;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 import org.springframework.util.backoff.BackOff;
+import org.springframework.util.backoff.BackOffExecution;
 import org.springframework.util.backoff.FixedBackOff;
 
 /**
@@ -47,6 +48,7 @@ import org.springframework.util.backoff.FixedBackOff;
  * performed so that the batch will be redelivered on the next poll.
  *
  * @author Gary Russell
+ * @author Leos Bitto
  * @since 2.3.7
  *
  */
@@ -67,6 +69,10 @@ class FallbackBatchErrorHandler extends ExceptionClassifier implements CommonErr
 	private boolean ackAfterHandle = true;
 
 	private boolean reclassifyOnExceptionChange = true;
+
+	private boolean resetStateOnExceptionChange = false;
+
+	private @Nullable FailedRecordTracker failureTracker;
 
 	/**
 	 * Construct an instance with a default {@link FixedBackOff} (unlimited attempts with
@@ -130,13 +136,30 @@ class FallbackBatchErrorHandler extends ExceptionClassifier implements CommonErr
 
 	/**
 	 * Set to false to not reclassify the exception if different from the previous
-	 * failure. If the changed exception is classified as retryable, the existing back off
-	 * sequence is used; a new sequence is not started. Default true.
+	 * failure. Default true. If the changed exception is classified as retryable, the
+	 * existing back off sequence is used when resetStateOnExceptionChange is set to
+	 * false; a new sequence is started when resetStateOnExceptionChange is set to true.
 	 * @param reclassifyOnExceptionChange false to not reclassify.
 	 * @since 2.9.7
 	 */
 	public void setReclassifyOnExceptionChange(boolean reclassifyOnExceptionChange) {
 		this.reclassifyOnExceptionChange = reclassifyOnExceptionChange;
+	}
+
+	/**
+	 * Set to false to keep the same back off sequence even when the exception changes
+	 * in subsequent retries. Default false. If set to true, a new sequence is started
+	 * when the exception changes.
+	 * @param resetStateOnExceptionChange true to start a new back off sequence
+	 * when the exception changes in subsequent retries
+	 * @since 3.3.16
+	 */
+	void setResetStateOnExceptionChange(boolean resetStateOnExceptionChange) {
+		this.resetStateOnExceptionChange = resetStateOnExceptionChange;
+	}
+
+	void setFailureTracker(FailedRecordTracker failedRecordTracker) {
+		this.failureTracker = failedRecordTracker;
 	}
 
 	@Override
@@ -149,9 +172,17 @@ class FallbackBatchErrorHandler extends ExceptionClassifier implements CommonErr
 		}
 		this.retrying.put(Thread.currentThread(), true);
 		try {
-			ErrorHandlingUtils.retryBatch(thrownException, records, consumer, container, invokeListener, this.backOff,
-					this.seeker, this.recoverer, this.logger, getLogLevel(), this.retryListeners, getClassifier(),
-					this.reclassifyOnExceptionChange);
+			BackOffExecution backOffExecution = null;
+			while (thrownException != null) {
+				if (backOffExecution == null || this.resetStateOnExceptionChange) {
+					BackOff backOffToUse = this.failureTracker == null ? this.backOff :
+							this.failureTracker.determineBackOff(records.iterator().next(), thrownException);
+					backOffExecution = backOffToUse.start();
+				}
+				thrownException = ErrorHandlingUtils.retryBatch(thrownException, records, consumer, container, invokeListener,
+						backOffExecution, this.seeker, this.recoverer, this.logger, getLogLevel(), this.retryListeners,
+						getClassifier(), this.reclassifyOnExceptionChange, this.resetStateOnExceptionChange);
+			}
 		}
 		finally {
 			this.retrying.remove(Thread.currentThread());

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FallbackBatchErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FallbackBatchErrorHandler.java
@@ -152,7 +152,7 @@ class FallbackBatchErrorHandler extends ExceptionClassifier implements CommonErr
 	 * when the exception changes.
 	 * @param resetStateOnExceptionChange true to start a new back off sequence
 	 * when the exception changes in subsequent retries
-	 * @since 3.3.16
+	 * @since 3.3.16, 4.0.6
 	 */
 	void setResetStateOnExceptionChange(boolean resetStateOnExceptionChange) {
 		this.resetStateOnExceptionChange = resetStateOnExceptionChange;

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/FallbackBatchErrorHandlerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/FallbackBatchErrorHandlerTests.java
@@ -287,6 +287,70 @@ public class FallbackBatchErrorHandlerTests {
 		assertThat(retries.get()).isEqualTo(3);
 	}
 
+	@Test
+	void reclassifyResetBackOffOnExceptionChange() {
+		AtomicReference<Exception> thrown = new AtomicReference<>();
+		DefaultErrorHandler eh = new DefaultErrorHandler((cr, ex) ->  {
+			thrown.set(ex);
+		}, new FixedBackOff(0L, 3));
+		eh.setResetStateOnExceptionChange(true);
+		ConsumerRecords<String, String> records = new ConsumerRecords<>(
+				Map.of(new TopicPartition("foo", 0),
+						List.of(new ConsumerRecord<>("foo", 0, 0L, null, "bar"))));
+		MessageListenerContainer container = mock(MessageListenerContainer.class);
+		given(container.isRunning()).willReturn(true);
+		AtomicInteger retries = new AtomicInteger();
+		eh.handleBatch(new IllegalStateException(), records, mock(Consumer.class), container,
+				() -> {
+					retries.incrementAndGet();
+					throw new ListenerExecutionFailedException("", new IllegalArgumentException());
+				});
+		assertThat(thrown.get()).isInstanceOf(ListenerExecutionFailedException.class)
+				.extracting("cause")
+				.isInstanceOf(IllegalArgumentException.class);
+		assertThat(retries.get()).isEqualTo(4);
+	}
+
+	@Test
+	void usingBackOffFunction() {
+		AtomicReference<Exception> thrown = new AtomicReference<>();
+		DefaultErrorHandler eh = new DefaultErrorHandler((cr, ex) ->  {
+			thrown.set(ex);
+		}, new FixedBackOff(0L, 2));
+		eh.setBackOffFunction((cr, ex) -> ex instanceof UnsupportedOperationException ?
+				new FixedBackOff(0L, 1) : null);
+		ConsumerRecords<String, String> records = new ConsumerRecords<>(
+				Map.of(new TopicPartition("foo", 0),
+						List.of(new ConsumerRecord<>("foo", 0, 0L, null, "bar"))));
+		MessageListenerContainer container = mock(MessageListenerContainer.class);
+		given(container.isRunning()).willReturn(true);
+
+		// first thrown exception is UnsupportedOperationException, so BackOffFunction should cause 1 retry
+		AtomicInteger retries = new AtomicInteger();
+		eh.handleBatch(new UnsupportedOperationException(), records, mock(Consumer.class), container,
+				() -> {
+					retries.incrementAndGet();
+					throw new ListenerExecutionFailedException("", new IllegalArgumentException());
+				});
+		assertThat(thrown.get()).isInstanceOf(ListenerExecutionFailedException.class)
+				.extracting("cause")
+				.isInstanceOf(IllegalArgumentException.class);
+		assertThat(retries.get()).isEqualTo(1);
+
+		// first thrown exception is IllegalArgumentException, so BackOffFunction should return null
+		// which means that DefaultErrorHandler should use its the default FixedBackOff with 2 retries
+		retries.set(0);
+		eh.handleBatch(new IllegalArgumentException(), records, mock(Consumer.class), container,
+				() -> {
+					retries.incrementAndGet();
+					throw new ListenerExecutionFailedException("", new IllegalArgumentException());
+				});
+		assertThat(thrown.get()).isInstanceOf(ListenerExecutionFailedException.class)
+				.extracting("cause")
+				.isInstanceOf(IllegalArgumentException.class);
+		assertThat(retries.get()).isEqualTo(2);
+	}
+
 	private boolean getRetryingFieldValue(FallbackBatchErrorHandler errorHandler) {
 		Field field = ReflectionUtils.findField(FallbackBatchErrorHandler.class, "retrying");
 		ReflectionUtils.makeAccessible(field);


### PR DESCRIPTION
This is a backport of the commit 7c9f5c0b0dcd5f027708112fdb703e5410f705fd to the branch 3.3.x which does not modify any existing public API. The only addition to the public API is a new overload of the method retryBatch in ErrorHandlingUtils which supports the implementation of a custom BackOffFunction and resetStateOnExceptionChange for the batch processing.