### PR TITLE
GH-4465: Fix unbounded async retry re-delivery

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -1522,8 +1522,17 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 					failedRecord.observation.scoped(() -> invokeErrorHandlerBySingleRecord(failedRecord));
 				}
 				catch (RecordInRetryException e) {
-					// Keep retryable async failures for the next poll loop.
-					this.failedRecords.addLast(failedRecord);
+					// Retry is in progress: the seek-after-handling error handler has
+					// repositioned the consumer to the failed record's offset, so the
+					// next poll will re-deliver it and a fresh FailedRecordTuple will
+					// be produced through the async failure callback. The
+					// FailedRecordTracker entry is keyed by topic-partition-offset and
+					// persists across loop iterations, so the attempt counter continues
+					// to advance correctly. Re-queueing the tuple here would cause the
+					// record to be processed twice per loop (once from the queue, once
+					// from the seek-induced re-delivery) and, after recovery resets the
+					// tracker entry, leaves the duplicate in the queue to start a new
+					// retry cycle — the unbounded re-delivery reported in GH-4465.
 				}
 				catch (Exception e) {
 					this.logger.warn(() ->

--- a/spring-kafka/src/test/kotlin/org/springframework/kafka/listener/EnableKafkaKotlinCoroutinesTests.kt
+++ b/spring-kafka/src/test/kotlin/org/springframework/kafka/listener/EnableKafkaKotlinCoroutinesTests.kt
@@ -125,13 +125,19 @@ class EnableKafkaKotlinCoroutinesTests {
 		// DefaultErrorHandler(FixedBackOff(interval, n)) must be delivered exactly
 		// n + 1 times (initial delivery + n retries) and then stop, matching the
 		// behaviour of a blocking listener with the same configuration.
+		//
+		// The recovered latch only signals the *first* recovery, so under the bug
+		// (#4465) it still trips while subsequent cycles keep re-delivering the
+		// record. The actual regression check is the delivery counter, which must
+		// reach 3 and stay there.
 		this.template.send("kotlinAsyncTestTopicBoundedRetry", "fail")
-		// Wait for the recoverer to run (which happens after retries are exhausted).
 		assertThat(this.config.boundedRetryRecoveredLatch.await(10, TimeUnit.SECONDS)).isTrue()
-		// Give the container a generous window in which any unbounded re-delivery
-		// loop would visibly grow the counter past the expected bound.
-		Thread.sleep(2_000)
-		assertThat(this.config.boundedRetryDeliveries.get()).isEqualTo(3)
+		await()
+			.pollDelay(Duration.ofSeconds(2))
+			.atMost(Duration.ofSeconds(3))
+			.untilAsserted {
+				assertThat(this.config.boundedRetryDeliveries.get()).isEqualTo(3)
+			}
 	}
 
 	@KafkaListener(id = "sendTopic", topics = ["kotlinAsyncTestTopic3"],

--- a/spring-kafka/src/test/kotlin/org/springframework/kafka/listener/EnableKafkaKotlinCoroutinesTests.kt
+++ b/spring-kafka/src/test/kotlin/org/springframework/kafka/listener/EnableKafkaKotlinCoroutinesTests.kt
@@ -44,9 +44,11 @@ import org.springframework.kafka.test.utils.KafkaTestUtils
 import org.springframework.messaging.handler.annotation.SendTo
 import org.springframework.test.annotation.DirtiesContext
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig
+import org.springframework.util.backoff.FixedBackOff
 import java.time.Duration
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
 
 
 /**
@@ -62,7 +64,7 @@ import java.util.concurrent.TimeUnit
 @DirtiesContext
 @EmbeddedKafka(topics = ["kotlinAsyncTestTopic1", "kotlinAsyncTestTopic2",
 		"kotlinAsyncBatchTestTopic1", "kotlinAsyncBatchTestTopic2", "kotlinReplyTopic1",
-		"kotlinAsyncTestTopicCommonHandler"], partitions = 1)
+		"kotlinAsyncTestTopicCommonHandler", "kotlinAsyncTestTopicBoundedRetry"], partitions = 1)
 class EnableKafkaKotlinCoroutinesTests {
 
 	@Autowired
@@ -117,6 +119,21 @@ class EnableKafkaKotlinCoroutinesTests {
 		assertThat(this.config.commonHandlerLatch.await(10, TimeUnit.SECONDS)).isTrue()
 	}
 
+	@Test
+	fun `test suspend function bounded retries with CommonErrorHandler`() {
+		// GH-4465: an always-failing suspend @KafkaListener with
+		// DefaultErrorHandler(FixedBackOff(interval, n)) must be delivered exactly
+		// n + 1 times (initial delivery + n retries) and then stop, matching the
+		// behaviour of a blocking listener with the same configuration.
+		this.template.send("kotlinAsyncTestTopicBoundedRetry", "fail")
+		// Wait for the recoverer to run (which happens after retries are exhausted).
+		assertThat(this.config.boundedRetryRecoveredLatch.await(10, TimeUnit.SECONDS)).isTrue()
+		// Give the container a generous window in which any unbounded re-delivery
+		// loop would visibly grow the counter past the expected bound.
+		Thread.sleep(2_000)
+		assertThat(this.config.boundedRetryDeliveries.get()).isEqualTo(3)
+	}
+
 	@KafkaListener(id = "sendTopic", topics = ["kotlinAsyncTestTopic3"],
 			containerFactory = "kafkaListenerContainerFactory")
 	class Listener {
@@ -156,6 +173,10 @@ class EnableKafkaKotlinCoroutinesTests {
 		val batchLatch2 = CountDownLatch(1)
 
 		val commonHandlerLatch = CountDownLatch(1)
+
+		val boundedRetryDeliveries = AtomicInteger()
+
+		val boundedRetryRecoveredLatch = CountDownLatch(1)
 
 		@Value("\${" + EmbeddedKafkaBroker.SPRING_EMBEDDED_KAFKA_BROKERS + "}")
 		private lateinit var brokerAddresses: String
@@ -244,6 +265,21 @@ class EnableKafkaKotlinCoroutinesTests {
 			return factory
 		}
 
+		@Bean
+		fun boundedRetryErrorHandler(): DefaultErrorHandler {
+			return DefaultErrorHandler({ _, _ -> boundedRetryRecoveredLatch.countDown() },
+					FixedBackOff(100L, 2L))
+		}
+
+		@Bean
+		fun kafkaListenerContainerFactoryWithBoundedRetry(): ConcurrentKafkaListenerContainerFactory<String, String> {
+			val factory: ConcurrentKafkaListenerContainerFactory<String, String>
+					= ConcurrentKafkaListenerContainerFactory()
+			factory.setConsumerFactory(kcf())
+			factory.setCommonErrorHandler(boundedRetryErrorHandler())
+			return factory
+		}
+
 		@KafkaListener(id = "kotlin", topics = ["kotlinAsyncTestTopic1"],
 				containerFactory = "kafkaListenerContainerFactory")
 		suspend fun listen(value: String, acknowledgment: Acknowledgment) {
@@ -280,6 +316,13 @@ class EnableKafkaKotlinCoroutinesTests {
 			if (value == "fail") {
 				throw RuntimeException("Test exception for CommonErrorHandler")
 			}
+		}
+
+		@KafkaListener(id = "kotlin-bounded-retry", topics = ["kotlinAsyncTestTopicBoundedRetry"],
+				containerFactory = "kafkaListenerContainerFactoryWithBoundedRetry")
+		suspend fun listenBoundedRetry(value: String) {
+			boundedRetryDeliveries.incrementAndGet()
+			throw RuntimeException("Always fail (bounded retry)")
 		}
 
 	}


### PR DESCRIPTION
Fixes #4465.

### Problem

With the change merged in #4254, async listener exceptions (Kotlin `suspend`, `Mono<?>`, `CompletableFuture<?>`) propagate to a seek-after-handling `CommonErrorHandler` such as `DefaultErrorHandler`. That path correctly drives `FailedRecordTracker` and seeks the consumer back to the failed offset for retry. After backoff is exhausted, the recoverer runs and the tracker entry is cleared.

However, the listener keeps being re-delivered forever instead of stopping after the configured number of retries (issue #4465). The reporter's minimal repro shows ~18–20 deliveries within 10s for `FixedBackOff(100L, 2L)` (which should produce exactly 3), and a fresh `Backoff … exhausted for suspend-topic-0@0` log line on every cycle.

### Root cause

`KafkaMessageListenerContainer$ListenerConsumer#handleAsyncFailure` (lines 1513–1536 on `main`) re-queues a `FailedRecordTuple` whenever `invokeErrorHandlerBySingleRecord` reports the record is still in retry:

```java
catch (RecordInRetryException e) {
    // Keep retryable async failures for the next poll loop.
    this.failedRecords.addLast(failedRecord);
}
```

For a seek-after-handling error handler, the handler has already repositioned the consumer to the failed offset, so the next poll re-delivers the record and produces *another* `FailedRecordTuple` via the async failure callback. Each loop iteration therefore processes the same record twice — once from the re-queued tuple, once from the seek-induced re-delivery — inflating `FailedRecordTracker`'s attempt counter at double the actual rate.

When backoff exhausts and the recoverer clears the tracker entry, the duplicate still sitting in `failedRecords` is then processed against an *empty* tracker, which creates a brand-new `FailedRecord(attempts = 1)` and starts a fresh retry cycle. That's the unbounded loop reported on the issue.

The synchronous (blocking) listener path is not affected because the listener throws before the container can ack, so no async failure callback fires and the queue stays empty.

### Fix

Drop the re-queue. The `FailedRecordTracker` entry is keyed by topic-partition-offset and survives across loop iterations independently of the `failedRecords` queue, so the attempt counter continues to advance correctly through the natural re-deliveries triggered by the handler's seek.

```java
catch (RecordInRetryException e) {
    // (no longer re-queue; explained in the comment in the diff)
}
```

A trace through the fixed code with `FixedBackOff(100L, 2L)`:

| Iter | Queue in  | Action                                       | Tracker attempts | Queue out |
| ---- | --------- | -------------------------------------------- | ---------------- | --------- |
| 1    | `[FR_1]`  | retry → seek to 0 → drop                     | 1                | `[]`      |
| 1'   | (poll)    | re-deliver offset 0 → Mono fails → enqueue   | 1                | `[FR_2]`  |
| 2    | `[FR_2]`  | retry → seek to 0 → drop                     | 2                | `[]`      |
| 2'   | (poll)    | re-deliver offset 0 → Mono fails → enqueue   | 2                | `[FR_3]`  |
| 3    | `[FR_3]`  | exhausted → recover → no seek                | (cleared)        | `[]`      |
| 4    | `[]`      | poll returns nothing (position past record)  | -                | `[]`      |

Three deliveries, then quiescence — matching the blocking listener.

### Test

Added `test suspend function bounded retries with CommonErrorHandler` alongside the existing test in `EnableKafkaKotlinCoroutinesTests` (the file PR #4254 used to validate the async error-handler integration). It uses `DefaultErrorHandler(FixedBackOff(100L, 2L))` against an always-failing suspend listener and asserts:

1. The configured recoverer is invoked (latch within 10s).
2. The listener delivery counter is exactly `3`.
3. Two additional seconds elapse with the counter still at `3` — to prove the loop has actually stopped, not merely been observed mid-flight.

Without the fix the test fails with `expected: 3 but was: 6` (on my machine), confirming the second retry cycle the issue describes.

### Verification

```
./gradlew :spring-kafka:test --tests "org.springframework.kafka.listener.*"
```

passes. Targeted runs:

- `EnableKafkaKotlinCoroutinesTests` — 7 tests, including the new one.
- `AsyncMonoRetryTopicScenarioTests` — 2 tests (the `@RetryableTopic` + async-return path that previously relied on the same `handleAsyncFailure` code).
- `ObservationTests`, `SeekToCurrentRecovererTests` — pass.

### Scope

- One source change in `KafkaMessageListenerContainer`'s `handleAsyncFailure` catch block.
- One test addition.
- No public API changes.
- No effect on the `@RetryableTopic` path: that path uses an error handler with `seeksAfterHandling() == false`, takes the `else` branch in `invokeErrorHandlerBySingleRecord`, and never throws `RecordInRetryException` to the `catch` modified here.
- No effect on blocking listeners: their failures never enter `failedRecords` in the first place.