### PR TITLE
GH-4468: Fix no-op ack detection for non-null Acknowledgment

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapter.java
@@ -40,11 +40,11 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.ShareConsumer;
 import org.apache.kafka.common.TopicPartition;
-import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 import reactor.core.publisher.Mono;
 
 import org.springframework.core.MethodParameter;
+import org.springframework.core.Nullness;
 import org.springframework.core.log.LogAccessor;
 import org.springframework.expression.BeanResolver;
 import org.springframework.expression.Expression;
@@ -98,6 +98,7 @@ import org.springframework.util.TypeUtils;
  * @author Huijin Hong
  * @author Soby Chacko
  * @author Sanghyeok An
+ * @author Abhishek Moondra
  */
 public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerSeekAware, AsyncRepliesAware {
 
@@ -883,7 +884,7 @@ public abstract class MessagingMessageListenerAdapter<K, V> implements ConsumerS
 			}
 			this.hasAckParameter |= isAck;
 			if (isAck) {
-				this.noOpAck |= methodParameter.getParameterAnnotation(NonNull.class) != null;
+				this.noOpAck |= Nullness.forMethodParameter(methodParameter) == Nullness.NON_NULL;
 			}
 			isNotConvertible |= isAck;
 			boolean isConsumer = parameterIsType(parameterType, Consumer.class);

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/EnableKafkaIntegrationTests.java
@@ -184,6 +184,7 @@ import static org.mockito.Mockito.spy;
  * @author Wang Zhiyang
  * @author Borahm Lee
  * @author Sean Sullivan
+ * @author Abhishek Moondra
  */
 @SpringJUnitConfig
 @DirtiesContext
@@ -2480,7 +2481,7 @@ public class EnableKafkaIntegrationTests {
 
 		@KafkaListener(id = "ackWithAutoContainer", topics = "annotated28", errorHandler = "badAckConfigErrorHandler",
 				containerFactory = "withNoReplyTemplateContainerFactory")
-		public void ackWithAutoContainerListener(String payload, Acknowledgment ack) {
+		public void ackWithAutoContainerListener(String payload, @Nullable Acknowledgment ack) {
 			// empty
 		}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapterTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/adapter/MessagingMessageListenerAdapterTests.java
@@ -20,6 +20,8 @@ import java.lang.reflect.Method;
 import java.util.concurrent.CompletableFuture;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import reactor.core.publisher.Mono;
 
@@ -31,6 +33,7 @@ import org.springframework.kafka.support.converter.RecordMessageConverter;
 import org.springframework.messaging.support.GenericMessage;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.BDDMockito.willReturn;
@@ -41,6 +44,7 @@ import static org.mockito.Mockito.verify;
 
 /**
  * @author Gary Russell
+ * @author Abhishek Moondra
  * @since 1.1.2
  *
  */
@@ -118,7 +122,24 @@ public class MessagingMessageListenerAdapterTests {
 				.withStackTraceContaining("MANUAL");
 	}
 
-	public void test(Acknowledgment ack) {
+	@Test
+	void noOpAckWhenAcknowledgmentParameterIsNonNull() throws NoSuchMethodException {
+		KafkaListenerAnnotationBeanPostProcessor<String, String> bpp = new KafkaListenerAnnotationBeanPostProcessor<>();
+		Method method = getClass().getDeclaredMethod("testNonNullAck", Acknowledgment.class);
+		RecordMessagingMessageListenerAdapter<String, String> adapter =
+				new RecordMessagingMessageListenerAdapter<>(this, method);
+		adapter.setHandlerMethod(
+				new HandlerAdapter(bpp.getMessageHandlerMethodFactory().createInvocableHandlerMethod(this, method)));
+		// A non-null Acknowledgment parameter must substitute a no-op ack, not fail with "No Acknowledgment available"
+		assertThatNoException().isThrownBy(() -> adapter.onMessage(
+				new ConsumerRecord<>("foo", 0, 0L, null, "foo"), null, null));
+	}
+
+	public void test(@Nullable Acknowledgment ack) {
+
+	}
+
+	public void testNonNullAck(@NonNull Acknowledgment ack) {
 
 	}
 


### PR DESCRIPTION
Fixes #4468.

The built-in DLT logging handler `LoggingDltListenerHandlerMethod.logMessage(Object, @NonNull Acknowledgment)` stopped working under a non-manual ack mode on 4.0. Its `@NonNull` is now the JSpecify `@NonNull` (a `TYPE_USE` annotation), which `MethodParameter.getParameterAnnotation()` doesn't return, so `noOpAck` stayed `false` and the DLT consumer failed with `No Acknowledgment available ... MANUAL AckMode` and re-published the record to the same DLT in a loop.

Switched the check in `MessagingMessageListenerAdapter.determineInferredType` to `Nullness.forMethodParameter()` (per the suggestion on the issue), which understands `TYPE_USE` and `@NullMarked` nullness.

Also added a test covering the non-null `Acknowledgment` parameter case, which wasn't covered before.
