### PR TITLE
GH-4388: Cross-reference alwaysStartAfterRefresh from autoStartup and autoStartDltHandler Javadoc

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListener.java
@@ -228,8 +228,15 @@ public @interface KafkaListener {
 	 * a {@link String}, in which case the {@link Boolean#parseBoolean(String)} is used to
 	 * obtain the value.
 	 * <p>SpEL {@code #{...}} and property place holders {@code ${...}} are supported.
+	 * <p><b>Note:</b> After the application context is refreshed,
+	 * {@link org.springframework.kafka.config.KafkaListenerEndpointRegistry#setAlwaysStartAfterRefresh(boolean)}
+	 * (which defaults to {@code true}) may cause containers to start regardless of this setting.
+	 * To honor this property in post-refresh scenarios (e.g. tests), set
+	 * {@code KafkaListenerEndpointRegistry.alwaysStartAfterRefresh} to {@code false}, or configure
+	 * {@code spring.kafka.listener.always-start-after-refresh=false} in your application properties.
 	 * @return true to auto start, false to not auto start.
 	 * @since 2.2
+	 * @see org.springframework.kafka.config.KafkaListenerEndpointRegistry#setAlwaysStartAfterRefresh(boolean)
 	 */
 	String autoStartup() default "";
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryableTopic.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/RetryableTopic.java
@@ -208,8 +208,15 @@ public @interface RetryableTopic {
 	/**
 	 * Override the container factory's {@code autoStartup} property for just the DLT container.
 	 * Usually used to not start the DLT container when {@code autoStartup} is true.
+	 * <p><b>Note:</b> After the application context is refreshed,
+	 * {@link org.springframework.kafka.config.KafkaListenerEndpointRegistry#setAlwaysStartAfterRefresh(boolean)}
+	 * (which defaults to {@code true}) may cause containers to start regardless of this setting.
+	 * To honor this property in post-refresh scenarios (e.g. tests), set
+	 * {@code KafkaListenerEndpointRegistry.alwaysStartAfterRefresh} to {@code false}, or configure
+	 * {@code spring.kafka.listener.always-start-after-refresh=false} in your application properties.
 	 * @return whether or not to override the factory.
 	 * @since 2.8
+	 * @see org.springframework.kafka.config.KafkaListenerEndpointRegistry#setAlwaysStartAfterRefresh(boolean)
 	 */
 	String autoStartDltHandler() default "";
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistry.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistry.java
@@ -178,8 +178,17 @@ public class KafkaListenerEndpointRegistry implements ListenerContainerRegistry,
 	 * context initialization. Set to false to apply the autoStartup property, even for
 	 * late endpoint binding. If this is called after the context is refreshed, it will
 	 * apply to any endpoints registered after that call.
+	 * <p>This setting also affects
+	 * {@link org.springframework.kafka.annotation.KafkaListener#autoStartup()} and
+	 * {@link org.springframework.kafka.annotation.RetryableTopic#autoStartDltHandler()}:
+	 * when {@code true} (the default), those properties are overridden after a context
+	 * refresh. To honor them in post-refresh scenarios (e.g. integration tests), set
+	 * this to {@code false} or configure
+	 * {@code spring.kafka.listener.always-start-after-refresh=false}.
 	 * @param alwaysStartAfterRefresh false to apply the property.
 	 * @since 2.8.7
+	 * @see org.springframework.kafka.annotation.KafkaListener#autoStartup()
+	 * @see org.springframework.kafka.annotation.RetryableTopic#autoStartDltHandler()
 	 */
 	public void setAlwaysStartAfterRefresh(boolean alwaysStartAfterRefresh) {
 		this.alwaysStartAfterRefresh = alwaysStartAfterRefresh;


### PR DESCRIPTION
## Summary

Addresses #4388 (Javadoc / docs improvement).

`KafkaListenerEndpointRegistry.setAlwaysStartAfterRefresh()` was the only place documenting that this flag overrides `autoStartup` after a context refresh — creating a hard-to-discover one-way reference. This leads to confusing behaviour in tests where `@KafkaListener(autoStartup = "false")` or `@RetryableTopic(autoStartDltHandler = "false")` appear to be silently ignored.

## Changes

- **`@RetryableTopic.autoStartDltHandler()`** — added a `Note` paragraph explaining that `alwaysStartAfterRefresh=true` (the default) can override this after context refresh, with a `@see` link to `setAlwaysStartAfterRefresh`.
- **`@KafkaListener.autoStartup()`** — same note and `@see` link.
- **`KafkaListenerEndpointRegistry.setAlwaysStartAfterRefresh()`** — added back-links to `@KafkaListener.autoStartup()` and `@RetryableTopic.autoStartDltHandler()` so the relationship is visible from both sides.

No behavioural changes; Javadoc only.

## Test plan

- [ ] `./gradlew javadoc` — verify no Javadoc warnings introduced
- [ ] Inspect generated Javadoc HTML for the three changed methods to confirm cross-links render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)