### PR TITLE
Allow extending Context outside package 

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaConsumerBackoffManager.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaConsumerBackoffManager.java
@@ -41,7 +41,7 @@ public interface KafkaConsumerBackoffManager {
 	 * Provides the state that will be used for backing off.
 	 * @since 2.7
 	 */
-	class Context {
+	protected class Context {
 
 		/**
 		 * The time after which the message should be processed,

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaConsumerBackoffManager.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaConsumerBackoffManager.java
@@ -41,7 +41,7 @@ public interface KafkaConsumerBackoffManager {
 	 * Provides the state that will be used for backing off.
 	 * @since 2.7
 	 */
-	protected class Context {
+	public class Context {
 
 		/**
 		 * The time after which the message should be processed,


### PR DESCRIPTION
When implementing the KafkaConsumerBackoffManager and need to extend the Context (e.g. to add Headers to it), the "extends" needs to be done in package org.springframework.kafka.listener 
due to "package visibility" of class Context.

Please change to "protected" or better to "public" as interface KafkaConsumerBackoffManager is public, too.