### PR TITLE
Add consumer exception handler callback

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/annotation-error-handling.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/annotation-error-handling.adoc
@@ -113,6 +113,23 @@ The container commits any pending offset commits before calling the error handle
 
 If you are using Spring Boot, you simply need to add the error handler as a `@Bean` and Boot will add it to the auto-configured factory.
 
+[[consumer-exception-handler]]
+=== Consumer Exception Handler
+
+Starting with version 4.2, `ContainerProperties` provides a `consumerExceptionHandler` callback for exceptions thrown by the Kafka `Consumer` outside listener invocation, such as commit exceptions.
+Configure the callback on the container properties:
+
+[source, java]
+----
+factory.getContainerProperties().setConsumerExceptionHandler((exception, consumer, container) -> {
+    ...
+});
+----
+
+When a `consumerExceptionHandler` is configured, it takes precedence over the container's `CommonErrorHandler` for these consumer exceptions.
+In that case, `CommonErrorHandler.handleOtherException()` is not invoked.
+If no `consumerExceptionHandler` is configured, the container falls back to `CommonErrorHandler.handleOtherException()`, when a `CommonErrorHandler` is present.
+
 [[backoff-handlers]]
 == Back Off Handlers
 

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/container-props.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/container-props.adoc
@@ -69,6 +69,11 @@ Useful when the consumer code cannot determine that an `ErrorHandlingDeserialize
 |`null`
 |A rebalance listener; see xref:kafka/receiving-messages/rebalance-listeners.adoc[Rebalancing Listeners].
 
+|[[consumerExceptionHandler]]<<consumerExceptionHandler,`consumerExceptionHandler`>>
+|`null`
+|A handler for consumer exceptions thrown outside listener invocation.
+When set, it is used instead of `CommonErrorHandler.handleOtherException()` for those exceptions; see xref:kafka/annotation-error-handling.adoc#consumer-exception-handler[Consumer Exception Handler].
+
 |[[commitRetries]]<<commitRetries,`commitRetries`>>
 |3
 |Set the number of retries `RetriableCommitFailedException` when using `syncCommits` set to true.

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerExceptionHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerExceptionHandler.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import org.apache.kafka.clients.consumer.Consumer;
+
+/**
+ * Callback for consumer exceptions occurring outside listener invocation.
+ *
+ * @author Aman Gautam
+ * @since 4.1.1
+ */
+@FunctionalInterface
+public interface ConsumerExceptionHandler {
+
+	void handle(Exception exception,
+			Consumer<?, ?> consumer,
+			MessageListenerContainer container);
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerExceptionHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerExceptionHandler.java
@@ -22,11 +22,18 @@ import org.apache.kafka.clients.consumer.Consumer;
  * Callback for consumer exceptions occurring outside listener invocation.
  *
  * @author Aman Gautam
- * @since 4.1.1
+ * @since 4.2
  */
 @FunctionalInterface
 public interface ConsumerExceptionHandler {
 
+	/**
+	 * Handle an exception thrown by the Kafka {@link Consumer} outside of listener
+	 * invocation.
+	 * @param exception the exception thrown by the consumer.
+	 * @param consumer the consumer in use by the container.
+	 * @param container the listener container.
+	 */
 	void handle(Exception exception,
 			Consumer<?, ?> consumer,
 			MessageListenerContainer container);

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
@@ -225,6 +225,18 @@ public class ContainerProperties extends ConsumerProperties {
 
 	private final List<Advice> adviceChain = new ArrayList<>();
 
+	private @Nullable ConsumerExceptionHandler consumerExceptionHandler;
+
+	public @Nullable ConsumerExceptionHandler getConsumerExceptionHandler() {
+		return this.consumerExceptionHandler;
+	}
+
+	public void setConsumerExceptionHandler(
+			@Nullable ConsumerExceptionHandler consumerExceptionHandler) {
+
+		this.consumerExceptionHandler = consumerExceptionHandler;
+	}
+
 	@Nullable
 	private Function<ConsumerRecord<?, ?>, Map<String, String>> micrometerTagsProvider;
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ContainerProperties.java
@@ -227,10 +227,28 @@ public class ContainerProperties extends ConsumerProperties {
 
 	private @Nullable ConsumerExceptionHandler consumerExceptionHandler;
 
+	/**
+	 * Return the handler for consumer exceptions thrown outside listener invocation.
+	 * @return the handler, or null when no handler has been configured.
+	 * @since 4.2
+	 */
 	public @Nullable ConsumerExceptionHandler getConsumerExceptionHandler() {
 		return this.consumerExceptionHandler;
 	}
 
+	/**
+	 * Set a handler for consumer exceptions thrown outside listener invocation, such as
+	 * commit exceptions. When this handler is configured, it handles consumer
+	 * exceptions and the container's {@link CommonErrorHandler}
+	 * {@code handleOtherException()} method is not invoked for those exceptions. When
+	 * this handler is not configured, consumer exceptions are delegated to
+	 * {@code CommonErrorHandler.handleOtherException()}, if a
+	 * {@link CommonErrorHandler} is configured. A
+	 * {@link org.apache.kafka.clients.consumer.RetriableCommitFailedException}
+	 * continues to bypass both handlers.
+	 * @param consumerExceptionHandler the handler, or null to clear it.
+	 * @since 4.2
+	 */
 	public void setConsumerExceptionHandler(
 			@Nullable ConsumerExceptionHandler consumerExceptionHandler) {
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -2086,9 +2086,21 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 				return;
 			}
 			try {
-				if (this.commonErrorHandler != null) {
-					this.commonErrorHandler.handleOtherException(e, this.consumer,
-							KafkaMessageListenerContainer.this.thisOrParentContainer, this.isBatchListener);
+				ConsumerExceptionHandler handler =
+						this.containerProperties.getConsumerExceptionHandler();
+
+				if (handler != null) {
+					handler.handle(
+							e,
+							this.consumer,
+							KafkaMessageListenerContainer.this.thisOrParentContainer);
+				}
+				else if (this.commonErrorHandler != null) {
+					this.commonErrorHandler.handleOtherException(
+							e,
+							this.consumer,
+							KafkaMessageListenerContainer.this.thisOrParentContainer,
+							this.isBatchListener);
 				}
 				else {
 					this.logger.error(e, "Consumer exception");

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/KafkaMessageListenerContainerTests.java
@@ -3474,6 +3474,135 @@ public class KafkaMessageListenerContainerTests {
 
 	@Test
 	@SuppressWarnings({ "unchecked", "rawtypes" })
+	void consumerExceptionHandlerCalledForConsumerException() throws InterruptedException {
+		ConsumerFactory<Integer, String> cf = mock(ConsumerFactory.class);
+		Consumer<Integer, String> consumer = mock(Consumer.class);
+		given(cf.createConsumer(eq("grp"), eq("clientId"), isNull(), any())).willReturn(consumer);
+		Map<String, Object> cfProps = new HashMap<>();
+		cfProps.put(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, 45000);
+		given(cf.getConfigurationProperties()).willReturn(cfProps);
+		final Map<TopicPartition, List<ConsumerRecord<Integer, String>>> records = new HashMap<>();
+		records.put(new TopicPartition("foo", 0), List.of(new ConsumerRecord<>("foo", 0, 0L, 1, "foo")));
+		ConsumerRecords<Integer, String> consumerRecords = new ConsumerRecords<>(records, Map.of());
+		ConsumerRecords<Integer, String> emptyRecords = new ConsumerRecords<>(Collections.emptyMap(), Map.of());
+		AtomicBoolean first = new AtomicBoolean(true);
+		given(consumer.poll(any(Duration.class))).willAnswer(i -> first.getAndSet(false) ? consumerRecords : emptyRecords);
+		RuntimeException commitException = new RuntimeException("Commit failed");
+		willThrow(commitException).given(consumer).commitSync(anyMap(), eq(Duration.ofSeconds(45)));
+		ContainerProperties containerProps = new ContainerProperties(new TopicPartitionOffset("foo", 0));
+		containerProps.setGroupId("grp");
+		containerProps.setClientId("clientId");
+		containerProps.setMessageListener((MessageListener) r -> {
+		});
+		containerProps.setMissingTopicsFatal(false);
+		CountDownLatch latch = new CountDownLatch(1);
+		ConsumerExceptionHandler handler = mock(ConsumerExceptionHandler.class);
+		willAnswer(i -> {
+			latch.countDown();
+			return null;
+		}).given(handler).handle(any(), any(), any());
+		containerProps.setConsumerExceptionHandler(handler);
+		KafkaMessageListenerContainer<Integer, String> container =
+				new KafkaMessageListenerContainer<>(cf, containerProps);
+		try {
+			container.start();
+			assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+			verify(handler).handle(commitException, consumer, container);
+		}
+		finally {
+			container.stop();
+		}
+	}
+
+	@Test
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	void commonErrorHandlerCalledForConsumerExceptionWhenConsumerExceptionHandlerNotConfigured()
+			throws InterruptedException {
+
+		ConsumerFactory<Integer, String> cf = mock(ConsumerFactory.class);
+		Consumer<Integer, String> consumer = mock(Consumer.class);
+		given(cf.createConsumer(eq("grp"), eq("clientId"), isNull(), any())).willReturn(consumer);
+		Map<String, Object> cfProps = new HashMap<>();
+		cfProps.put(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, 45000);
+		given(cf.getConfigurationProperties()).willReturn(cfProps);
+		final Map<TopicPartition, List<ConsumerRecord<Integer, String>>> records = new HashMap<>();
+		records.put(new TopicPartition("foo", 0), List.of(new ConsumerRecord<>("foo", 0, 0L, 1, "foo")));
+		ConsumerRecords<Integer, String> consumerRecords = new ConsumerRecords<>(records, Map.of());
+		ConsumerRecords<Integer, String> emptyRecords = new ConsumerRecords<>(Collections.emptyMap(), Map.of());
+		AtomicBoolean first = new AtomicBoolean(true);
+		given(consumer.poll(any(Duration.class))).willAnswer(i -> first.getAndSet(false) ? consumerRecords : emptyRecords);
+		RuntimeException commitException = new RuntimeException("Commit failed");
+		willThrow(commitException).given(consumer).commitSync(anyMap(), eq(Duration.ofSeconds(45)));
+		ContainerProperties containerProps = new ContainerProperties(new TopicPartitionOffset("foo", 0));
+		containerProps.setGroupId("grp");
+		containerProps.setClientId("clientId");
+		containerProps.setMessageListener((MessageListener) r -> {
+		});
+		containerProps.setMissingTopicsFatal(false);
+		CountDownLatch latch = new CountDownLatch(1);
+		CommonErrorHandler errorHandler = mock(CommonErrorHandler.class);
+		willAnswer(i -> {
+			latch.countDown();
+			return null;
+		}).given(errorHandler).handleOtherException(any(), any(), any(), eq(false));
+		KafkaMessageListenerContainer<Integer, String> container =
+				new KafkaMessageListenerContainer<>(cf, containerProps);
+		container.setCommonErrorHandler(errorHandler);
+		try {
+			container.start();
+			assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
+			verify(errorHandler).handleOtherException(commitException, consumer, container, false);
+		}
+		finally {
+			container.stop();
+		}
+	}
+
+	@Test
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	void retriableCommitFailedExceptionDoesNotInvokeConsumerExceptionHandlers() throws InterruptedException {
+		ConsumerFactory<Integer, String> cf = mock(ConsumerFactory.class);
+		Consumer<Integer, String> consumer = mock(Consumer.class);
+		given(cf.createConsumer(eq("grp"), eq("clientId"), isNull(), any())).willReturn(consumer);
+		Map<String, Object> cfProps = new HashMap<>();
+		cfProps.put(ConsumerConfig.DEFAULT_API_TIMEOUT_MS_CONFIG, 45000);
+		given(cf.getConfigurationProperties()).willReturn(cfProps);
+		final Map<TopicPartition, List<ConsumerRecord<Integer, String>>> records = new HashMap<>();
+		records.put(new TopicPartition("foo", 0), List.of(new ConsumerRecord<>("foo", 0, 0L, 1, "foo")));
+		ConsumerRecords<Integer, String> consumerRecords = new ConsumerRecords<>(records, Map.of());
+		ConsumerRecords<Integer, String> emptyRecords = new ConsumerRecords<>(Collections.emptyMap(), Map.of());
+		AtomicBoolean first = new AtomicBoolean(true);
+		given(consumer.poll(any(Duration.class))).willAnswer(i -> first.getAndSet(false) ? consumerRecords : emptyRecords);
+		CountDownLatch commitLatch = new CountDownLatch(4);
+		willAnswer(i -> {
+			commitLatch.countDown();
+			throw new RetriableCommitFailedException("");
+		}).given(consumer).commitSync(anyMap(), eq(Duration.ofSeconds(45)));
+		ContainerProperties containerProps = new ContainerProperties(new TopicPartitionOffset("foo", 0));
+		containerProps.setGroupId("grp");
+		containerProps.setClientId("clientId");
+		containerProps.setMessageListener((MessageListener) r -> {
+		});
+		containerProps.setMissingTopicsFatal(false);
+		ConsumerExceptionHandler handler = mock(ConsumerExceptionHandler.class);
+		containerProps.setConsumerExceptionHandler(handler);
+		CommonErrorHandler errorHandler = mock(CommonErrorHandler.class);
+		KafkaMessageListenerContainer<Integer, String> container =
+				new KafkaMessageListenerContainer<>(cf, containerProps);
+		container.setCommonErrorHandler(errorHandler);
+		try {
+			container.start();
+			assertThat(commitLatch.await(10, TimeUnit.SECONDS)).isTrue();
+			verify(handler, never()).handle(any(), any(), any());
+			verify(errorHandler, never()).handleOtherException(any(), any(), any(), eq(false));
+		}
+		finally {
+			container.stop();
+		}
+	}
+
+	@Test
+	@SuppressWarnings({ "unchecked", "rawtypes" })
 	void testFatalErrorOnAuthenticationException() throws InterruptedException {
 		ConsumerFactory<Integer, String> cf = mock(ConsumerFactory.class);
 		ContainerProperties containerProps = new ContainerProperties(topic1);


### PR DESCRIPTION
Fixes #4490

Adds a dedicated ConsumerExceptionHandler callback that can be configured through ContainerProperties.

The callback is invoked from KafkaMessageListenerContainer.ListenerConsumer#handleConsumerException, allowing applications to react to consumer-level exceptions without configuring a CommonErrorHandler.

This is useful for applications that rely on AfterRollbackProcessor-based listener error handling and do not want to participate in the CommonErrorHandler flow, while still being able to handle fatal consumer exceptions.
