### PR TITLE
fix: replace Bitnami images with open Soldevelo equivalents

### DIFF
--- a/samples/sample-07/compose.yaml
+++ b/samples/sample-07/compose.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   broker:
-    image: bitnami/kafka:3.7.0
+    image: soldevelo/kafka:3.7.1
     hostname: broker
     container_name: broker
     ports:


### PR DESCRIPTION
## Fix: replace restricted Bitnami images

Since **August 28, 2025**, Bitnami distributes most container images only through paid VMware Tanzu subscriptions. Pulling them without a valid subscription may fail silently or return stale image layers, which is a supply-chain reliability concern.

This PR replaces every affected reference with the corresponding image from [SolDevelo/containers](https://github.com/SolDevelo/containers) - a community fork of `bitnami/containers` that publishes identical, freely accessible images to Docker Hub under the `soldevelo/` namespace.

No configuration changes beyond the image tag itself are required.

## Replaced references

- `bitnami/kafka:3.7.0` → [`soldevelo/kafka:3.7.1-debian-12-r0`](https://hub.docker.com/r/soldevelo/kafka)