### PR TITLE
4.0.x: Cherry-pick `813f6891` to fix test regressions from the #4505 backport

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -78,7 +78,6 @@ import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.internals.RecordHeader;
 import org.jspecify.annotations.Nullable;
 
-import org.springframework.aop.support.AopUtils;
 import org.springframework.beans.BeanUtils;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEventPublisher;
@@ -112,7 +111,6 @@ import org.springframework.kafka.listener.ContainerProperties.AssignmentCommitOp
 import org.springframework.kafka.listener.ContainerProperties.EOSMode;
 import org.springframework.kafka.listener.adapter.AsyncRepliesAware;
 import org.springframework.kafka.listener.adapter.FilteringMessageListenerAdapter;
-import org.springframework.kafka.listener.adapter.KafkaBackoffAwareMessageListenerAdapter;
 import org.springframework.kafka.listener.adapter.RecordMessagingMessageListenerAdapter;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.kafka.support.KafkaHeaders;
@@ -176,6 +174,7 @@ import org.springframework.util.StringUtils;
  * @author Hyoungjune Kim
  * @author Jinhui Kim
  * @author Minchul Son
+ * @author Youngjoo Kim
  */
 public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		extends AbstractMessageListenerContainer<K, V> implements ConsumerPauseResumeEventPublisher {
@@ -923,15 +922,15 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 				this.pollThreadStateProcessor = setUpPollProcessor(false);
 				this.observationEnabled = this.containerProperties.isObservationEnabled();
 
-				if (!AopUtils.isAopProxy(this.genericListener) &&
-						this.genericListener instanceof KafkaBackoffAwareMessageListenerAdapter<?, ?>) {
-
-					KafkaBackoffAwareMessageListenerAdapter<K, V> genListener =
-							(KafkaBackoffAwareMessageListenerAdapter<K, V>) this.genericListener;
-					if (genListener.getDelegate() instanceof RecordMessagingMessageListenerAdapter<K, V> adapterListener) {
-						// This means that the async retry feature is supported only for SingleRecordListener with @RetryableTopic.
-						adapterListener.setCallbackForAsyncFailure(this::callbackForAsyncFailure);
-					}
+				Object target = this.listener;
+				while (target instanceof DelegatingMessageListener<?> dml) {
+					target = dml.getDelegate();
+				}
+				if (target instanceof RecordMessagingMessageListenerAdapter<?, ?>) {
+					@SuppressWarnings("unchecked")
+					RecordMessagingMessageListenerAdapter<K, V> adapter =
+							(RecordMessagingMessageListenerAdapter<K, V>) target;
+					adapter.setCallbackForAsyncFailure(this::callbackForAsyncFailure);
 				}
 			}
 			else {

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -175,6 +175,7 @@ import org.springframework.util.StringUtils;
  * @author Jinhui Kim
  * @author Minchul Son
  * @author Youngjoo Kim
+ * @author Bill Kim
  */
 public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		extends AbstractMessageListenerContainer<K, V> implements ConsumerPauseResumeEventPublisher {

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/micrometer/ObservationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/micrometer/ObservationTests.java
@@ -85,6 +85,7 @@ import org.springframework.kafka.core.KafkaAdmin;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.listener.DefaultErrorHandler;
 import org.springframework.kafka.listener.MessageListenerContainer;
 import org.springframework.kafka.listener.RecordInterceptor;
 import org.springframework.kafka.requestreply.ReplyingKafkaTemplate;
@@ -100,6 +101,7 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 import org.springframework.util.StringUtils;
+import org.springframework.util.backoff.FixedBackOff;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -114,6 +116,7 @@ import static org.mockito.Mockito.mock;
  * @author Soby Chacko
  * @author Francois Rosiere
  * @author Christian Fredriksson
+ * @author Youngjoo Kim
  *
  * @since 3.0
  */
@@ -693,6 +696,9 @@ public class ObservationTests {
 					// Enable async acks to trigger async failure handling
 					container.getContainerProperties().setAsyncAcks(true);
 					container.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL);
+				}
+				if (container.getListenerId().equals("obs6") || container.getListenerId().equals("obs7")) {
+					container.setCommonErrorHandler(new DefaultErrorHandler(new FixedBackOff(0L, 0)));
 				}
 				if (container.getListenerId().equals("obs4")) {
 					container.setRecordInterceptor(new RecordInterceptor<>() {


### PR DESCRIPTION
Follow-up to the backport of #4505 on `4.0.x` (`ed31b093`). The cherry-pick depends on a precursor that exists on `main` but was never backported to `4.0.x`:

- `813f6891` — Support `CommonErrorHandler` for suspend functions. On `main`, `setCallbackForAsyncFailure(...)` is wired for any `RecordMessagingMessageListenerAdapter` (via `DelegatingMessageListener` extraction). On `4.0.x` it is only wired when the listener is a `KafkaBackoffAwareMessageListenerAdapter` (i.e., `@RetryableTopic` only), so a plain `suspend @KafkaListener` + `DefaultErrorHandler` never routes its async failure into `failedRecords`. With `ed31b093` in place but without `813f6891`, the three suspend-listener tests bundled into the backport never receive their recoverer callback and time out on the latch (`test suspend function with CommonErrorHandler`, `test suspend function bounded retries with CommonErrorHandler`, `test suspend function bounded retries for two records on the same partition`).

This PR cherry-picks `813f6891` onto `4.0.x` so the backport works as intended. Re-ran the full `./gradlew :spring-kafka:test` sweep locally on `4.0.x` with this commit applied — green, including the three previously failing tests and `ObservationTests` (which `813f6891` also touches).

The other potential precursor — `dfe52787` — is effectively already on `4.0.x` because `ed31b093` bundled both its container change (removal of `failedRecords.addLast(failedRecord)`) and its regression test. Cherry-picking `dfe52787` here produces only redundant conflicts, so it is not included.

The second commit adds `Bill Kim` to the class-level `@author` list of `KafkaMessageListenerContainer` — attribution for the GH-4504 fix that landed via #4505 but was omitted from the `@author` list on merge. Happy to drop this commit if you'd prefer to keep the PR scope strictly to the cherry-pick.

If you'd prefer to back out the backport from `4.0.x` instead, feel free to close this — happy to defer.