### PR TITLE
Fix batch listener backoff state reset in multi-partition containers

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonDelegatingErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonDelegatingErrorHandler.java
@@ -16,11 +16,14 @@
 
 package org.springframework.kafka.listener;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+
+import org.apache.kafka.common.TopicPartition;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -95,6 +98,12 @@ public class CommonDelegatingErrorHandler implements CommonErrorHandler {
 	public void clearThreadState() {
 		this.defaultErrorHandler.clearThreadState();
 		this.delegates.values().forEach(CommonErrorHandler::clearThreadState);
+	}
+
+	@Override
+	public void clearThreadStateFor(Collection<TopicPartition> partitions) {
+		this.defaultErrorHandler.clearThreadStateFor(partitions);
+		this.delegates.values().forEach(h -> h.clearThreadStateFor(partitions));
 	}
 
 	@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonErrorHandler.java
@@ -166,6 +166,15 @@ public interface CommonErrorHandler extends DeliveryAttemptAware {
 	}
 
 	/**
+	 * Clear thread state only for the given partitions. Called after a successful batch
+	 * invocation to avoid resetting backoff state for partitions that are still retrying.
+	 * @param partitions the partitions whose retry state should be cleared.
+	 * @since 4.0
+	 */
+	default void clearThreadStateFor(Collection<TopicPartition> partitions) {
+	}
+
+	/**
 	 * Return true if the offset should be committed for a handled error (no exception
 	 * thrown).
 	 * @return true to commit.

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonMixedErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonMixedErrorHandler.java
@@ -16,11 +16,13 @@
 
 package org.springframework.kafka.listener;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
 
 import org.springframework.kafka.support.TopicPartitionOffset;
 import org.springframework.util.Assert;
@@ -103,6 +105,12 @@ public class CommonMixedErrorHandler implements CommonErrorHandler {
 	public void clearThreadState() {
 		this.batchErrorHandler.clearThreadState();
 		this.recordErrorHandler.clearThreadState();
+	}
+
+	@Override
+	public void clearThreadStateFor(Collection<TopicPartition> partitions) {
+		this.batchErrorHandler.clearThreadStateFor(partitions);
+		this.recordErrorHandler.clearThreadStateFor(partitions);
 	}
 
 	@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordProcessor.java
@@ -16,12 +16,14 @@
 
 package org.springframework.kafka.listener;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 
 import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.core.log.LogAccessor;
@@ -177,6 +179,10 @@ public abstract class FailedRecordProcessor extends ExceptionClassifier implemen
 
 	public void clearThreadState() {
 		this.failureTracker.clearThreadState();
+	}
+
+	public void clearThreadStateFor(Collection<TopicPartition> partitions) {
+		this.failureTracker.clearThreadStateFor(partitions);
 	}
 
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordTracker.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordTracker.java
@@ -246,6 +246,13 @@ class FailedRecordTracker implements RecoveryStrategy {
 		this.failures.remove(Thread.currentThread());
 	}
 
+	void clearThreadStateFor(java.util.Collection<TopicPartition> partitions) {
+		Map<TopicPartition, FailedRecord> map = this.failures.get(Thread.currentThread());
+		if (map != null) {
+			partitions.forEach(map::remove);
+		}
+	}
+
 	ConsumerAwareRecordRecoverer getRecoverer() {
 		return this.recoverer;
 	}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -2397,7 +2397,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 				if (this.batchFailed) {
 					this.batchFailed = false;
 					if (this.commonErrorHandler != null) {
-						this.commonErrorHandler.clearThreadState();
+						this.commonErrorHandler.clearThreadStateFor(records.partitions());
 					}
 					getAfterRollbackProcessor().clearThreadState();
 				}


### PR DESCRIPTION
## Problem

In a non-concurrent `KafkaMessageListenerContainer` with multiple partitions, when a successful batch follows a prior failure, `doInvokeBatchListener` calls `commonErrorHandler.clearThreadState()`. This wipes the entire `FailedRecordTracker` map for the current thread, resetting the failure count for **all** partitions — including partitions that are still inside their backoff/retry cycle.

The result: a broken record that should be retried N times (or sent to the DLQ after N attempts) restarts its counter every time any **other** partition successfully processes a batch, so it never exhausts its retries and never reaches the DLQ.

Reproduction scenario (from #4371):
1. Two-partition topic, non-concurrent container, backoff+DLQ configured
2. Partition A has a broken record, partition B has healthy records
3. Partition A fails → `batchFailed = true`, `FailedRecordTracker` records attempt 1 for A
4. Error handler seeks A back, commits B
5. Next poll only returns B's records → success → `clearThreadState()` → A's failure count wiped
6. A is un-paused; failure count is 1 again → cycle repeats, DLQ never reached

## Fix

Introduce `clearThreadStateFor(Collection<TopicPartition> partitions)` throughout the error-handler stack:

- `FailedRecordTracker` — removes only the specified partitions from the per-thread failure map
- `FailedRecordProcessor` — public delegate to tracker
- `CommonErrorHandler` — new default (no-op) so existing custom handlers need no changes
- `CommonMixedErrorHandler` / `CommonDelegatingErrorHandler` — delegate to sub-handlers
- `KafkaMessageListenerContainer.doInvokeBatchListener` — calls `clearThreadStateFor(records.partitions())` instead of `clearThreadState()`

This scopes the reset to only the partitions that were actually part of the successful batch, leaving backoff state intact for partitions still retrying.

The existing `clearThreadState()` call (on thread termination) is unchanged.

## Checklist
- [ ] Tests added/updated
- [ ] `@since` tag added to new API (`CommonErrorHandler.clearThreadStateFor`)

Closes #4371