### PR TITLE
GH-4524: Fix Kafka send overload nullability

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaOperations.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaOperations.java
@@ -86,7 +86,7 @@ public interface KafkaOperations<K, V> {
 	 * @param data the data.
 	 * @return a Future for the {@link SendResult}.
 	 */
-	CompletableFuture<SendResult<K, V>> sendDefault(Integer partition, K key, @Nullable V data);
+	CompletableFuture<SendResult<K, V>> sendDefault(Integer partition, @Nullable K key, @Nullable V data);
 
 	/**
 	 * Send the data to the default topic with the provided key and partition.
@@ -97,7 +97,8 @@ public interface KafkaOperations<K, V> {
 	 * @return a Future for the {@link SendResult}.
 	 * @since 1.3
 	 */
-	CompletableFuture<SendResult<K, V>> sendDefault(Integer partition, Long timestamp, K key, @Nullable V data);
+	CompletableFuture<SendResult<K, V>> sendDefault(@Nullable Integer partition, Long timestamp, @Nullable K key,
+			@Nullable V data);
 
 	/**
 	 * Send the data to the provided topic with no key or partition.
@@ -124,7 +125,7 @@ public interface KafkaOperations<K, V> {
 	 * @param data the data.
 	 * @return a Future for the {@link SendResult}.
 	 */
-	CompletableFuture<SendResult<K, V>> send(String topic, Integer partition, K key, @Nullable V data);
+	CompletableFuture<SendResult<K, V>> send(String topic, Integer partition, @Nullable K key, @Nullable V data);
 
 	/**
 	 * Send the data to the provided topic with the provided key and partition.
@@ -136,7 +137,8 @@ public interface KafkaOperations<K, V> {
 	 * @return a Future for the {@link SendResult}.
 	 * @since 1.3
 	 */
-	CompletableFuture<SendResult<K, V>> send(String topic, Integer partition, Long timestamp, K key, @Nullable V data);
+	CompletableFuture<SendResult<K, V>> send(String topic, @Nullable Integer partition, Long timestamp,
+			@Nullable K key, @Nullable V data);
 
 	/**
 	 * Send the provided {@link ProducerRecord}.

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaTemplate.java
@@ -584,13 +584,14 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 	}
 
 	@Override
-	public CompletableFuture<SendResult<K, V>> sendDefault(Integer partition, K key, @Nullable V data) {
+	public CompletableFuture<SendResult<K, V>> sendDefault(Integer partition, @Nullable K key, @Nullable V data) {
 		Assert.state(this.defaultTopic != null, "'defaultTopic' must not be null");
 		return send(this.defaultTopic, partition, key, data);
 	}
 
 	@Override
-	public CompletableFuture<SendResult<K, V>> sendDefault(Integer partition, Long timestamp, K key, @Nullable V data) {
+	public CompletableFuture<SendResult<K, V>> sendDefault(@Nullable Integer partition, Long timestamp, @Nullable K key,
+			@Nullable V data) {
 		Assert.state(this.defaultTopic != null, "'defaultTopic' must not be null");
 		return send(this.defaultTopic, partition, timestamp, key, data);
 	}
@@ -608,14 +609,14 @@ public class KafkaTemplate<K, V> implements KafkaOperations<K, V>, ApplicationCo
 	}
 
 	@Override
-	public CompletableFuture<SendResult<K, V>> send(String topic, Integer partition, K key, @Nullable V data) {
+	public CompletableFuture<SendResult<K, V>> send(String topic, Integer partition, @Nullable K key, @Nullable V data) {
 		ProducerRecord<K, V> producerRecord = new ProducerRecord<>(topic, partition, key, data);
 		return observeSend(producerRecord);
 	}
 
 	@Override
-	public CompletableFuture<SendResult<K, V>> send(String topic, Integer partition, Long timestamp, K key,
-			@Nullable V data) {
+	public CompletableFuture<SendResult<K, V>> send(String topic, @Nullable Integer partition, Long timestamp,
+			@Nullable K key, @Nullable V data) {
 
 		ProducerRecord<K, V> producerRecord = new ProducerRecord<>(topic, partition, timestamp, key, data);
 		return observeSend(producerRecord);


### PR DESCRIPTION
Fixes #4524

Aligns the nullability contracts of `KafkaOperations` and `KafkaTemplate`
with the behavior supported by Apache Kafka's `ProducerRecord`.

- Marks keys as nullable for keyless records
- Marks partitions as nullable in timestamp-aware overloads where the producer may select the target partition
- Keeps the interface and implementation declarations consistent

This change only updates the public nullability contract and does not change runtime behavior.

## Verification

- `./gradlew :spring-kafka:test`
- `./gradlew check`
- `git diff --check`