### PR TITLE
Update `Topic Partition Assignment` anchor

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/appendix/change-history.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/appendix/change-history.adoc
@@ -345,7 +345,7 @@ See xref:kafka/seek.adoc#seek[Seek API Docs] for more details.
 [[x32-annotation-partition-offset-seek-position]]
 === @PartitionOffset support for SeekPosition
 Adding `seekPosition` property to `@PartitionOffset` support for `TopicPartitionOffset.SeekPosition`.
-See xref:kafka/receiving-messages/listener-annotation.adoc#manual-assignment[manual-assignment] for more details.
+See xref:kafka/receiving-messages/listener-annotation.adoc#topic-partition-assignment[Topic Partition Assignment] for more details.
 
 [[x32-topic-partition-offset-constructor]]
 === New constructor in TopicPartitionOffset that accepts a function to compute the offset to seek to
@@ -829,7 +829,7 @@ See xref:kafka/events.adoc[Application Events] and xref:kafka/events.adoc#idle-c
 When using manual partition assignment, you can now specify a wildcard for determining which partitions should be reset to the initial offset.
 In addition, if the listener implements `ConsumerSeekAware`, `onPartitionsAssigned()` is called after the manual assignment.
 (Also added in version 2.5.5).
-See xref:kafka/receiving-messages/listener-annotation.adoc#manual-assignment[Explicit Partition Assignment] for more information.
+See xref:kafka/receiving-messages/listener-annotation.adoc#topic-partition-assignment[Topic Partition Assignment] for more information.
 
 Convenience methods have been added to `AbstractConsumerSeekAware` to make seeking easier.
 See <<seek>> for more information.

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/seek.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/seek.adoc
@@ -23,7 +23,7 @@ When using group management, `onPartitionsAssigned` is called when partitions ar
 You can use this method, for example, for setting initial offsets for the partitions, by calling the callback.
 You can also use this method to associate this thread's callback with the assigned partitions (see the example below).
 You must use the callback argument, not the one passed into `registerSeekCallback`.
-Starting with version 2.5.5, this method is called, even when using xref:kafka/receiving-messages/listener-annotation.adoc#manual-assignment[manual partition assignment].
+Starting with version 2.5.5, this method is called, even when using xref:kafka/receiving-messages/listener-annotation.adoc#topic-partition-assignment[Topic Partition Assignment].
 
 `onPartitionsRevoked` is called when the container is stopped or Kafka revokes assignments.
 You should discard this thread's callback and remove any associations to the revoked partitions.

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/tips.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/tips.adoc
@@ -45,7 +45,7 @@ public static class PartitionFinder {
 Using this in conjunction with `ConsumerConfig.AUTO_OFFSET_RESET_CONFIG=earliest` will load all records each time the application is started.
 You should also set the container's `AckMode` to `MANUAL` to prevent the container from committing offsets for a `null` consumer group.
 Starting with version 3.1, the container will automatically coerce the `AckMode` to `MANUAL` when manual topic assignment is used with no consumer `group.id`.
-However, starting with version 2.5.5, as shown above, you can apply an initial offset to all partitions; see xref:kafka/receiving-messages/listener-annotation.adoc#manual-assignment[Explicit Partition Assignment] for more information.
+However, starting with version 2.5.5, as shown above, you can apply an initial offset to all partitions; see xref:kafka/receiving-messages/listener-annotation.adoc#topic-partition-assignment[Topic Partition Assignment] for more information.
 
 [[ex-jdbc-sync]]
 == Examples of Kafka Transactions with Other Transaction Managers


### PR DESCRIPTION
Commit 4f1906c renamed `Explicit Partition Assignment` to `Topic Partition Assignment` in `listener-annotation.adoc`. This commit updates the related anchor references in `change-history.adoc`, `seek.adoc`, and `tips.adoc`.

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.adoc).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
