### PR TITLE
GH-4537: Negative cache failed cluster id lookups

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/micrometer.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/micrometer.adoc
@@ -120,6 +120,10 @@ The sender and receiver contexts `remoteServiceName` properties are set to the K
 If, for some reason - perhaps lack of admin permissions, you cannot retrieve the cluster id, starting with version 3.1, you can set a manual `clusterId` on the `KafkaAdmin` and inject it into ``KafkaTemplate``s and listener containers.
 When it is `null` (default), the admin will invoke the `describeCluster` admin operation to retrieve it from the broker.
 
+Starting with version 4.1.1, a failed `describeCluster` attempt is remembered and is not retried until the `clusterIdRetryInterval` of the `KafkaAdmin` has elapsed; it defaults to 5 minutes.
+Each attempt creates an `Admin` instance and blocks for up to the `operationTimeout`, so, without this interval, every observed operation pays that cost while the cluster id is unavailable.
+Set `clusterIdRetryInterval` to `Duration.ZERO` to attempt the fetch on every call, as in earlier versions.
+
 [[batch-listener-obs]]
 === Batch Listener Observations
 

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -98,3 +98,11 @@ This enables consistent exception classification across both single and batch pr
 
 Note that to preserve backward compatibility, the default value for `resetStateOnExceptionChange` is `false` in `FailedBatchProcessor`, unlike `FailedRecordProcessor` where it defaults to `true`.
 If you want consistent behavior across both, call `setResetStateOnExceptionChange(true)` on your `DefaultErrorHandler` instance.
+
+[[x41-kafka-admin-cluster-id-retry]]
+=== `KafkaAdmin` Cluster Id Retry Interval
+
+When `KafkaAdmin.clusterId()` cannot retrieve the cluster id from the broker, the failure is now remembered and the fetch is not attempted again until the new `clusterIdRetryInterval` has elapsed; it defaults to 5 minutes.
+Previously every call retried, so an observation-enabled listener container created an `Admin` instance and blocked for up to the operation timeout on each record while the cluster id was unavailable.
+This changes the default behavior: set `clusterIdRetryInterval` to `Duration.ZERO` on the `KafkaAdmin` to opt out and attempt the fetch on every call, as before.
+See xref:kafka/micrometer.adoc#observation[Micrometer Observation] for more information.

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaAdmin.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaAdmin.java
@@ -373,9 +373,9 @@ public class KafkaAdmin extends KafkaResourceFactory
 
 	/**
 	 * Return the cluster id, fetching it from the broker on the first call. A failed
-	 * fetch is remembered and not attempted again until
-	 * {@link #setClusterIdRetryInterval(Duration)} has elapsed; each attempt creates an
-	 * {@link Admin} instance and blocks for up to
+	 * fetch is remembered and not attempted again until the
+	 * {@link #setClusterIdRetryInterval(Duration) clusterIdRetryInterval} has elapsed;
+	 * each attempt creates an {@link Admin} instance and blocks for up to
 	 * {@link #setOperationTimeout(int) operationTimeout}, so retrying on every call can
 	 * stall callers such as an observation-enabled listener container.
 	 * @return the cluster id, or null if it has not been fetched successfully.

--- a/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaAdmin.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/core/KafkaAdmin.java
@@ -93,6 +93,13 @@ public class KafkaAdmin extends KafkaResourceFactory
 	 */
 	public static final Duration DEFAULT_CLOSE_TIMEOUT = Duration.ofSeconds(10);
 
+	/**
+	 * The default interval between attempts to obtain the cluster id after a failed
+	 * attempt, as 5 minutes.
+	 * @since 4.1.1
+	 */
+	public static final Duration DEFAULT_CLUSTER_ID_RETRY_INTERVAL = Duration.ofMinutes(5);
+
 	private static final int DEFAULT_OPERATION_TIMEOUT = 30;
 
 	private static final LogAccessor LOGGER = new LogAccessor(LogFactory.getLog(KafkaAdmin.class));
@@ -109,6 +116,8 @@ public class KafkaAdmin extends KafkaResourceFactory
 
 	private Duration closeTimeout = DEFAULT_CLOSE_TIMEOUT;
 
+	private Duration clusterIdRetryInterval = DEFAULT_CLUSTER_ID_RETRY_INTERVAL;
+
 	private int operationTimeout = DEFAULT_OPERATION_TIMEOUT;
 
 	private boolean fatalIfBrokerNotAvailable;
@@ -120,6 +129,8 @@ public class KafkaAdmin extends KafkaResourceFactory
 	private boolean modifyTopicConfigs;
 
 	private @Nullable String clusterId;
+
+	private volatile long lastClusterIdFailure;
 
 	/**
 	 * Create an instance with an {@link Admin} based on the supplied
@@ -230,6 +241,20 @@ public class KafkaAdmin extends KafkaResourceFactory
 	 */
 	public @Nullable String getClusterId() {
 		return this.clusterId;
+	}
+
+	/**
+	 * Set the minimum interval between attempts to fetch the cluster id from the broker
+	 * after a failed attempt. Defaults to
+	 * {@link #DEFAULT_CLUSTER_ID_RETRY_INTERVAL 5 minutes}. Set to {@link Duration#ZERO}
+	 * to attempt a fetch on every {@link #clusterId()} call.
+	 * @param clusterIdRetryInterval the interval.
+	 * @since 4.1.1
+	 * @see #clusterId()
+	 */
+	public void setClusterIdRetryInterval(Duration clusterIdRetryInterval) {
+		Assert.notNull(clusterIdRetryInterval, "'clusterIdRetryInterval' cannot be null");
+		this.clusterIdRetryInterval = clusterIdRetryInterval;
 	}
 
 	@Override
@@ -346,10 +371,19 @@ public class KafkaAdmin extends KafkaResourceFactory
 		return newTopicsList;
 	}
 
+	/**
+	 * Return the cluster id, fetching it from the broker on the first call. A failed
+	 * fetch is remembered and not attempted again until
+	 * {@link #setClusterIdRetryInterval(Duration)} has elapsed; each attempt creates an
+	 * {@link Admin} instance and blocks for up to
+	 * {@link #setOperationTimeout(int) operationTimeout}, so retrying on every call can
+	 * stall callers such as an observation-enabled listener container.
+	 * @return the cluster id, or null if it has not been fetched successfully.
+	 */
 	@Override
 	@Nullable
 	public String clusterId() {
-		if (this.clusterId == null) {
+		if (this.clusterId == null && clusterIdFetchDue()) {
 			try (Admin client = createAdmin()) {
 				this.clusterId = client.describeCluster().clusterId().get(this.operationTimeout, TimeUnit.SECONDS);
 				if (this.clusterId == null) {
@@ -360,10 +394,17 @@ public class KafkaAdmin extends KafkaResourceFactory
 				Thread.currentThread().interrupt();
 			}
 			catch (Exception ex) {
+				this.lastClusterIdFailure = System.currentTimeMillis();
 				LOGGER.error(ex, "Could not obtain cluster info");
 			}
 		}
 		return this.clusterId;
+	}
+
+	private boolean clusterIdFetchDue() {
+		long lastFailure = this.lastClusterIdFailure;
+		return lastFailure == 0
+				|| System.currentTimeMillis() - lastFailure >= this.clusterIdRetryInterval.toMillis();
 	}
 
 	@Override

--- a/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaAdminTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/KafkaAdminTests.java
@@ -17,6 +17,7 @@
 package org.springframework.kafka.core;
 
 import java.lang.reflect.Method;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -27,6 +28,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.kafka.clients.CommonClientConfigs;
@@ -312,6 +314,57 @@ public class KafkaAdminTests {
 
 		};
 		assertThat(admin.clusterId()).isEqualTo("null");
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void clusterIdFailureIsNotRetriedWithinRetryInterval() throws Exception {
+		AtomicInteger attempts = new AtomicInteger();
+		AdminClient mock = mock(AdminClient.class);
+		DescribeClusterResult result = mock(DescribeClusterResult.class);
+		KafkaFuture<String> fut = mock(KafkaFuture.class);
+		given(fut.get(30, TimeUnit.SECONDS)).willThrow(new TimeoutException("test"));
+		given(result.clusterId()).willReturn(fut);
+		given(mock.describeCluster()).willReturn(result);
+		KafkaAdmin admin = new KafkaAdmin(Map.of()) {
+
+			@Override
+			protected Admin createAdmin() {
+				attempts.incrementAndGet();
+				return mock;
+			}
+
+		};
+		assertThat(admin.clusterId()).isNull();
+		assertThat(admin.clusterId()).isNull();
+		assertThat(admin.clusterId()).isNull();
+		assertThat(attempts.get()).isEqualTo(1);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void clusterIdIsFetchedAgainAfterRetryInterval() throws Exception {
+		AtomicInteger attempts = new AtomicInteger();
+		AdminClient mock = mock(AdminClient.class);
+		DescribeClusterResult result = mock(DescribeClusterResult.class);
+		KafkaFuture<String> fut = mock(KafkaFuture.class);
+		given(fut.get(30, TimeUnit.SECONDS)).willThrow(new TimeoutException("test"))
+				.willReturn("some-cluster");
+		given(result.clusterId()).willReturn(fut);
+		given(mock.describeCluster()).willReturn(result);
+		KafkaAdmin admin = new KafkaAdmin(Map.of()) {
+
+			@Override
+			protected Admin createAdmin() {
+				attempts.incrementAndGet();
+				return mock;
+			}
+
+		};
+		admin.setClusterIdRetryInterval(Duration.ZERO);
+		assertThat(admin.clusterId()).isNull();
+		assertThat(admin.clusterId()).isEqualTo("some-cluster");
+		assertThat(attempts.get()).isEqualTo(2);
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #4537

`KafkaAdmin.clusterId()` only caches the success path. When the lookup fails the
field stays `null`, so the next call creates another `Admin` instance and blocks
for up to `operationTimeout` again. A listener container with observation enabled
resolves the cluster id for every record (`KafkaRecordReceiverContext` invokes the
supplier eagerly), so an admin that cannot reach the broker turns into a per record
stall plus a continuous stream of admin client reconnect logging, for as long as
records keep arriving.

This change remembers the time of a failed lookup and skips further attempts until
`clusterIdRetryInterval` has elapsed, five minutes by default. Behavior otherwise
is unchanged:

- a successful lookup is still cached for the lifetime of the bean
- an explicitly set cluster id still short circuits the lookup
- `setClusterIdRetryInterval(Duration.ZERO)` restores the previous behavior of
  attempting a fetch on every call

## Verification

`clusterIdFailureIsNotRetriedWithinRetryInterval` is the regression gate. Dropping
the `clusterIdFetchDue()` guard and keeping the test makes it fail with
`expected: 1 but was: 3`. `clusterIdIsFetchedAgainAfterRetryInterval` covers the new
setter and the fetch that happens once the interval has elapsed.

Run locally on JDK 25, based on `5d44034`:

- `./gradlew :spring-kafka:test --tests 'org.springframework.kafka.core.*'`, 118 tests,
  0 failures, 1 pre-existing skip
- `./gradlew :spring-kafka:test --tests 'org.springframework.kafka.support.micrometer.*'`,
  29 tests, 0 failures, 4 skips (the observation tests that consume the cluster id)
- `./gradlew :spring-kafka:check -x test`, includes `checkstyleMain` and `checkstyleTest`
- `git diff --check`

I did not reproduce the reporter's full SASL scenario against a live broker; the
tests drive the failure path through a mocked `Admin` instead.
