### PR TITLE
GH-4545: Delegate `onPartitionsAssigned` in `CommonDelegatingErrorHandler`

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonDelegatingErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonDelegatingErrorHandler.java
@@ -16,6 +16,7 @@
 
 package org.springframework.kafka.listener;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -25,6 +26,7 @@ import java.util.Map.Entry;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.kafka.support.ExceptionMatcher;
@@ -39,6 +41,7 @@ import org.springframework.util.Assert;
  * @author Adrian Chlebosz
  * @author Antonin Arquey
  * @author Dan Blackney
+ * @author Alexander Makarov
  * @since 2.8
  *
  */
@@ -95,6 +98,15 @@ public class CommonDelegatingErrorHandler implements CommonErrorHandler {
 	public void clearThreadState() {
 		this.defaultErrorHandler.clearThreadState();
 		this.delegates.values().forEach(CommonErrorHandler::clearThreadState);
+	}
+
+	@Override
+	public void onPartitionsAssigned(Consumer<?, ?> consumer, Collection<TopicPartition> partitions,
+			Runnable publishPause) {
+
+		this.defaultErrorHandler.onPartitionsAssigned(consumer, partitions, publishPause);
+		this.delegates.values()
+				.forEach(handler -> handler.onPartitionsAssigned(consumer, partitions, publishPause));
 	}
 
 	@Override

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/CommonDelegatingErrorHandlerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/CommonDelegatingErrorHandlerTests.java
@@ -17,23 +17,32 @@
 package org.springframework.kafka.listener;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.kafka.KafkaException;
 import org.springframework.kafka.core.KafkaProducerException;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.util.backoff.FixedBackOff;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willAnswer;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -45,6 +54,7 @@ import static org.mockito.Mockito.verify;
  * @author Adrian Chlebosz
  * @author Antonin Arquey
  * @author Dan Blackney
+ * @author Alexander Makarov
  * @since 2.8
  *
  */
@@ -267,6 +277,57 @@ public class CommonDelegatingErrorHandlerTests {
 		assertThatThrownBy(() -> delegatingErrorHandler.setErrorHandlers(delegates))
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessage("All delegates must return the same value when calling 'seeksAfterHandling()'");
+	}
+
+	@Test
+	void testOnPartitionsAssignedDelegates() {
+		var def = mock(CommonErrorHandler.class);
+		var one = mock(CommonErrorHandler.class);
+		var two = mock(CommonErrorHandler.class);
+		var eh = new CommonDelegatingErrorHandler(def);
+		eh.setErrorHandlers(Map.of(IllegalStateException.class, one, IllegalArgumentException.class, two));
+		var consumer = mock(Consumer.class);
+		var partitions = List.of(new TopicPartition("foo", 0));
+		Runnable publishPause = () -> {
+		};
+
+		eh.onPartitionsAssigned(consumer, partitions, publishPause);
+
+		verify(def).onPartitionsAssigned(consumer, partitions, publishPause);
+		verify(one).onPartitionsAssigned(consumer, partitions, publishPause);
+		verify(two).onPartitionsAssigned(consumer, partitions, publishPause);
+	}
+
+	@Test
+	void testRePauseOnRebalanceDuringBatchRetry() {
+		var recovered = new ArrayList<ConsumerRecord<?, ?>>();
+		var defaultHandler = new DefaultErrorHandler((cr, ex) -> recovered.add(cr), new FixedBackOff(0L, 1L));
+		var eh = new CommonDelegatingErrorHandler(defaultHandler);
+		Map<TopicPartition, List<ConsumerRecord<Object, Object>>> map = new HashMap<>();
+		map.put(new TopicPartition("foo", 0),
+				Collections.singletonList(new ConsumerRecord<>("foo", 0, 0L, "foo", "bar")));
+		ConsumerRecords<?, ?> records = new ConsumerRecords<>(map, Map.of());
+		var consumer = mock(Consumer.class);
+		given(consumer.assignment()).willReturn(map.keySet());
+		var pubPauseCalled = new AtomicBoolean();
+		// a rebalance completes while the retry back off is in progress
+		willAnswer(inv -> {
+			eh.onPartitionsAssigned(consumer, List.of(new TopicPartition("foo", 1)),
+					() -> pubPauseCalled.set(true));
+			return records;
+		}).given(consumer).poll(any());
+		var container = mock(KafkaMessageListenerContainer.class);
+		given(container.getContainerFor(any(), anyInt())).willReturn(container);
+		given(container.isRunning()).willReturn(true);
+
+		eh.handleBatch(new RuntimeException(), records, consumer, container, () -> {
+			throw new RuntimeException();
+		});
+
+		assertThat(recovered).hasSize(1);
+		// the newly assigned partitions must be re-paused so that their records are not fetched and discarded
+		assertThat(pubPauseCalled.get()).isTrue();
+		verify(consumer, atLeast(2)).pause(any());
 	}
 
 	private Exception wrap(Exception ex) {


### PR DESCRIPTION
Fixes #4545

`CommonDelegatingErrorHandler` does not override `onPartitionsAssigned()`, so the call hits the no-op default method on `CommonErrorHandler` and is never forwarded to the default handler or any delegate. The callback was added in #2340 but was not implemented here.

Consequently, when a rebalance completes while the wrapped handler is inside `retryBatch()`'s back off, `FallbackBatchErrorHandler` never gets the chance to re-pause the newly assigned partitions. The keep-alive polls in the retry loop then fetch records from those partitions and discard them, advancing the positions. Those records are never delivered to the listener, and subsequent commits make the loss permanent — with no error raised.

## Changes

Override `onPartitionsAssigned()` to invoke the default error handler and all the delegates.

The callback is not exception-scoped (there is no exception to classify on), so it is propagated to every handler, consistent with how `clearThreadState()` already fans out. This does not cause duplicate pause events in practice: `FallbackBatchErrorHandler.onPartitionsAssigned()` only acts when it is retrying on the current thread, and at most one handler can be inside `handleBatch()` on the consumer thread at a time.

## Tests

Two tests added to `CommonDelegatingErrorHandlerTests`, both of which fail on `main` and pass with the fix:

- `testOnPartitionsAssignedDelegates` — verifies the callback reaches the default handler and every delegate.
- `testRePauseOnRebalanceDuringBatchRetry` — reproduces the reported scenario end to end: a `DefaultErrorHandler` wrapped in `CommonDelegatingErrorHandler`, with a rebalance triggered from the keep-alive poll during the retry back off, and asserts the newly assigned partitions are re-paused and the paused event is published.

`./gradlew :spring-kafka:test --tests '*ErrorHandler*' --tests '*FailedBatch*' --tests '*SeekTo*'` and checkstyle both pass.