### PR TITLE
GH-4545: Delegate onPartitionsAssigned in CommonDelegatingErrorHandler

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonDelegatingErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonDelegatingErrorHandler.java
@@ -41,6 +41,7 @@ import org.springframework.util.Assert;
  * @author Adrian Chlebosz
  * @author Antonin Arquey
  * @author Dan Blackney
+ * @author Burak Kalayci
  * @since 2.8
  *
  */

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonDelegatingErrorHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/CommonDelegatingErrorHandler.java
@@ -16,6 +16,7 @@
 
 package org.springframework.kafka.listener;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -25,6 +26,7 @@ import java.util.Map.Entry;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
 import org.jspecify.annotations.Nullable;
 
 import org.springframework.kafka.support.ExceptionMatcher;
@@ -95,6 +97,15 @@ public class CommonDelegatingErrorHandler implements CommonErrorHandler {
 	public void clearThreadState() {
 		this.defaultErrorHandler.clearThreadState();
 		this.delegates.values().forEach(CommonErrorHandler::clearThreadState);
+	}
+
+	@Override
+	public void onPartitionsAssigned(Consumer<?, ?> consumer, Collection<TopicPartition> partitions,
+			Runnable publishPause) {
+
+		this.defaultErrorHandler.onPartitionsAssigned(consumer, partitions, publishPause);
+		this.delegates.values()
+				.forEach(handler -> handler.onPartitionsAssigned(consumer, partitions, publishPause));
 	}
 
 	@Override

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/CommonDelegatingErrorHandlerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/CommonDelegatingErrorHandlerTests.java
@@ -17,12 +17,16 @@
 package org.springframework.kafka.listener;
 
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.kafka.KafkaException;
@@ -33,6 +37,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -267,6 +273,27 @@ public class CommonDelegatingErrorHandlerTests {
 		assertThatThrownBy(() -> delegatingErrorHandler.setErrorHandlers(delegates))
 				.isInstanceOf(IllegalArgumentException.class)
 				.hasMessage("All delegates must return the same value when calling 'seeksAfterHandling()'");
+	}
+
+	@Test
+	void onPartitionsAssignedIsForwardedToDefaultAndDelegates() {
+		var defaultHandler = mock(CommonErrorHandler.class);
+		var one = mock(CommonErrorHandler.class);
+		var two = mock(CommonErrorHandler.class);
+		var eh = new CommonDelegatingErrorHandler(defaultHandler);
+		eh.setErrorHandlers(Map.of(IllegalStateException.class, one, IllegalArgumentException.class, two));
+
+		Consumer<?, ?> consumer = mock(Consumer.class);
+		Collection<TopicPartition> partitions = List.of(new TopicPartition("topic", 0));
+		AtomicInteger publishPauseInvocations = new AtomicInteger();
+		Runnable publishPause = publishPauseInvocations::incrementAndGet;
+
+		eh.onPartitionsAssigned(consumer, partitions, publishPause);
+
+		verify(defaultHandler).onPartitionsAssigned(same(consumer), eq(partitions), same(publishPause));
+		verify(one).onPartitionsAssigned(same(consumer), eq(partitions), same(publishPause));
+		verify(two).onPartitionsAssigned(same(consumer), eq(partitions), same(publishPause));
+		assertThat(publishPauseInvocations).hasValue(0);
 	}
 
 	private Exception wrap(Exception ex) {

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/CommonDelegatingErrorHandlerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/CommonDelegatingErrorHandlerTests.java
@@ -51,6 +51,7 @@ import static org.mockito.Mockito.verify;
  * @author Adrian Chlebosz
  * @author Antonin Arquey
  * @author Dan Blackney
+ * @author Burak Kalayci
  * @since 2.8
  *
  */


### PR DESCRIPTION
Fixes #4545

## Summary
`CommonDelegatingErrorHandler` did not override `onPartitionsAssigned()`, so the call hit the no-op default on `CommonErrorHandler` and was never forwarded to the default handler or any delegate.

When a rebalance completes while a wrapped handler is inside `retryBatch()` back-off, newly assigned partitions are not re-paused. Keep-alive polls in the retry loop can then fetch and discard records from those partitions, advancing offsets without delivery.

This change forwards `onPartitionsAssigned` to the default handler and all delegates, mirroring `clearThreadState()`. The callback is not exception-scoped; handlers that are not actively retrying no-op, so only the retrying handler acts.

## Test plan
- [x] `./gradlew :spring-kafka:test --tests "org.springframework.kafka.listener.CommonDelegatingErrorHandlerTests"` — 12/12 GREEN (includes new `onPartitionsAssignedIsForwardedToDefaultAndDelegates`)
- [x] RED observed before the production change (`WantedButNotInvoked` on default/delegate `onPartitionsAssigned`)