### PR TITLE
Use Gradle version catalog for dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	ext.isCI = System.getenv('GITHUB_ACTION')
-	ext.kotlinVersion = '2.3.21'
+	ext.kotlinVersion = libs.versions.kotlinVersion.get()
 	repositories {
 		gradlePluginPortal()
 		mavenCentral()
@@ -14,8 +14,8 @@ buildscript {
 plugins {
 	id 'base'
 	id 'idea'
-	id 'io.freefair.aggregate-javadoc' version '9.2.0'
-	id 'io.spring.nullability' version '0.0.14' apply false
+	alias(libs.plugins.aggregate.javadoc)
+	alias(libs.plugins.nullability) apply false
 }
 
 
@@ -32,26 +32,26 @@ ext {
 	linkScmConnection = 'https://github.com/spring-projects/spring-kafka.git'
 	linkScmDevConnection = 'git@github.com:spring-projects/spring-kafka.git'
 
-	assertjVersion = '3.27.7'
-	awaitilityVersion = '4.3.0'
-	hamcrestVersion = '3.0'
-	hibernateValidationVersion = '9.1.3.Final'
-	jacksonBomVersion = '2.21.5'
-	jackson3Version = '3.2.1'
-	jaywayJsonPathVersion = '3.0.0'
-	junitJupiterVersion = '6.1.2'
-	kafkaVersion = '4.3.1'
-	kotlinCoroutinesVersion = '1.10.2'
-	log4jVersion = '2.25.5'
-	micrometerDocsVersion = '1.0.4'
-	micrometerVersion = '1.18.0-SNAPSHOT'
-	micrometerTracingVersion = '1.8.0-SNAPSHOT'
-	mockitoVersion = '5.23.0'
-	reactorVersion = '2026.0.0-SNAPSHOT'
-	slf4jVersion = '2.0.18'
-	springBootVersion = '4.0.3' // docs module
-	springDataVersion = '2026.1.0-SNAPSHOT'
-	springVersion = '7.1.0-SNAPSHOT'
+	assertjVersion = libs.versions.assertjVersion.get()
+	awaitilityVersion = libs.versions.awaitilityVersion.get()
+	hamcrestVersion = libs.versions.hamcrestVersion.get()
+	hibernateValidationVersion = libs.versions.hibernateValidationVersion.get()
+	jacksonBomVersion = libs.versions.jacksonVersion.get()
+	jackson3Version = libs.versions.jackson3Version.get()
+	jaywayJsonPathVersion = libs.versions.jaywayJsonPathVersion.get()
+	junitJupiterVersion = libs.versions.junitJupiterVersion.get()
+	kafkaVersion = libs.versions.kafkaVersion.get()
+	kotlinCoroutinesVersion = libs.versions.kotlinCoroutinesVersion.get()
+	log4jVersion = libs.versions.log4jVersion.get()
+	micrometerDocsVersion = libs.versions.micrometerDocsVersion.get()
+	micrometerVersion = libs.versions.micrometerVersion.get()
+	micrometerTracingVersion = libs.versions.micrometerTracingVersion.get()
+	mockitoVersion = libs.versions.mockitoVersion.get()
+	reactorVersion = libs.versions.reactorVersion.get()
+	slf4jVersion = libs.versions.slf4jVersion.get()
+	springBootVersion = libs.versions.springBootVersion.get() // docs module
+	springDataVersion = libs.versions.springDataVersion.get()
+	springVersion = libs.versions.springVersion.get()
 
 	idPrefix = 'kafka'
 
@@ -94,15 +94,16 @@ allprojects {
 	}
 
 	dependencies {
-		dependencyManagement(platform("com.fasterxml.jackson:jackson-bom:$jacksonBomVersion"))
-		dependencyManagement(platform("tools.jackson:jackson-bom:$jackson3Version"))
-		dependencyManagement(platform("org.junit:junit-bom:$junitJupiterVersion"))
-		dependencyManagement(platform("org.springframework:spring-framework-bom:$springVersion"))
-		dependencyManagement(platform("io.projectreactor:reactor-bom:$reactorVersion"))
-		dependencyManagement(platform("org.apache.logging.log4j:log4j-bom:$log4jVersion"))
-		dependencyManagement(platform("org.springframework.data:spring-data-bom:$springDataVersion"))
-		dependencyManagement(platform("io.micrometer:micrometer-bom:$micrometerVersion"))
-		dependencyManagement(platform("io.micrometer:micrometer-tracing-bom:$micrometerTracingVersion"))
+		dependencyManagement(platform(libs.com.fasterxml.jackson.bom))
+		dependencyManagement(platform(libs.tools.jackson.bom))
+		dependencyManagement(platform(libs.org.junit.bom))
+		dependencyManagement(platform(libs.spring.framework.bom))
+		dependencyManagement(platform(libs.io.projectreactor.bom))
+		dependencyManagement(platform(libs.apache.logging.log4j.bom))
+		dependencyManagement(platform(libs.spring.data.bom))
+		dependencyManagement(platform(libs.io.micrometer.bom))
+		dependencyManagement(platform(libs.io.micrometer.tracing.bom))
+		dependencyManagement(platform(libs.org.jetbrains.kotlinx.coroutines.bom))
 	}
 }
 
@@ -163,9 +164,9 @@ configure(javaProjects) { subproject ->
 		testImplementation 'org.junit.jupiter:junit-jupiter-params'
 		testImplementation 'org.jetbrains.kotlin:kotlin-reflect'
 		testImplementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
-		testImplementation "org.awaitility:awaitility:$awaitilityVersion"
-		testImplementation "org.hamcrest:hamcrest-core:$hamcrestVersion"
-		testImplementation "org.assertj:assertj-core:$assertjVersion"
+		testImplementation libs.org.awaitility
+		testImplementation libs.org.hamcrest.core
+		testImplementation libs.org.assertj.core
 
 		testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
 		testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
@@ -327,11 +328,11 @@ project ('spring-kafka') {
 		api 'org.springframework:spring-context'
 		api 'org.springframework:spring-messaging'
 		api 'org.springframework:spring-tx'
-		api "org.apache.kafka:kafka-clients:$kafkaVersion"
+		api libs.apache.kafka.clients
 		api 'io.micrometer:micrometer-observation'
 
-		optionalApi "org.apache.kafka:kafka-streams:$kafkaVersion"
-		optionalApi "org.jetbrains.kotlinx:kotlinx-coroutines-reactor:$kotlinCoroutinesVersion"
+		optionalApi libs.apache.kafka.streams
+		optionalApi 'org.jetbrains.kotlinx:kotlinx-coroutines-reactor'
 		optionalApi 'com.fasterxml.jackson.core:jackson-core'
 		optionalApi 'com.fasterxml.jackson.core:jackson-databind'
 		optionalApi 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8'
@@ -342,15 +343,15 @@ project ('spring-kafka') {
 		optionalApi 'tools.jackson.datatype:jackson-datatype-joda'
 		optionalApi 'tools.jackson.module:jackson-module-kotlin'
 		optionalApi 'org.springframework.data:spring-data-commons'
-		optionalApi "com.jayway.jsonpath:json-path:$jaywayJsonPathVersion"
+		optionalApi libs.com.jayway.jsonpath
 		optionalApi 'io.projectreactor:reactor-core'
 		optionalApi 'io.micrometer:micrometer-core'
 		optionalApi 'io.micrometer:micrometer-tracing'
 
 		testImplementation project (':spring-kafka-test')
 		testImplementation 'io.projectreactor:reactor-test'
-		testImplementation "org.mockito:mockito-junit-jupiter:$mockitoVersion"
-		testImplementation "org.hibernate.validator:hibernate-validator:$hibernateValidationVersion"
+		testImplementation libs.org.mockito.junit.jupiter
+		testImplementation libs.org.hibernate.validator
 		testImplementation 'io.micrometer:micrometer-tracing-integration-test'
 	}
 
@@ -385,23 +386,23 @@ project ('spring-kafka-test') {
 	description = 'Spring Kafka Test Support'
 
 	dependencies {
-		api "org.slf4j:slf4j-api:$slf4jVersion"
+		api libs.org.slf4j.api
 		api 'org.springframework:spring-context'
 		api 'org.springframework:spring-test'
-		api "org.apache.kafka:kafka-clients:$kafkaVersion:test"
-		api "org.apache.kafka:kafka-server:$kafkaVersion"
-		api "org.apache.kafka:kafka-test-common-runtime:$kafkaVersion"
-		api "org.apache.kafka:kafka-metadata:$kafkaVersion"
-		api "org.apache.kafka:kafka-server-common:$kafkaVersion"
-		api "org.apache.kafka:kafka-server-common:$kafkaVersion:test"
-		api "org.apache.kafka:kafka-streams-test-utils:$kafkaVersion"
+		api "org.apache.kafka:kafka-clients:${libs.versions.kafkaVersion.get()}:test"
+		api libs.apache.kafka.server
+		api libs.apache.kafka.test.common.runtime
+		api libs.apache.kafka.metadata
+		api libs.apache.kafka.server.common
+		api "org.apache.kafka:kafka-server-common:${libs.versions.kafkaVersion.get()}:test"
+		api libs.apache.kafka.streams.test.utils
 		api 'org.junit.jupiter:junit-jupiter-api'
 		api 'org.junit.platform:junit-platform-launcher'
 
-		optionalApi "org.hamcrest:hamcrest-core:$hamcrestVersion"
-		optionalApi "org.mockito:mockito-core:$mockitoVersion"
+		optionalApi libs.org.hamcrest.core
+		optionalApi libs.org.mockito.core
 		optionalApi 'org.apache.logging.log4j:log4j-core'
-		optionalApi "org.assertj:assertj-core:$assertjVersion"
+		optionalApi libs.org.assertj.core
 	}
 }
 
@@ -410,7 +411,7 @@ configurations {
 }
 
 dependencies {
-	micrometerDocs "io.micrometer:micrometer-docs-generator:$micrometerDocsVersion"
+	micrometerDocs libs.io.micrometer.docs.generator
 }
 
 def observationInputDir = file('spring-kafka/src/main/java/org/springframework/kafka/support/micrometer').absolutePath

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
 	ext.isCI = System.getenv('GITHUB_ACTION')
-	ext.kotlinVersion = libs.versions.kotlinVersion.get()
+	ext.kotlinVersion = '2.3.21'
 	repositories {
 		gradlePluginPortal()
 		mavenCentral()
@@ -31,27 +31,6 @@ ext {
 	linkScmUrl = 'https://github.com/spring-projects/spring-kafka'
 	linkScmConnection = 'https://github.com/spring-projects/spring-kafka.git'
 	linkScmDevConnection = 'git@github.com:spring-projects/spring-kafka.git'
-
-	assertjVersion = libs.versions.assertjVersion.get()
-	awaitilityVersion = libs.versions.awaitilityVersion.get()
-	hamcrestVersion = libs.versions.hamcrestVersion.get()
-	hibernateValidationVersion = libs.versions.hibernateValidationVersion.get()
-	jacksonBomVersion = libs.versions.jacksonVersion.get()
-	jackson3Version = libs.versions.jackson3Version.get()
-	jaywayJsonPathVersion = libs.versions.jaywayJsonPathVersion.get()
-	junitJupiterVersion = libs.versions.junitJupiterVersion.get()
-	kafkaVersion = libs.versions.kafkaVersion.get()
-	kotlinCoroutinesVersion = libs.versions.kotlinCoroutinesVersion.get()
-	log4jVersion = libs.versions.log4jVersion.get()
-	micrometerDocsVersion = libs.versions.micrometerDocsVersion.get()
-	micrometerVersion = libs.versions.micrometerVersion.get()
-	micrometerTracingVersion = libs.versions.micrometerTracingVersion.get()
-	mockitoVersion = libs.versions.mockitoVersion.get()
-	reactorVersion = libs.versions.reactorVersion.get()
-	slf4jVersion = libs.versions.slf4jVersion.get()
-	springBootVersion = libs.versions.springBootVersion.get() // docs module
-	springDataVersion = libs.versions.springDataVersion.get()
-	springVersion = libs.versions.springVersion.get()
 
 	idPrefix = 'kafka'
 
@@ -156,14 +135,13 @@ configure(javaProjects) { subproject ->
 
 	// dependencies that are common across all java projects
 	dependencies {
-		def spotBugs = 'com.github.spotbugs:spotbugs-annotations:4.9.8'
-		compileOnly spotBugs
-		testRuntimeOnly spotBugs
+		compileOnly libs.com.github.spotbugs.annotations
+		testRuntimeOnly libs.com.github.spotbugs.annotations
 
 		testImplementation 'org.junit.jupiter:junit-jupiter-api'
 		testImplementation 'org.junit.jupiter:junit-jupiter-params'
 		testImplementation 'org.jetbrains.kotlin:kotlin-reflect'
-		testImplementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
+		testImplementation libs.kotlin.stdlib.jdk8
 		testImplementation libs.org.awaitility
 		testImplementation libs.org.hamcrest.core
 		testImplementation libs.org.assertj.core
@@ -389,12 +367,12 @@ project ('spring-kafka-test') {
 		api libs.org.slf4j.api
 		api 'org.springframework:spring-context'
 		api 'org.springframework:spring-test'
-		api "org.apache.kafka:kafka-clients:${libs.versions.kafkaVersion.get()}:test"
+		api(libs.apache.kafka.clients) { artifact { classifier = 'test' } }
 		api libs.apache.kafka.server
 		api libs.apache.kafka.test.common.runtime
 		api libs.apache.kafka.metadata
 		api libs.apache.kafka.server.common
-		api "org.apache.kafka:kafka-server-common:${libs.versions.kafkaVersion.get()}:test"
+		api(libs.apache.kafka.server.common) { artifact { classifier = 'test' } }
 		api libs.apache.kafka.streams.test.utils
 		api 'org.junit.jupiter:junit-jupiter-api'
 		api 'org.junit.platform:junit-platform-launcher'

--- a/build.gradle
+++ b/build.gradle
@@ -141,7 +141,7 @@ configure(javaProjects) { subproject ->
 		testImplementation 'org.junit.jupiter:junit-jupiter-api'
 		testImplementation 'org.junit.jupiter:junit-jupiter-params'
 		testImplementation 'org.jetbrains.kotlin:kotlin-reflect'
-		testImplementation libs.kotlin.stdlib.jdk8
+		testImplementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
 		testImplementation libs.org.awaitility
 		testImplementation libs.org.hamcrest.core
 		testImplementation libs.org.assertj.core

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,60 @@
+[versions]
+# Spring Portfolio dependencies. Usually managed by release train
+micrometerTracingVersion = "1.8.0-SNAPSHOT"
+micrometerVersion = "1.18.0-SNAPSHOT"
+micrometerDocsVersion = "1.0.4"
+reactorVersion = "2026.0.0-SNAPSHOT"
+springBootVersion = "4.0.3"
+springDataVersion = "2026.1.0-SNAPSHOT"
+springVersion = "7.1.0-SNAPSHOT"
+
+# Third-party dependencies
+assertjVersion = "3.27.7"
+awaitilityVersion = "4.3.0"
+hamcrestVersion = "3.0"
+hibernateValidationVersion = "9.1.3.Final"
+jacksonVersion = "2.21.5"
+jackson3Version = "3.2.1"
+jaywayJsonPathVersion = "3.0.0"
+junitJupiterVersion = "6.1.2"
+kafkaVersion = "4.3.1"
+kotlinVersion = "2.3.21"
+kotlinCoroutinesVersion = "1.10.2"
+log4jVersion = "2.25.5"
+mockitoVersion = "5.23.0"
+slf4jVersion = "2.0.18"
+
+[libraries]
+com-fasterxml-jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version.ref = "jacksonVersion" }
+com-jayway-jsonpath = { module = "com.jayway.jsonpath:json-path", version.ref = "jaywayJsonPathVersion" }
+io-micrometer-bom = { module = "io.micrometer:micrometer-bom", version.ref = "micrometerVersion" }
+io-micrometer-tracing-bom = { module = "io.micrometer:micrometer-tracing-bom", version.ref = "micrometerTracingVersion" }
+io-micrometer-docs-generator = { module = "io.micrometer:micrometer-docs-generator", version.ref = "micrometerDocsVersion" }
+io-projectreactor-bom = { module = "io.projectreactor:reactor-bom", version.ref = "reactorVersion" }
+apache-kafka-clients = { module = "org.apache.kafka:kafka-clients", version.ref = "kafkaVersion" }
+apache-kafka-streams = { module = "org.apache.kafka:kafka-streams", version.ref = "kafkaVersion" }
+apache-kafka-server = { module = "org.apache.kafka:kafka-server", version.ref = "kafkaVersion" }
+apache-kafka-test-common-runtime = { module = "org.apache.kafka:kafka-test-common-runtime", version.ref = "kafkaVersion" }
+apache-kafka-metadata = { module = "org.apache.kafka:kafka-metadata", version.ref = "kafkaVersion" }
+apache-kafka-server-common = { module = "org.apache.kafka:kafka-server-common", version.ref = "kafkaVersion" }
+apache-kafka-streams-test-utils = { module = "org.apache.kafka:kafka-streams-test-utils", version.ref = "kafkaVersion" }
+apache-logging-log4j-bom = { module = "org.apache.logging.log4j:log4j-bom", version.ref = "log4jVersion" }
+org-assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertjVersion" }
+org-awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitilityVersion" }
+org-hamcrest-core = { module = "org.hamcrest:hamcrest-core", version.ref = "hamcrestVersion" }
+org-hibernate-validator = { module = "org.hibernate.validator:hibernate-validator", version.ref = "hibernateValidationVersion" }
+org-jetbrains-kotlinx-coroutines-bom = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-bom", version.ref = "kotlinCoroutinesVersion" }
+org-junit-bom = { module = "org.junit:junit-bom", version.ref = "junitJupiterVersion" }
+org-mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockitoVersion" }
+org-mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockitoVersion" }
+org-slf4j-api = { module = "org.slf4j:slf4j-api", version.ref = "slf4jVersion" }
+org-springframework-boot-starter = { module = "org.springframework.boot:spring-boot-starter", version.ref = "springBootVersion" }
+spring-data-bom = { module = "org.springframework.data:spring-data-bom", version.ref = "springDataVersion" }
+spring-framework-bom = { module = "org.springframework:spring-framework-bom", version.ref = "springVersion" }
+tools-jackson-bom = { module = "tools.jackson:jackson-bom", version.ref = "jackson3Version" }
+
+[plugins]
+aggregate-javadoc = { id = "io.freefair.aggregate-javadoc", version = "9.2.0" }
+nullability = { id = "io.spring.nullability", version = "0.0.14" }
+antora = { id = "org.antora", version = "1.0.0" }
+io-spring-antora-generate-yml = { id = "io.spring.antora.generate-antora-yml", version = "0.0.1" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ kotlinCoroutinesVersion = "1.10.2"
 log4jVersion = "2.25.5"
 mockitoVersion = "5.23.0"
 slf4jVersion = "2.0.18"
+spotbugsVersion = "4.9.8"
 
 [libraries]
 com-fasterxml-jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version.ref = "jacksonVersion" }
@@ -52,6 +53,8 @@ org-springframework-boot-starter = { module = "org.springframework.boot:spring-b
 spring-data-bom = { module = "org.springframework.data:spring-data-bom", version.ref = "springDataVersion" }
 spring-framework-bom = { module = "org.springframework:spring-framework-bom", version.ref = "springVersion" }
 tools-jackson-bom = { module = "tools.jackson:jackson-bom", version.ref = "jackson3Version" }
+kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlinVersion" }
+com-github-spotbugs-annotations = { module = "com.github.spotbugs:spotbugs-annotations", version.ref = "spotbugsVersion" }
 
 [plugins]
 aggregate-javadoc = { id = "io.freefair.aggregate-javadoc", version = "9.2.0" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,6 @@ jackson3Version = "3.2.1"
 jaywayJsonPathVersion = "3.0.0"
 junitJupiterVersion = "6.1.2"
 kafkaVersion = "4.3.1"
-kotlinVersion = "2.3.21"
 kotlinCoroutinesVersion = "1.10.2"
 log4jVersion = "2.25.5"
 mockitoVersion = "5.23.0"
@@ -53,7 +52,6 @@ org-springframework-boot-starter = { module = "org.springframework.boot:spring-b
 spring-data-bom = { module = "org.springframework.data:spring-data-bom", version.ref = "springDataVersion" }
 spring-framework-bom = { module = "org.springframework:spring-framework-bom", version.ref = "springVersion" }
 tools-jackson-bom = { module = "tools.jackson:jackson-bom", version.ref = "jackson3Version" }
-kotlin-stdlib-jdk8 = { module = "org.jetbrains.kotlin:kotlin-stdlib-jdk8", version.ref = "kotlinVersion" }
 com-github-spotbugs-annotations = { module = "com.github.spotbugs:spotbugs-annotations", version.ref = "spotbugsVersion" }
 
 [plugins]

--- a/spring-kafka-docs/build.gradle
+++ b/spring-kafka-docs/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'org.antora' version '1.0.0'
-    id 'io.spring.antora.generate-antora-yml' version '0.0.1'
+    alias(libs.plugins.antora)
+    alias(libs.plugins.io.spring.antora.generate.yml)
 }
 
 apply from: "${rootDir}/gradle/docs.gradle"
@@ -33,7 +33,7 @@ configurations {
 }
 
 dependencies {
-    implementation "org.springframework.boot:spring-boot-starter:$springBootVersion"
+    implementation libs.org.springframework.boot.starter
     implementation project (':spring-kafka')
     implementation 'org.jetbrains.kotlin:kotlin-stdlib'
     implementation 'tools.jackson.core:jackson-databind'


### PR DESCRIPTION
- Introduce gradle/libs.versions.toml to centralize dependency and plugin versions.

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.md).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
