### PR TITLE
Fix tx offset lag when marker batch is separate

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -1512,6 +1512,14 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			}
 			debugRecords(records);
 
+			// If the poll returned nothing, run the tx-offset fix a second time now that
+			// the consumer's fetch position may have advanced past a transaction marker
+			// that arrived in a separate batch after the records were committed. The fix
+			// at the top of this method runs before the poll, so it sees the pre-poll
+			// position; this call sees the post-poll position and can correct the lag.
+			if (records == null || records.count() == 0) {
+				fixTxOffsetsIfNeeded();
+			}
 			invokeIfHaveRecords(records);
 			if (this.remainingRecords == null) {
 				resumeConsumerIfNecessary();


### PR DESCRIPTION
Fix tx offset correction lag when marker arrives in a separate fetch batch.

On a loaded broker the transaction data batch and its END marker can arrive in separate fetch responses, opening a window where checkIdle() fires before fixTxOffsetsIfNeeded() sees the advanced position.

**Auto-cherry-pick to `4.1.x` & `4.0.x`**

