### PR TITLE
GH-3947: Align batch observation meter tags

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/micrometer.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/micrometer.adoc
@@ -100,7 +100,9 @@ Using Micrometer for observation is now supported, since version 3.0, for the `K
 
 Set `observationEnabled` to `true` on the `KafkaTemplate` and `ContainerProperties` to enable observation; this will disable xref:kafka/micrometer.adoc[Micrometer Timers] because the timers will now be managed with each observation.
 
-IMPORTANT: Micrometer Observation does not support batch listener; this will enable Micrometer Timers
+When observation is enabled for a batch listener and `recordObservationsInBatch` is `false` (the default), a single batch-level observation is created for the whole batch invocation.
+This uses the same low-cardinality meter tags as non-batch listeners so Prometheus does not reject mixed batch and non-batch meters under the `spring.kafka.listener` name.
+See xref:kafka/micrometer.adoc#batch-listener-obs[Batch Listener Observations].
 
 Refer to {micrometer-tracing-reference-url}[Micrometer Tracing] for more information.
 
@@ -127,10 +129,12 @@ Set `clusterIdRetryInterval` to `Duration.ZERO` to attempt the fetch on every ca
 [[batch-listener-obs]]
 === Batch Listener Observations
 
-When using a batch listener, by default, no observations are created, even if a `ObservationRegistry` is present.
-This is because the scope of an observation is tied to the thread, and with a batch listener, there is no one-to-one mapping between an observation and a record.
+When using a batch listener with `observationEnabled` set to `true` and `recordObservationsInBatch` left at the default (`false`), Spring for Apache Kafka creates **one observation for the entire batch** (using the first record for messaging source tags).
+That observation uses the same low-cardinality keys as a non-batch listener (`spring.kafka.listener.id`, `messaging.*`, and Micrometer's `error` tag), so mixing batch and non-batch listeners does not break Prometheus registration of `spring.kafka.listener` meters.
+Optional tag values that are unavailable use the Micrometer placeholder `none`.
 
-To enable per-record observations in a batch listener, set the container factory property `recordObservationsInBatch` to `true`.
+There is still no one-to-one mapping between an observation and each record in the batch.
+To enable **per-record** observations in a batch listener, set the container factory property `recordObservationsInBatch` to `true`.
 
 [source,java]
 ----

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -6,3 +6,26 @@
 
 This section covers the changes made from version 4.1 to version 4.2.
 For changes in earlier versions, see xref:appendix/change-history.adoc[Change History].
+
+[[x42-listener-observation-tags]]
+=== Listener Observation Meter Tags
+
+When `observationEnabled` is `true`, batch listeners create a batch-level observation (unless `recordObservationsInBatch` is enabled for per-record observations) using the same low-cardinality meter tags as non-batch listeners.
+Optional tag values use the Micrometer placeholder `none` when unavailable.
+This prevents Prometheus registration failures when an application mixes batch and non-batch listeners under the `spring.kafka.listener` meter name.
+See xref:kafka/micrometer.adoc#batch-listener-obs[Batch Listener Observations].
+
+==== Backward Compatibility
+
+These changes affect existing meters and dashboards:
+
+* **Batch listeners with `observationEnabled=true`:** Previously these used legacy `MicrometerHolder` timers with `name` / `result` / `exception` tags.
+They now emit observation-based meters with `messaging.*` tags (and Micrometer's `error` tag).
+Dashboards or recording rules that matched the old tag structure will stop matching and must be updated to the observation tag keys.
+
+* **All listeners (batch and non-batch) without a consumer group:** `messaging.kafka.consumer.group` was previously omitted from the low-cardinality tag set when no group was configured.
+It is now always present with value `none` (and the same applies to high-cardinality optional tags such as `messaging.kafka.client_id` and `messaging.consumer.id` when unavailable).
+Exact label-set matching queries that assumed the tag was absent need to be revised.
+
+These behavioral changes are intentional so that all `spring.kafka.listener` meters share one consistent tag key set for Prometheus.
+They ship in **4.2** only (they cannot be backported to 4.1).

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -178,6 +178,7 @@ import org.springframework.util.StringUtils;
  * @author Minchul Son
  * @author Youngjoo Kim
  * @author Bill Kim
+ * @author Hakaze Arimu
  */
 public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		extends AbstractMessageListenerContainer<K, V> implements ConsumerPauseResumeEventPublisher {
@@ -1321,8 +1322,9 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		private @Nullable MicrometerHolder obtainMicrometerHolder() {
 			MicrometerHolder holder = null;
 			try {
+				// Skip legacy timers when observation is active as mixed tag key sets break Prometheus registration.
 				if (KafkaUtils.MICROMETER_PRESENT && this.containerProperties.isMicrometerEnabled()
-						&& !this.observationEnabled) {
+						&& !this.containerProperties.isObservationEnabled()) {
 
 					Function<@Nullable Object, Map<String, String>> mergedProvider =
 							cr -> this.containerProperties.getMicrometerTags();
@@ -2570,8 +2572,14 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			}
 		}
 
+		/**
+		 * Emit a short-lived observation per record when {@code recordObservationsInBatch} is true.
+		 * Does not invoke the listener or open a scope around listener execution; the batch
+		 * listener still runs via {@link #doInvokeBatchListenerBody} outside these observations
+		 * (see docs: per-record batch observations are not propagated to the listener method).
+		 * @param recordList the records in the batch.
+		 */
 		private void invokeBatchWithIndividualRecordObservation(List<ConsumerRecord<K, V>> recordList) {
-			// Create individual observations for each record without scopes
 			for (ConsumerRecord<K, V> record : recordList) {
 				Observation observation = KafkaListenerObservation.LISTENER_OBSERVATION.observation(
 						this.containerProperties.getObservationConvention(),
@@ -2582,6 +2590,51 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 				observation.observe(() -> {
 					this.logger.debug(() -> "Observing record in batch: " + KafkaUtils.format(record));
 				});
+			}
+		}
+
+		/**
+		 * Observe the entire batch listener invocation when observation is enabled but
+		 * per-record observations are not. Uses the first record for context tags so meters
+		 * share the same low-cardinality keys as non-batch listeners.
+		 * @param records the consumer records for the batch.
+		 * @param recordList the list of records passed to the listener.
+		 */
+		private void invokeBatchOnMessageWithObservation(final ConsumerRecords<K, V> records,
+				List<ConsumerRecord<K, V>> recordList) {
+
+			if (recordList.isEmpty()) {
+				// No record to derive messaging source tags; still invoke the listener.
+				doInvokeBatchListenerBody(records, recordList);
+				return;
+			}
+			ConsumerRecord<K, V> contextRecord = recordList.get(0);
+			Observation observation = KafkaListenerObservation.LISTENER_OBSERVATION.observation(
+					this.containerProperties.getObservationConvention(),
+					DefaultKafkaListenerObservationConvention.INSTANCE,
+					() -> new KafkaRecordReceiverContext(contextRecord, getListenerId(), getClientId(),
+							this.consumerGroupId, this::clusterId),
+					this.observationRegistry);
+			observation.observe(() -> doInvokeBatchListenerBody(records, recordList));
+		}
+
+		/**
+		 * Invoke the batch listener (full poll result or list).
+		 * @param records the consumer records for the batch.
+		 * @param recordList the list of records passed to the listener.
+		 */
+		private void doInvokeBatchListenerBody(final ConsumerRecords<K, V> records,
+				List<ConsumerRecord<K, V>> recordList) {
+
+			if (this.wantsFullRecords) {
+				Objects.requireNonNull(this.batchListener).onMessage(records, // NOSONAR
+						this.isAnyManualAck
+								? new ConsumerBatchAcknowledgment(records, recordList)
+								: null,
+						this.consumer);
+			}
+			else {
+				doInvokeBatchOnMessage(records, recordList); // NOSONAR
 			}
 		}
 
@@ -2608,18 +2661,17 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 
 			try {
 				if (this.observationEnabled) {
+					// recordObservationsInBatch: emit per-record spans only (listener runs below, unobserved)
 					invokeBatchWithIndividualRecordObservation(recordList);
 				}
 
-				if (this.wantsFullRecords) {
-					Objects.requireNonNull(this.batchListener).onMessage(records, // NOSONAR
-							this.isAnyManualAck
-									? new ConsumerBatchAcknowledgment(records, recordList)
-									: null,
-							this.consumer);
+				if (this.containerProperties.isObservationEnabled() && !this.observationEnabled) {
+					// Batch-level observation wraps the listener (same meter tags as non-batch)
+					invokeBatchOnMessageWithObservation(records, recordList);
 				}
 				else {
-					doInvokeBatchOnMessage(records, recordList); // NOSONAR
+					// Listener body: unobserved when recordObservationsInBatch, or when observation is off
+					doInvokeBatchListenerBody(records, recordList);
 				}
 				batchInterceptAfter(records, null);
 				successTimer(sample, null);

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/micrometer/KafkaListenerObservation.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/micrometer/KafkaListenerObservation.java
@@ -16,6 +16,7 @@
 
 package org.springframework.kafka.support.micrometer;
 
+import io.micrometer.common.KeyValue;
 import io.micrometer.common.KeyValues;
 import io.micrometer.common.docs.KeyName;
 import io.micrometer.observation.Observation.Context;
@@ -33,6 +34,7 @@ import org.springframework.util.StringUtils;
  * @author Christian Mergenthaler
  * @author Wang Zhiyang
  * @author Christian Fredriksson
+ * @author Hakaze Arimu
  *
  * @since 3.0
  *
@@ -227,21 +229,18 @@ public enum KafkaListenerObservation implements ObservationDocumentation {
 		@Override
 		@NonNull
 		public KeyValues getLowCardinalityKeyValues(KafkaRecordReceiverContext context) {
+			// Always include optional tags (use "none" when missing) so batch and non-batch
+			// listeners register meters with a consistent tag set for Prometheus.
 			String groupId = context.getGroupId();
-			KeyValues keyValues = KeyValues.of(
+			return KeyValues.of(
 					ListenerLowCardinalityTags.LISTENER_ID.withValue(context.getListenerId()),
 					ListenerLowCardinalityTags.MESSAGING_SYSTEM.withValue("kafka"),
 					ListenerLowCardinalityTags.MESSAGING_OPERATION.withValue("process"),
 					ListenerLowCardinalityTags.MESSAGING_SOURCE_NAME.withValue(context.getSource()),
-					ListenerLowCardinalityTags.MESSAGING_SOURCE_KIND.withValue("topic")
+					ListenerLowCardinalityTags.MESSAGING_SOURCE_KIND.withValue("topic"),
+					ListenerLowCardinalityTags.MESSAGING_CONSUMER_GROUP.withValue(
+							StringUtils.hasText(groupId) ? groupId : KeyValue.NONE_VALUE)
 			);
-
-			if (StringUtils.hasText(groupId)) {
-				keyValues = keyValues
-						.and(ListenerLowCardinalityTags.MESSAGING_CONSUMER_GROUP.withValue(groupId));
-			}
-
-			return keyValues;
 		}
 
 		@Override
@@ -249,22 +248,14 @@ public enum KafkaListenerObservation implements ObservationDocumentation {
 		public KeyValues getHighCardinalityKeyValues(KafkaRecordReceiverContext context) {
 			String clientId = context.getClientId();
 			String consumerId = getConsumerId(context.getGroupId(), clientId);
-			KeyValues keyValues = KeyValues.of(
+			return KeyValues.of(
 					ListenerHighCardinalityTags.MESSAGING_PARTITION.withValue(context.getPartition()),
-					ListenerHighCardinalityTags.MESSAGING_OFFSET.withValue(context.getOffset())
+					ListenerHighCardinalityTags.MESSAGING_OFFSET.withValue(context.getOffset()),
+					ListenerHighCardinalityTags.MESSAGING_CLIENT_ID.withValue(
+							StringUtils.hasText(clientId) ? clientId : KeyValue.NONE_VALUE),
+					ListenerHighCardinalityTags.MESSAGING_CONSUMER_ID.withValue(
+							StringUtils.hasText(consumerId) ? consumerId : KeyValue.NONE_VALUE)
 			);
-
-			if (StringUtils.hasText(clientId)) {
-				keyValues = keyValues
-						.and(ListenerHighCardinalityTags.MESSAGING_CLIENT_ID.withValue(clientId));
-			}
-
-			if (StringUtils.hasText(consumerId)) {
-				keyValues = keyValues
-						.and(ListenerHighCardinalityTags.MESSAGING_CONSUMER_ID.withValue(consumerId));
-			}
-
-			return keyValues;
 		}
 
 		@Override

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/micrometer/BatchIndividualRecordObservationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/micrometer/BatchIndividualRecordObservationTests.java
@@ -149,9 +149,10 @@ public class BatchIndividualRecordObservationTests {
 	}
 
 	@Test
-	void batchIndividualRecordObservationDisabledCreatesNoIndividualObservations(
+	void batchLevelObservationWhenRecordObservationsInBatchDisabled(
 			@Autowired BatchListenerWithoutIndividualObservation batchListener,
-			@Autowired KafkaTemplate<Integer, String> template, @Autowired TestObservationHandler observationHandler)
+			@Autowired KafkaTemplate<Integer, String> template, @Autowired TestObservationHandler observationHandler,
+			@Autowired MeterRegistry meterRegistry)
 			throws InterruptedException {
 
 		// Clear any existing observations
@@ -164,10 +165,19 @@ public class BatchIndividualRecordObservationTests {
 		// Wait for batch processing
 		assertThat(batchListener.latch.await(10, TimeUnit.SECONDS)).isTrue();
 
-		// When individual record observation is disabled, no individual observations should be created
+		// When individual record observation is disabled, one observation is created for the batch
 		assertThat(observationHandler.getStartedObservations())
-				.as("No individual observations should be created when batch individual observation is disabled")
-				.isZero();
+				.as("Batch-level observation should be created when recordObservationsInBatch is false")
+				.isGreaterThanOrEqualTo(1);
+
+		// Meters use observation tags (not legacy name/result/exception tags)
+		assertThat(meterRegistry.find("spring.kafka.listener")
+				.tagKeys("spring.kafka.listener.id", "messaging.system", "messaging.operation",
+						"messaging.source.name", "messaging.source.kind", "messaging.kafka.consumer.group")
+				.timers())
+				.isNotEmpty();
+		assertThat(meterRegistry.find("spring.kafka.listener").tagKeys("name", "result", "exception").timers())
+				.isEmpty();
 	}
 
 	@Configuration

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/micrometer/KafkaListenerObservationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/micrometer/KafkaListenerObservationTests.java
@@ -16,27 +16,69 @@
 
 package org.springframework.kafka.support.micrometer;
 
+import io.micrometer.common.KeyValue;
+import io.micrometer.common.KeyValues;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.kafka.support.micrometer.KafkaListenerObservation.DefaultKafkaListenerObservationConvention;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * @author Christian Fredriksson
+ * @author Hakaze Arimu
  */
 public class KafkaListenerObservationTests {
 
 	@Test
-	void lowCardinalityKeyValues() {
+	void lowCardinalityKeyValuesAlwaysIncludeOptionalTags() {
 		ConsumerRecord<String, String> record = new ConsumerRecord<>("topic", 1, 2, "key", "value");
 		KafkaRecordReceiverContext context = new KafkaRecordReceiverContext(record, "listener", () -> null);
-		DefaultKafkaListenerObservationConvention.INSTANCE.getLowCardinalityKeyValues(context);
+		KeyValues keyValues = DefaultKafkaListenerObservationConvention.INSTANCE.getLowCardinalityKeyValues(context);
+		assertThat(keyValues.stream().map(KeyValue::getKey))
+				.containsExactlyInAnyOrder(
+						"spring.kafka.listener.id",
+						"messaging.system",
+						"messaging.operation",
+						"messaging.source.name",
+						"messaging.source.kind",
+						"messaging.kafka.consumer.group");
+		assertThat(keyValues.stream()
+				.filter(kv -> "messaging.kafka.consumer.group".equals(kv.getKey()))
+				.map(KeyValue::getValue)
+				.findFirst())
+				.contains(KeyValue.NONE_VALUE);
 	}
 
 	@Test
-	void highCardinalityKeyValues() {
+	void lowCardinalityKeyValuesIncludeGroupWhenPresent() {
+		ConsumerRecord<String, String> record = new ConsumerRecord<>("topic", 1, 2, "key", "value");
+		KafkaRecordReceiverContext context =
+				new KafkaRecordReceiverContext(record, "listener", "client-1", "group-1", () -> null);
+		KeyValues keyValues = DefaultKafkaListenerObservationConvention.INSTANCE.getLowCardinalityKeyValues(context);
+		assertThat(keyValues.stream()
+				.filter(kv -> "messaging.kafka.consumer.group".equals(kv.getKey()))
+				.map(KeyValue::getValue)
+				.findFirst())
+				.contains("group-1");
+	}
+
+	@Test
+	void highCardinalityKeyValuesAlwaysIncludeOptionalTags() {
 		ConsumerRecord<String, String> record = new ConsumerRecord<>("topic", 1, 2, "key", "value");
 		KafkaRecordReceiverContext context = new KafkaRecordReceiverContext(record, "listener", () -> null);
-		DefaultKafkaListenerObservationConvention.INSTANCE.getHighCardinalityKeyValues(context);
+		KeyValues keyValues = DefaultKafkaListenerObservationConvention.INSTANCE.getHighCardinalityKeyValues(context);
+		assertThat(keyValues.stream().map(KeyValue::getKey))
+				.containsExactlyInAnyOrder(
+						"messaging.kafka.source.partition",
+						"messaging.kafka.message.offset",
+						"messaging.kafka.client_id",
+						"messaging.consumer.id");
+		assertThat(keyValues.stream()
+				.filter(kv -> "messaging.kafka.client_id".equals(kv.getKey())
+						|| "messaging.consumer.id".equals(kv.getKey()))
+				.map(KeyValue::getValue))
+				.containsOnly(KeyValue.NONE_VALUE);
 	}
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/micrometer/MixedBatchRecordObservationMetersTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/micrometer/MixedBatchRecordObservationMetersTests.java
@@ -1,0 +1,284 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.support.micrometer;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.observation.DefaultMeterObservationHandler;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.observation.ObservationRegistry;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.util.backoff.FixedBackOff;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+/**
+ * Regression for GH-3947: mixed batch and non-batch listeners with observation enabled
+ * must register {@code spring.kafka.listener} meters with a consistent tag key set.
+ *
+ * @author Hakaze Arimu
+ * @since 4.2
+ */
+@SpringJUnitConfig
+@EmbeddedKafka(topics = {
+		MixedBatchRecordObservationMetersTests.RECORD_TOPIC,
+		MixedBatchRecordObservationMetersTests.BATCH_TOPIC,
+		MixedBatchRecordObservationMetersTests.BATCH_FAIL_TOPIC
+}, partitions = 1)
+@DirtiesContext
+public class MixedBatchRecordObservationMetersTests {
+
+	public static final String RECORD_TOPIC = "mixed.obs.record";
+
+	public static final String BATCH_TOPIC = "mixed.obs.batch";
+
+	public static final String BATCH_FAIL_TOPIC = "mixed.obs.batch.fail";
+
+	@Test
+	void mixedBatchAndRecordListenersShareMeterTagKeys(
+			@Autowired RecordListener recordListener,
+			@Autowired BatchListener batchListener,
+			@Autowired KafkaTemplate<Integer, String> template,
+			@Autowired MeterRegistry meterRegistry)
+			throws Exception {
+
+		template.send(RECORD_TOPIC, "record-1").get(10, TimeUnit.SECONDS);
+		template.send(BATCH_TOPIC, "batch-1").get(10, TimeUnit.SECONDS);
+
+		assertThat(recordListener.latch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(batchListener.latch.await(10, TimeUnit.SECONDS)).isTrue();
+
+		await().untilAsserted(() -> {
+			List<Timer> timers = meterRegistry.find("spring.kafka.listener").timers().stream().toList();
+			assertThat(timers).hasSizeGreaterThanOrEqualTo(2);
+
+			// Both listeners must contribute meters; legacy MicrometerHolder tags must not appear
+			Set<String> allTagKeys = timers.stream()
+					.flatMap(t -> t.getId().getTags().stream())
+					.map(tag -> tag.getKey())
+					.collect(Collectors.toSet());
+			assertThat(allTagKeys)
+					.contains("spring.kafka.listener.id", "messaging.system", "messaging.operation",
+							"messaging.source.name", "messaging.source.kind", "messaging.kafka.consumer.group",
+							"error")
+					.doesNotContain("name", "result", "exception");
+
+			// Every timer must use the same tag key set (Prometheus requirement)
+			Set<Set<String>> tagKeySets = timers.stream()
+					.map(t -> t.getId().getTags().stream().map(tag -> tag.getKey()).collect(Collectors.toSet()))
+					.collect(Collectors.toSet());
+			assertThat(tagKeySets)
+					.as("all spring.kafka.listener timers must share one tag key set")
+					.hasSize(1);
+
+			// Both listener ids present
+			Set<String> listenerIds = timers.stream()
+					.map(t -> t.getId().getTag("spring.kafka.listener.id"))
+					.collect(Collectors.toSet());
+			assertThat(listenerIds).anyMatch(id -> id != null && id.startsWith("mixedRecord-"));
+			assertThat(listenerIds).anyMatch(id -> id != null && id.startsWith("mixedBatch-"));
+		});
+	}
+
+	@Test
+	void batchListenerFailureRecordsObservationErrorNotLegacyExceptionTag(
+			@Autowired FailingBatchListener failingBatchListener,
+			@Autowired KafkaTemplate<Integer, String> template,
+			@Autowired MeterRegistry meterRegistry)
+			throws Exception {
+
+		template.send(BATCH_FAIL_TOPIC, "batch-fail-1").get(10, TimeUnit.SECONDS);
+		assertThat(failingBatchListener.latch.await(10, TimeUnit.SECONDS)).isTrue();
+
+		await().untilAsserted(() -> {
+			// Observation-based meter records the failure under the "error" tag (not "none")
+			List<Timer> failureTimers = meterRegistry.find("spring.kafka.listener")
+					.tag("spring.kafka.listener.id", "mixedBatchFail-0")
+					.timers()
+					.stream()
+					.filter(t -> {
+						String error = t.getId().getTag("error");
+						return error != null && !"none".equals(error);
+					})
+					.toList();
+			assertThat(failureTimers)
+					.as("batch failure should produce an observation meter with a non-none error tag")
+					.isNotEmpty();
+			assertThat(failureTimers.get(0).count()).isGreaterThanOrEqualTo(1);
+
+			// Legacy MicrometerHolder failure timers use exception as a tag key — must not appear
+			assertThat(meterRegistry.find("spring.kafka.listener").tagKeys("exception").timers()).isEmpty();
+			assertThat(meterRegistry.find("spring.kafka.listener").tagKeys("name", "result", "exception").timers())
+					.isEmpty();
+		});
+	}
+
+	@Configuration
+	@EnableKafka
+	static class Config {
+
+		@Bean
+		ProducerFactory<Integer, String> producerFactory(EmbeddedKafkaBroker broker) {
+			return new DefaultKafkaProducerFactory<>(KafkaTestUtils.producerProps(broker));
+		}
+
+		@Bean
+		ConsumerFactory<Integer, String> consumerFactory(EmbeddedKafkaBroker broker) {
+			return new DefaultKafkaConsumerFactory<>(
+					KafkaTestUtils.consumerProps(broker, "mixed-obs", false));
+		}
+
+		@Bean
+		KafkaTemplate<Integer, String> template(ProducerFactory<Integer, String> pf) {
+			return new KafkaTemplate<>(pf);
+		}
+
+		@Bean
+		MeterRegistry meterRegistry() {
+			return new SimpleMeterRegistry();
+		}
+
+		@Bean
+		ObservationRegistry observationRegistry(MeterRegistry meterRegistry) {
+			ObservationRegistry observationRegistry = ObservationRegistry.create();
+			observationRegistry.observationConfig()
+					.observationHandler(new DefaultMeterObservationHandler(meterRegistry));
+			return observationRegistry;
+		}
+
+		@Bean
+		ConcurrentKafkaListenerContainerFactory<Integer, String> recordFactory(
+				ConsumerFactory<Integer, String> cf, ObservationRegistry observationRegistry) {
+
+			ConcurrentKafkaListenerContainerFactory<Integer, String> factory =
+					new ConcurrentKafkaListenerContainerFactory<>();
+			factory.setConsumerFactory(cf);
+			factory.setBatchListener(false);
+			factory.getContainerProperties().setObservationEnabled(true);
+			factory.getContainerProperties().setObservationRegistry(observationRegistry);
+			return factory;
+		}
+
+		@Bean
+		ConcurrentKafkaListenerContainerFactory<Integer, String> batchFactory(
+				ConsumerFactory<Integer, String> cf, ObservationRegistry observationRegistry) {
+
+			ConcurrentKafkaListenerContainerFactory<Integer, String> factory =
+					new ConcurrentKafkaListenerContainerFactory<>();
+			factory.setConsumerFactory(cf);
+			factory.setBatchListener(true);
+			factory.getContainerProperties().setObservationEnabled(true);
+			factory.getContainerProperties().setObservationRegistry(observationRegistry);
+			factory.getContainerProperties().setRecordObservationsInBatch(false);
+			return factory;
+		}
+
+		@Bean
+		ConcurrentKafkaListenerContainerFactory<Integer, String> failingBatchFactory(
+				ConsumerFactory<Integer, String> cf, ObservationRegistry observationRegistry) {
+
+			ConcurrentKafkaListenerContainerFactory<Integer, String> factory =
+					new ConcurrentKafkaListenerContainerFactory<>();
+			factory.setConsumerFactory(cf);
+			factory.setBatchListener(true);
+			factory.getContainerProperties().setObservationEnabled(true);
+			factory.getContainerProperties().setObservationRegistry(observationRegistry);
+			factory.getContainerProperties().setRecordObservationsInBatch(false);
+			// Recover immediately so the test does not loop on the failed batch
+			factory.setCommonErrorHandler(new DefaultErrorHandler((rec, ex) -> {
+			}, new FixedBackOff(0L, 0L)));
+			return factory;
+		}
+
+		@Bean
+		RecordListener recordListener() {
+			return new RecordListener();
+		}
+
+		@Bean
+		BatchListener batchListener() {
+			return new BatchListener();
+		}
+
+		@Bean
+		FailingBatchListener failingBatchListener() {
+			return new FailingBatchListener();
+		}
+
+	}
+
+	static class RecordListener {
+
+		final CountDownLatch latch = new CountDownLatch(1);
+
+		@KafkaListener(id = "mixedRecord", topics = RECORD_TOPIC, containerFactory = "recordFactory")
+		void listen(ConsumerRecord<Integer, String> in) {
+			this.latch.countDown();
+		}
+
+	}
+
+	static class BatchListener {
+
+		final CountDownLatch latch = new CountDownLatch(1);
+
+		@KafkaListener(id = "mixedBatch", topics = BATCH_TOPIC, containerFactory = "batchFactory")
+		void listen(List<ConsumerRecord<Integer, String>> records) {
+			this.latch.countDown();
+		}
+
+	}
+
+	static class FailingBatchListener {
+
+		final CountDownLatch latch = new CountDownLatch(1);
+
+		@KafkaListener(id = "mixedBatchFail", topics = BATCH_FAIL_TOPIC, containerFactory = "failingBatchFactory")
+		void listen(List<ConsumerRecord<Integer, String>> records) {
+			this.latch.countDown();
+			throw new RuntimeException("batch observation failure");
+		}
+
+	}
+
+}


### PR DESCRIPTION
## Description

Fixes #3947

When `observationEnabled` is true, non-batch listeners register
`spring.kafka.listener` meters via Micrometer Observation
(`messaging.*` + `spring.kafka.listener.id` + `error` tags), while
batch listeners previously fell back to legacy `MicrometerHolder`
timers (`name` / `result` / `exception` tags). Prometheus rejects
registering the same meter name with different tag key sets, so
adding a batch listener could break existing non-batch metrics.

### Changes

- When observation is enabled and `recordObservationsInBatch` is
  `false`, create a **batch-level** Observation wrapping the batch
  listener invocation (first record supplies source tags).
- Do not create legacy `MicrometerHolder` timers whenever
  `ContainerProperties.observationEnabled` is true (including batch).
- Always emit optional observation tags, using Micrometer's `none`
  placeholder when a value is unavailable (same approach as
  spring-data-mongodb #4994).
- Docs / what's-new updates for batch listener observations.

### Tests

```
./gradlew :spring-kafka:test \
  --tests org.springframework.kafka.support.micrometer.KafkaListenerObservationTests \
  --tests org.springframework.kafka.support.micrometer.MixedBatchRecordObservationMetersTests \
  --tests org.springframework.kafka.support.micrometer.BatchIndividualRecordObservationTests \
  --tests org.springframework.kafka.support.micrometer.MicrometerMetricsTests \
  --tests org.springframework.kafka.support.micrometer.ObservationTests \
  --tests org.springframework.kafka.support.micrometer.MicrometerHolderTests
```

**25/25 green** (Temurin 21). Also `:spring-kafka:checkstyleMain` +
`checkstyleTest` clean.

New regression: `MixedBatchRecordObservationMetersTests` asserts
mixed batch + record listeners share one `spring.kafka.listener` tag
key set.