### PR TITLE
Fix typo in ConsumerProperties#setAuthExceptionRetryInterval javadoc

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerProperties.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConsumerProperties.java
@@ -386,7 +386,7 @@ public class ConsumerProperties {
 	}
 
 	/**
-	 * Set the interval between retries after and
+	 * Set the interval between retries after an
 	 * {@link org.apache.kafka.common.errors.AuthenticationException} or
 	 * {@code org.apache.kafka.common.errors.AuthorizationException} is thrown by
 	 * {@code KafkaConsumer}. By default the field is null and retries are disabled. In


### PR DESCRIPTION
This PR fixes a small typo in a comment. While configuring a kafka consumer, I was reading this javadoc to try to understand the behavior, and I found the wording genuinely confusing at first. Fixing the typo in the hopes that it saves others from the same confusion.