### PR TITLE
Fix kotlinx-coroutines-reactor version catalog entry

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,7 +82,6 @@ allprojects {
 		dependencyManagement(platform(libs.spring.data.bom))
 		dependencyManagement(platform(libs.io.micrometer.bom))
 		dependencyManagement(platform(libs.io.micrometer.tracing.bom))
-		dependencyManagement(platform(libs.org.jetbrains.kotlinx.coroutines.bom))
 	}
 }
 
@@ -310,7 +309,7 @@ project ('spring-kafka') {
 		api 'io.micrometer:micrometer-observation'
 
 		optionalApi libs.apache.kafka.streams
-		optionalApi 'org.jetbrains.kotlinx:kotlinx-coroutines-reactor'
+		optionalApi libs.org.jetbrains.kotlinx.coroutines.reactor
 		optionalApi 'com.fasterxml.jackson.core:jackson-core'
 		optionalApi 'com.fasterxml.jackson.core:jackson-databind'
 		optionalApi 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,7 +43,7 @@ org-assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj
 org-awaitility = { module = "org.awaitility:awaitility", version.ref = "awaitilityVersion" }
 org-hamcrest-core = { module = "org.hamcrest:hamcrest-core", version.ref = "hamcrestVersion" }
 org-hibernate-validator = { module = "org.hibernate.validator:hibernate-validator", version.ref = "hibernateValidationVersion" }
-org-jetbrains-kotlinx-coroutines-bom = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-bom", version.ref = "kotlinCoroutinesVersion" }
+org-jetbrains-kotlinx-coroutines-reactor = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-reactor", version.ref = "kotlinCoroutinesVersion" }
 org-junit-bom = { module = "org.junit:junit-bom", version.ref = "junitJupiterVersion" }
 org-mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockitoVersion" }
 org-mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter", version.ref = "mockitoVersion" }


### PR DESCRIPTION
- Remove the kotlinx-coroutines-bom platform import since only kotlinx-coroutines-reactor is consumed
- Replace the unversioned kotlinx-coroutines-reactor dependency with a version-pinned catalog alias
- Rename the catalog entry from org-jetbrains-kotlinx-coroutines-bom to org-jetbrains-kotlinx-coroutines-reactor to match its module

_The 4.0.x cherry-pick will not merge smoothly because it is using a version not a BOM._

**Auto-cherry-pick to `4.1.x`, `4.0.x`**

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.md).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
