### PR TITLE
Exclude volatile 'Created-By' manifest attribute from build cache keys

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,20 @@ gradle.projectsEvaluated {
 allprojects {
 	group = 'org.springframework.kafka'
 
+	// 'Created-By' records the exact JDK build that produced a jar, so it changes
+	// whenever a CI runner picks up a different JDK patch release. That rewrites the
+	// jar bytes and, with them, the runtime classpath fingerprint of every Test task
+	// consuming the jar - a guaranteed build cache miss for an artifact whose code is
+	// unchanged. The attribute is provenance metadata and cannot affect runtime
+	// behaviour, so keep publishing it but leave it out of the cache key.
+	normalization {
+		runtimeClasspath {
+			metaInf {
+				ignoreAttribute('Created-By')
+			}
+		}
+	}
+
 	repositories {
 		mavenCentral()
 		maven { url 'https://repo.spring.io/milestone' }


### PR DESCRIPTION
## Problem

`:spring-kafka:test` misses the build cache on essentially every CI run, even for
an unchanged commit. On [ge.spring.io](https://ge.spring.io) this single task is
the largest source of avoidable cache-miss waste on the instance.

The cause is the jar manifest. Every module's manifest carries:

```groovy
'Created-By': "JDK ${System.properties['java.version']} (${System.properties['java.specification.vendor']})",
```

`java.version` is the full patch version of the JVM running the build. GitHub
Actions runners do not all carry the same JDK patch release, so two runs of the
same commit can produce byte-different jars. Those jars sit on the runtime
classpath of the sibling modules' `Test` tasks, so the difference propagates
straight into the test task's classpath fingerprint and forces a cache miss for
an artifact whose code is identical.

## Evidence

Two CI builds of commit `054791f5` on branch `4.1.x` — same OS (Windows Server
2025), same Gradle (9.4.1), same requested task (`test`), 18 seconds apart:

| Build | Runner JDK |
|---|---|
| [`q4a3rboq4kzts`](https://ge.spring.io/s/q4a3rboq4kzts) | Temurin 17.0.20+8 |
| [`th3yrbdluimca`](https://ge.spring.io/s/th3yrbdluimca) | Temurin 17.0.19+10 |

The Develocity build comparison reports exactly three diverging work units:

- `:spring-kafka:jar` — one differing input file: `spring-kafka/build/tmp/jar/MANIFEST.MF`
- `:spring-kafka-test:jar` — one differing input file: `spring-kafka-test/build/tmp/jar/MANIFEST.MF`
- `:spring-kafka:test` — one differing input root on `stableClasspath`:
  `spring-kafka-test/build/libs/spring-kafka-test-4.1.1-SNAPSHOT.jar`

For a pair of builds of the same commit whose runners had the *same* JDK patch
release, neither `jar` task diverges at all — which confirms the JDK patch
version is what moves the manifest.

## Fix

`Created-By` is provenance metadata; it cannot affect runtime behaviour. Declare
it ignored for runtime classpath normalization. The attribute is still written
into the published jar — it just stops contributing to build cache keys.

```groovy
normalization {
    runtimeClasspath {
        metaInf {
            ignoreAttribute('Created-By')
        }
    }
}
```

This leaves the published artifacts byte-for-byte as they are today, so it is not
a change to what users download.

## Validation

Built `spring-kafka-test`'s jar, then produced two copies differing **only** in
the `Created-By` manifest line (verified entry-by-entry: `META-INF/MANIFEST.MF`
is the sole differing entry). Each was placed on `:spring-kafka:test`'s runtime
classpath and the task's build cache key was read from
`-Dorg.gradle.caching.debug=true`:

| | `Created-By: JDK 25.0.1` | `Created-By: JDK 25.0.2` | |
|---|---|---|---|
| before | `c4bfe3875e958182c24e55dd120adacb` | `0c495aa5b7602e354b0eb2fed6448467` | ✗ miss |
| after | `64ae8d9437e8b00a48b01b11cb4acb2d` | `64ae8d9437e8b00a48b01b11cb4acb2d` | ✓ hit |

As a correctness guard, a third jar with a genuinely added class entry still
produces a different key (`a929ba1afdfb620c3c28baa56eafd946`) with the fix
applied — real classpath changes are still detected. `:spring-kafka:test` ran and
passed in every one of these builds.

## Scope — what this does not fix

This addresses one confirmed cause, and it should not be read as making
`:spring-kafka:test` fully cacheable across CI runs. Comparing further pairs of
CI builds of commit `054791f5` whose runners had *identical* JDK patch releases,
identical OS, CPU count, locale and charset, `:spring-kafka:test` **still**
lands on a different cache key each time — six builds of that commit produce six
distinct keys. In those same-JDK pairs the Develocity comparison reports **no**
differing file inputs; it flags only the Java-version-related value inputs
(`javaVersion`, `javaLauncher.metadata.languageVersion`,
`javaLauncher.metadata.taskInputs.languageVersion`), which I could not attribute
to a concrete cause from the data available through the build comparison API.

So there is a second, independent source of volatility on this task that remains
open. This PR removes the one that is proven and fixable in this repository;
tracking down the remainder is worth a follow-up.
