### PR TITLE
GH-4567: Honor autoStartup after registry stop

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistry.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistry.java
@@ -389,6 +389,7 @@ public class KafkaListenerEndpointRegistry implements ListenerContainerRegistry,
 	@Override
 	public void stop() {
 		this.running = false;
+		this.contextRefreshed = false;
 		for (MessageListenerContainer listenerContainer : getListenerContainers()) {
 			listenerContainer.stop();
 		}
@@ -397,6 +398,7 @@ public class KafkaListenerEndpointRegistry implements ListenerContainerRegistry,
 	@Override
 	public void stop(Runnable callback) {
 		this.running = false;
+		this.contextRefreshed = false;
 		Collection<MessageListenerContainer> listenerContainersToStop = getListenerContainers();
 		if (!listenerContainersToStop.isEmpty()) {
 			AggregatingCallback aggregatingCallback = new AggregatingCallback(listenerContainersToStop.size(),

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistry.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/KafkaListenerEndpointRegistry.java
@@ -441,15 +441,10 @@ public class KafkaListenerEndpointRegistry implements ListenerContainerRegistry,
 		}
 	}
 
-	private static final class AggregatingCallback implements Runnable {
-
-		private final AtomicInteger count;
-
-		private final Runnable finishCallback;
+	private record AggregatingCallback(AtomicInteger count, Runnable finishCallback) implements Runnable {
 
 		private AggregatingCallback(int count, Runnable finishCallback) {
-			this.count = new AtomicInteger(count);
-			this.finishCallback = finishCallback;
+			this(new AtomicInteger(count), finishCallback);
 		}
 
 		@Override

--- a/spring-kafka/src/test/java/org/springframework/kafka/config/KafkaListenerEndpointRegistryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/config/KafkaListenerEndpointRegistryTests.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
 import org.springframework.kafka.listener.MessageListenerContainer;
@@ -38,11 +39,15 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 /**
  * @author Gary Russell
  * @author Joo Hyuk Kim
  * @author Artem Bilan
+ * @author arimu1
  *
  * @since 2.8.9
  */
@@ -144,6 +149,33 @@ public class KafkaListenerEndpointRegistryTests {
 	}
 
 	@Test
+	void stopThenStartHonorsAutoStartupWhenAlwaysStartAfterRefreshTrue() {
+		KafkaListenerEndpointRegistry registry = new KafkaListenerEndpointRegistry();
+		GenericApplicationContext context = new GenericApplicationContext();
+		context.refresh();
+		registry.setApplicationContext(context);
+		MessageListenerContainer container = registerAutoStartupFalseContainer(registry, "listener");
+		registry.start();
+		verify(container, never()).start();
+		registry.onApplicationEvent(new ContextRefreshedEvent(context));
+		registry.stop();
+		registry.start();
+		verify(container, never()).start();
+	}
+
+	@Test
+	void startAfterRefreshWithoutStopStartsContainersWhenAlwaysStartAfterRefreshTrue() {
+		KafkaListenerEndpointRegistry registry = new KafkaListenerEndpointRegistry();
+		GenericApplicationContext context = new GenericApplicationContext();
+		context.refresh();
+		registry.setApplicationContext(context);
+		MessageListenerContainer container = registerAutoStartupFalseContainer(registry, "listener");
+		registry.onApplicationEvent(new ContextRefreshedEvent(context));
+		registry.start();
+		verify(container, times(1)).start();
+	}
+
+	@Test
 	void verifyUnregisteredListenerContainer() {
 		KafkaListenerEndpointRegistry registry = new KafkaListenerEndpointRegistry();
 		GenericApplicationContext applicationContext = new GenericApplicationContext();
@@ -185,6 +217,20 @@ public class KafkaListenerEndpointRegistryTests {
 
 	private static void registerWithListenerIds(KafkaListenerEndpointRegistry registry, List<String> names) {
 		names.forEach(name -> registerListenerWithId(registry, name));
+	}
+
+	private static MessageListenerContainer registerAutoStartupFalseContainer(KafkaListenerEndpointRegistry registry,
+			String id) {
+
+		KafkaListenerEndpoint endpoint = mock(KafkaListenerEndpoint.class);
+		@SuppressWarnings("unchecked")
+		KafkaListenerContainerFactory<MessageListenerContainer> factory = mock(KafkaListenerContainerFactory.class);
+		given(endpoint.getId()).willReturn(id);
+		MessageListenerContainer container = mock(MessageListenerContainer.class);
+		given(container.isAutoStartup()).willReturn(false);
+		given(factory.createListenerContainer(endpoint)).willReturn(container);
+		registry.registerListenerContainer(endpoint, factory);
+		return container;
 	}
 
 	private static void registerListenerWithId(KafkaListenerEndpointRegistry registry, String id) {

--- a/spring-kafka/src/test/java/org/springframework/kafka/config/KafkaListenerEndpointRegistryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/config/KafkaListenerEndpointRegistryTests.java
@@ -220,11 +220,10 @@ public class KafkaListenerEndpointRegistryTests {
 	private static MessageListenerContainer registerAutoStartupFalseContainer(KafkaListenerEndpointRegistry registry,
 			String id) {
 
-		KafkaListenerEndpoint endpoint = mock(KafkaListenerEndpoint.class);
-		@SuppressWarnings("unchecked")
-		KafkaListenerContainerFactory<MessageListenerContainer> factory = mock(KafkaListenerContainerFactory.class);
+		KafkaListenerEndpoint endpoint = mock();
 		given(endpoint.getId()).willReturn(id);
-		MessageListenerContainer container = mock(MessageListenerContainer.class);
+		KafkaListenerContainerFactory<MessageListenerContainer> factory = mock();
+		MessageListenerContainer container = mock();
 		given(container.isAutoStartup()).willReturn(false);
 		given(factory.createListenerContainer(endpoint)).willReturn(container);
 		registry.registerListenerContainer(endpoint, factory);

--- a/spring-kafka/src/test/java/org/springframework/kafka/config/KafkaListenerEndpointRegistryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/config/KafkaListenerEndpointRegistryTests.java
@@ -40,14 +40,12 @@ import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 /**
  * @author Gary Russell
  * @author Joo Hyuk Kim
  * @author Artem Bilan
- * @author arimu1
  *
  * @since 2.8.9
  */
@@ -149,7 +147,7 @@ public class KafkaListenerEndpointRegistryTests {
 	}
 
 	@Test
-	void stopThenStartHonorsAutoStartupWhenAlwaysStartAfterRefreshTrue() {
+	void stopThenStartHonorsAutoStartupFalse() {
 		KafkaListenerEndpointRegistry registry = new KafkaListenerEndpointRegistry();
 		GenericApplicationContext context = new GenericApplicationContext();
 		context.refresh();
@@ -164,7 +162,7 @@ public class KafkaListenerEndpointRegistryTests {
 	}
 
 	@Test
-	void startAfterRefreshWithoutStopStartsContainersWhenAlwaysStartAfterRefreshTrue() {
+	void startAfterRefreshWithoutStopStartsContainerRegardlessOfAutoStartup() {
 		KafkaListenerEndpointRegistry registry = new KafkaListenerEndpointRegistry();
 		GenericApplicationContext context = new GenericApplicationContext();
 		context.refresh();
@@ -172,7 +170,7 @@ public class KafkaListenerEndpointRegistryTests {
 		MessageListenerContainer container = registerAutoStartupFalseContainer(registry, "listener");
 		registry.onApplicationEvent(new ContextRefreshedEvent(context));
 		registry.start();
-		verify(container, times(1)).start();
+		verify(container).start();
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #4567

## Summary

`KafkaListenerEndpointRegistry` sets `contextRefreshed` on the first `ContextRefreshedEvent` and never clears it. After that, every registry `start()` (including those triggered by `ConfigurableApplicationContext.restart()` in Spring Framework 7.0.3+ test context pause/resume) unconditionally starts all listener containers when `alwaysStartAfterRefresh` is `true` (the default), ignoring `autoStartup=false`.

This change resets `contextRefreshed` when the registry stops (`stop()` and `stop(Runnable)`), so a subsequent `start()`/`restart()` re-applies each container's `autoStartup` setting. The default for `alwaysStartAfterRefresh` is unchanged, and late endpoint registration after refresh still starts containers immediately when `alwaysStartAfterRefresh` is `true`.

## Test plan

- [x] `./gradlew :spring-kafka:test --tests "org.springframework.kafka.config.KafkaListenerEndpointRegistryTests.stopThenStartHonorsAutoStartupWhenAlwaysStartAfterRefreshTrue"`
- [x] `./gradlew :spring-kafka:test --tests "org.springframework.kafka.config.KafkaListenerEndpointRegistryTests.startAfterRefreshWithoutStopStartsContainersWhenAlwaysStartAfterRefreshTrue"`
- [x] Prove-it: `stopThenStartHonorsAutoStartupWhenAlwaysStartAfterRefreshTrue` fails without the production change and passes with it
- Platform: macOS (darwin 25.6.0), JDK 21 (Eclipse Temurin 21.0.11+10)

## AI disclosure

Implementation and tests were written with AI assistance (Cursor) and reviewed by the contributor before submission.