### PR TITLE
GH-4569: Close delegates in DelegatingByTypeSerializer

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingByTypeSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingByTypeSerializer.java
@@ -34,6 +34,7 @@ import org.springframework.util.Assert;
  * @author Artem Bilan
  * @author Wang Zhiyang
  * @author Mahesh Aravind V
+ * @author Jiwoo Lee
  *
  * @since 2.7.9
  *
@@ -120,6 +121,11 @@ public class DelegatingByTypeSerializer implements Serializer<Object> {
 		}
 		Serializer<Object> delegate = findDelegate(data);
 		return delegate.serialize(topic, headers, data);
+	}
+
+	@Override
+	public void close() {
+		this.delegates.values().forEach(Serializer::close);
 	}
 
 	protected  <T> Serializer<T> findDelegate(T data) {

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/DelegatingSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/DelegatingSerializationTests.java
@@ -53,6 +53,7 @@ import static org.mockito.Mockito.verify;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Soby Chacko
+ * @author Jiwoo Lee
  *
  * @since 2.3
  *
@@ -306,6 +307,19 @@ public class DelegatingSerializationTests {
 						() -> serializer.serialize("foo", new Bytes(foo)))
 				.withMessageMatching("No matching delegate for type: " + Bytes.class.getName()
 						+ "; supported types: \\[(java.lang.Number, \\[B|\\[B, java.lang.Number)]");
+	}
+
+	@Test
+	void byTypeCloseClosesDelegates() {
+		Serializer<String> stringSerializer = spy(new StringSerializer());
+		Serializer<byte[]> bytesSerializer = spy(new ByteArraySerializer());
+		DelegatingByTypeSerializer serializer = new DelegatingByTypeSerializer(
+				Map.of(String.class, stringSerializer, byte[].class, bytesSerializer));
+
+		serializer.close();
+
+		verify(stringSerializer).close();
+		verify(bytesSerializer).close();
 	}
 
 }


### PR DESCRIPTION
Fixes #4569

## Summary

`DelegatingByTypeSerializer` forwards `configure()` to every delegate but never overrode `close()`, so the call hit the `Serializer#close()` no-op default and the delegates were never closed. `delegates` is private with no accessor, so nothing else can close them either.

`close()` does get there in normal use: `KafkaProducer#close()` closes its key and value serializers, and `DefaultKafkaProducerFactory` reaches the same place via `closeDelegate()` on `reset()`, `destroy()` or a `ContextStoppedEvent`.

This forwards `close()`, mirroring `DelegatingSerializer#close()`. `DelegatingByTopicSerializer` already inherits the same behaviour from `DelegatingByTopicSerialization`, and both deserializer wrappers were already fine.

## Test plan

- [x] New `DelegatingSerializationTests#byTypeCloseClosesDelegates`, next to the existing `byType` tests. RED before the fix with `Wanted but not invoked: stringSerializer.close()`; reverting just the production file brings it back (11 tests, 1 failed)
- [x] `./gradlew :spring-kafka:test --tests 'org.springframework.kafka.support.serializer.*' --tests '*BatchListenerConversionTests'` - 67 tests, 0 failures, plus `checkstyleMain` and `checkstyleTest`. JDK 25, `main` at `f9be4ab22`

One caveat: the serializers shipped here have a no-op `close()`, so this only shows up with a delegate that holds something, a Confluent `KafkaAvroSerializer` and its schema registry client for instance. I drove the contract with a spy rather than against one of those.
