### PR TITLE
Close the default delegate in DelegatingByTopicSerialization

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingByTopicSerialization.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingByTopicSerialization.java
@@ -43,6 +43,7 @@ import org.springframework.util.StringUtils;
  * @author Wang Zhiyang
  * @author Sanghyeok An
  * @author Borahm Lee
+ * @author Rene Choi
  *
  * @since 2.8
  *
@@ -315,14 +316,20 @@ public abstract class DelegatingByTopicSerialization<T extends Closeable> implem
 
 	@Override
 	public void close() {
-		this.delegates.values().forEach(delegate -> {
-			try {
-				delegate.close();
-			}
-			catch (IOException ex) {
-				LOGGER.error(ex, () -> "Failed to close " + delegate);
-			}
-		});
+		this.delegates.values().forEach(this::closeDelegate);
+		closeDelegate(this.defaultDelegate);
+	}
+
+	private void closeDelegate(@Nullable T delegate) {
+		if (delegate == null) {
+			return;
+		}
+		try {
+			delegate.close();
+		}
+		catch (IOException ex) {
+			LOGGER.error(ex, () -> "Failed to close " + delegate);
+		}
 	}
 
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/DelegatingByTopicSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/DelegatingByTopicSerializationTests.java
@@ -19,22 +19,28 @@ package org.springframework.kafka.support.serializer;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.BytesDeserializer;
 import org.apache.kafka.common.serialization.BytesSerializer;
+import org.apache.kafka.common.serialization.Deserializer;
 import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.IntegerSerializer;
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 /**
  * @author Gary Russell
  * @author Wang Zhiyang
+ * @author Rene Choi
  *
  * @since 2.8
  *
@@ -129,6 +135,32 @@ public class DelegatingByTopicSerializationTests {
 		configs.put(DelegatingByTopicSerializer.KEY_SERIALIZATION_TOPIC_DEFAULT, ByteArrayDeserializer.class);
 		deserializer.configure(configs, true);
 		assertThatDeserializer(deserializer);
+	}
+
+	@Test
+	void closeClosesDefaultSerializerDelegate() {
+		Serializer<?> patternDelegate = spy(new StringSerializer());
+		Serializer<?> defaultDelegate = spy(new ByteArraySerializer());
+		DelegatingByTopicSerializer serializer = new DelegatingByTopicSerializer(
+				Map.of(Pattern.compile("foo"), patternDelegate), defaultDelegate);
+
+		serializer.close();
+
+		verify(patternDelegate).close();
+		verify(defaultDelegate).close();
+	}
+
+	@Test
+	void closeClosesDefaultDeserializerDelegate() {
+		Deserializer<?> patternDelegate = spy(new StringDeserializer());
+		Deserializer<?> defaultDelegate = spy(new ByteArrayDeserializer());
+		DelegatingByTopicDeserializer deserializer = new DelegatingByTopicDeserializer(
+				Map.of(Pattern.compile("foo"), patternDelegate), defaultDelegate);
+
+		deserializer.close();
+
+		verify(patternDelegate).close();
+		verify(defaultDelegate).close();
 	}
 
 	private void assertThatSerializer(DelegatingByTopicSerializer serializer) {


### PR DESCRIPTION
**Auto-cherry-pick to `4.1.x` & `4.0.x`** (both carry the same `close()`).

`DelegatingByTopicSerialization` holds the fallback (de)serializer in its own `defaultDelegate` field, outside the `delegates` map (`buildDefault()` passes a null pattern, so it is never added).

`configure()` covers it, but `close()` only walks `delegates.values()`, so the default delegate is never closed. The field is private with no accessor, so the application cannot compensate.

`close()` is reached in normal use: `KafkaProducer#close()` and `KafkaConsumer#close()` close their (de)serializers. Both `DelegatingByTopicSerializer` and `DelegatingByTopicDeserializer` inherit this `close()`.

This is the omission GH-4569 fixed for `DelegatingByTypeSerializer`, whose fix cited this class as one that already closes what it configures.

The added tests fail before the change.
