### PR TITLE
GH-4591: Register lambda Converter beans by type

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessor.java
@@ -71,6 +71,7 @@ import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.core.MethodIntrospector;
 import org.springframework.core.OrderComparator;
 import org.springframework.core.Ordered;
+import org.springframework.core.ResolvableType;
 import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.core.convert.TypeDescriptor;
@@ -151,6 +152,7 @@ import org.springframework.validation.Validator;
  * @author Omer Celik
  * @author Go BeomJun
  * @author Maxim Ceban
+ * @author Burak Kalaycı
  *
  * @see KafkaListener
  * @see KafkaListenerErrorHandler
@@ -1187,27 +1189,62 @@ public class KafkaListenerAnnotationBeanPostProcessor<K, V>
 	}
 
 	private void addFormatters(FormatterRegistry registry) {
-		for (Converter<?, ?> converter : getBeansOfType(Converter.class)) {
+		if (!(this.beanFactory instanceof ListableBeanFactory lbf)) {
+			return;
+		}
+		lbf.getBeansOfType(Converter.class)
+				.forEach((name, converter) -> addConverter(registry, lbf, name, converter));
+		lbf.getBeansOfType(ConverterFactory.class).values().forEach(factory -> addConverterFactory(registry, factory));
+		for (GenericConverter converter : lbf.getBeansOfType(GenericConverter.class).values()) {
 			registry.addConverter(converter);
 		}
-		for (ConverterFactory<?, ?> converter : getBeansOfType(ConverterFactory.class)) {
-			registry.addConverterFactory(converter);
-		}
-		for (GenericConverter converter : getBeansOfType(GenericConverter.class)) {
-			registry.addConverter(converter);
-		}
-		for (Formatter<?> formatter : getBeansOfType(Formatter.class)) {
+		for (Formatter<?> formatter : lbf.getBeansOfType(Formatter.class).values()) {
 			registry.addFormatter(formatter);
 		}
 	}
 
-	private <T> Collection<T> getBeansOfType(Class<T> type) {
-		if (KafkaListenerAnnotationBeanPostProcessor.this.beanFactory instanceof ListableBeanFactory lbf) {
-			return lbf.getBeansOfType(type).values();
+	@SuppressWarnings({UNCHECKED, "rawtypes"})
+	private void addConverter(FormatterRegistry registry, ListableBeanFactory lbf, String beanName,
+			Converter<?, ?> converter) {
+
+		ResolvableType type = getBeanResolvableType(lbf, beanName).as(Converter.class);
+		Class<?> sourceType = type.resolveGeneric(0);
+		Class<?> targetType = type.resolveGeneric(1);
+		if (sourceType != null && targetType != null) {
+			registry.addConverter(sourceType, targetType, (Converter) converter);
+			return;
 		}
-		else {
-			return Collections.emptySet();
+		try {
+			registry.addConverter(converter);
 		}
+		catch (IllegalArgumentException ex) {
+			this.logger.debug(ex, () -> "Skipping Converter bean '" + beanName
+					+ "' because its source/target types cannot be determined");
+		}
+	}
+
+	private void addConverterFactory(FormatterRegistry registry, ConverterFactory<?, ?> converterFactory) {
+		try {
+			registry.addConverterFactory(converterFactory);
+		}
+		catch (IllegalArgumentException ex) {
+			this.logger.debug(ex, () -> "Skipping ConverterFactory bean "
+					+ converterFactory.getClass().getName()
+					+ " because its source/target types cannot be determined");
+		}
+	}
+
+	private ResolvableType getBeanResolvableType(ListableBeanFactory lbf, String beanName) {
+		if (lbf instanceof ConfigurableListableBeanFactory clbf) {
+			try {
+				return clbf.getBeanDefinition(beanName).getResolvableType();
+			}
+			catch (NoSuchBeanDefinitionException ex) {
+				// Fall through to the runtime bean type, which may still carry generics.
+			}
+		}
+		Class<?> beanType = lbf.getType(beanName);
+		return beanType != null ? ResolvableType.forClass(beanType) : ResolvableType.NONE;
 	}
 
 	/**

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessorTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/KafkaListenerAnnotationBeanPostProcessorTests.java
@@ -20,6 +20,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.time.LocalDate;
 
 import org.junit.jupiter.api.Test;
 
@@ -27,6 +28,7 @@ import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.converter.Converter;
 import org.springframework.kafka.config.AbstractKafkaListenerEndpoint;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.config.KafkaListenerEndpoint;
@@ -42,6 +44,7 @@ import static org.mockito.Mockito.mock;
 /**
  * @author Sanghyeok An
  * @author Maxim Ceban
+ * @author Burak Kalaycı
  *
  * @since 4.0.0
  */
@@ -84,6 +87,30 @@ class KafkaListenerAnnotationBeanPostProcessorTests {
 		assertThat(registry.getAllListenerContainers().iterator().next()
 				.getContainerProperties().getTopics())
 				.containsExactly("programmatically-resolved-topic");
+
+		ctx.close();
+	}
+
+	@Test
+	void shouldStartWhenConverterBeanIsLambda() {
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
+		ctx.register(LambdaConverterConfig.class);
+		ctx.refresh();
+
+		KafkaListenerEndpointRegistry registry = ctx.getBean(KafkaListenerEndpointRegistry.class);
+		assertThat(registry.getAllListenerContainers()).hasSize(1);
+
+		ctx.close();
+	}
+
+	@Test
+	void shouldStartWhenConverterBeanIsMethodReference() {
+		AnnotationConfigApplicationContext ctx = new AnnotationConfigApplicationContext();
+		ctx.register(MethodReferenceConverterConfig.class);
+		ctx.refresh();
+
+		KafkaListenerEndpointRegistry registry = ctx.getBean(KafkaListenerEndpointRegistry.class);
+		assertThat(registry.getAllListenerContainers()).hasSize(1);
 
 		ctx.close();
 	}
@@ -169,6 +196,66 @@ class KafkaListenerAnnotationBeanPostProcessorTests {
 				akle.setTopics("programmatically-resolved-topic");
 			}
 			return super.createListenerContainer(endpoint);
+		}
+
+	}
+
+	@EnableKafka
+	@Configuration
+	static class LambdaConverterConfig {
+
+		@SuppressWarnings("unchecked")
+		@Bean
+		ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory() {
+			ConcurrentKafkaListenerContainerFactory<String, Object> factory =
+					new ConcurrentKafkaListenerContainerFactory<>();
+			factory.setConsumerFactory(mock(ConsumerFactory.class));
+			factory.setAutoStartup(false);
+			return factory;
+		}
+
+		@Bean
+		Converter<String, LocalDate> localDateConverter() {
+			return source -> LocalDate.parse(source);
+		}
+
+		@Component
+		static class Listener {
+
+			@KafkaListener(topics = "topic1")
+			public void listen(String message) {
+			}
+
+		}
+
+	}
+
+	@EnableKafka
+	@Configuration
+	static class MethodReferenceConverterConfig {
+
+		@SuppressWarnings("unchecked")
+		@Bean
+		ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory() {
+			ConcurrentKafkaListenerContainerFactory<String, Object> factory =
+					new ConcurrentKafkaListenerContainerFactory<>();
+			factory.setConsumerFactory(mock(ConsumerFactory.class));
+			factory.setAutoStartup(false);
+			return factory;
+		}
+
+		@Bean
+		Converter<String, LocalDate> localDateConverter() {
+			return LocalDate::parse;
+		}
+
+		@Component
+		static class Listener {
+
+			@KafkaListener(topics = "topic1")
+			public void listen(String message) {
+			}
+
 		}
 
 	}


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-kafka/issues/4591

`KafkaListenerAnnotationBeanPostProcessor.addFormatters` registered every `Converter` bean via the single-argument `FormatterRegistry.addConverter(Converter)` overload, which reflects `S` and `T` from the converter class. Lambda and method-reference beans have no generic signature, so a `Converter` that Boot accepts elsewhere aborted `@KafkaListener` processing.

This change resolves `S`/`T` from the bean definition `ResolvableType` (the `@Bean` method signature) and registers through the `Class, Class, Converter` overload. If the types still cannot be determined, the converter is skipped instead of failing context refresh. The same skip is applied to `ConverterFactory` beans that cannot be introspected.

## Test plan

Executed:

- `./gradlew :spring-kafka:test --tests org.springframework.kafka.annotation.KafkaListenerAnnotationBeanPostProcessorTests` (5 tests)
- `./gradlew :spring-kafka:test --tests org.springframework.kafka.annotation.EnableKafkaIntegrationTests` (42 tests)
- `./gradlew :spring-kafka:checkstyleMain :spring-kafka:checkstyleTest`