### PR TITLE
GH-4593: Apply factory configuration in createContainer(String...)

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/config/ShareKafkaListenerContainerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/ShareKafkaListenerContainerFactory.java
@@ -218,13 +218,16 @@ public class ShareKafkaListenerContainerFactory<K, V>
 
 	@Override
 	public ShareKafkaMessageListenerContainer<K, V> createContainer(String... topics) {
-		return createContainerInstance(new KafkaListenerEndpointAdapter() {
+		KafkaListenerEndpoint endpoint = new KafkaListenerEndpointAdapter() {
 
 			@Override
 			public Collection<String> getTopics() {
 				return Arrays.asList(topics);
 			}
-		});
+		};
+		ShareKafkaMessageListenerContainer<K, V> instance = createContainerInstance(endpoint);
+		initializeContainer(instance, endpoint);
+		return instance;
 	}
 
 	@Override

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ShareKafkaMessageListenerContainerUnitTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ShareKafkaMessageListenerContainerUnitTests.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.kafka.config.KafkaListenerEndpoint;
 import org.springframework.kafka.config.ShareKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ShareConsumerFactory;
@@ -235,6 +236,32 @@ public class ShareKafkaMessageListenerContainerUnitTests {
 		container.setShareConsumerRecordRecoverer(customRecoverer);
 
 		assertThat(container.getShareConsumerRecordRecoverer()).isSameAs(customRecoverer);
+	}
+
+	/**
+	 * The programmatic entry point must configure the container the same way the
+	 * endpoint-driven one does. {@code createListenerContainer(KafkaListenerEndpoint)}
+	 * calls {@code initializeContainer(...)}; {@code createContainer(String...)} must
+	 * too, otherwise every factory-level setting is silently dropped.
+	 */
+	@Test
+	void createContainerByTopicsShouldApplyFactoryConfiguration() {
+		ShareConsumerRecordRecoverer customRecoverer = (record, ex) -> AcknowledgeType.RELEASE;
+		ApplicationEventPublisher publisher = mock(ApplicationEventPublisher.class);
+		ShareKafkaListenerContainerFactory<String, String> factory =
+				new ShareKafkaListenerContainerFactory<>(shareConsumerFactory);
+		factory.setShareConsumerRecordRecoverer(customRecoverer);
+		factory.setApplicationEventPublisher(publisher);
+		factory.setAutoStartup(false);
+		factory.setPhase(42);
+
+		ShareKafkaMessageListenerContainer<String, String> container =
+				factory.createContainer("test-topic");
+
+		assertThat(container.getShareConsumerRecordRecoverer()).isSameAs(customRecoverer);
+		assertThat(container.getApplicationEventPublisher()).isSameAs(publisher);
+		assertThat(container.isAutoStartup()).isFalse();
+		assertThat(container.getPhase()).isEqualTo(42);
 	}
 
 	@Test


### PR DESCRIPTION
**Problem**

`ShareKafkaListenerContainerFactory.createContainer(String... topics)` returned `createContainerInstance(endpoint)` without calling `initializeContainer(...)`, while the sibling `createListenerContainer(KafkaListenerEndpoint)` calls it (line 160).

Factory-level settings were therefore silently dropped on the programmatic path: the copied `ContainerProperties`, concurrency, `autoStartup`, phase, `applicationContext`, `applicationEventPublisher`, the `ShareConsumerRecordRecoverer`, `groupId` and `clientIdPrefix`.

**Root cause**

The class implements `KafkaListenerContainerFactory` directly rather than extending `AbstractKafkaListenerContainerFactory`, so there is no inherited path guaranteeing `initializeContainer` runs on every creation route.

**Solution**

Hoist the endpoint to a local and call `initializeContainer(instance, endpoint)`, matching `createListenerContainer`. +5/-2 in one file.

**Tests**

Added `createContainerByTopicsShouldApplyFactoryConfiguration` to the existing `ShareKafkaMessageListenerContainerUnitTests`, asserting the recoverer, event publisher, `autoStartup` and phase are applied via `createContainer(String...)`.

It fails on current `main` with an `AssertionError` (the container holds the default `REJECTING` recoverer instead of the configured one) and passes with this change. I also reverted only the production hunk while keeping the test, and confirmed it fails again with an `AssertionError` rather than a compile error, so the test genuinely exercises the change.

Locally: the full `*Share*` suite is 66 tests / 0 failures (including the 27 integration tests), and `checkstyleMain` is clean, on JDK 25.

**Risk**

Low. Additive only — no API added, removed or renamed. The behaviour change is confined to the previously-unconfigured path.

Fixes GH-4593
