### PR TITLE
GH-4325: Expose client instance IDs for share consumers

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ShareKafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ShareKafkaMessageListenerContainer.java
@@ -16,10 +16,12 @@
 
 package org.springframework.kafka.listener;
 
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -39,6 +41,7 @@ import org.apache.kafka.clients.consumer.internals.ShareAcknowledgementMode;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.CorruptRecordException;
 import org.apache.kafka.common.errors.RecordDeserializationException;
 import org.jspecify.annotations.Nullable;
@@ -104,6 +107,7 @@ import org.springframework.util.Assert;
  * @author Soby Chacko
  * @author Maxwell Balla
  * @author Youngjoo Kim
+ * @author Omar Morales Ortega
  *
  * @since 4.0
  *
@@ -194,6 +198,44 @@ public class ShareKafkaMessageListenerContainer<K, V>
 		finally {
 			this.lifecycleLock.unlock();
 		}
+	}
+
+	/**
+	 * Get the broker-assigned client instance IDs, keyed by the client id of
+	 * each running share consumer. The instance id correlates client metrics
+	 * with broker-side telemetry and is distinct from the client id returned by
+	 * {@link #getClientId()}. Returns an empty map when the container is not
+	 * running.
+	 * <p>
+	 * The client instance id is requested from each consumer sequentially, so
+	 * the worst-case wait is {@code concurrency x timeout}. Client telemetry
+	 * must be enabled ({@code enable.metrics.push=true}, the default).
+	 * @param timeout the maximum time to wait per consumer for the broker to
+	 * assign an instance id (must be non-negative; zero means do not wait)
+	 * @return the client instance ids keyed by client id; the value is
+	 * {@code null} for a consumer whose id was not assigned within the timeout
+	 * @see #metrics()
+	 */
+	public Map<String, Uuid> getClientInstanceIds(Duration timeout) {
+		List<ShareListenerConsumer> snapshot;
+		this.lifecycleLock.lock();
+		try {
+			snapshot = new ArrayList<>(this.consumers);
+		}
+		finally {
+			this.lifecycleLock.unlock();
+		}
+		if (snapshot.isEmpty()) {
+			return Collections.emptyMap();
+		}
+		Map<String, Uuid> instanceIds = new LinkedHashMap<>();
+		for (ShareListenerConsumer consumer : snapshot) {
+			String consumerClientId = consumer.getClientId();
+			if (consumerClientId != null) {
+				instanceIds.put(consumerClientId, consumer.consumer.clientInstanceId(timeout));
+			}
+		}
+		return Collections.unmodifiableMap(instanceIds);
 	}
 
 	@Override

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ShareKafkaMessageListenerContainerUnitTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ShareKafkaMessageListenerContainerUnitTests.java
@@ -34,6 +34,7 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.ShareConsumer;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -735,6 +736,81 @@ public class ShareKafkaMessageListenerContainerUnitTests {
 		finally {
 			container.stop();
 			executor.destroy();
+		}
+	}
+
+	@Test
+	void shouldReturnEmptyClientInstanceIdsWhenNotRunning() {
+		ContainerProperties containerProperties = new ContainerProperties("test-topic");
+		containerProperties.setMessageListener(messageListener);
+
+		ShareKafkaMessageListenerContainer<String, String> container =
+				new ShareKafkaMessageListenerContainer<>(shareConsumerFactory, containerProperties);
+
+		assertThat(container.getClientInstanceIds(Duration.ZERO)).isEmpty();
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void shouldReturnClientInstanceIdsForRunningConsumers() {
+		ShareConsumerFactory<String, String> mockFactory = mock(ShareConsumerFactory.class);
+		given(mockFactory.getConfigurationProperties()).willReturn(Map.of());
+
+		ShareConsumer<String, String> mockConsumer = mock(ShareConsumer.class);
+		given(mockFactory.createShareConsumer(any(), any(), any())).willReturn(mockConsumer);
+		Uuid instanceId = Uuid.randomUuid();
+		given(mockConsumer.clientInstanceId(any())).willReturn(instanceId);
+		given(mockConsumer.poll(any())).willAnswer(invocation -> {
+			Thread.sleep(10);
+			return new ConsumerRecords<>(Map.of());
+		});
+
+		ContainerProperties containerProperties = new ContainerProperties("test-topic");
+		containerProperties.setMessageListener(messageListener);
+
+		ShareKafkaMessageListenerContainer<String, String> container =
+				new ShareKafkaMessageListenerContainer<>(mockFactory, containerProperties);
+		container.setBeanName("clientInstanceIdContainer");
+		container.start();
+		try {
+			Map<String, Uuid> instanceIds = container.getClientInstanceIds(Duration.ZERO);
+			assertThat(instanceIds).hasSize(1).containsKey("clientInstanceIdContainer");
+			assertThat(instanceIds.get("clientInstanceIdContainer")).isEqualTo(instanceId);
+		}
+		finally {
+			container.stop();
+		}
+		assertThat(container.getClientInstanceIds(Duration.ZERO)).isEmpty();
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void shouldPropagateClientInstanceIdException() {
+		ShareConsumerFactory<String, String> mockFactory = mock(ShareConsumerFactory.class);
+		given(mockFactory.getConfigurationProperties()).willReturn(Map.of());
+
+		ShareConsumer<String, String> mockConsumer = mock(ShareConsumer.class);
+		given(mockFactory.createShareConsumer(any(), any(), any())).willReturn(mockConsumer);
+		given(mockConsumer.clientInstanceId(any())).willThrow(new IllegalStateException("telemetry disabled"));
+		given(mockConsumer.poll(any())).willAnswer(invocation -> {
+			Thread.sleep(10);
+			return new ConsumerRecords<>(Map.of());
+		});
+
+		ContainerProperties containerProperties = new ContainerProperties("test-topic");
+		containerProperties.setMessageListener(messageListener);
+
+		ShareKafkaMessageListenerContainer<String, String> container =
+				new ShareKafkaMessageListenerContainer<>(mockFactory, containerProperties);
+		container.setBeanName("clientInstanceIdErrorContainer");
+		container.start();
+		try {
+			assertThatExceptionOfType(IllegalStateException.class)
+					.isThrownBy(() -> container.getClientInstanceIds(Duration.ZERO))
+					.withMessage("telemetry disabled");
+		}
+		finally {
+			container.stop();
 		}
 	}
 }


### PR DESCRIPTION
GH-4325: Expose client instance IDs for share consumers

Fixes https://github.com/spring-projects/spring-kafka/issues/4325

Adds `getClientInstanceIds(Duration)` to `ShareKafkaMessageListenerContainer`,
delegating to `ShareConsumer.clientInstanceId(Duration)` so the broker-assigned
client instance IDs (KIP-714 telemetry) can be correlated with client metrics.

The method returns the IDs keyed by client id, or an empty map when the
container is not running. The value is `null` for a consumer whose id was not
assigned within the timeout.

Tests passed.