### PR TITLE
Fix DeadLetterPublishingRecoverer API names in error-handling docs

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/annotation-error-handling.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/annotation-error-handling.adoc
@@ -1009,14 +1009,14 @@ The reason for the two properties is because, while you might want to retain onl
 `appendOriginalHeaders` is applied to all headers named `*ORIGINAL*` while `stripPreviousExceptionHeaders` is applied to all headers named `*EXCEPTION*`.
 
 Starting with version 2.8.4, you now can control which of the standard headers will be added to the output record.
-See the `enum HeadersToAdd` for the generic names of the (currently) 10 standard headers that are added by default (these are not the actual header names, just an abstraction; the actual header names are set up by the `getHeaderNames()` method which subclasses can override.
+See the `enum HeadersToAdd` for the generic names of the (currently) 10 standard headers that are added by default (these are not the actual header names, just an abstraction; the actual header names are supplied by the `setHeaderNamesSupplier()` method).
 
-To exclude headers, use the `excludeHeaders()` method; for example, to suppress adding the exception stack trace in a header, use:
+To exclude headers, use the `excludeHeader()` method; for example, to suppress adding the exception stack trace in a header, use:
 
 [source, java]
 ----
 DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(template);
-recoverer.excludeHeaders(HeaderNames.HeadersToAdd.EX_STACKTRACE);
+recoverer.excludeHeader(HeaderNames.HeadersToAdd.EX_STACKTRACE);
 ----
 
 In addition, you can completely customize the addition of exception headers by adding an `ExceptionHeadersCreator`; this also disables all standard exception headers.


### PR DESCRIPTION
Two references in `annotation-error-handling.adoc` name APIs that do not exist.

**`excludeHeaders()` — the documented sample does not compile**

The prose and the code sample both use the plural form:

```java
recoverer.excludeHeaders(HeaderNames.HeadersToAdd.EX_STACKTRACE);
```

The actual method is singular — `excludeHeader(HeaderNames.HeadersToAdd...)`, `DeadLetterPublishingRecoverer` line 419.

**`getHeaderNames()` — documents an extension point that no longer exists**

The same paragraph says the actual header names "are set up by the `getHeaderNames()` method which subclasses can override". That method is not present anywhere in `spring-kafka/src/main/java` — a repository-wide grep returns nothing. Header names are supplied via `setHeaderNamesSupplier(Supplier<HeaderNames>)` (line 723).

Corrected both, and closed the unbalanced parenthesis on that sentence while there.
