### PR TITLE
GH-4601: Honor the container properties client id in share containers

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ShareKafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ShareKafkaMessageListenerContainer.java
@@ -57,6 +57,7 @@ import org.springframework.kafka.event.ConsumerStoppedEvent.Reason;
 import org.springframework.kafka.event.ShareConsumerStoppingEvent;
 import org.springframework.kafka.support.ShareAcknowledgment;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 /**
  * Share consumer container using the Java {@link ShareConsumer}.
@@ -265,7 +266,11 @@ public class ShareKafkaMessageListenerContainer<K, V>
 	}
 
 	private String determineClientId(int index) {
-		String baseClientId = this.clientId != null ? this.clientId : getBeanName();
+		String baseClientId = this.clientId;
+		if (baseClientId == null) {
+			String propertiesClientId = getContainerProperties().getClientId();
+			baseClientId = StringUtils.hasText(propertiesClientId) ? propertiesClientId : getBeanName();
+		}
 		if (this.concurrency > 1) {
 			return baseClientId + "-" + index;
 		}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ShareKafkaMessageListenerContainerUnitTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ShareKafkaMessageListenerContainerUnitTests.java
@@ -290,6 +290,69 @@ public class ShareKafkaMessageListenerContainerUnitTests {
 
 	@Test
 	@SuppressWarnings("unchecked")
+	void shouldUseClientIdFromContainerProperties() {
+		ShareConsumerFactory<String, String> mockFactory = mock(ShareConsumerFactory.class);
+		given(mockFactory.getConfigurationProperties()).willReturn(Map.of());
+		ShareConsumer<String, String> mockConsumer = mock(ShareConsumer.class);
+		given(mockFactory.createShareConsumer(any(), any(), any())).willReturn(mockConsumer);
+
+		ContainerProperties containerProperties = new ContainerProperties("test-topic");
+		containerProperties.setMessageListener(messageListener);
+		containerProperties.setClientId("share-client-from-properties");
+
+		ShareKafkaMessageListenerContainer<String, String> container =
+				new ShareKafkaMessageListenerContainer<>(mockFactory, containerProperties);
+		container.setBeanName("clientIdFromPropertiesContainer");
+		container.start();
+		container.stop();
+
+		verify(mockFactory).createShareConsumer(any(), eq("share-client-from-properties"), any());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void shouldPreferTheClientIdSetOnTheContainer() {
+		ShareConsumerFactory<String, String> mockFactory = mock(ShareConsumerFactory.class);
+		given(mockFactory.getConfigurationProperties()).willReturn(Map.of());
+		ShareConsumer<String, String> mockConsumer = mock(ShareConsumer.class);
+		given(mockFactory.createShareConsumer(any(), any(), any())).willReturn(mockConsumer);
+
+		ContainerProperties containerProperties = new ContainerProperties("test-topic");
+		containerProperties.setMessageListener(messageListener);
+		containerProperties.setClientId("share-client-from-properties");
+
+		ShareKafkaMessageListenerContainer<String, String> container =
+				new ShareKafkaMessageListenerContainer<>(mockFactory, containerProperties);
+		container.setBeanName("clientIdOnContainerContainer");
+		container.setClientId("share-client-on-container");
+		container.start();
+		container.stop();
+
+		verify(mockFactory).createShareConsumer(any(), eq("share-client-on-container"), any());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void shouldFallBackToTheBeanNameWhenNoClientIdIsConfigured() {
+		ShareConsumerFactory<String, String> mockFactory = mock(ShareConsumerFactory.class);
+		given(mockFactory.getConfigurationProperties()).willReturn(Map.of());
+		ShareConsumer<String, String> mockConsumer = mock(ShareConsumer.class);
+		given(mockFactory.createShareConsumer(any(), any(), any())).willReturn(mockConsumer);
+
+		ContainerProperties containerProperties = new ContainerProperties("test-topic");
+		containerProperties.setMessageListener(messageListener);
+
+		ShareKafkaMessageListenerContainer<String, String> container =
+				new ShareKafkaMessageListenerContainer<>(mockFactory, containerProperties);
+		container.setBeanName("beanNameFallbackContainer");
+		container.start();
+		container.stop();
+
+		verify(mockFactory).createShareConsumer(any(), eq("beanNameFallbackContainer"), any());
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
 	void shouldUseCommitSyncByDefault() throws Exception {
 		ShareConsumerFactory<String, String> mockFactory = mock(ShareConsumerFactory.class);
 		given(mockFactory.getConfigurationProperties()).willReturn(Map.of());


### PR DESCRIPTION
Fixes GH-4601

`ShareKafkaMessageListenerContainer.determineClientId` read only the client id set directly on the
container, so the value `ShareKafkaListenerContainerFactory` copies from an endpoint's
`clientIdPrefix` into the container properties, and any factory level client id, were both dropped
and the consumer fell back to the bean name. `kafka-queues.adoc` lists `clientId` among the
supported share container properties.

The container property is now used when no client id was set on the container itself, which keeps
`setClientId` at the highest precedence and leaves the bean name as the last resort.

Three unit tests cover the three sources; the container-properties one fails on `main`.
