### PR TITLE
GH-4603: Handle a missing source record in the recovering Streams handlers

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/streams/RecoveringProcessingExceptionHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/streams/RecoveringProcessingExceptionHandler.java
@@ -26,6 +26,7 @@ import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.streams.errors.ErrorHandlerContext;
 import org.apache.kafka.streams.errors.ProcessingExceptionHandler;
 import org.apache.kafka.streams.processor.api.Record;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.kafka.listener.ConsumerRecordRecoverer;
 
@@ -54,17 +55,25 @@ public class RecoveringProcessingExceptionHandler
 	 * {@inheritDoc}
 	 */
 	@Override
-	public Response handleError(ErrorHandlerContext context, Record<?, ?> record, Exception exception) {
+	public Response handleError(ErrorHandlerContext context, @Nullable Record<?, ?> record, Exception exception) {
+		if (record == null || context.topic() == null) {
+			// Raised from a punctuation callback: there is no source record to recover.
+			return fail();
+		}
+
+		byte[] sourceRawKey = context.sourceRawKey();
+		byte[] sourceRawValue = context.sourceRawValue();
+
 		ConsumerRecord<byte[], byte[]> sourceRecord = new ConsumerRecord<>(
 				context.topic(),
 				context.partition(),
 				context.offset(),
 				context.timestamp(),
 				TimestampType.NO_TIMESTAMP_TYPE,
-				context.sourceRawKey().length,
-				context.sourceRawValue().length,
-				context.sourceRawKey(),
-				context.sourceRawValue(),
+				sourceRawKey != null ? sourceRawKey.length : ConsumerRecord.NULL_SIZE,
+				sourceRawValue != null ? sourceRawValue.length : ConsumerRecord.NULL_SIZE,
+				sourceRawKey,
+				sourceRawValue,
 				context.headers(),
 				Optional.empty(),
 				Optional.empty());

--- a/spring-kafka/src/main/java/org/springframework/kafka/streams/RecoveringProductionExceptionHandler.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/streams/RecoveringProductionExceptionHandler.java
@@ -54,6 +54,11 @@ public class RecoveringProductionExceptionHandler
 	 */
 	@Override
 	public Response handleError(ErrorHandlerContext context, ProducerRecord<byte[], byte[]> record, Exception exception) {
+		if (context.topic() == null) {
+			// The error was not raised while processing an input record, so there is nothing to recover.
+			return fail();
+		}
+
 		return handleErrorCommon(context, buildConsumerRecord(context, record), exception, buildSourceRecord(context));
 	}
 
@@ -63,6 +68,11 @@ public class RecoveringProductionExceptionHandler
 	@SuppressWarnings("rawtypes")
 	@Override
 	public Response handleSerializationError(ErrorHandlerContext context, ProducerRecord record, Exception exception, SerializationExceptionOrigin origin) {
+		if (context.topic() == null) {
+			// The error was not raised while processing an input record, so there is nothing to recover.
+			return fail();
+		}
+
 		return handleErrorCommon(context, buildConsumerRecord(context, record), exception, buildSourceRecord(context));
 	}
 
@@ -107,16 +117,19 @@ public class RecoveringProductionExceptionHandler
 	}
 
 	private ConsumerRecord<byte[], byte[]> buildSourceRecord(ErrorHandlerContext context) {
+		byte[] sourceRawKey = context.sourceRawKey();
+		byte[] sourceRawValue = context.sourceRawValue();
+
 		return new ConsumerRecord<>(
 				context.topic(),
 				context.partition(),
 				context.offset(),
 				context.timestamp(),
 				TimestampType.NO_TIMESTAMP_TYPE,
-				context.sourceRawKey().length,
-				context.sourceRawValue().length,
-				context.sourceRawKey(),
-				context.sourceRawValue(),
+				sourceRawKey != null ? sourceRawKey.length : ConsumerRecord.NULL_SIZE,
+				sourceRawValue != null ? sourceRawValue.length : ConsumerRecord.NULL_SIZE,
+				sourceRawKey,
+				sourceRawValue,
 				context.headers(),
 				Optional.empty(),
 				Optional.empty());

--- a/spring-kafka/src/test/java/org/springframework/kafka/streams/RecoveringProcessingExceptionHandlerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/streams/RecoveringProcessingExceptionHandlerTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.kafka.streams;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -26,10 +27,13 @@ import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.streams.errors.ErrorHandlerContext;
 import org.apache.kafka.streams.errors.ProcessingExceptionHandler;
 import org.apache.kafka.streams.processor.api.Record;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.kafka.support.KafkaHeaders;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 /**
  * @author Loïc Greffier
@@ -77,6 +81,30 @@ class RecoveringProcessingExceptionHandlerTests
 				this.record.headers(),
 				Optional.empty(),
 				Optional.empty());
+	}
+
+	@Test
+	void shouldFailWhenTriggeredFromPunctuation() {
+		Map<String, Object> configs = new HashMap<>();
+		configs.put(RecoveringProcessingExceptionHandler.RECOVERER, new Recoverer());
+		RecoveringProcessingExceptionHandler handler = createHandler(configs);
+
+		// Kafka calls the handler from a punctuation callback with no record and a context
+		// whose topic and raw key and value are all null
+		assertResponseShouldFail(handler.handleError(mock(ErrorHandlerContext.class), null,
+				new IllegalArgumentException()));
+	}
+
+	@Test
+	void shouldRecoverWhenTheRawKeyAndValueAreNotAvailable() {
+		Map<String, Object> configs = new HashMap<>();
+		configs.put(RecoveringProcessingExceptionHandler.RECOVERER, new Recoverer());
+		RecoveringProcessingExceptionHandler handler = createHandler(configs);
+		ErrorHandlerContext context = createMockContext();
+		given(context.sourceRawKey()).willReturn(null);
+		given(context.sourceRawValue()).willReturn(null);
+
+		assertResponseShouldResume(handler.handleError(context, this.record, new IllegalArgumentException()));
 	}
 
 	@Override

--- a/spring-kafka/src/test/java/org/springframework/kafka/streams/RecoveringProductionExceptionHandlerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/streams/RecoveringProductionExceptionHandlerTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.kafka.streams;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
@@ -25,10 +26,13 @@ import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.streams.errors.ErrorHandlerContext;
 import org.apache.kafka.streams.errors.ProductionExceptionHandler;
+import org.junit.jupiter.api.Test;
 
 import org.springframework.kafka.support.KafkaHeaders;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 
 /**
  * @author Loïc Greffier
@@ -77,6 +81,31 @@ class RecoveringProductionExceptionHandlerTests
 				this.record.headers(),
 				Optional.empty(),
 				Optional.empty());
+	}
+
+	@Test
+	void shouldFailWhenThereIsNoSourceRecord() {
+		Map<String, Object> configs = new HashMap<>();
+		configs.put(RecoveringProductionExceptionHandler.RECOVERER, new Recoverer());
+		RecoveringProductionExceptionHandler handler = createHandler(configs);
+
+		// Streams builds a context with no topic when the failure is not tied to an input record
+		assertResponseShouldFail(handler.handleError(mock(ErrorHandlerContext.class), this.record,
+				new IllegalArgumentException()));
+		assertResponseShouldFail(handler.handleSerializationError(mock(ErrorHandlerContext.class), this.record,
+				new IllegalArgumentException(), ProductionExceptionHandler.SerializationExceptionOrigin.VALUE));
+	}
+
+	@Test
+	void shouldRecoverWhenTheRawKeyAndValueAreNotAvailable() {
+		Map<String, Object> configs = new HashMap<>();
+		configs.put(RecoveringProductionExceptionHandler.RECOVERER, new Recoverer());
+		RecoveringProductionExceptionHandler handler = createHandler(configs);
+		ErrorHandlerContext context = createMockContext();
+		given(context.sourceRawKey()).willReturn(null);
+		given(context.sourceRawValue()).willReturn(null);
+
+		assertResponseShouldResume(handler.handleError(context, this.record, new IllegalArgumentException()));
 	}
 
 	@Override


### PR DESCRIPTION
Fixes GH-4603

The recovering Streams handlers dereferenced `context.sourceRawKey()`, `context.sourceRawValue()`
and the record, which Kafka documents as null when the failure comes from a punctuation callback or
is not tied to an input record. The processing handler threw `NullPointerException` and the
production handler passed a null topic into `ConsumerRecord`, so a handler installed to recover
errors killed the stream thread instead.

Both now return `fail()` when there is no source record to recover, and the raw key and value sizes
fall back to `ConsumerRecord.NULL_SIZE` when Kafka does not provide them, which is what the existing
code already does for the forwarded record.

Four unit tests cover the punctuation and missing-raw-value paths; they throw on `main`.
