### PR TITLE
GH-4605: Name the validated property in Assert messages

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerEndpoint.java
@@ -64,6 +64,7 @@ import org.springframework.util.ObjectUtils;
  * @author Wang Zhiyang
  * @author Sanghyeok An
  * @author Borahm Lee
+ * @author OhKyu Chan
  *
  * @see MethodKafkaListenerEndpoint
  */
@@ -218,7 +219,7 @@ public abstract class AbstractKafkaListenerEndpoint<K, V>
 	 * @see #setTopicPattern(Pattern)
 	 */
 	public void setTopicPartitions(TopicPartitionOffset... topicPartitions) {
-		Assert.notNull(topicPartitions, "'topics' must not be null");
+		Assert.notNull(topicPartitions, "'topicPartitions' must not be null");
 		this.topicPartitions.clear();
 		this.topicPartitions.addAll(Arrays.asList(topicPartitions));
 	}

--- a/spring-kafka/src/main/java/org/springframework/kafka/requestreply/ReplyingKafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/requestreply/ReplyingKafkaTemplate.java
@@ -74,6 +74,7 @@ import org.springframework.util.Assert;
  * @author Borahm Lee
  * @author Francois Rosiere
  * @author Mikhail Polivakha
+ * @author OhKyu Chan
  *
  * @since 2.1.3
  *
@@ -193,7 +194,7 @@ public class ReplyingKafkaTemplate<K, V, R> extends KafkaTemplate<K, V> implemen
 	 */
 	public void setDefaultReplyTimeout(Duration defaultReplyTimeout) {
 		Assert.notNull(defaultReplyTimeout, "'defaultReplyTimeout' cannot be null");
-		Assert.isTrue(defaultReplyTimeout.toMillis() >= 0, "'replyTimeout' must be >= 0");
+		Assert.isTrue(defaultReplyTimeout.toMillis() >= 0, "'defaultReplyTimeout' must be >= 0");
 		this.defaultReplyTimeout = defaultReplyTimeout;
 	}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/config/AbstractKafkaListenerEndpointTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/config/AbstractKafkaListenerEndpointTests.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.config;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.kafka.support.TopicPartitionOffset;
+
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+/**
+ * @author OhKyu Chan
+ *
+ * @since 4.2
+ */
+public class AbstractKafkaListenerEndpointTests {
+
+	@Test
+	void setTopicsRejectsNullNamingItsOwnProperty() {
+		MethodKafkaListenerEndpoint<String, String> endpoint = new MethodKafkaListenerEndpoint<>();
+
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> endpoint.setTopics((String[]) null))
+				.withMessage("'topics' must not be null");
+	}
+
+	@Test
+	void setTopicPartitionsRejectsNullNamingItsOwnProperty() {
+		MethodKafkaListenerEndpoint<String, String> endpoint = new MethodKafkaListenerEndpoint<>();
+
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> endpoint.setTopicPartitions((TopicPartitionOffset[]) null))
+				.withMessage("'topicPartitions' must not be null");
+	}
+
+}

--- a/spring-kafka/src/test/java/org/springframework/kafka/requestreply/ReplyingKafkaTemplateTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/requestreply/ReplyingKafkaTemplateTests.java
@@ -90,6 +90,7 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -103,6 +104,7 @@ import static org.mockito.Mockito.verify;
  * @author Soby Chacko
  * @author Mikhail Polivakha
  * @author Ngoc Nhan
+ * @author OhKyu Chan
  * @since 2.1.3
  *
  */
@@ -880,6 +882,19 @@ public class ReplyingKafkaTemplateTests {
 				.build();
 		// was NPE here
 		template.sendAndReceive(new ProducerRecord("foo", 0, "bar", "baz"), null).getSendFuture().get();
+	}
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	@Test
+	void setDefaultReplyTimeoutRejectsNegativeNamingItsOwnProperty() {
+		ProducerFactory pf = mock(ProducerFactory.class);
+		GenericMessageListenerContainer container = mock(GenericMessageListenerContainer.class);
+		given(container.getContainerProperties()).willReturn(new ContainerProperties("two"));
+		ReplyingKafkaTemplate template = new ReplyingKafkaTemplate(pf, container);
+
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> template.setDefaultReplyTimeout(Duration.ofMillis(-1)))
+				.withMessage("'defaultReplyTimeout' must be >= 0");
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-kafka/issues/4605

`AbstractKafkaListenerEndpoint#setTopics` and `#setTopicPartitions` are two distinct, mutually exclusive properties, but both rejected null with `'topics' must not be null`, so a failure on `topicPartitions` pointed the caller at a property they may never have set. The message has been copied from `setTopics` since `c0fe2c2f`, the original `@KafkaListener` commit.

`ReplyingKafkaTemplate#setDefaultReplyTimeout` disagreed with itself: the `notNull` check named `defaultReplyTimeout` while the `isTrue` check named `replyTimeout`, which in that class is the per-send timeout parameter of `sendAndReceive(record, replyTimeout)`, not this property. The `isTrue` message was carried over unchanged from the old `setReplyTimeout(long)` when `220a5aae` (GH-1244) split the property in 2.3; that setter has since been removed, so the name no longer refers to a property at all.

* Name the property each check actually validates

Both new tests fail before the change with the old messages and pass after. A third test pins the already correct `setTopics` message so the two cannot converge again.