### PR TITLE
Apply Nullability to ReplyingKafkaTemplate

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/requestreply/ReplyingKafkaTemplate.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/requestreply/ReplyingKafkaTemplate.java
@@ -75,6 +75,7 @@ import org.springframework.util.Assert;
  * @author Francois Rosiere
  * @author Mikhail Polivakha
  * @author OhKyu Chan
+ * @author Ngoc Nhan
  *
  * @since 2.1.3
  *
@@ -92,9 +93,9 @@ public class ReplyingKafkaTemplate<K, V, R> extends KafkaTemplate<K, V> implemen
 
 	private final ConcurrentMap<Object, RequestReplyFuture<K, V, R>> futures = new ConcurrentHashMap<>();
 
-	private final byte[] replyTopic;
+	private final byte @Nullable [] replyTopic;
 
-	private final byte[] replyPartition;
+	private final byte @Nullable [] replyPartition;
 
 	private TaskScheduler scheduler = new ThreadPoolTaskScheduler();
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/requestreply/ReplyingKafkaTemplateTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/requestreply/ReplyingKafkaTemplateTests.java
@@ -31,6 +31,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
 
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -87,6 +88,7 @@ import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -938,6 +940,18 @@ public class ReplyingKafkaTemplateTests {
 			template.stop();
 			template.destroy();
 		}
+	}
+
+	@Test
+	public void replyTopicAndReplyPartitionCanBeNullDuringInitialization() {
+
+		ProducerFactory<Integer, String> pf = mock();
+		GenericMessageListenerContainer<Integer, String> container = mock();
+		given(container.getContainerProperties()).willReturn(new ContainerProperties((Pattern) null));
+		ReplyingKafkaTemplate<Integer, String, String> template = new ReplyingKafkaTemplate<>(pf, container);
+
+		assertThat(ReflectionTestUtils.getField(template, ReplyingKafkaTemplate.class, "replyTopic")).isNull();
+		assertThat(ReflectionTestUtils.getField(template, ReplyingKafkaTemplate.class, "replyPartition")).isNull();
 	}
 
 	@Configuration


### PR DESCRIPTION
`replyTopic` and `replyPartition` can be null because `tempReplyTopic` can remain null during the initialization of ReplyingKafkaTemplate.

<!--
Thanks for contributing to Spring for Apache Kafka.
Please provide a brief description of your pull-request and reference any related issue numbers (prefix references with #) or StackOverflow questions.

See the [Contributor Guidelines for more information](https://github.com/spring-projects/spring-kafka/blob/main/CONTRIBUTING.md).
In particular, ensure the first line of the first commit comment is limited to 50 characters.
-->
