### PR TITLE
GH-4623: Fix multi-value headers with JSON types

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/AbstractKafkaHeaderMapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/AbstractKafkaHeaderMapper.java
@@ -307,14 +307,26 @@ public abstract class AbstractKafkaHeaderMapper implements KafkaHeaderMapper {
 	 * @since 4.0
 	 */
 	protected void fromUserHeader(String headerName, Header header, final Map<String, Object> headers) {
+		fromUserHeader(headerName, headerValueToAddIn(header), headers);
+	}
+
+	/**
+	 * Add the already converted header value to the target headers, collecting values
+	 * for headers matching a multi-value pattern into a {@link List}.
+	 * @param headerName the header name.
+	 * @param headerValue the converted header value.
+	 * @param headers the target headers.
+	 * @since 4.2
+	 */
+	protected void fromUserHeader(String headerName, @Nullable Object headerValue, final Map<String, Object> headers) {
 		if (!doesMatchMultiValueHeader(headerName)) {
-			headers.put(headerName, headerValueToAddIn(header));
+			headers.put(headerName, headerValue);
 		}
 		else {
 			@SuppressWarnings("unchecked")
 			List<Object> headerValues = (List<Object>)
 					headers.computeIfAbsent(headerName, key -> new ArrayList<>());
-			headerValues.add(headerValueToAddIn(header));
+			headerValues.add(headerValue);
 		}
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/DefaultKafkaHeaderMapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/DefaultKafkaHeaderMapper.java
@@ -392,22 +392,22 @@ public class DefaultKafkaHeaderMapper extends AbstractKafkaHeaderMapper {
 			logger.error(e, () -> "Could not load class for header: " + header.key());
 		}
 		if (String.class.equals(type) && (header.value().length == 0 || header.value()[0] != '"')) {
-			headers.put(header.key(), new String(header.value(), getCharset()));
+			fromUserHeader(header.key(), new String(header.value(), getCharset()), headers);
 		}
 		else {
 			if (trusted) {
 				try {
 					Object value = decodeValue(header, type);
-					headers.put(header.key(), value);
+					fromUserHeader(header.key(), value, headers);
 				}
 				catch (IOException e) {
 					logger.error(e, () ->
 							"Could not decode json type: " + requestedType + " for key: " + header.key());
-					headers.put(header.key(), header.value());
+					fromUserHeader(header.key(), header.value(), headers);
 				}
 			}
 			else {
-				headers.put(header.key(), new NonTrustedHeaderType(header.value(), requestedType));
+				fromUserHeader(header.key(), new NonTrustedHeaderType(header.value(), requestedType), headers);
 			}
 		}
 	}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/JsonKafkaHeaderMapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/JsonKafkaHeaderMapper.java
@@ -382,22 +382,22 @@ public class JsonKafkaHeaderMapper extends AbstractKafkaHeaderMapper {
 			logger.error(e, () -> "Could not load class for header: " + header.key());
 		}
 		if (String.class.equals(type) && (header.value().length == 0 || header.value()[0] != '"')) {
-			headers.put(header.key(), new String(header.value(), getCharset()));
+			fromUserHeader(header.key(), new String(header.value(), getCharset()), headers);
 		}
 		else {
 			if (trusted) {
 				try {
 					Object value = decodeValue(header, type);
-					headers.put(header.key(), value);
+					fromUserHeader(header.key(), value, headers);
 				}
 				catch (Exception e) {
 					logger.error(e, () ->
 							"Could not decode json type: " + requestedType + " for key: " + header.key());
-					headers.put(header.key(), header.value());
+					fromUserHeader(header.key(), header.value(), headers);
 				}
 			}
 			else {
-				headers.put(header.key(), new NonTrustedHeaderType(header.value(), requestedType));
+				fromUserHeader(header.key(), new NonTrustedHeaderType(header.value(), requestedType), headers);
 			}
 		}
 	}

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/JsonKafkaHeaderMapperTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/JsonKafkaHeaderMapperTests.java
@@ -662,6 +662,41 @@ public class JsonKafkaHeaderMapperTests {
 	}
 
 	@Test
+	void multiValueHeaderWithJsonTypesRoundTrip() {
+		// GIVEN
+		String multiValueStringHeader = "test-multi-value-string";
+		String multiValueIntHeader = "test-multi-value-int";
+
+		Message<String> message = MessageBuilder
+				.withPayload("test-multi-value-header")
+				.setHeader(multiValueStringHeader, List.of("value1", "value2"))
+				.setHeader(multiValueIntHeader, List.of(1, 2))
+				.build();
+
+		JsonKafkaHeaderMapper mapper = new JsonKafkaHeaderMapper();
+		mapper.setMultiValueHeaderPatterns("test-multi-*");
+
+		Headers recordHeaders = new RecordHeaders();
+		mapper.fromHeaders(message.getHeaders(), recordHeaders);
+
+		assertThat(recordHeaders.headers(multiValueStringHeader)).hasSize(2);
+		assertThat(recordHeaders.headers(multiValueIntHeader)).hasSize(2);
+
+		// WHEN
+		Map<String, Object> mappedHeaders = new HashMap<>();
+		mapper.toHeaders(recordHeaders, mappedHeaders);
+
+		// THEN
+		assertThat(mappedHeaders)
+				.extractingByKey(multiValueStringHeader, InstanceOfAssertFactories.list(String.class))
+				.containsExactly("value1", "value2");
+
+		assertThat(mappedHeaders)
+				.extractingByKey(multiValueIntHeader, InstanceOfAssertFactories.list(Integer.class))
+				.containsExactly(1, 2);
+	}
+
+	@Test
 	void deserializationExceptionHeadersAreMappedAsNonByteArray() {
 		JsonKafkaHeaderMapper mapper = new JsonKafkaHeaderMapper();
 


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-kafka/issues/4623

`JsonKafkaHeaderMapper.toHeaders` only routed headers **without** a `spring_json_header_types` entry through `AbstractKafkaHeaderMapper.fromUserHeader`, which holds the multi-value collection logic. Any non-`byte[]` outbound value always produces a JSON types entry, and `populateJsonValueHeader` used `headers.put(...)` in every branch, so successive values of a multi-value header overwrote each other — only the last value survived the inbound mapping, contradicting the documented behavior ("collected into a `List`"). The deprecated `DefaultKafkaHeaderMapper` had the same defect and is fixed for parity.

A `fromUserHeader` overload accepting the already-converted value is extracted in `AbstractKafkaHeaderMapper` (`@since 4.2`), and all `populateJsonValueHeader` branches route through it in both mappers.

Added a round-trip regression test (String and Integer multi-value headers) that fails on `main` and passes with the fix; `JsonKafkaHeaderMapperTests` 39/39, `SimpleKafkaHeaderMapperTests` 10/10, checkstyle passes.