### PR TITLE
GH-4624: Fix most-specific delegate selection

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingByTypeSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingByTypeSerializer.java
@@ -16,10 +16,9 @@
 
 package org.springframework.kafka.support.serializer;
 
-import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.TreeMap;
 
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.header.Headers;
@@ -41,22 +40,7 @@ import org.springframework.util.Assert;
  */
 public class DelegatingByTypeSerializer implements Serializer<Object> {
 
-	private static final Comparator<Class<?>> DELEGATES_ASSIGNABILITY_COMPARATOR =
-			(class1, class2) -> {
-
-				if (class1 == class2) {
-					return 0; // Classes are the same
-				}
-				if (class1.isAssignableFrom(class2)) {
-					return 1; // class2 is a superclass or superinterface of class1, so class2 should come first
-				}
-				if (class2.isAssignableFrom(class1)) {
-					return -1; // class1 is a superclass or superinterface of class2, so class1 should come first
-				}
-				return class1.getName().compareTo(class2.getName()); // If no inheritance relation, compare by name
-			};
-
-	private final Map<Class<?>, Serializer<?>> delegates = new TreeMap<>(DELEGATES_ASSIGNABILITY_COMPARATOR);
+	private final Map<Class<?>, Serializer<?>> delegates = new LinkedHashMap<>();
 
 	private final boolean assignable;
 
@@ -154,15 +138,26 @@ public class DelegatingByTypeSerializer implements Serializer<Object> {
 			return (Serializer<T>) delegate;
 		}
 		else {
-			for (Entry<Class<?>, Serializer<?>> entry : delegates.entrySet()) {
-				if (entry.getKey().isAssignableFrom(data.getClass())) {
-					return (Serializer<T>) entry.getValue();
+			Serializer<?> delegate = delegates.get(data.getClass());
+			if (delegate == null) {
+				Class<?> mostSpecific = null;
+				for (Entry<Class<?>, Serializer<?>> entry : delegates.entrySet()) {
+					Class<?> candidate = entry.getKey();
+					if (candidate.isAssignableFrom(data.getClass())
+							&& (mostSpecific == null || mostSpecific.isAssignableFrom(candidate))) {
+
+						mostSpecific = candidate;
+						delegate = entry.getValue();
+					}
 				}
 			}
-			throw new SerializationException("No matching delegate for type: " + data.getClass().getName()
-					+ "; supported types: " + delegates.keySet().stream()
-					.map(Class::getName)
-					.toList());
+			if (delegate == null) {
+				throw new SerializationException("No matching delegate for type: " + data.getClass().getName()
+						+ "; supported types: " + delegates.keySet().stream()
+						.map(Class::getName)
+						.toList());
+			}
+			return (Serializer<T>) delegate;
 		}
 	}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/DelegatingSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/DelegatingSerializationTests.java
@@ -310,6 +310,24 @@ public class DelegatingSerializationTests {
 	}
 
 	@Test
+	void assignableSelectsMostSpecificDespiteUnrelatedTypeInBetween() {
+		Serializer<?> ifaceSerializer = mock(Serializer.class);
+		Serializer<?> implSerializer = mock(Serializer.class);
+		Serializer<?> unrelatedSerializer = mock(Serializer.class);
+
+		// Using LinkedHashMap to ensure the order is always wrong
+		Map<Class<?>, Serializer<?>> delegates = new LinkedHashMap<>();
+		delegates.put(MiddleUnrelated.class, unrelatedSerializer);
+		delegates.put(AwareIface.class, ifaceSerializer);
+		delegates.put(ZebraImpl.class, implSerializer);
+
+		DelegatingByTypeSerializer serializer = new DelegatingByTypeSerializer(delegates, true);
+
+		assertThat(serializer.findDelegate(new ZebraImpl())).isSameAs(implSerializer);
+		assertThat(serializer.findDelegate(new MiddleUnrelated())).isSameAs(unrelatedSerializer);
+	}
+
+	@Test
 	void byTypeCloseClosesDelegates() {
 		Serializer<String> stringSerializer = spy(new StringSerializer());
 		Serializer<byte[]> bytesSerializer = spy(new ByteArraySerializer());
@@ -320,6 +338,15 @@ public class DelegatingSerializationTests {
 
 		verify(stringSerializer).close();
 		verify(bytesSerializer).close();
+	}
+
+	interface AwareIface {
+	}
+
+	static class MiddleUnrelated {
+	}
+
+	static class ZebraImpl implements AwareIface {
 	}
 
 }


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-kafka/issues/4624

The delegate map in `DelegatingByTypeSerializer` was ordered with an assignability comparator that is not transitive (assignability with a class-name fallback), so `TreeMap` iteration order was undefined. In assignable mode the lookup could return a more general delegate — even when an exact delegate for the value's class was registered (interface `A`, unrelated `M`, `Z implements A` with names `A < M < Z` inserted as `M, A, Z` iterates `A, M, Z`).

Since no total order exists for assignability, the sorted map is replaced with a `LinkedHashMap` and `findDelegate` now does an exact-class lookup first, then a scan keeping the most specific assignable key. This preserves the GH-3953 guarantee — its regression test (`shouldOrderDelegatesSoChildComesBeforeParent`) still passes.

Added a regression test with the cycle-producing fixture that fails on `main` and passes with the fix; `DelegatingSerializationTests` 12/12, checkstyle passes.