### PR TITLE
Improve trusted-packages error message guidance

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/headers.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/headers.adoc
@@ -82,7 +82,8 @@ You can trust additional packages with the `addTrustedPackages` method.
 Trust is **exact-package-name only**: a class is trusted only when its declaring package appears verbatim in the trusted list.
 Subpackages are *not* trusted transitively; each must be registered explicitly.
 If you receive messages from untrusted sources, register only the specific packages you need.
-To trust all packages without restriction, use `mapper.addTrustedPackages("+++*+++")` — though this is not recommended with untrusted sources.
+To trust every package, pass `+++*+++` to `addTrustedPackages` (for example, `mapper.addTrustedPackages("+++*+++")` or `spring.json.trusted.packages=+++*+++`).
+Trusting all packages means any type on the classpath can be deserialized from message headers, so prefer registering the specific packages you need.
 Classes in a non-trusted package are returned to the application as a `NonTrustedHeaderType` value instead of being deserialized.
 
 [source, java]

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/mapping/DefaultJackson2JavaTypeMapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/mapping/DefaultJackson2JavaTypeMapper.java
@@ -128,9 +128,10 @@ public class DefaultJackson2JavaTypeMapper extends AbstractJavaTypeMapper
 					throw new IllegalArgumentException("The class '" + classId
 							+ "' is not in the trusted packages: "
 							+ this.trustedPackages + ". "
-							+ "If you believe this class is safe to deserialize, please provide its name. "
-							+ "If the serialization is only done by a trusted source, you can also enable "
-							+ "trust all (*).");
+							+ "If you believe this class is safe to deserialize, add its package via the "
+							+ "'spring.json.trusted.packages' property or the 'addTrustedPackages()' method. "
+							+ "Trusting all packages with '*' allows any type on the classpath to be "
+							+ "deserialized, so list the specific packages you need instead.");
 				}
 				else {
 					return TypeFactory.defaultInstance()

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/mapping/DefaultJacksonJavaTypeMapper.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/mapping/DefaultJacksonJavaTypeMapper.java
@@ -279,9 +279,10 @@ public class DefaultJacksonJavaTypeMapper implements JacksonJavaTypeMapper, Bean
 					throw new IllegalArgumentException("The class '" + classId
 							+ "' is not in the trusted packages: "
 							+ this.trustedPackages + ". "
-							+ "If you believe this class is safe to deserialize, please provide its name. "
-							+ "If the serialization is only done by a trusted source, you can also enable "
-							+ "trust all (*).");
+							+ "If you believe this class is safe to deserialize, add its package via the "
+							+ "'spring.json.trusted.packages' property or the 'addTrustedPackages()' method. "
+							+ "Trusting all packages with '*' allows any type on the classpath to be "
+							+ "deserialized, so list the specific packages you need instead.");
 				}
 				else {
 					return this.typeFactory

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/JsonSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/JsonSerializationTests.java
@@ -158,7 +158,10 @@ public class JsonSerializationTests {
 		assertThatIllegalArgumentException()
 				.isThrownBy(() -> dummyEntityJsonDeserializer
 						.deserialize(topic, headers, jsonWriter.serialize(topic, entity)))
-				.withMessageContaining("not in the trusted packages");
+				.withMessageContaining("not in the trusted packages")
+				.withMessageContaining("spring.json.trusted.packages")
+				.withMessageContaining("addTrustedPackages")
+				.withMessageNotContaining("trust all (*)");
 	}
 
 	@Test


### PR DESCRIPTION
**Auto-cherry-pick to `4.1.x` & `4.0.x`**

Update the trusted packages error message and reference docs to point to the current configuration options.
