### PR TITLE
GH-3448: Guard parent from stale children

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ChildAwareMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ChildAwareMessageListenerContainer.java
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.kafka.listener;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.TopicPartition;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.kafka.event.ConsumerStoppedEvent;
+
+/**
+ * A parent container view associated with one generation of child containers. Mutating
+ * operations from an old generation are ignored after the parent has restarted.
+ *
+ * @param <K> the key type.
+ * @param <V> the value type.
+ * @author Sudhanshu Ratna Thakur
+ * @since 4.2
+ */
+final class ChildAwareMessageListenerContainer<K, V> implements MessageListenerContainer {
+
+	private final ConcurrentMessageListenerContainer<K, V> parent;
+
+	private final long generation;
+
+	ChildAwareMessageListenerContainer(ConcurrentMessageListenerContainer<K, V> parent, long generation) {
+
+		this.parent = parent;
+		this.generation = generation;
+	}
+
+	@Override
+	public void setupMessageListener(Object messageListener) {
+		this.parent.invokeIfGenerationCurrent(this.generation, () -> this.parent.setupMessageListener(messageListener));
+	}
+
+	@Override
+	public Map<String, Map<MetricName, ? extends Metric>> metrics() {
+		return this.parent.metrics();
+	}
+
+	@Override
+	public ContainerProperties getContainerProperties() {
+		return this.parent.getContainerProperties();
+	}
+
+	@Override
+	@Nullable
+	public Collection<TopicPartition> getAssignedPartitions() {
+		return this.parent.getAssignedPartitions();
+	}
+
+	@Override
+	@Nullable
+	public Map<String, Collection<TopicPartition>> getAssignmentsByClientId() {
+		return this.parent.getAssignmentsByClientId();
+	}
+
+	@Override
+	public void enforceRebalance() {
+		this.parent.invokeIfGenerationCurrent(this.generation, this.parent::enforceRebalance);
+	}
+
+	@Override
+	public void pause() {
+		this.parent.invokeIfGenerationCurrent(this.generation, this.parent::pause);
+	}
+
+	@Override
+	public void resume() {
+		this.parent.invokeIfGenerationCurrent(this.generation, this.parent::resume);
+	}
+
+	@Override
+	public void pausePartition(TopicPartition topicPartition) {
+		this.parent.invokeIfGenerationCurrent(this.generation, () -> this.parent.pausePartition(topicPartition));
+	}
+
+	@Override
+	public void resumePartition(TopicPartition topicPartition) {
+		this.parent.invokeIfGenerationCurrent(this.generation, () -> this.parent.resumePartition(topicPartition));
+	}
+
+	@Override
+	public boolean isPartitionPauseRequested(TopicPartition topicPartition) {
+		return this.parent.isPartitionPauseRequested(topicPartition);
+	}
+
+	@Override
+	public boolean isPartitionPaused(TopicPartition topicPartition) {
+		return this.parent.isPartitionPaused(topicPartition);
+	}
+
+	@Override
+	public boolean isPauseRequested() {
+		return this.parent.isPauseRequested();
+	}
+
+	@Override
+	public boolean isContainerPaused() {
+		return this.parent.isContainerPaused();
+	}
+
+	@Override
+	public boolean isAutoStartup() {
+		return this.parent.isAutoStartup();
+	}
+
+	@Override
+	public void setAutoStartup(boolean autoStartup) {
+		this.parent.invokeIfGenerationCurrent(this.generation, () -> this.parent.setAutoStartup(autoStartup));
+	}
+
+	@Override
+	@Nullable
+	public String getGroupId() {
+		return this.parent.getGroupId();
+	}
+
+	@Override
+	public String getListenerId() {
+		return this.parent.getListenerId();
+	}
+
+	@Override
+	@Nullable
+	public String getMainListenerId() {
+		return this.parent.getMainListenerId();
+	}
+
+	@Override
+	@Nullable
+	public byte[] getListenerInfo() {
+		return this.parent.getListenerInfo();
+	}
+
+	@Override
+	public boolean isChildRunning() {
+		return this.parent.isChildRunning();
+	}
+
+	@Override
+	public boolean isInExpectedState() {
+		return this.parent.isInExpectedState();
+	}
+
+	@Override
+	public void stopAbnormally(Runnable callback) {
+		this.parent.stopIfGenerationCurrent(this.generation, callback, false);
+	}
+
+	@Override
+	public MessageListenerContainer getContainerFor(String topic, int partition) {
+		return this.parent.getContainerFor(topic, partition);
+	}
+
+	@Override
+	public void childStopped(MessageListenerContainer childContainer, ConsumerStoppedEvent.Reason reason) {
+		this.parent.childStopped(childContainer, reason);
+	}
+
+	@Override
+	public void childStarted(MessageListenerContainer childContainer) {
+		this.parent.childStarted(childContainer);
+	}
+
+	@Override
+	public void start() {
+		this.parent.invokeIfGenerationCurrent(this.generation, this.parent::start);
+	}
+
+	@Override
+	public void stop() {
+		CountDownLatch latch = new CountDownLatch(1);
+		if (this.parent.stopIfGenerationCurrent(this.generation, latch::countDown, true)) {
+			try {
+				latch.await(getContainerProperties().getShutdownTimeout(), TimeUnit.MILLISECONDS); // NOSONAR
+			}
+			catch (@SuppressWarnings("unused") InterruptedException ex) {
+				Thread.currentThread().interrupt();
+			}
+		}
+	}
+
+	@Override
+	public void stop(Runnable callback) {
+		this.parent.stopIfGenerationCurrent(this.generation, callback, true);
+	}
+
+	@Override
+	public boolean isRunning() {
+		return this.parent.isRunning();
+	}
+
+	@Override
+	public int getPhase() {
+		return this.parent.getPhase();
+	}
+
+	@Override
+	public String toString() {
+		return this.parent.toString();
+	}
+
+}

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainer.java
@@ -76,6 +76,8 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 
 	private volatile @Nullable Reason reason;
 
+	private long generation;
+
 	/**
 	 * Construct an instance with the supplied configuration properties.
 	 * The topic partitions are distributed evenly across the delegate
@@ -313,7 +315,42 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 			container = new KafkaMessageListenerContainer<>(this, this.consumerFactory, // NOSONAR
 					containerProperties, partitionSubset(containerProperties, i));
 		}
+		container.setErrorHandlerContainer(new ChildAwareMessageListenerContainer<>(this, this.generation));
 		return container;
+	}
+
+	void invokeIfGenerationCurrent(long childGeneration, Runnable operation) {
+		this.lifecycleLock.lock();
+		try {
+			if (this.generation == childGeneration) {
+				operation.run();
+			}
+		}
+		finally {
+			this.lifecycleLock.unlock();
+		}
+	}
+
+	boolean stopIfGenerationCurrent(long childGeneration, Runnable callback, boolean normal) {
+		this.lifecycleLock.lock();
+		try {
+			if (this.generation != childGeneration) {
+				return false;
+			}
+			if (!isRunning()) {
+				callback.run();
+			}
+			else if (normal) {
+				stop(callback);
+			}
+			else {
+				stopAbnormally(callback);
+			}
+			return true;
+		}
+		finally {
+			this.lifecycleLock.unlock();
+		}
 	}
 
 	private @Nullable TopicPartitionOffset @Nullable [] partitionSubset(ContainerProperties containerProperties, int index) {
@@ -545,6 +582,7 @@ public class ConcurrentMessageListenerContainer<K, V> extends AbstractMessageLis
 	}
 
 	private void clearState() {
+		this.generation++;
 		this.containers.clear();
 		this.startedContainers.set(0);
 		this.reason = null;

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/KafkaMessageListenerContainer.java
@@ -193,6 +193,8 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 
 	private final AbstractMessageListenerContainer<K, V> thisOrParentContainer;
 
+	private MessageListenerContainer errorHandlerContainer;
+
 	private final @Nullable TopicPartitionOffset @Nullable [] topicPartitions;
 
 	private @Nullable String clientIdSuffix;
@@ -247,12 +249,17 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 		super(consumerFactory, containerProperties);
 		Assert.notNull(consumerFactory, "A ConsumerFactory must be provided");
 		this.thisOrParentContainer = container == null ? this : container;
+		this.errorHandlerContainer = this.thisOrParentContainer;
 		if (topicPartitions != null) {
 			this.topicPartitions = Arrays.copyOf(topicPartitions, topicPartitions.length);
 		}
 		else {
 			this.topicPartitions = containerProperties.getTopicPartitions();
 		}
+	}
+
+	void setErrorHandlerContainer(MessageListenerContainer errorHandlerContainer) {
+		this.errorHandlerContainer = errorHandlerContainer;
 	}
 
 	/**
@@ -2139,7 +2146,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 			try {
 				if (this.commonErrorHandler != null) {
 					this.commonErrorHandler.handleOtherException(e, this.consumer,
-							KafkaMessageListenerContainer.this.thisOrParentContainer, this.isBatchListener);
+							KafkaMessageListenerContainer.this.errorHandlerContainer, this.isBatchListener);
 				}
 				else {
 					this.logger.error(e, "Consumer exception");
@@ -2716,12 +2723,12 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 						|| this.transactionManager != null || rte instanceof CommitFailedException) {
 
 					this.commonErrorHandler.handleBatch(rte, records, this.consumer,
-							KafkaMessageListenerContainer.this.thisOrParentContainer,
+							KafkaMessageListenerContainer.this.errorHandlerContainer,
 							() -> invokeBatchOnMessageWithRecordsOrList(records, list));
 				}
 				else {
 					ConsumerRecords<K, V> afterHandling = this.commonErrorHandler.handleBatchAndReturnRemaining(rte,
-							records, this.consumer, KafkaMessageListenerContainer.this.thisOrParentContainer,
+							records, this.consumer, KafkaMessageListenerContainer.this.errorHandlerContainer,
 							() -> invokeBatchOnMessageWithRecordsOrList(records, list));
 
 					if (afterHandling != null && !afterHandling.isEmpty()) {
@@ -3181,7 +3188,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 				List<ConsumerRecord<?, ?>> retryRecords = List.of(cRecord);
 				try {
 					this.commonErrorHandler.handleRemaining(rte, retryRecords, this.consumer,
-							KafkaMessageListenerContainer.this.thisOrParentContainer);
+							KafkaMessageListenerContainer.this.errorHandlerContainer);
 				}
 				catch (RecordInRetryException e) {
 					removeOffsetsInBatch(retryRecords);
@@ -3192,7 +3199,7 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 				boolean handled = false;
 				try {
 					handled = this.commonErrorHandler.handleOne(rte, cRecord, this.consumer,
-							KafkaMessageListenerContainer.this.thisOrParentContainer);
+							KafkaMessageListenerContainer.this.errorHandlerContainer);
 				}
 				catch (Exception ex) {
 					this.logger.error(ex, "ErrorHandler threw unexpected exception");
@@ -3230,13 +3237,13 @@ public class KafkaMessageListenerContainer<K, V> // NOSONAR line count
 						retryRecords.add(iterator.next());
 					}
 					this.commonErrorHandler.handleRemaining(rte, retryRecords, this.consumer,
-							KafkaMessageListenerContainer.this.thisOrParentContainer);
+							KafkaMessageListenerContainer.this.errorHandlerContainer);
 				}
 				else {
 					boolean handled = false;
 					try {
 						handled = this.commonErrorHandler.handleOne(rte, cRecord, this.consumer,
-								KafkaMessageListenerContainer.this.thisOrParentContainer);
+								KafkaMessageListenerContainer.this.errorHandlerContainer);
 					}
 					catch (Exception ex) {
 						this.logger.error(ex, "ErrorHandler threw unexpected exception");

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerMockTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerMockTests.java
@@ -181,8 +181,14 @@ public class ConcurrentMessageListenerContainerMockTests {
 		});
 		container.start();
 		assertThat(latch.await(10, TimeUnit.SECONDS)).isTrue();
-		assertThat(errorContainer.get()).isSameAs(container);
-		container.stop();
+		MessageListenerContainer childAwareContainer = errorContainer.get();
+		assertThat(childAwareContainer).isNotSameAs(container);
+		assertThat(childAwareContainer.getContainerProperties()).isSameAs(container.getContainerProperties());
+		assertThat(childAwareContainer.isRunning()).isEqualTo(container.isRunning());
+		CountDownLatch stopped = new CountDownLatch(1);
+		childAwareContainer.stop(stopped::countDown);
+		assertThat(stopped.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(container.isRunning()).isFalse();
 	}
 
 	@SuppressWarnings({ "rawtypes", "unchecked" })

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ConcurrentMessageListenerContainerTests.java
@@ -68,6 +68,7 @@ import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
@@ -89,7 +90,8 @@ import static org.mockito.Mockito.mock;
 		ConcurrentMessageListenerContainerTests.topic6, ConcurrentMessageListenerContainerTests.topic7,
 		ConcurrentMessageListenerContainerTests.topic8, ConcurrentMessageListenerContainerTests.topic9,
 		ConcurrentMessageListenerContainerTests.topic10, ConcurrentMessageListenerContainerTests.topic11,
-		ConcurrentMessageListenerContainerTests.topic12, ConcurrentMessageListenerContainerTests.topic13},
+		ConcurrentMessageListenerContainerTests.topic12, ConcurrentMessageListenerContainerTests.topic13,
+		ConcurrentMessageListenerContainerTests.topic14},
 		brokerProperties = "group.initial.rebalance.delay.ms:500")
 public class ConcurrentMessageListenerContainerTests {
 
@@ -118,6 +120,8 @@ public class ConcurrentMessageListenerContainerTests {
 	public static final String topic12 = "testTopic12";
 
 	public static final String topic13 = "testTopic13";
+
+	public static final String topic14 = "testTopic14";
 
 	private static EmbeddedKafkaBroker embeddedKafka;
 
@@ -1112,6 +1116,63 @@ public class ConcurrentMessageListenerContainerTests {
 		});
 
 		this.logger.info("Stop containerStartStop");
+	}
+
+	@Test
+	void fencedChildFromPreviousRunDoesNotStopRestartedParent() throws Exception {
+		Map<String, Object> consumerProps = KafkaTestUtils.consumerProps(embeddedKafka, "fencedChild", true);
+		DefaultKafkaConsumerFactory<Integer, String> consumerFactory =
+				new DefaultKafkaConsumerFactory<>(consumerProps);
+		ContainerProperties containerProperties = new ContainerProperties(topic14);
+		CountDownLatch blockedListener = new CountDownLatch(1);
+		CountDownLatch releaseListener = new CountDownLatch(1);
+		CountDownLatch oldListenerFailed = new CountDownLatch(1);
+		AtomicBoolean firstRecord = new AtomicBoolean(true);
+		containerProperties.setMessageListener((MessageListener<Integer, String>) record -> {
+			if (firstRecord.getAndSet(false)) {
+				blockedListener.countDown();
+				try {
+					releaseListener.await(30, TimeUnit.SECONDS);
+				}
+				catch (InterruptedException ex) {
+					Thread.currentThread().interrupt();
+					throw new IllegalStateException(ex);
+				}
+				oldListenerFailed.countDown();
+				throw new IllegalStateException("test exception from fenced child");
+			}
+		});
+
+		ConcurrentMessageListenerContainer<Integer, String> container =
+				new ConcurrentMessageListenerContainer<>(consumerFactory, containerProperties);
+		container.setConcurrency(2);
+		container.setCommonErrorHandler(new CommonContainerStoppingErrorHandler(Runnable::run));
+		container.start();
+		ContainerTestUtils.waitForAssignment(container, embeddedKafka.getPartitionsPerTopic());
+
+		Map<String, Object> producerProps = KafkaTestUtils.producerProps(embeddedKafka);
+		DefaultKafkaProducerFactory<Integer, String> producerFactory =
+				new DefaultKafkaProducerFactory<>(producerProps);
+		KafkaTemplate<Integer, String> template = new KafkaTemplate<>(producerFactory);
+		try {
+			template.send(topic14, 0, 0, "block").get(10, TimeUnit.SECONDS);
+			assertThat(blockedListener.await(10, TimeUnit.SECONDS)).isTrue();
+
+			container.stop();
+			container.start();
+			assertThat(container.isRunning()).isTrue();
+			assertThat(container.getContainers()).allMatch(MessageListenerContainer::isRunning);
+
+			releaseListener.countDown();
+			assertThat(oldListenerFailed.await(10, TimeUnit.SECONDS)).isTrue();
+			await().during(Duration.ofSeconds(1)).atMost(Duration.ofSeconds(5))
+					.untilAsserted(() -> assertThat(container.isRunning()).isTrue());
+		}
+		finally {
+			releaseListener.countDown();
+			container.stop();
+			producerFactory.destroy();
+		}
 	}
 
 }


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-kafka/issues/3448

## Problem

A child `KafkaMessageListenerContainer` can still be processing a record after its concurrent parent is stopped. If the parent is immediately restarted and that old child then fails, its error handler receives the parent and can stop the newly started generation of children.

I reproduced this on current `main` at `6c80b79505f362c69d7e400c9905332c5f6f87fc`; the new regression test failed because the restarted parent changed from running to stopped.

## Change

- give each child error handler a parent-container view bound to the parent generation that created it;
- increment the generation whenever the concurrent parent starts a new child set;
- serialize the generation check and mutating operation with the existing lifecycle lock;
- ignore mutations from stale generations while delegating reads and current-generation operations to the parent; and
- keep the change internal, without new public API.

This is narrower than the closed #3537 approach: it does not subclass `AbstractMessageListenerContainer` or change its constructors/visibility. One observable internal-contract change is that an error handler receives a delegating `MessageListenerContainer` view instead of the identical concurrent-parent object; the view delegates the container API and preserves current-generation stop behavior.

## Tests

Failing before / passing after:

- `ConcurrentMessageListenerContainerTests.fencedChildFromPreviousRunDoesNotStopRestartedParent`

Compatibility:

- `ConcurrentMessageListenerContainerMockTests.testCorrectContainerForConsumerError` verifies the current-generation view exposes parent state and can stop the parent with callback completion.
- Complete `ConcurrentMessageListenerContainerMockTests` and `ConcurrentMessageListenerContainerTests`: 43 tests passed.
- `:spring-kafka:checkstyleMain` and `:spring-kafka:checkstyleTest`: passed.
- Full `./gradlew :spring-kafka:test --no-daemon`: passed in 4m06s.

All commits include the DCO `Signed-off-by` trailer.