### PR TITLE
GH-4634: Prevent ShareConsumerAcknowledgment state regression to RENEW

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/ShareKafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/ShareKafkaMessageListenerContainer.java
@@ -796,7 +796,7 @@ public class ShareKafkaMessageListenerContainer<K, V>
 			private void acknowledgeInternal(AcknowledgeType type) {
 				if (type == AcknowledgeType.RENEW) {
 					AcknowledgeType current = this.acknowledgmentType.get();
-					if (current == AcknowledgeType.ACCEPT || current == AcknowledgeType.RELEASE || current == AcknowledgeType.REJECT) {
+					if (isTerminal(current)) {
 						throw new IllegalStateException(
 								String.format("Record at offset %d has already been terminally acknowledged with type %s",
 										this.record.offset(), current));
@@ -827,8 +827,13 @@ public class ShareKafkaMessageListenerContainer<K, V>
 						new PendingAcknowledgment<>(this.record, type));
 			}
 
-		void notifyAcknowledged(AcknowledgeType type) {
-				this.acknowledgmentType.set(type);
+			void notifyAcknowledged(AcknowledgeType type) {
+				this.acknowledgmentType.accumulateAndGet(type,
+						(current, next) -> isTerminal(current) ? current : next);
+			}
+
+			private static boolean isTerminal(@Nullable AcknowledgeType type) {
+				return type == AcknowledgeType.ACCEPT || type == AcknowledgeType.RELEASE || type == AcknowledgeType.REJECT;
 			}
 
 			boolean isAcknowledged() {

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ShareKafkaMessageListenerContainerUnitTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ShareKafkaMessageListenerContainerUnitTests.java
@@ -51,6 +51,7 @@ import org.springframework.kafka.event.ConsumerStoppedEvent;
 import org.springframework.kafka.event.ConsumerStoppedEvent.Reason;
 import org.springframework.kafka.event.ShareConsumerStoppingEvent;
 import org.springframework.kafka.listener.ContainerProperties.ShareAckMode;
+import org.springframework.kafka.support.ShareAcknowledgment;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -899,6 +900,61 @@ public class ShareKafkaMessageListenerContainerUnitTests {
 			assertThatExceptionOfType(IllegalStateException.class)
 					.isThrownBy(() -> container.getClientInstanceIds(Duration.ZERO))
 					.withMessage("telemetry disabled");
+		}
+		finally {
+			container.stop();
+		}
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	void shareConsumerAcknowledgmentStateShouldNotRegressFromTerminalToRenew() throws Exception {
+		ShareConsumerFactory<String, String> mockFactory = mock(ShareConsumerFactory.class);
+		given(mockFactory.getConfigurationProperties()).willReturn(Map.of());
+		ShareConsumer<String, String> mockConsumer = mock(ShareConsumer.class);
+		given(mockFactory.createShareConsumer(any(), any(), any())).willReturn(mockConsumer);
+
+		ConsumerRecord<String, String> record = new ConsumerRecord<>("test-topic", 0, 0L, "key", "value");
+		ConsumerRecords<String, String> records = new ConsumerRecords<>(Map.of(new TopicPartition("test-topic", 0), List.of(record)));
+
+		CountDownLatch pollLatch = new CountDownLatch(1);
+		lenient().when(mockConsumer.poll(any())).thenAnswer(invocation -> {
+			if (pollLatch.getCount() > 0) {
+				pollLatch.countDown();
+				return records;
+			}
+			Thread.sleep(10);
+			return ConsumerRecords.empty();
+		});
+
+		CountDownLatch ackLatch = new CountDownLatch(1);
+		AtomicReference<ShareAcknowledgment> ackRef = new AtomicReference<>();
+
+		ContainerProperties containerProperties = new ContainerProperties("test-topic");
+		containerProperties.setShareAckMode(ShareAckMode.MANUAL);
+		containerProperties.setMessageListener((AcknowledgingShareConsumerAwareMessageListener<String, String>)
+				(rec, ack, consumer) -> {
+					ackRef.set(ack);
+					ack.renew();
+					ack.acknowledge();
+					ackLatch.countDown();
+				});
+
+		ShareKafkaMessageListenerContainer<String, String> container =
+				new ShareKafkaMessageListenerContainer<>(mockFactory, containerProperties);
+		container.setBeanName("shareAckRegressionTestContainer");
+		container.start();
+
+		try {
+			assertThat(ackLatch.await(5, TimeUnit.SECONDS)).isTrue();
+			Thread.sleep(100);
+
+			ShareAcknowledgment ack = ackRef.get();
+			assertThat(ack).isNotNull();
+
+			assertThatExceptionOfType(IllegalStateException.class)
+					.isThrownBy(ack::release)
+					.withMessageContaining("has already been acknowledged with type accept");
 		}
 		finally {
 			container.stop();


### PR DESCRIPTION
### Summary
Fixes #4634

In `ShareAckMode.MANUAL`, when a `renew()` call is followed by a terminal acknowledgment (`acknowledge()`, `release()`, or `reject()`) before the consumer thread drains the queued acknowledgments, `notifyAcknowledged(RENEW)` on the consumer thread was unconditionally overwriting `acknowledgmentType`, regressing the state back to `RENEW`.

This regression allowed subsequent calls on the already-completed acknowledgment to pass the `compareAndSet(RENEW, type)` guard and queue duplicate terminal acknowledgments to Kafka.

### Changes
- Updated `notifyAcknowledged(AcknowledgeType type)` in `ShareConsumerAcknowledgment` to use `accumulateAndGet` guarded by `isTerminal(current)`.
- Added unit test `shareConsumerAcknowledgmentStateShouldNotRegressFromTerminalToRenew` to `ShareKafkaMessageListenerContainerUnitTests`.

### Checklist
- [x] Contributor Covenant Code of Conduct followed
- [x] Developer Certificate of Origin (DCO) Signed-off (`git commit -s`)
- [x] Unit tests added & passing (`./gradlew :spring-kafka:test`)
- [x] Code conventions adhered to (tabs, formatting)
