### PR TITLE
Apply nullability to `Serializer` subclass

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingByTopicSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingByTopicSerializer.java
@@ -71,9 +71,13 @@ public class DelegatingByTopicSerializer extends DelegatingByTopicSerialization<
 		return instance instanceof Serializer;
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public byte @Nullable [] serialize(String topic, @Nullable Object data) {
-		throw new UnsupportedOperationException();
+		if (data == null) {
+			return null;
+		}
+		return ((Serializer<Object>) findDelegate(topic)).serialize(topic, data);
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingByTopicSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingByTopicSerializer.java
@@ -21,11 +21,16 @@ import java.util.regex.Pattern;
 
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Serializer;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.util.Assert;
 
 /**
  * A {@link Serializer} that delegates to other serializers based on a topic pattern.
  *
  * @author Gary Russell
+ * @author Ngoc Nhan
+ *
  * @since 2.8
  *
  */
@@ -67,13 +72,14 @@ public class DelegatingByTopicSerializer extends DelegatingByTopicSerialization<
 	}
 
 	@Override
-	public byte[] serialize(String topic, Object data) {
+	public byte @Nullable [] serialize(String topic, @Nullable Object data) {
 		throw new UnsupportedOperationException();
 	}
 
-	@SuppressWarnings({"unchecked", "NullAway"}) // Dataflow analysis limitation
+	@SuppressWarnings("unchecked")
 	@Override
-	public byte[] serialize(String topic, Headers headers, Object data) {
+	public byte @Nullable [] serialize(String topic, Headers headers, @Nullable Object data) {
+		Assert.notNull(headers, "'headers' cannot be null");
 		if (data == null) {
 			return null;
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingByTopicSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingByTopicSerializer.java
@@ -23,8 +23,6 @@ import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Serializer;
 import org.jspecify.annotations.Nullable;
 
-import org.springframework.util.Assert;
-
 /**
  * A {@link Serializer} that delegates to other serializers based on a topic pattern.
  *
@@ -83,7 +81,6 @@ public class DelegatingByTopicSerializer extends DelegatingByTopicSerialization<
 	@SuppressWarnings("unchecked")
 	@Override
 	public byte @Nullable [] serialize(String topic, Headers headers, @Nullable Object data) {
-		Assert.notNull(headers, "'headers' cannot be null");
 		if (data == null) {
 			return null;
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingByTypeSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingByTypeSerializer.java
@@ -101,7 +101,6 @@ public class DelegatingByTypeSerializer implements Serializer<Object> {
 
 	@Override
 	public byte @Nullable [] serialize(String topic, Headers headers, @Nullable Object data) {
-		Assert.notNull(headers, "'headers' cannot be null");
 		if (data == null) {
 			return null;
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingByTypeSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingByTypeSerializer.java
@@ -23,6 +23,7 @@ import java.util.Map.Entry;
 import org.apache.kafka.common.errors.SerializationException;
 import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Serializer;
+import org.jspecify.annotations.Nullable;
 
 import org.springframework.util.Assert;
 
@@ -35,6 +36,7 @@ import org.springframework.util.Assert;
  * @author Mahesh Aravind V
  * @author Jiwoo Lee
  * @author Seonghun Lee
+ * @author Ngoc Nhan
  *
  * @since 2.7.9
  *
@@ -88,9 +90,8 @@ public class DelegatingByTypeSerializer implements Serializer<Object> {
 		this.delegates.values().forEach(del -> del.configure(configs, isKey));
 	}
 
-	@SuppressWarnings("NullAway") // Dataflow analysis limitation
 	@Override
-	public byte[] serialize(String topic, Object data) {
+	public byte @Nullable [] serialize(String topic, @Nullable Object data) {
 		if (data == null) {
 			return null;
 		}
@@ -98,9 +99,9 @@ public class DelegatingByTypeSerializer implements Serializer<Object> {
 		return delegate.serialize(topic, data);
 	}
 
-	@SuppressWarnings("NullAway") // Dataflow analysis limitation
 	@Override
-	public byte[] serialize(String topic, Headers headers, Object data) {
+	public byte @Nullable [] serialize(String topic, Headers headers, @Nullable Object data) {
+		Assert.notNull(headers, "'headers' cannot be null");
 		if (data == null) {
 			return null;
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingSerializer.java
@@ -39,6 +39,8 @@ import org.springframework.util.StringUtils;
  * we will delegate to that serializer type.
  *
  * @author Gary Russell
+ * @author Ngoc Nhan
+ *
  * @since 2.3
  *
  */
@@ -183,13 +185,13 @@ public class DelegatingSerializer implements Serializer<Object> {
 	}
 
 	@Override
-	public byte[] serialize(String topic, Object data) {
+	public byte @Nullable [] serialize(String topic, @Nullable Object data) {
 		throw new UnsupportedOperationException();
 	}
 
-	@SuppressWarnings("NullAway") // Dataflow analysis limitation
 	@Override
-	public byte[] serialize(String topic, Headers headers, Object data) {
+	public byte @Nullable [] serialize(String topic, Headers headers, @Nullable Object data) {
+		Assert.notNull(headers, "'headers' cannot be null");
 		if (data == null) {
 			return null;
 		}
@@ -230,8 +232,7 @@ public class DelegatingSerializer implements Serializer<Object> {
 	/*
 	 * Package for testing.
 	 */
-	@SuppressWarnings("NullAway") // Dataflow analysis limitation
-	byte[] trySerdes(Object data) {
+	byte @Nullable [] trySerdes(Object data) {
 		try {
 			Serde<? extends Object> serdeFrom = Serdes.serdeFrom(data.getClass());
 			Serializer<?> serializer = serdeFrom.serializer();

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingSerializer.java
@@ -191,7 +191,6 @@ public class DelegatingSerializer implements Serializer<Object> {
 
 	@Override
 	public byte @Nullable [] serialize(String topic, Headers headers, @Nullable Object data) {
-		Assert.notNull(headers, "'headers' cannot be null");
 		if (data == null) {
 			return null;
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JacksonJsonSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JacksonJsonSerializer.java
@@ -55,6 +55,7 @@ import org.springframework.util.StringUtils;
  * @author Omer Celik
  * @author Soby Chacko
  * @author Trond Ziarkowski
+ * @author Ngoc Nhan
  *
  * @since 4.0
  */
@@ -99,7 +100,7 @@ public class JacksonJsonSerializer<T> implements Serializer<T> {
 		this((JavaType) null, jsonMapper);
 	}
 
-	public JacksonJsonSerializer(TypeReference<? super T> targetType, JsonMapper jsonMapper) {
+	public JacksonJsonSerializer(@Nullable TypeReference<? super T> targetType, JsonMapper jsonMapper) {
 		this(targetType == null ? null : jsonMapper.constructType(targetType.getType()), jsonMapper);
 	}
 
@@ -205,10 +206,11 @@ public class JacksonJsonSerializer<T> implements Serializer<T> {
 
 	@Override
 	public byte @Nullable [] serialize(String topic, Headers headers, @Nullable T data) {
+		Assert.notNull(headers, "'headers' cannot be null");
 		if (data == null) {
 			return null;
 		}
-		if (this.addTypeInfo && headers != null) {
+		if (this.addTypeInfo) {
 			this.typeMapper.fromJavaType(this.jsonMapper.constructType(data.getClass()), headers);
 		}
 		return serialize(topic, data);

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JacksonJsonSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JacksonJsonSerializer.java
@@ -206,11 +206,10 @@ public class JacksonJsonSerializer<T> implements Serializer<T> {
 
 	@Override
 	public byte @Nullable [] serialize(String topic, Headers headers, @Nullable T data) {
-		Assert.notNull(headers, "'headers' cannot be null");
 		if (data == null) {
 			return null;
 		}
-		if (this.addTypeInfo) {
+		if (this.addTypeInfo && headers != null) {
 			this.typeMapper.fromJavaType(this.jsonMapper.constructType(data.getClass()), headers);
 		}
 		return serialize(topic, data);

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerializer.java
@@ -208,11 +208,10 @@ public class JsonSerializer<T> implements Serializer<T> {
 
 	@Override
 	public byte @Nullable [] serialize(String topic, Headers headers, @Nullable T data) {
-		Assert.notNull(headers, "'headers' cannot be null");
 		if (data == null) {
 			return null;
 		}
-		if (this.addTypeInfo) {
+		if (this.addTypeInfo && headers != null) {
 			this.typeMapper.fromJavaType(this.objectMapper.constructType(data.getClass()), headers);
 		}
 		return serialize(topic, data);

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JsonSerializer.java
@@ -55,6 +55,7 @@ import org.springframework.util.StringUtils;
  * @author Elliot Kennedy
  * @author Wang Zhiyang
  * @author Omer Celik
+ * @author Ngoc Nhan
  *
  * @deprecated since 4.0 in favor of {@link JacksonJsonSerializer} for Jackson 3.
  */
@@ -101,7 +102,7 @@ public class JsonSerializer<T> implements Serializer<T> {
 		this((JavaType) null, objectMapper);
 	}
 
-	public JsonSerializer(TypeReference<? super T> targetType, ObjectMapper objectMapper) {
+	public JsonSerializer(@Nullable TypeReference<? super T> targetType, ObjectMapper objectMapper) {
 		this(targetType == null ? null : objectMapper.constructType(targetType.getType()), objectMapper);
 	}
 
@@ -205,21 +206,20 @@ public class JsonSerializer<T> implements Serializer<T> {
 		return mappingsMap;
 	}
 
-	@SuppressWarnings("NullAway") // Dataflow analysis limitation
 	@Override
-	public byte[] serialize(String topic, Headers headers, @Nullable T data) {
+	public byte @Nullable [] serialize(String topic, Headers headers, @Nullable T data) {
+		Assert.notNull(headers, "'headers' cannot be null");
 		if (data == null) {
 			return null;
 		}
-		if (this.addTypeInfo && headers != null) {
+		if (this.addTypeInfo) {
 			this.typeMapper.fromJavaType(this.objectMapper.constructType(data.getClass()), headers);
 		}
 		return serialize(topic, data);
 	}
 
-	@SuppressWarnings("NullAway") // Dataflow analysis limitation
 	@Override
-	public byte[] serialize(String topic, @Nullable T data) {
+	public byte @Nullable [] serialize(String topic, @Nullable T data) {
 		if (data == null) {
 			return null;
 		}

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/StringOrBytesSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/StringOrBytesSerializer.java
@@ -24,8 +24,6 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.jspecify.annotations.Nullable;
 
-import org.springframework.util.Assert;
-
 /**
  * A serializer that can handle {@code byte[]}, {@link Bytes} and {@link String}.
  * Convenient when used with one of the Json message converters.
@@ -67,7 +65,6 @@ public class StringOrBytesSerializer implements Serializer<Object> {
 
 	@Override
 	public byte @Nullable [] serialize(String topic, Headers headers, @Nullable Object data) {
-		Assert.notNull(headers, "'headers' cannot be null");
 		return serialize(topic, data);
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/StringOrBytesSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/StringOrBytesSerializer.java
@@ -18,9 +18,13 @@ package org.springframework.kafka.support.serializer;
 
 import java.util.Map;
 
+import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.common.utils.Bytes;
+import org.jspecify.annotations.Nullable;
+
+import org.springframework.util.Assert;
 
 /**
  * A serializer that can handle {@code byte[]}, {@link Bytes} and {@link String}.
@@ -40,9 +44,8 @@ public class StringOrBytesSerializer implements Serializer<Object> {
 		this.stringSerializer.configure(configs, isKey);
 	}
 
-	@SuppressWarnings("NullAway") // Dataflow analysis limitation
 	@Override
-	public byte[] serialize(String topic, Object data) {
+	public byte @Nullable [] serialize(String topic, @Nullable Object data) {
 		if (data == null) {
 			return null;
 		}
@@ -60,6 +63,12 @@ public class StringOrBytesSerializer implements Serializer<Object> {
 		}
 
 		throw new IllegalStateException("This serializer can only handle byte[], Bytes or String values");
+	}
+
+	@Override
+	public byte @Nullable [] serialize(String topic, Headers headers, @Nullable Object data) {
+		Assert.notNull(headers, "'headers' cannot be null");
+		return serialize(topic, data);
 	}
 
 	@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ToStringSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ToStringSerializer.java
@@ -93,8 +93,10 @@ public class ToStringSerializer<T> implements Serializer<T> {
 
 	@Override
 	public byte @Nullable [] serialize(String topic, Headers headers, @Nullable T data) {
-		Assert.notNull(headers, "'headers' cannot be null");
-		if (this.addTypeInfo && data != null) {
+		if (data == null) {
+			return null;
+		}
+		if (this.addTypeInfo && headers != null) {
 			headers.add(this.typeInfoHeader, data.getClass().getName().getBytes());
 		}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ToStringSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ToStringSerializer.java
@@ -34,6 +34,8 @@ import org.springframework.util.Assert;
  *
  * @author Alexei Klenin
  * @author Gary Russell
+ * @author Ngoc Nhan
+ *
  * @since 2.5
  */
 public class ToStringSerializer<T> implements Serializer<T> {
@@ -81,22 +83,24 @@ public class ToStringSerializer<T> implements Serializer<T> {
 	}
 
 	@Override
-	public byte[] serialize(String topic, @Nullable T data) {
-		return serialize(topic, null, data);
-	}
+	public byte @Nullable [] serialize(String topic, @Nullable T data) {
 
-	@Override
-	@SuppressWarnings("NullAway") // Dataflow analysis limitation
-	public byte[] serialize(String topic, @Nullable Headers headers, @Nullable T data) {
 		if (data == null) {
 			return null;
 		}
 
-		if (this.addTypeInfo && headers != null) {
+		return data.toString().getBytes(this.charset);
+	}
+
+	@Override
+	public byte @Nullable [] serialize(String topic, Headers headers, @Nullable T data) {
+
+		Assert.notNull(headers, "'headers' cannot be null");
+		if (this.addTypeInfo && data != null) {
 			headers.add(this.typeInfoHeader, data.getClass().getName().getBytes());
 		}
 
-		return data.toString().getBytes(this.charset);
+		return serialize(topic, data);
 	}
 
 	@Override

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ToStringSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ToStringSerializer.java
@@ -84,7 +84,6 @@ public class ToStringSerializer<T> implements Serializer<T> {
 
 	@Override
 	public byte @Nullable [] serialize(String topic, @Nullable T data) {
-
 		if (data == null) {
 			return null;
 		}
@@ -94,7 +93,6 @@ public class ToStringSerializer<T> implements Serializer<T> {
 
 	@Override
 	public byte @Nullable [] serialize(String topic, Headers headers, @Nullable T data) {
-
 		Assert.notNull(headers, "'headers' cannot be null");
 		if (this.addTypeInfo && data != null) {
 			headers.add(this.typeInfoHeader, data.getClass().getName().getBytes());

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/DelegatingByTopicSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/DelegatingByTopicSerializationTests.java
@@ -35,7 +35,6 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
@@ -173,9 +172,6 @@ public class DelegatingByTopicSerializationTests {
 
 			assertThat(serializer.serialize("topic", null)).isNull();
 			assertThat(serializer.serialize("topic", new RecordHeaders(), null)).isNull();
-			assertThatIllegalArgumentException()
-					.isThrownBy(() -> serializer.serialize("topic", null, null))
-					.withMessage("'headers' cannot be null");
 		}
 	}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/DelegatingByTopicSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/DelegatingByTopicSerializationTests.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.BytesDeserializer;
@@ -34,6 +35,8 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
@@ -41,6 +44,7 @@ import static org.mockito.Mockito.verify;
  * @author Gary Russell
  * @author Wang Zhiyang
  * @author Rene Choi
+ * @author Ngoc Nhan
  *
  * @since 2.8
  *
@@ -161,6 +165,20 @@ public class DelegatingByTopicSerializationTests {
 
 		verify(patternDelegate).close();
 		verify(defaultDelegate).close();
+	}
+
+	@Test
+	void serializeWithNullDataOrHeaders() {
+
+		try (DelegatingByTopicSerializer serializer = new DelegatingByTopicSerializer()) {
+
+			assertThat(serializer.serialize("topic", new RecordHeaders(), null)).isNull();
+			assertThatExceptionOfType(UnsupportedOperationException.class)
+					.isThrownBy(() -> serializer.serialize("topic", null));
+			assertThatIllegalArgumentException()
+					.isThrownBy(() -> serializer.serialize("topic", null, null))
+					.withMessage("'headers' cannot be null");
+		}
 	}
 
 	private void assertThatSerializer(DelegatingByTopicSerializer serializer) {

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/DelegatingByTopicSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/DelegatingByTopicSerializationTests.java
@@ -76,7 +76,7 @@ public class DelegatingByTopicSerializationTests {
 		deserializer.configure(configs, false);
 		assertThatDeserializer(deserializer);
 		assertThat(deserializer.findDelegate("Foo")).isInstanceOf(BytesDeserializer.class);
-		byte[] serialized = serializer.serialize("baz", null, "qux");
+		byte[] serialized = serializer.serialize("baz", new RecordHeaders(), "qux");
 		assertThat(deserializer.deserialize("baz", null, serialized)).isEqualTo("qux");
 		assertThat(deserializer.deserialize("baz", null, ByteBuffer.wrap(serialized))).isEqualTo("qux");
 	}
@@ -119,7 +119,7 @@ public class DelegatingByTopicSerializationTests {
 		configs.put(DelegatingByTopicSerializer.KEY_SERIALIZATION_TOPIC_DEFAULT, ByteArrayDeserializer.class);
 		deserializer.configure(configs, true);
 		assertThatDeserializer(deserializer);
-		byte[] serialized = serializer.serialize("baz", null, "qux");
+		byte[] serialized = serializer.serialize("baz", new RecordHeaders(), "qux");
 		assertThat(deserializer.deserialize("baz", null, serialized)).isEqualTo("qux");
 		assertThat(deserializer.deserialize("baz", null, ByteBuffer.wrap(serialized))).isEqualTo("qux");
 	}

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/DelegatingByTopicSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/DelegatingByTopicSerializationTests.java
@@ -35,7 +35,6 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
@@ -76,7 +75,7 @@ public class DelegatingByTopicSerializationTests {
 		deserializer.configure(configs, false);
 		assertThatDeserializer(deserializer);
 		assertThat(deserializer.findDelegate("Foo")).isInstanceOf(BytesDeserializer.class);
-		byte[] serialized = serializer.serialize("baz", new RecordHeaders(), "qux");
+		byte[] serialized = serializer.serialize("baz", "qux");
 		assertThat(deserializer.deserialize("baz", null, serialized)).isEqualTo("qux");
 		assertThat(deserializer.deserialize("baz", null, ByteBuffer.wrap(serialized))).isEqualTo("qux");
 	}
@@ -119,7 +118,7 @@ public class DelegatingByTopicSerializationTests {
 		configs.put(DelegatingByTopicSerializer.KEY_SERIALIZATION_TOPIC_DEFAULT, ByteArrayDeserializer.class);
 		deserializer.configure(configs, true);
 		assertThatDeserializer(deserializer);
-		byte[] serialized = serializer.serialize("baz", new RecordHeaders(), "qux");
+		byte[] serialized = serializer.serialize("baz", "qux");
 		assertThat(deserializer.deserialize("baz", null, serialized)).isEqualTo("qux");
 		assertThat(deserializer.deserialize("baz", null, ByteBuffer.wrap(serialized))).isEqualTo("qux");
 	}
@@ -172,9 +171,8 @@ public class DelegatingByTopicSerializationTests {
 
 		try (DelegatingByTopicSerializer serializer = new DelegatingByTopicSerializer()) {
 
+			assertThat(serializer.serialize("topic", null)).isNull();
 			assertThat(serializer.serialize("topic", new RecordHeaders(), null)).isNull();
-			assertThatExceptionOfType(UnsupportedOperationException.class)
-					.isThrownBy(() -> serializer.serialize("topic", null));
 			assertThatIllegalArgumentException()
 					.isThrownBy(() -> serializer.serialize("topic", null, null))
 					.withMessage("'headers' cannot be null");

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/DelegatingSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/DelegatingSerializationTests.java
@@ -44,7 +44,6 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -345,24 +344,17 @@ public class DelegatingSerializationTests {
 
 	@Test
 	void serializeWithNullDataOrHeaders() {
-
 		try (DelegatingSerializer serializer = new DelegatingSerializer()) {
 
 			assertThat(serializer.serialize("topic", new RecordHeaders(), null)).isNull();
 			assertThatExceptionOfType(UnsupportedOperationException.class)
 					.isThrownBy(() -> serializer.serialize("topic", null));
-			assertThatIllegalArgumentException()
-					.isThrownBy(() -> serializer.serialize("topic", null, null))
-					.withMessage("'headers' cannot be null");
 		}
 
 		try (DelegatingByTypeSerializer serializer = new DelegatingByTypeSerializer(Map.of())) {
 
 			assertThat(serializer.serialize("topic", null)).isNull();
 			assertThat(serializer.serialize("topic", new RecordHeaders(), null)).isNull();
-			assertThatIllegalArgumentException()
-					.isThrownBy(() -> serializer.serialize("topic", null, null))
-					.withMessage("'headers' cannot be null");
 		}
 	}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/DelegatingSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/DelegatingSerializationTests.java
@@ -44,6 +44,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -55,6 +56,7 @@ import static org.mockito.Mockito.verify;
  * @author Soby Chacko
  * @author Jiwoo Lee
  * @author Seonghun Lee
+ * @author Ngoc Nhan
  *
  * @since 2.3
  *
@@ -339,6 +341,29 @@ public class DelegatingSerializationTests {
 
 		verify(stringSerializer).close();
 		verify(bytesSerializer).close();
+	}
+
+	@Test
+	void serializeWithNullDataOrHeaders() {
+
+		try (DelegatingSerializer serializer = new DelegatingSerializer()) {
+
+			assertThat(serializer.serialize("topic", new RecordHeaders(), null)).isNull();
+			assertThatExceptionOfType(UnsupportedOperationException.class)
+					.isThrownBy(() -> serializer.serialize("topic", null));
+			assertThatIllegalArgumentException()
+					.isThrownBy(() -> serializer.serialize("topic", null, null))
+					.withMessage("'headers' cannot be null");
+		}
+
+		try (DelegatingByTypeSerializer serializer = new DelegatingByTypeSerializer(Map.of())) {
+
+			assertThat(serializer.serialize("topic", null)).isNull();
+			assertThat(serializer.serialize("topic", new RecordHeaders(), null)).isNull();
+			assertThatIllegalArgumentException()
+					.isThrownBy(() -> serializer.serialize("topic", null, null))
+					.withMessage("'headers' cannot be null");
+		}
 	}
 
 	interface AwareIface {

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/JsonSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/JsonSerializationTests.java
@@ -64,6 +64,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
  * @author Gary Russell
  * @author Ivan Ponomarev
  * @author Soby Chacko
+ * @author Ngoc Nhan
  */
 public class JsonSerializationTests {
 
@@ -456,6 +457,19 @@ public class JsonSerializationTests {
 
 			String typeHeader = new String(headers.lastHeader("__TypeId__").value(), StandardCharsets.UTF_8);
 			assertThat(typeHeader).isEqualTo("my-alias");
+		}
+	}
+
+	@Test
+	void serializeWithNullDataOrHeaders() {
+
+		try (JacksonJsonSerializer<Object> serializer = new JacksonJsonSerializer<>()) {
+
+			assertThat(serializer.serialize("topic", null)).isNull();
+			assertThat(serializer.serialize("topic", new RecordHeaders(), null)).isNull();
+			assertThatIllegalArgumentException()
+					.isThrownBy(() -> serializer.serialize("topic", null, null))
+					.withMessage("'headers' cannot be null");
 		}
 	}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/JsonSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/JsonSerializationTests.java
@@ -467,9 +467,6 @@ public class JsonSerializationTests {
 
 			assertThat(serializer.serialize("topic", null)).isNull();
 			assertThat(serializer.serialize("topic", new RecordHeaders(), null)).isNull();
-			assertThatIllegalArgumentException()
-					.isThrownBy(() -> serializer.serialize("topic", null, null))
-					.withMessage("'headers' cannot be null");
 		}
 	}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/StringOrBytesSerializerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/StringOrBytesSerializerTests.java
@@ -27,7 +27,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 /**
@@ -62,14 +61,10 @@ public class StringOrBytesSerializerTests {
 
 	@Test
 	void serializeWithNullDataOrHeaders() {
-
 		try (StringOrBytesSerializer serializer = new StringOrBytesSerializer()) {
 
 			assertThat(serializer.serialize("topic", null)).isNull();
 			assertThat(serializer.serialize("topic", new RecordHeaders(), null)).isNull();
-			assertThatIllegalArgumentException()
-					.isThrownBy(() -> serializer.serialize("topic", null, null))
-					.withMessage("'headers' cannot be null");
 		}
 	}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/StringOrBytesSerializerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/StringOrBytesSerializerTests.java
@@ -20,12 +20,14 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.Map;
 
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.apache.kafka.common.utils.Bytes;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
 /**
@@ -56,6 +58,19 @@ public class StringOrBytesSerializerTests {
 		assertThat(serializer.serialize("null", null)).isNull();
 		assertThatIllegalStateException().isThrownBy(() -> serializer.serialize("ex", 0))
 				.withMessage("This serializer can only handle byte[], Bytes or String values");
+	}
+
+	@Test
+	void serializeWithNullDataOrHeaders() {
+
+		try (StringOrBytesSerializer serializer = new StringOrBytesSerializer()) {
+
+			assertThat(serializer.serialize("topic", null)).isNull();
+			assertThat(serializer.serialize("topic", new RecordHeaders(), null)).isNull();
+			assertThatIllegalArgumentException()
+					.isThrownBy(() -> serializer.serialize("topic", null, null))
+					.withMessage("'headers' cannot be null");
+		}
 	}
 
 }

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/ToStringSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/ToStringSerializationTests.java
@@ -31,7 +31,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.kafka.support.serializer.testentities.DummyEntity;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 /**
  *
@@ -330,9 +329,6 @@ public class ToStringSerializationTests {
 
 			assertThat(serializer.serialize("topic", null)).isNull();
 			assertThat(serializer.serialize("topic", new RecordHeaders(), null)).isNull();
-			assertThatIllegalArgumentException()
-					.isThrownBy(() -> serializer.serialize("topic", null, null))
-					.withMessage("'headers' cannot be null");
 		}
 	}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/ToStringSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/ToStringSerializationTests.java
@@ -31,11 +31,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.kafka.support.serializer.testentities.DummyEntity;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
 /**
  *
  * @author Alexei Klenin
  * @author Gary Russell
+ * @author Ngoc Nhan
  *
  * @since 2.5
  */
@@ -319,6 +321,19 @@ public class ToStringSerializationTests {
 				.hasFieldOrPropertyWithValue("third", true);
 		assertThat(deserializedWithUtf8.first)
 				.isNotEqualTo("tôtô");
+	}
+
+	@Test
+	void serializeWithNullDataOrHeaders() {
+
+		try (ToStringSerializer<Object> serializer = new ToStringSerializer<>()) {
+
+			assertThat(serializer.serialize("topic", null)).isNull();
+			assertThat(serializer.serialize("topic", new RecordHeaders(), null)).isNull();
+			assertThatIllegalArgumentException()
+					.isThrownBy(() -> serializer.serialize("topic", null, null))
+					.withMessage("'headers' cannot be null");
+		}
 	}
 
 	public static Object parseWithHeaders(@Nullable String str, Headers headers) {


### PR DESCRIPTION
* Add `@Nullable` to `targetType`
* Remove `@SuppressWarnings("NullAway")`
* Add `@Nullable` to the return value of `serialize`
* Add `@Nullable` to `data`
* `Implement DelegatingByTopicSerializer#serialize`

See https://kafka.apache.org/43/javadoc/org/apache/kafka/common/serialization/Serializer.html