### PR TITLE
Configure the default delegate in DelegatingByTopicSerialization

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingByTopicSerialization.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/DelegatingByTopicSerialization.java
@@ -128,6 +128,9 @@ public abstract class DelegatingByTopicSerialization<T extends Closeable> implem
 		if (configs.containsKey(configKey)) {
 			buildDefault(configs, configKey, isKey, configs.get(configKey));
 		}
+		else if (this.defaultDelegate != null) {
+			configureDelegate(configs, isKey, this.defaultDelegate);
+		}
 		configKey = configKey();
 		Object value = configs.get(configKey);
 		if (value == null) {

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/DelegatingByTopicSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/DelegatingByTopicSerializationTests.java
@@ -17,6 +17,7 @@
 package org.springframework.kafka.support.serializer;
 
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -173,6 +174,36 @@ public class DelegatingByTopicSerializationTests {
 			assertThat(serializer.serialize("topic", null)).isNull();
 			assertThat(serializer.serialize("topic", new RecordHeaders(), null)).isNull();
 		}
+	}
+
+	@Test
+	void configureConfiguresDefaultSerializerDelegate() {
+		Serializer<?> patternDelegate = spy(new StringSerializer());
+		Serializer<?> defaultDelegate = spy(new StringSerializer());
+		DelegatingByTopicSerializer serializer = new DelegatingByTopicSerializer(
+				Map.of(Pattern.compile("foo"), patternDelegate), defaultDelegate);
+		Map<String, Object> configs = Map.of("value.serializer.encoding", "UTF-16");
+
+		serializer.configure(configs, false);
+
+		verify(patternDelegate).configure(configs, false);
+		verify(defaultDelegate).configure(configs, false);
+		assertThat(serializer.serialize("other", "abc")).isEqualTo("abc".getBytes(StandardCharsets.UTF_16));
+	}
+
+	@Test
+	void configureConfiguresDefaultDeserializerDelegate() {
+		Deserializer<?> patternDelegate = spy(new StringDeserializer());
+		Deserializer<?> defaultDelegate = spy(new StringDeserializer());
+		DelegatingByTopicDeserializer deserializer = new DelegatingByTopicDeserializer(
+				Map.of(Pattern.compile("foo"), patternDelegate), defaultDelegate);
+		Map<String, Object> configs = Map.of("value.deserializer.encoding", "UTF-16");
+
+		deserializer.configure(configs, false);
+
+		verify(patternDelegate).configure(configs, false);
+		verify(defaultDelegate).configure(configs, false);
+		assertThat(deserializer.deserialize("other", null, "abc".getBytes(StandardCharsets.UTF_16))).isEqualTo("abc");
 	}
 
 	private void assertThatSerializer(DelegatingByTopicSerializer serializer) {


### PR DESCRIPTION
The fallback delegate lives in its own `defaultDelegate` field, outside the pattern-keyed `delegates` map: `buildDefault()` passes a `null` pattern, so `instantiateAndConfigure()` never puts it there.

`configure()` walks `delegates.values()`, then rebuilds the default only when the config map carries the default key. A default passed to the two-arg constructor is never configured, while the pattern delegates handed to that same constructor are. `findDelegate()` returns it for every topic with no pattern match.

#4588 closed the same gap in `close()`; its description said `configure()` covered the default, which holds only when the config map supplies it.

* Configure the constructor-supplied default when the config map does not replace it

The new tests fail before the change with zero interactions on that delegate.
