### PR TITLE
Do not validate a null deserialized value

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ErrorHandlingDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/ErrorHandlingDeserializer.java
@@ -222,8 +222,8 @@ public class ErrorHandlingDeserializer<T> implements Deserializer<T> {
 		}
 	}
 
-	private T validate(T deserialized) {
-		if (this.validator == null || !this.validator.supports(deserialized.getClass())) {
+	private @Nullable T validate(@Nullable T deserialized) {
+		if (deserialized == null || this.validator == null || !this.validator.supports(deserialized.getClass())) {
 			return deserialized;
 		}
 		this.validator.validateObject(deserialized).failOnError(IllegalStateException::new);

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ErrorHandlingDeserializerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ErrorHandlingDeserializerTests.java
@@ -177,6 +177,17 @@ public class ErrorHandlingDeserializerTests {
 				.isEqualTo("test validation");
 	}
 
+	@Test
+	void validateNullValue() {
+		ErrorHandlingDeserializer<String> ehd = new ErrorHandlingDeserializer<>(new StringDeserializer());
+		ehd.configure(Map.of(ErrorHandlingDeserializer.VALIDATOR_CLASS, Val.class.getName()), false);
+
+		Headers headers = new RecordHeaders();
+		assertThat(ehd.deserialize("foo", headers, (byte[]) null)).isNull();
+		assertThat(headers.lastHeader(KafkaUtils.VALUE_DESERIALIZER_EXCEPTION_HEADER)).isNull();
+		assertThat(ehd.deserialize("foo", (byte[]) null)).isNull();
+	}
+
 	@Configuration
 	@EnableKafka
 	public static class Config {


### PR DESCRIPTION
`validate()` calls `deserialized.getClass()`, so a record with a null value throws `NullPointerException` whenever a validator is configured. `deserialize()` catches it and adds a `DeserializationException` header, so a tombstone is reported as a failed deserialization and routed to the DLT.

Measured on `main` (d2d0dfd64), `StringDeserializer` delegate plus the existing `Val` validator:

```
cause=java.lang.NullPointerException
  at ErrorHandlingDeserializer.validate(ErrorHandlingDeserializer.java:226)
  at ErrorHandlingDeserializer.deserialize(ErrorHandlingDeserializer.java:217)
```

Without a validator the check short-circuits, which is why it shows up only in that combination.

The new `validateNullValue` test fails before the change and passes after; 82 tests in the two affected classes' packages, 0 failures, checkstyle clean.
