### PR TITLE
GH-4394: Add record converter to share factory

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/config/ShareKafkaListenerContainerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/ShareKafkaListenerContainerFactory.java
@@ -33,6 +33,7 @@ import org.springframework.kafka.listener.ShareConsumerRecordRecoverer;
 import org.springframework.kafka.listener.ShareKafkaMessageListenerContainer;
 import org.springframework.kafka.support.JavaUtils;
 import org.springframework.kafka.support.TopicPartitionOffset;
+import org.springframework.kafka.support.converter.RecordMessageConverter;
 import org.springframework.util.Assert;
 
 /**
@@ -52,6 +53,7 @@ import org.springframework.util.Assert;
  *
  * @author Soby Chacko
  * @author Kumar Gaurav
+ * @author Sudhanshu Ratna Thakur
  *
  * @since 4.0
  */
@@ -70,6 +72,8 @@ public class ShareKafkaListenerContainerFactory<K, V>
 	private int concurrency = 1;
 
 	private @Nullable ShareConsumerRecordRecoverer recordRecoverer;
+
+	private @Nullable RecordMessageConverter recordMessageConverter;
 
 	@SuppressWarnings("NullAway.Init")
 	private ApplicationEventPublisher applicationEventPublisher;
@@ -134,6 +138,16 @@ public class ShareKafkaListenerContainerFactory<K, V>
 	}
 
 	/**
+	 * Set the message converter to use if dynamic argument type matching is needed for
+	 * record listeners.
+	 * @param recordMessageConverter the converter.
+	 * @since 4.2
+	 */
+	public void setRecordMessageConverter(RecordMessageConverter recordMessageConverter) {
+		this.recordMessageConverter = recordMessageConverter;
+	}
+
+	/**
 	 * Obtain the factory-level container properties - set properties as needed
 	 * and they will be copied to each listener container instance created by this factory.
 	 * @return the properties.
@@ -156,8 +170,7 @@ public class ShareKafkaListenerContainerFactory<K, V>
 		if (endpoint instanceof AbstractKafkaListenerEndpoint abstractKafkaListenerEndpoint) {
 			configureEndpoint(abstractKafkaListenerEndpoint);
 		}
-		// TODO: No message converter for queue at the moment
-		endpoint.setupListenerContainer(instance, null);
+		endpoint.setupListenerContainer(instance, this.recordMessageConverter);
 		initializeContainer(instance, endpoint);
 		return instance;
 	}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ShareKafkaMessageListenerContainerUnitTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ShareKafkaMessageListenerContainerUnitTests.java
@@ -52,6 +52,7 @@ import org.springframework.kafka.event.ConsumerStoppedEvent.Reason;
 import org.springframework.kafka.event.ShareConsumerStoppingEvent;
 import org.springframework.kafka.listener.ContainerProperties.ShareAckMode;
 import org.springframework.kafka.support.ShareAcknowledgment;
+import org.springframework.kafka.support.converter.RecordMessageConverter;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -286,6 +287,36 @@ public class ShareKafkaMessageListenerContainerUnitTests {
 				factory.createListenerContainer(endpoint);
 
 		assertThat(container.getShareConsumerRecordRecoverer()).isSameAs(customRecoverer);
+	}
+
+	@Test
+	void factoryShouldPropagateRecordMessageConverterToEndpoint() {
+		RecordMessageConverter messageConverter = mock(RecordMessageConverter.class);
+		ShareKafkaListenerContainerFactory<String, String> factory =
+				new ShareKafkaListenerContainerFactory<>(shareConsumerFactory);
+		factory.setRecordMessageConverter(messageConverter);
+
+		KafkaListenerEndpoint endpoint = mock(KafkaListenerEndpoint.class);
+		given(endpoint.getTopics()).willReturn(List.of("test-topic"));
+		given(endpoint.getConcurrency()).willReturn(null);
+
+		ShareKafkaMessageListenerContainer<String, String> container = factory.createListenerContainer(endpoint);
+
+		verify(endpoint).setupListenerContainer(container, messageConverter);
+	}
+
+	@Test
+	void factoryShouldPreserveDefaultMessageConverterBehavior() {
+		ShareKafkaListenerContainerFactory<String, String> factory =
+				new ShareKafkaListenerContainerFactory<>(shareConsumerFactory);
+
+		KafkaListenerEndpoint endpoint = mock(KafkaListenerEndpoint.class);
+		given(endpoint.getTopics()).willReturn(List.of("test-topic"));
+		given(endpoint.getConcurrency()).willReturn(null);
+
+		ShareKafkaMessageListenerContainer<String, String> container = factory.createListenerContainer(endpoint);
+
+		verify(endpoint).setupListenerContainer(container, null);
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- add `RecordMessageConverter` configuration to `ShareKafkaListenerContainerFactory`
- propagate the configured converter to `KafkaListenerEndpoint` setup
- preserve and test the existing default behavior when no converter is configured

This is the bounded first increment discussed in the issue. Result forwarding and `@SendTo` support remain separate follow-up work.

Fixes #4394

## Validation

- Added regression coverage that fails before the change because the Share factory has no converter setter.
- `ShareKafkaMessageListenerContainerUnitTests`: 39 tests passed.
- `checkstyleMain` and `checkstyleTest`: passed.
- Full `:spring-kafka:test`: the affected tests passed; three unrelated embedded-broker timing tests failed under the parallel full-suite run and all three passed when rerun independently.
