### PR TITLE
GH-4654: Allow configuring a KafkaAdmin on the container factory

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/container-factory.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/container-factory.adoc
@@ -52,3 +52,18 @@ public ContainerPostProcessor<String, String, AbstractMessageListenerContainer<S
 @KafkaListener(..., containerPostProcessor="customContainerPostProcessor", ...)
 ----
 
+Starting with version 4.2, you can set a `KafkaAdmin` on the factory; it is applied to every container the factory creates.
+The container uses it to resolve the cluster id for observation (see xref:kafka/micrometer.adoc[Monitoring]).
+
+[source, java]
+----
+@Bean
+public KafkaListenerContainerFactory<?> kafkaListenerContainerFactory(KafkaAdmin kafkaAdmin) {
+    ConcurrentKafkaListenerContainerFactory<Integer, String> factory =
+            new ConcurrentKafkaListenerContainerFactory<>();
+    ...
+    factory.setKafkaAdmin(kafkaAdmin);
+    return factory;
+}
+----
+

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -7,6 +7,13 @@
 This section covers the changes made from version 4.1 to version 4.2.
 For changes in earlier versions, see xref:appendix/change-history.adoc[Change History].
 
+[[x42-container-factory-kafka-admin]]
+=== `KafkaAdmin` on the Listener Container Factory
+
+`AbstractKafkaListenerContainerFactory` now exposes a `setKafkaAdmin(KafkaAdmin)`.
+The configured `KafkaAdmin` is applied to every container the factory creates, which the container uses to resolve the cluster id for observation.
+See xref:kafka/container-factory.adoc[Container Factory].
+
 [[x42-error-handler-partition-scoped-clear]]
 === Partition-Scoped Thread State Clearing in Error Handlers
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/config/AbstractKafkaListenerContainerFactory.java
@@ -33,6 +33,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.core.log.LogAccessor;
 import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.KafkaAdmin;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.listener.AbstractMessageListenerContainer;
 import org.springframework.kafka.listener.AfterRollbackProcessor;
@@ -62,6 +63,7 @@ import org.springframework.util.Assert;
  * @author Gary Russell
  * @author Artem Bilan
  * @author Christian Fredriksson
+ * @author Soby Chacko
  *
  * @see AbstractMessageListenerContainer
  */
@@ -115,6 +117,8 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 	private @Nullable Boolean changeConsumerThreadName;
 
 	private @Nullable Function<MessageListenerContainer, String> threadNameSupplier;
+
+	private @Nullable KafkaAdmin kafkaAdmin;
 
 	@Override
 	public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
@@ -368,6 +372,17 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 		this.threadNameSupplier = threadNameSupplier;
 	}
 
+	/**
+	 * Set the {@link KafkaAdmin} to apply to each container created by this factory;
+	 * it is used to find the cluster id for observation.
+	 * @param kafkaAdmin the admin.
+	 * @since 4.2
+	 * @see AbstractMessageListenerContainer#setKafkaAdmin(KafkaAdmin)
+	 */
+	public void setKafkaAdmin(KafkaAdmin kafkaAdmin) {
+		this.kafkaAdmin = kafkaAdmin;
+	}
+
 	@SuppressWarnings({"unchecked", "NullAway"})
 	@Override
 	public C createListenerContainer(KafkaListenerEndpoint endpoint) {
@@ -438,7 +453,8 @@ public abstract class AbstractKafkaListenerContainerFactory<C extends AbstractMe
 				.acceptIfNotNull(this.commonErrorHandler, instance::setCommonErrorHandler)
 				.acceptIfNotNull(this.missingTopicsFatal, instance.getContainerProperties()::setMissingTopicsFatal)
 				.acceptIfNotNull(this.changeConsumerThreadName, instance::setChangeConsumerThreadName)
-				.acceptIfNotNull(this.threadNameSupplier, instance::setThreadNameSupplier);
+				.acceptIfNotNull(this.threadNameSupplier, instance::setThreadNameSupplier)
+				.acceptIfNotNull(this.kafkaAdmin, instance::setKafkaAdmin);
 		Boolean autoStart = endpoint.getAutoStartup();
 		if (autoStart != null) {
 			instance.setAutoStartup(autoStart);

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/ContainerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/ContainerFactoryTests.java
@@ -95,15 +95,14 @@ public class ContainerFactoryTests {
 		assertThat(container.getContainerProperties().getGroupId()).isEqualTo("myGroup");
 	}
 
-	@SuppressWarnings("unchecked")
 	@Test
 	void kafkaAdminTransferred() {
 		ConcurrentKafkaListenerContainerFactory<String, String> factory =
 				new ConcurrentKafkaListenerContainerFactory<>();
-		factory.setConsumerFactory(mock(ConsumerFactory.class));
-		KafkaAdmin kafkaAdmin = mock(KafkaAdmin.class);
+		factory.setConsumerFactory(mock());
+		KafkaAdmin kafkaAdmin = mock();
 		factory.setKafkaAdmin(kafkaAdmin);
-		ConcurrentMessageListenerContainer<String, String> container = factory.createContainer("foo");
+		ConcurrentMessageListenerContainer<String, String> container = factory.createContainer("testTopic");
 		assertThat(container.getKafkaAdmin()).isSameAs(kafkaAdmin);
 	}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/annotation/ContainerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/annotation/ContainerFactoryTests.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.kafka.config.AbstractKafkaListenerEndpoint;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.KafkaAdmin;
 import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
 import org.springframework.kafka.listener.MessageListenerContainer;
 import org.springframework.kafka.listener.adapter.MessagingMessageListenerAdapter;
@@ -35,6 +36,7 @@ import static org.mockito.Mockito.mock;
 
 /**
  * @author Gary Russell
+ * @author Soby Chacko
  * @since 2.2
  *
  */
@@ -91,6 +93,18 @@ public class ContainerFactoryTests {
 				endpoint);
 		assertThat(container.getContainerProperties().getClientId()).isEqualTo("myClientId");
 		assertThat(container.getContainerProperties().getGroupId()).isEqualTo("myGroup");
+	}
+
+	@SuppressWarnings("unchecked")
+	@Test
+	void kafkaAdminTransferred() {
+		ConcurrentKafkaListenerContainerFactory<String, String> factory =
+				new ConcurrentKafkaListenerContainerFactory<>();
+		factory.setConsumerFactory(mock(ConsumerFactory.class));
+		KafkaAdmin kafkaAdmin = mock(KafkaAdmin.class);
+		factory.setKafkaAdmin(kafkaAdmin);
+		ConcurrentMessageListenerContainer<String, String> container = factory.createContainer("foo");
+		assertThat(container.getKafkaAdmin()).isSameAs(kafkaAdmin);
 	}
 
 }


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-kafka/issues/4654

Add `setKafkaAdmin(KafkaAdmin)` to `AbstractKafkaListenerContainerFactory` and apply it to each container it creates. Previously the admin could only be set on the containers individually.

