### PR TITLE
Copy the type resolver in copyWithType

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JacksonJsonDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JacksonJsonDeserializer.java
@@ -656,6 +656,7 @@ public class JacksonJsonDeserializer<T> implements Deserializer<T> {
 		result.removeTypeHeaders = this.removeTypeHeaders;
 		result.typeMapper = this.typeMapper;
 		result.typeMapperExplicitlySet = this.typeMapperExplicitlySet;
+		result.typeResolver = this.typeResolver;
 		return result;
 	}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/JsonSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/JsonSerializationTests.java
@@ -430,6 +430,19 @@ public class JsonSerializationTests {
 	}
 
 	@Test
+	void testCopyWithTypeKeepsTypeResolver() {
+		JacksonJsonDeserializer<Object> deser = new JacksonJsonDeserializer<>()
+				.trustedPackages("*")
+				.typeResolver(JsonSerializationTests::fooBarJavaTypeForTopic);
+		JacksonJsonDeserializer<Object> copy = deser.copyWithType(Object.class);
+		assertThat(copy.deserialize("", "{\"foo\":\"bar\"}".getBytes())).isInstanceOf(Foo.class);
+		assertThat(copy.deserialize("", new RecordHeaders(), "{\"bar\":\"baz\"}".getBytes()))
+				.isInstanceOf(Bar.class);
+		deser.close();
+		copy.close();
+	}
+
+	@Test
 	void configRejectedIgnoredAfterPropertiesSet() {
 		JacksonJsonDeserializer<Object> deser = new JacksonJsonDeserializer<>();
 		deser.setUseTypeHeaders(false);


### PR DESCRIPTION
`JacksonJsonDeserializer.copyWithType` copies `removeTypeHeaders`, the type mapper and `typeMapperExplicitlySet` into the new instance, but not `typeResolver`.

`typeResolver` is set by `setTypeResolver`, `setTypeFunction` or the `spring.json.value.type.method` property, and `deserialize` consults it ahead of the headers and of the target type. A deserializer configured that way loses its type function when copied: the copy ignores it and reads every record as the target type.

#3725 settled the contract here: "for consistency the `copyWithType()` has to be exactly a copy of original `JsonDeserializer`". Header-based type resolution is copied today, function-based resolution is not.

`testCopyWithTypeKeepsTypeResolver` covers it. On `main` it gets a `LinkedHashMap` where the original resolver returns `Foo`.
