### PR TITLE
GH-4660: Require topics for share containers

### DIFF
--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractShareKafkaMessageListenerContainer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/AbstractShareKafkaMessageListenerContainer.java
@@ -17,7 +17,6 @@
 package org.springframework.kafka.listener;
 
 import java.util.concurrent.locks.ReentrantLock;
-import java.util.regex.Pattern;
 
 import org.apache.commons.logging.LogFactory;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
@@ -32,7 +31,6 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.core.log.LogAccessor;
 import org.springframework.kafka.core.ShareConsumerFactory;
-import org.springframework.kafka.support.TopicPartitionOffset;
 import org.springframework.util.Assert;
 
 /**
@@ -48,6 +46,7 @@ import org.springframework.util.Assert;
  *
  * @author Soby Chacko
  * @author Ngoc Nhan
+ * @author Burak Kalayci
  * @since 4.0
  */
 public abstract class AbstractShareKafkaMessageListenerContainer<K, V>
@@ -98,26 +97,9 @@ public abstract class AbstractShareKafkaMessageListenerContainer<K, V>
 		Assert.notNull(shareConsumerFactory, "'shareConsumerFactory' cannot be null");
 		this.shareConsumerFactory = (ShareConsumerFactory<K, V>) shareConsumerFactory;
 		String[] topics = containerProperties.getTopics();
-		if (topics != null) {
-			this.containerProperties = new ContainerProperties(topics);
-		}
-		else {
-			Pattern topicPattern = containerProperties.getTopicPattern();
-			if (topicPattern != null) {
-				this.containerProperties = new ContainerProperties(topicPattern);
-			}
-			else {
-				TopicPartitionOffset[] topicPartitions = containerProperties.getTopicPartitions();
-				if (topicPartitions != null) {
-					this.containerProperties = new ContainerProperties(topicPartitions);
-				}
-				else {
-					throw new IllegalStateException("topics, topicPattern, or topicPartitions must be provided");
-				}
-			}
-		}
-		BeanUtils.copyProperties(containerProperties, this.containerProperties,
-				"topics", "topicPartitions", "topicPattern");
+		Assert.notNull(topics, "'topics' must be provided");
+		this.containerProperties = new ContainerProperties(topics);
+		BeanUtils.copyProperties(containerProperties, this.containerProperties, "topics");
 	}
 
 	@Override

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/ShareKafkaMessageListenerContainerUnitTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/ShareKafkaMessageListenerContainerUnitTests.java
@@ -26,6 +26,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.regex.Pattern;
 
 import org.apache.kafka.clients.consumer.AcknowledgeType;
 import org.apache.kafka.clients.consumer.AcknowledgementCommitCallback;
@@ -52,6 +53,7 @@ import org.springframework.kafka.event.ConsumerStoppedEvent.Reason;
 import org.springframework.kafka.event.ShareConsumerStoppingEvent;
 import org.springframework.kafka.listener.ContainerProperties.ShareAckMode;
 import org.springframework.kafka.support.ShareAcknowledgment;
+import org.springframework.kafka.support.TopicPartitionOffset;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -78,6 +80,7 @@ import static org.mockito.Mockito.verify;
  * @author Maxwell Balla
  * @author Kumar Gaurav
  * @author OhKyu Chan
+ * @author Burak Kalayci
  * @since 4.0
  */
 @ExtendWith(MockitoExtension.class)
@@ -182,6 +185,27 @@ public class ShareKafkaMessageListenerContainerUnitTests {
 		assertThatExceptionOfType(IllegalArgumentException.class)
 				.isThrownBy(() -> container.setConcurrency(-1))
 				.withMessageContaining("concurrency must be greater than 0");
+	}
+
+	@Test
+	void shouldRejectTopicPatternAtConstruction() {
+		ContainerProperties containerProperties = new ContainerProperties(Pattern.compile("test-.*"));
+
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> new ShareKafkaMessageListenerContainer<>(this.shareConsumerFactory,
+						containerProperties))
+				.withMessage("'topics' must be provided");
+	}
+
+	@Test
+	void shouldRejectTopicPartitionsAtConstruction() {
+		ContainerProperties containerProperties =
+				new ContainerProperties(new TopicPartitionOffset("test-topic", 0));
+
+		assertThatExceptionOfType(IllegalArgumentException.class)
+				.isThrownBy(() -> new ShareKafkaMessageListenerContainer<>(this.shareConsumerFactory,
+						containerProperties))
+				.withMessage("'topics' must be provided");
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

Share consumer containers only support explicit topic names. The constructor now requires `topics` via `Assert.notNull` and copies the rest of the properties onto a topics-based `ContainerProperties`. Pattern and partition shapes fail immediately with `IllegalArgumentException` instead of an NPE at `start()`.

Fixes #4660

## Test plan

Executed:

- `./gradlew :spring-kafka:test --tests org.springframework.kafka.listener.ShareKafkaMessageListenerContainerUnitTests` (39/0)
- `./gradlew :spring-kafka:checkstyleMain :spring-kafka:checkstyleTest`