### PR TITLE
Remove warning during `:spring-kafka:compileTestJava`

### DIFF
--- a/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/core/DefaultKafkaConsumerFactoryTests.java
@@ -70,6 +70,7 @@ import static org.mockito.Mockito.verify;
  * @author Adrian Gygax
  * @author Soby Chacko
  * @author Yaniv Nahoum
+ * @author Ngoc Nhan
  *
  * @since 1.0.6
  */
@@ -115,7 +116,7 @@ public class DefaultKafkaConsumerFactoryTests {
 					@Override
 					protected KafkaConsumer<String, String> createKafkaConsumer(Map<String, Object> configProps) {
 						capturedConfig.set(new ConsumerConfig(configProps));
-						return mock(KafkaConsumer.class);
+						return mock();
 					}
 				};
 
@@ -143,7 +144,7 @@ public class DefaultKafkaConsumerFactoryTests {
 					@Override
 					protected Consumer<String, String> createRawConsumer(Map<String, Object> configProps) {
 						capturedConfig.set(new ConsumerConfig(configProps));
-						return mock(Consumer.class);
+						return mock();
 					}
 				};
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/DefaultKafkaHeaderMapperTrustPackagesTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/DefaultKafkaHeaderMapperTrustPackagesTests.java
@@ -24,7 +24,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Tests for trusting packages in {@link DefaultKafkaHeaderMapper}.
  *
  * @author Soby Chacko
+ * @author Ngoc Nhan
  */
+@SuppressWarnings("removal")
 public class DefaultKafkaHeaderMapperTrustPackagesTests {
 
 	@Test


### PR DESCRIPTION
This PR removes the warning emitted during the `:spring-kafka:compileTestJava` build process.

<img width="1360" height="611" alt="image" src="https://github.com/user-attachments/assets/292f3f3e-a70b-4c6e-9d68-279e55179c9f" />
