### PR TITLE
GH-4535: Permit configuring JsonMapper backing Jackson serdes

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/serdes.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/serdes.adoc
@@ -115,11 +115,19 @@ They have no effect if you have provided `Serializer` and `Deserializer` instanc
 * `JacksonJsonDeserializer.TYPE_MAPPINGS` (default `empty`): See xref:kafka/serdes.adoc#serdes-mapping-types[Mapping Types].
 * `JacksonJsonDeserializer.KEY_TYPE_METHOD` (default `empty`): See xref:kafka/serdes.adoc#serdes-type-methods[Using Methods to Determine Types].
 * `JacksonJsonDeserializer.VALUE_TYPE_METHOD` (default `empty`): See xref:kafka/serdes.adoc#serdes-type-methods[Using Methods to Determine Types].
+* `JacksonJsonSerializer.MAPPER` / `JacksonJsonDeserializer.MAPPER` (`spring.json.mapper`): Custom `JsonMapper` instance, class (`Supplier<JsonMapper>`, `Consumer<JsonMapper.Builder>`, or `JsonMapper`), or static method reference.
+* `JacksonJsonSerializer.KEY_MAPPER` / `JacksonJsonDeserializer.KEY_MAPPER` (`spring.json.key.mapper`): Custom `JsonMapper` for keys.
+* `JacksonJsonSerializer.VALUE_MAPPER` / `JacksonJsonDeserializer.VALUE_MAPPER` (`spring.json.value.mapper`): Custom `JsonMapper` for values.
+* `JacksonJsonSerializer.MAPPER_METHOD` / `JacksonJsonDeserializer.MAPPER_METHOD` (`spring.json.mapper.method`): Static method reference (e.g. `com.example.Config.createMapper`) returning `JsonMapper` or `JsonMapper.Builder`.
+* `JacksonJsonSerializer.KEY_MAPPER_METHOD` / `JacksonJsonDeserializer.KEY_MAPPER_METHOD` (`spring.json.key.mapper.method`): Static method reference returning key `JsonMapper`.
+* `JacksonJsonSerializer.VALUE_MAPPER_METHOD` / `JacksonJsonDeserializer.VALUE_MAPPER_METHOD` (`spring.json.value.mapper.method`): Static method reference returning value `JsonMapper`.
 
 Starting with version 2.2, the type information headers (if added by the serializer) are removed by the deserializer.
 You can revert to the previous behavior by setting the `removeTypeHeaders` property to `false`, either directly on the deserializer or with the configuration property described earlier.
 
 See also xref:tips.adoc#tip-json[Customizing the JacksonJsonSerializer and JacksonJsonDeserializer].
+
+Starting with version 4.2, you can also configure the backing `JsonMapper` directly via properties as described in xref:kafka/serdes.adoc#serdes-custom-mapper-properties[Customizing the JsonMapper via Properties].
 
 IMPORTANT: Starting with version 2.8, if you construct the serializer or deserializer programmatically as shown in xref:kafka/serdes.adoc#prog-json[Programmatic Construction], the above properties will be applied by the factories, as long as you have not set any properties explicitly (using `set*()` methods or using the fluent API).
 Previously, when creating programmatically, the configuration properties were never applied; this is still the case if you explicitly set properties on the object directly.
@@ -243,6 +251,26 @@ JacksonJsonDeserializer<Object> deser = new JacksonJsonDeserializer<>()
 public static JavaType thing1Thing2JavaTypeForTopic(String topic, byte[] data, Headers headers) {
     ...
 }
+----
+
+[[serdes-custom-mapper-properties]]
+=== Customizing the JsonMapper via Properties
+
+Starting with version 4.2, you can configure a custom `JsonMapper` directly through configuration properties, without creating custom subclasses of `JacksonJsonSerializer` or `JacksonJsonDeserializer`.
+This is especially useful when using frameworks such as Spring Cloud Stream Kafka Binder, where (de)serializers are instantiated by the Kafka client using no-arg constructors and configured via property maps.
+
+The following configuration options are supported:
+
+* **Direct instance**: In Java-based configuration, supply a pre-built `JsonMapper` instance via `JacksonJsonSerializer.MAPPER` (or `KEY_MAPPER` / `VALUE_MAPPER`).
+* **Supplier**: Specify a class or instance that implements `Supplier<JsonMapper>`. If a class name (or `Class<?>`) is provided, it is instantiated using its default constructor.
+* **Builder Customizer**: Specify a class or instance that implements `Consumer<JsonMapper.Builder>`. The customizer receives `JacksonMapperUtils.enhancedJsonMapper().rebuild()` to apply specific features or modules.
+* **Static method reference**: Set `spring.json.mapper.method` (or `spring.json.key.mapper.method` / `spring.json.value.mapper.method`), or specify a method reference in `spring.json.mapper`. The method must be declared as `public static` and can take `(Map<String, ?> configs, boolean isKey)`, `(Map<String, ?> configs)`, or `()`, returning `JsonMapper` or `JsonMapper.Builder`.
+
+The following example configures a custom `JsonMapper` via a static method in `application.properties`:
+
+[source, properties]
+----
+spring.kafka.consumer.properties.spring.json.value.mapper.method=com.example.KafkaJsonConfig.customValueMapper
 ----
 
 [[prog-json]]

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/tips.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/tips.adoc
@@ -168,7 +168,8 @@ public void sendToKafka(String in) {
 
 The serializer and deserializer support a number of customizations using properties, see xref:kafka/serdes.adoc#json-serde[JSON] for more information.
 The `kafka-clients` code, not Spring, instantiates these objects, unless you inject them directly into the consumer and producer factories.
-If you wish to configure the (de)serializer using properties, but wish to use, say, a custom `JsonMapper`, simply create a subclass and pass the custom mapper into the `super` constructor. For example:
+Starting with version 4.2, you can configure a custom `JsonMapper` directly via configuration properties (`spring.json.mapper`, `spring.json.key.mapper`, `spring.json.value.mapper`, or `spring.json.mapper.method`) as described in xref:kafka/serdes.adoc#serdes-custom-mapper-properties[Customizing the JsonMapper via Properties].
+Alternatively, you can simply create a subclass and pass the custom mapper into the `super` constructor. For example:
 
 [source, java]
 ----

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -14,6 +14,14 @@ For changes in earlier versions, see xref:appendix/change-history.adoc[Change Hi
 The configured `KafkaAdmin` is applied to every container the factory creates, which the container uses to resolve the cluster id for observation.
 See xref:kafka/container-factory.adoc[Container Factory].
 
+[[x42-configure-json-mapper]]
+=== Configuring `JsonMapper` via Properties for `JacksonJsonSerializer` and `JacksonJsonDeserializer`
+
+`JacksonJsonSerializer` and `JacksonJsonDeserializer` now support configuring the backing `JsonMapper` using Kafka configuration properties (`spring.json.mapper`, `spring.json.key.mapper`, `spring.json.value.mapper`, and method variants `*.mapper.method`).
+This allows supplying a `JsonMapper` instance, a `Supplier<JsonMapper>` class or instance, a `Consumer<JsonMapper.Builder>` customizer, or a static factory method reference without needing to create custom subclasses.
+Additionally, fluent `.jsonMapper(JsonMapper)` and `setJsonMapper(JsonMapper)` APIs are now available on `JacksonJsonSerializer`, `JacksonJsonDeserializer`, and `JacksonJsonSerde`.
+See xref:kafka/serdes.adoc#serdes-custom-mapper-properties[Customizing the JsonMapper via Properties] and xref:tips.adoc#tip-json[Customizing the JacksonJsonSerializer and JacksonJsonDeserializer].
+
 [[x42-error-handler-partition-scoped-clear]]
 === Partition-Scoped Thread State Clearing in Error Handlers
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/JacksonMapperUtils.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/JacksonMapperUtils.java
@@ -16,11 +16,22 @@
 
 package org.springframework.kafka.support;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.jspecify.annotations.Nullable;
 import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.MapperFeature;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.SerializationFeature;
 import tools.jackson.databind.json.JsonMapper;
+
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
 
 /**
  * The utilities for Jackson {@link ObjectMapper} instances.
@@ -46,6 +57,182 @@ public final class JacksonMapperUtils {
 				.enable(SerializationFeature.FAIL_ON_EMPTY_BEANS)
 				.addModule(new MimeTypeJacksonModule())
 				.build();
+	}
+
+	/**
+	 * Resolve a {@link JsonMapper} from the configuration map based on key-specific or common properties.
+	 * Checks properties in order:
+	 * 1. key/value-specific mapper property
+	 * 2. key/value-specific method property
+	 * 3. common mapper property
+	 * 4. common method property
+	 *
+	 * @param configs the configuration map.
+	 * @param isKey whether configuring for a key or value.
+	 * @param keyMapperProperty property name for key mapper (e.g. spring.json.key.mapper).
+	 * @param valueMapperProperty property name for value mapper (e.g. spring.json.value.mapper).
+	 * @param defaultMapperProperty common property name for mapper (e.g. spring.json.mapper).
+	 * @param keyMethodProperty property name for key mapper method (e.g. spring.json.key.mapper.method).
+	 * @param valueMethodProperty property name for value mapper method (e.g. spring.json.value.mapper.method).
+	 * @param defaultMethodProperty common property name for mapper method (e.g. spring.json.mapper.method).
+	 * @param classLoader the class loader to use.
+	 * @return the resolved {@link JsonMapper}, or {@code null} if no mapper configuration was specified.
+	 * @since 4.2
+	 */
+	public static @Nullable JsonMapper resolveJsonMapper(Map<String, ?> configs, boolean isKey,
+			@Nullable String keyMapperProperty, @Nullable String valueMapperProperty,
+			@Nullable String defaultMapperProperty,
+			@Nullable String keyMethodProperty, @Nullable String valueMethodProperty,
+			@Nullable String defaultMethodProperty,
+			@Nullable ClassLoader classLoader) {
+
+		ClassLoader cl = classLoader != null ? classLoader : ClassUtils.getDefaultClassLoader();
+		String specificMapperKey = isKey ? keyMapperProperty : valueMapperProperty;
+		String specificMethodKey = isKey ? keyMethodProperty : valueMethodProperty;
+
+		if (specificMapperKey != null && configs.containsKey(specificMapperKey)) {
+			return resolveMapperValue(configs.get(specificMapperKey), configs, isKey, cl);
+		}
+		if (specificMethodKey != null && configs.containsKey(specificMethodKey)) {
+			return invokeStaticMapperMethod(configs.get(specificMethodKey), configs, isKey, cl);
+		}
+		if (defaultMapperProperty != null && configs.containsKey(defaultMapperProperty)) {
+			return resolveMapperValue(configs.get(defaultMapperProperty), configs, isKey, cl);
+		}
+		if (defaultMethodProperty != null && configs.containsKey(defaultMethodProperty)) {
+			return invokeStaticMapperMethod(configs.get(defaultMethodProperty), configs, isKey, cl);
+		}
+		return null;
+	}
+
+	@SuppressWarnings("unchecked")
+	private static JsonMapper resolveMapperValue(Object value, Map<String, ?> configs, boolean isKey,
+			@Nullable ClassLoader classLoader) {
+
+		if (value instanceof JsonMapper jsonMapper) {
+			return jsonMapper;
+		}
+		if (value instanceof JsonMapper.Builder builder) {
+			return builder.build();
+		}
+		if (value instanceof Supplier<?> supplier) {
+			return convertToMapper(supplier.get());
+		}
+		if (value instanceof Consumer<?> consumer) {
+			JsonMapper.Builder builder = enhancedJsonMapper().rebuild();
+			((Consumer<JsonMapper.Builder>) consumer).accept(builder);
+			return builder.build();
+		}
+		if (value instanceof Class<?> clazz) {
+			return instantiateMapperClass(clazz);
+		}
+		if (value instanceof String str) {
+			if (ClassUtils.isPresent(str, classLoader)) {
+				try {
+					Class<?> clazz = ClassUtils.forName(str, classLoader);
+					return instantiateMapperClass(clazz);
+				}
+				catch (ClassNotFoundException | LinkageError e) {
+					throw new IllegalStateException("Failed to load mapper class: " + str, e);
+				}
+			}
+			if (str.lastIndexOf('.') > 1) {
+				return invokeStaticMapperMethod(str, configs, isKey, classLoader);
+			}
+			throw new IllegalStateException("Cannot resolve '" + str + "' as a class or method for JsonMapper");
+		}
+		throw new IllegalStateException("Unsupported type for JsonMapper configuration: " + value.getClass());
+	}
+
+	@SuppressWarnings("unchecked")
+	private static JsonMapper instantiateMapperClass(Class<?> clazz) {
+		try {
+			if (Supplier.class.isAssignableFrom(clazz)) {
+				Supplier<?> supplier = (Supplier<?>) clazz.getDeclaredConstructor().newInstance();
+				return convertToMapper(supplier.get());
+			}
+			if (Consumer.class.isAssignableFrom(clazz)) {
+				Consumer<JsonMapper.Builder> customizer =
+						(Consumer<JsonMapper.Builder>) clazz.getDeclaredConstructor().newInstance();
+				JsonMapper.Builder builder = enhancedJsonMapper().rebuild();
+				customizer.accept(builder);
+				return builder.build();
+			}
+			if (JsonMapper.class.isAssignableFrom(clazz)) {
+				return (JsonMapper) clazz.getDeclaredConstructor().newInstance();
+			}
+			throw new IllegalStateException("Class " + clazz.getName()
+					+ " must implement Supplier<JsonMapper>, Consumer<JsonMapper.Builder>, or extend JsonMapper");
+		}
+		catch (Exception e) {
+			throw new IllegalStateException("Failed to instantiate mapper class: " + clazz.getName(), e);
+		}
+	}
+
+	private static JsonMapper invokeStaticMapperMethod(Object methodProp, Map<String, ?> configs, boolean isKey,
+			@Nullable ClassLoader classLoader) {
+
+		Assert.isInstanceOf(String.class, methodProp, "'method' configuration must be a String");
+		String methodProperty = (String) methodProp;
+		int lastDotPosn = methodProperty.lastIndexOf('.');
+		Assert.state(lastDotPosn > 1,
+				"The method property needs to be a class name followed by the method name, separated by '.'");
+		Class<?> clazz;
+		try {
+			clazz = ClassUtils.forName(methodProperty.substring(0, lastDotPosn), classLoader);
+		}
+		catch (ClassNotFoundException | LinkageError e) {
+			throw new IllegalStateException(e);
+		}
+		String methodName = methodProperty.substring(lastDotPosn + 1);
+		Method method;
+		Object[] args;
+		try {
+			method = clazz.getDeclaredMethod(methodName, Map.class, boolean.class);
+			args = new Object[] { configs, isKey };
+		}
+		catch (NoSuchMethodException e1) {
+			try {
+				method = clazz.getDeclaredMethod(methodName, Map.class);
+				args = new Object[] { configs };
+			}
+			catch (NoSuchMethodException e2) {
+				try {
+					method = clazz.getDeclaredMethod(methodName);
+					args = new Object[0];
+				}
+				catch (NoSuchMethodException e3) {
+					IllegalStateException ise = new IllegalStateException(
+							"The mapper method must take '(Map, boolean)', '(Map)', or '()'", e3);
+					ise.addSuppressed(e1);
+					ise.addSuppressed(e2);
+					throw ise;
+				}
+			}
+		}
+		Assert.state(Modifier.isStatic(method.getModifiers()), method + " must be static");
+		try {
+			Object result = method.invoke(null, args);
+			return convertToMapper(result);
+		}
+		catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+			throw new IllegalStateException("Failed to invoke mapper method: " + method, e);
+		}
+	}
+
+	private static JsonMapper convertToMapper(@Nullable Object result) {
+		Assert.state(result != null, "Mapper provider returned null");
+		if (result instanceof JsonMapper jsonMapper) {
+			return jsonMapper;
+		}
+		if (result instanceof JsonMapper.Builder builder) {
+			return builder.build();
+		}
+		if (result instanceof Supplier<?> supplier) {
+			return convertToMapper(supplier.get());
+		}
+		throw new IllegalStateException("Mapper provider must return JsonMapper or JsonMapper.Builder, but was: "
+				+ result.getClass().getName());
 	}
 
 	private JacksonMapperUtils() {

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JacksonJsonDeserializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JacksonJsonDeserializer.java
@@ -117,6 +117,42 @@ public class JacksonJsonDeserializer<T> implements Deserializer<T> {
 	 */
 	public static final String VALUE_TYPE_METHOD = "spring.json.value.type.method";
 
+	/**
+	 * Kafka config property for key {@link JsonMapper}.
+	 * @since 4.2
+	 */
+	public static final String KEY_MAPPER = "spring.json.key.mapper";
+
+	/**
+	 * Kafka config property for value {@link JsonMapper}.
+	 * @since 4.2
+	 */
+	public static final String VALUE_MAPPER = "spring.json.value.mapper";
+
+	/**
+	 * Kafka config property for {@link JsonMapper} (fallback for key and value).
+	 * @since 4.2
+	 */
+	public static final String MAPPER = "spring.json.mapper";
+
+	/**
+	 * Kafka config property for key {@link JsonMapper} method (e.g. 'com.Foo.createMapper').
+	 * @since 4.2
+	 */
+	public static final String KEY_MAPPER_METHOD = "spring.json.key.mapper.method";
+
+	/**
+	 * Kafka config property for value {@link JsonMapper} method (e.g. 'com.Foo.createMapper').
+	 * @since 4.2
+	 */
+	public static final String VALUE_MAPPER_METHOD = "spring.json.value.mapper.method";
+
+	/**
+	 * Kafka config property for {@link JsonMapper} method (fallback for key and value).
+	 * @since 4.2
+	 */
+	public static final String MAPPER_METHOD = "spring.json.mapper.method";
+
 	private static final Set<String> OUR_KEYS = new HashSet<>();
 
 	static {
@@ -128,9 +164,15 @@ public class JacksonJsonDeserializer<T> implements Deserializer<T> {
 		OUR_KEYS.add(USE_TYPE_INFO_HEADERS);
 		OUR_KEYS.add(KEY_TYPE_METHOD);
 		OUR_KEYS.add(VALUE_TYPE_METHOD);
+		OUR_KEYS.add(KEY_MAPPER);
+		OUR_KEYS.add(VALUE_MAPPER);
+		OUR_KEYS.add(MAPPER);
+		OUR_KEYS.add(KEY_MAPPER_METHOD);
+		OUR_KEYS.add(VALUE_MAPPER_METHOD);
+		OUR_KEYS.add(MAPPER_METHOD);
 	}
 
-	protected final JsonMapper jsonMapper; // NOSONAR
+	protected JsonMapper jsonMapper; // NOSONAR
 
 	protected @Nullable JavaType targetType; // NOSONAR
 
@@ -312,6 +354,29 @@ public class JacksonJsonDeserializer<T> implements Deserializer<T> {
 		initialize(targetType, useHeadersIfPresent);
 	}
 
+	/**
+	 * Return the configured {@link JsonMapper}.
+	 * @return the json mapper.
+	 * @since 4.2
+	 */
+	public JsonMapper getJsonMapper() {
+		return this.jsonMapper;
+	}
+
+	/**
+	 * Set a customized {@link JsonMapper}.
+	 * @param jsonMapper the json mapper.
+	 * @since 4.2
+	 */
+	public void setJsonMapper(JsonMapper jsonMapper) {
+		Assert.notNull(jsonMapper, "'jsonMapper' cannot be null");
+		this.jsonMapper = jsonMapper;
+		if (this.targetType != null) {
+			this.reader = this.jsonMapper.readerFor(this.targetType);
+		}
+		this.setterCalled = true;
+	}
+
 	public JacksonJavaTypeMapper getTypeMapper() {
 		return this.typeMapper;
 	}
@@ -403,6 +468,7 @@ public class JacksonJsonDeserializer<T> implements Deserializer<T> {
 					"JsonDeserializer must be configured with property setters, or via configuration properties; not both");
 			doSetUseTypeMapperForKey(isKey);
 			setUpTypePrecedence(configs);
+			setUpJsonMapper(configs, isKey);
 			setupTarget(configs, isKey);
 			if (configs.containsKey(TRUSTED_PACKAGES)
 					&& configs.get(TRUSTED_PACKAGES) instanceof String) {
@@ -421,6 +487,19 @@ public class JacksonJsonDeserializer<T> implements Deserializer<T> {
 		}
 		finally {
 			this.trustedPackagesLock.unlock();
+		}
+	}
+
+	private void setUpJsonMapper(Map<String, ?> configs, boolean isKey) {
+		JsonMapper configuredMapper = JacksonMapperUtils.resolveJsonMapper(configs, isKey,
+				KEY_MAPPER, VALUE_MAPPER, MAPPER,
+				KEY_MAPPER_METHOD, VALUE_MAPPER_METHOD, MAPPER_METHOD,
+				getClass().getClassLoader());
+		if (configuredMapper != null) {
+			this.jsonMapper = configuredMapper;
+			if (this.targetType != null) {
+				this.reader = this.jsonMapper.readerFor(this.targetType);
+			}
 		}
 	}
 
@@ -739,6 +818,18 @@ public class JacksonJsonDeserializer<T> implements Deserializer<T> {
 	 */
 	public JacksonJsonDeserializer<T> typeResolver(JacksonJsonTypeResolver resolver) {
 		setTypeResolver(resolver);
+		return this;
+	}
+
+	/**
+	 * Fluent API to set a customized {@link JsonMapper}.
+	 * @param jsonMapper the json mapper.
+	 * @return this deserializer.
+	 * @since 4.2
+	 * @see #setJsonMapper(JsonMapper)
+	 */
+	public JacksonJsonDeserializer<T> jsonMapper(JsonMapper jsonMapper) {
+		setJsonMapper(jsonMapper);
 		return this;
 	}
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JacksonJsonSerde.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JacksonJsonSerde.java
@@ -206,4 +206,16 @@ public class JacksonJsonSerde<T> implements Serde<T> {
 		return this;
 	}
 
+	/**
+	 * Use the supplied {@link JsonMapper}.
+	 * @param mapper the mapper.
+	 * @return the serde.
+	 * @since 4.2
+	 */
+	public JacksonJsonSerde<T> jsonMapper(JsonMapper mapper) {
+		this.jsonSerializer.setJsonMapper(mapper);
+		this.jsonDeserializer.setJsonMapper(mapper);
+		return this;
+	}
+
 }

--- a/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JacksonJsonSerializer.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/support/serializer/JacksonJsonSerializer.java
@@ -17,7 +17,9 @@
 package org.springframework.kafka.support.serializer;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
@@ -72,7 +74,58 @@ public class JacksonJsonSerializer<T> implements Serializer<T> {
 	 */
 	public static final String TYPE_MAPPINGS = "spring.json.type.mapping";
 
-	protected final JsonMapper jsonMapper; // NOSONAR
+	/**
+	 * Kafka config property for key {@link JsonMapper}.
+	 * @since 4.2
+	 */
+	public static final String KEY_MAPPER = "spring.json.key.mapper";
+
+	/**
+	 * Kafka config property for value {@link JsonMapper}.
+	 * @since 4.2
+	 */
+	public static final String VALUE_MAPPER = "spring.json.value.mapper";
+
+	/**
+	 * Kafka config property for {@link JsonMapper} (fallback for key and value).
+	 * @since 4.2
+	 */
+	public static final String MAPPER = "spring.json.mapper";
+
+	/**
+	 * Kafka config property for key {@link JsonMapper} method (e.g. 'com.Foo.createMapper').
+	 * @since 4.2
+	 */
+	public static final String KEY_MAPPER_METHOD = "spring.json.key.mapper.method";
+
+	/**
+	 * Kafka config property for value {@link JsonMapper} method (e.g. 'com.Foo.createMapper').
+	 * @since 4.2
+	 */
+	public static final String VALUE_MAPPER_METHOD = "spring.json.value.mapper.method";
+
+	/**
+	 * Kafka config property for {@link JsonMapper} method (fallback for key and value).
+	 * @since 4.2
+	 */
+	public static final String MAPPER_METHOD = "spring.json.mapper.method";
+
+	private static final Set<String> OUR_KEYS = new HashSet<>();
+
+	static {
+		OUR_KEYS.add(ADD_TYPE_INFO_HEADERS);
+		OUR_KEYS.add(TYPE_MAPPINGS);
+		OUR_KEYS.add(KEY_MAPPER);
+		OUR_KEYS.add(VALUE_MAPPER);
+		OUR_KEYS.add(MAPPER);
+		OUR_KEYS.add(KEY_MAPPER_METHOD);
+		OUR_KEYS.add(VALUE_MAPPER_METHOD);
+		OUR_KEYS.add(MAPPER_METHOD);
+	}
+
+	protected JsonMapper jsonMapper; // NOSONAR
+
+	protected @Nullable JavaType targetType; // NOSONAR
 
 	protected boolean addTypeInfo = true; // NOSONAR
 
@@ -106,8 +159,30 @@ public class JacksonJsonSerializer<T> implements Serializer<T> {
 
 	public JacksonJsonSerializer(@Nullable JavaType targetType, JsonMapper jsonMapper) {
 		Assert.notNull(jsonMapper, "'jsonMapper' must not be null.");
+		this.targetType = targetType;
 		this.jsonMapper = jsonMapper;
 		this.writer = jsonMapper.writerFor(targetType);
+	}
+
+	/**
+	 * Return the configured {@link JsonMapper}.
+	 * @return the json mapper.
+	 * @since 4.2
+	 */
+	public JsonMapper getJsonMapper() {
+		return this.jsonMapper;
+	}
+
+	/**
+	 * Set a customized {@link JsonMapper}.
+	 * @param jsonMapper the json mapper.
+	 * @since 4.2
+	 */
+	public void setJsonMapper(JsonMapper jsonMapper) {
+		Assert.notNull(jsonMapper, "'jsonMapper' cannot be null");
+		this.jsonMapper = jsonMapper;
+		this.writer = this.jsonMapper.writerFor(this.targetType);
+		this.setterCalled = true;
 	}
 
 	public boolean isAddTypeInfo() {
@@ -160,10 +235,17 @@ public class JacksonJsonSerializer<T> implements Serializer<T> {
 			if (this.configured) {
 				return;
 			}
-			Assert.state(!this.setterCalled
-							|| (!configs.containsKey(ADD_TYPE_INFO_HEADERS) && !configs.containsKey(TYPE_MAPPINGS)),
+			Assert.state(!this.setterCalled || !configsHasOurKeys(configs),
 					"JsonSerializer must be configured with property setters, or via configuration properties; not both");
 			setUseTypeMapperForKey(isKey);
+			JsonMapper configuredMapper = JacksonMapperUtils.resolveJsonMapper(configs, isKey,
+					KEY_MAPPER, VALUE_MAPPER, MAPPER,
+					KEY_MAPPER_METHOD, VALUE_MAPPER_METHOD, MAPPER_METHOD,
+					getClass().getClassLoader());
+			if (configuredMapper != null) {
+				this.jsonMapper = configuredMapper;
+				this.writer = this.jsonMapper.writerFor(this.targetType);
+			}
 			if (configs.containsKey(ADD_TYPE_INFO_HEADERS)) {
 				Object config = configs.get(ADD_TYPE_INFO_HEADERS);
 				if (config instanceof Boolean configBoolean) {
@@ -185,6 +267,15 @@ public class JacksonJsonSerializer<T> implements Serializer<T> {
 		finally {
 			this.globalLock.unlock();
 		}
+	}
+
+	private boolean configsHasOurKeys(Map<String, ?> configs) {
+		for (String key : configs.keySet()) {
+			if (OUR_KEYS.contains(key)) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	protected static Map<String, Class<?>> createMappings(String mappings) {
@@ -304,6 +395,18 @@ public class JacksonJsonSerializer<T> implements Serializer<T> {
 	 */
 	public JacksonJsonSerializer<T> typeMapper(JacksonJavaTypeMapper mapper) {
 		setTypeMapper(mapper);
+		return this;
+	}
+
+	/**
+	 * Fluent API to set a customized {@link JsonMapper}.
+	 * @param jsonMapper the json mapper.
+	 * @return this serializer.
+	 * @since 4.2
+	 * @see #setJsonMapper(JsonMapper)
+	 */
+	public JacksonJsonSerializer<T> jsonMapper(JsonMapper jsonMapper) {
+		setJsonMapper(jsonMapper);
 		return this;
 	}
 

--- a/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/JsonSerializationTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/support/serializer/JsonSerializationTests.java
@@ -27,6 +27,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -43,6 +45,8 @@ import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.JavaType;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.type.TypeFactory;
 
 import org.springframework.beans.DirectFieldAccessor;
@@ -67,6 +71,10 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
  * @author Ngoc Nhan
  */
 public class JsonSerializationTests {
+
+	private static final JsonMapper CUSTOM_STATIC_MAPPER = JsonMapper.builder().build();
+
+	private static final JsonMapper CUSTOM_STATIC_MAPPER_WITH_CONFIGS = JsonMapper.builder().build();
 
 	private StringSerializer stringWriter;
 
@@ -456,6 +464,152 @@ public class JsonSerializationTests {
 	}
 
 	@Test
+	void configureCustomJsonMapperInstance() {
+		JsonMapper customMapper = JsonMapper.builder().build();
+		try (JacksonJsonSerializer<Object> ser = new JacksonJsonSerializer<>();
+				JacksonJsonDeserializer<Foo> deser = new JacksonJsonDeserializer<>(Foo.class)) {
+
+			Map<String, Object> configs = Map.of(JacksonJsonSerializer.MAPPER, customMapper);
+			ser.configure(configs, false);
+			deser.configure(configs, false);
+
+			assertThat(ser.getJsonMapper()).isSameAs(customMapper);
+			assertThat(deser.getJsonMapper()).isSameAs(customMapper);
+
+			byte[] bytes = ser.serialize("topic", new Foo());
+			Foo foo = deser.deserialize("topic", bytes);
+			assertThat(foo).isNotNull();
+			assertThat(foo.foo).isEqualTo("foo");
+		}
+	}
+
+	@Test
+	void configureKeyAndValueSpecificMapper() {
+		JsonMapper keyMapper = JsonMapper.builder().build();
+		JsonMapper valueMapper = JsonMapper.builder().build();
+
+		try (JacksonJsonSerializer<Object> keySer = new JacksonJsonSerializer<>();
+				JacksonJsonSerializer<Object> valueSer = new JacksonJsonSerializer<>();
+				JacksonJsonDeserializer<Object> keyDeser = new JacksonJsonDeserializer<>();
+				JacksonJsonDeserializer<Object> valueDeser = new JacksonJsonDeserializer<>()) {
+
+			Map<String, Object> configs = Map.of(
+					JacksonJsonSerializer.KEY_MAPPER, keyMapper,
+					JacksonJsonSerializer.VALUE_MAPPER, valueMapper);
+
+			keySer.configure(configs, true);
+			valueSer.configure(configs, false);
+			keyDeser.configure(configs, true);
+			valueDeser.configure(configs, false);
+
+			assertThat(keySer.getJsonMapper()).isSameAs(keyMapper);
+			assertThat(valueSer.getJsonMapper()).isSameAs(valueMapper);
+			assertThat(keyDeser.getJsonMapper()).isSameAs(keyMapper);
+			assertThat(valueDeser.getJsonMapper()).isSameAs(valueMapper);
+		}
+	}
+
+	@Test
+	void configureJsonMapperSupplierClassAndInstance() {
+		try (JacksonJsonSerializer<Object> ser1 = new JacksonJsonSerializer<>();
+				JacksonJsonDeserializer<Object> deser1 = new JacksonJsonDeserializer<>();
+				JacksonJsonSerializer<Object> ser2 = new JacksonJsonSerializer<>();
+				JacksonJsonDeserializer<Object> deser2 = new JacksonJsonDeserializer<>()) {
+
+			ser1.configure(Map.of(JacksonJsonSerializer.MAPPER, new CustomMapperSupplier()), false);
+			deser1.configure(Map.of(JacksonJsonDeserializer.MAPPER, new CustomMapperSupplier()), false);
+			assertThat(ser1.getJsonMapper()).isNotNull();
+			assertThat(deser1.getJsonMapper()).isNotNull();
+
+			ser2.configure(Map.of(JacksonJsonSerializer.MAPPER, CustomMapperSupplier.class.getName()), false);
+			deser2.configure(Map.of(JacksonJsonDeserializer.MAPPER, CustomMapperSupplier.class), false);
+			assertThat(ser2.getJsonMapper()).isNotNull();
+			assertThat(deser2.getJsonMapper()).isNotNull();
+		}
+	}
+
+	@Test
+	void configureJsonMapperCustomizerClass() {
+		try (JacksonJsonSerializer<Object> ser = new JacksonJsonSerializer<>()) {
+			ser.configure(Map.of(JacksonJsonSerializer.MAPPER, CustomMapperBuilderCustomizer.class.getName()), false);
+			assertThat(ser.getJsonMapper().isEnabled(SerializationFeature.INDENT_OUTPUT)).isTrue();
+		}
+	}
+
+	@Test
+	void configureJsonMapperMethod() {
+		try (JacksonJsonSerializer<Object> ser = new JacksonJsonSerializer<>();
+				JacksonJsonDeserializer<Object> deser = new JacksonJsonDeserializer<>()) {
+
+			String methodName = getClass().getName() + ".customMapperForMethod";
+			ser.configure(Map.of(JacksonJsonSerializer.MAPPER_METHOD, methodName), false);
+			deser.configure(Map.of(JacksonJsonDeserializer.MAPPER_METHOD, methodName), false);
+
+			assertThat(ser.getJsonMapper()).isSameAs(CUSTOM_STATIC_MAPPER);
+			assertThat(deser.getJsonMapper()).isSameAs(CUSTOM_STATIC_MAPPER);
+		}
+	}
+
+	@Test
+	void configureJsonMapperMethodWithConfigs() {
+		try (JacksonJsonSerializer<Object> ser = new JacksonJsonSerializer<>();
+				JacksonJsonDeserializer<Object> deser = new JacksonJsonDeserializer<>()) {
+
+			String methodName = getClass().getName() + ".customMapperForMethodWithConfigs";
+			ser.configure(Map.of(JacksonJsonSerializer.MAPPER, methodName), true);
+			deser.configure(Map.of(JacksonJsonDeserializer.MAPPER, methodName), true);
+
+			assertThat(ser.getJsonMapper()).isSameAs(CUSTOM_STATIC_MAPPER_WITH_CONFIGS);
+			assertThat(deser.getJsonMapper()).isSameAs(CUSTOM_STATIC_MAPPER_WITH_CONFIGS);
+		}
+	}
+
+	@Test
+	void setJsonMapperAndFluentApi() {
+		JsonMapper customMapper = JsonMapper.builder().build();
+		try (JacksonJsonSerializer<Object> ser = new JacksonJsonSerializer<>().jsonMapper(customMapper);
+				JacksonJsonDeserializer<Object> deser = new JacksonJsonDeserializer<>().jsonMapper(customMapper);
+				JacksonJsonSerde<Object> serde = new JacksonJsonSerde<>().jsonMapper(customMapper)) {
+
+			assertThat(ser.getJsonMapper()).isSameAs(customMapper);
+			assertThat(deser.getJsonMapper()).isSameAs(customMapper);
+			assertThat(serde.serializer().getJsonMapper()).isSameAs(customMapper);
+			assertThat(serde.deserializer().getJsonMapper()).isSameAs(customMapper);
+		}
+	}
+
+	@Test
+	void configRejectedWhenSetterCalledWithMapper() {
+		try (JacksonJsonSerializer<Object> ser = new JacksonJsonSerializer<>();
+				JacksonJsonDeserializer<Object> deser = new JacksonJsonDeserializer<>()) {
+
+			ser.setJsonMapper(JsonMapper.builder().build());
+			deser.setJsonMapper(JsonMapper.builder().build());
+
+			Map<String, Object> configs = Map.of(JacksonJsonSerializer.MAPPER, JsonMapper.builder().build());
+			assertThatIllegalStateException().isThrownBy(() -> ser.configure(configs, false));
+			assertThatIllegalStateException().isThrownBy(() -> deser.configure(configs, false));
+		}
+	}
+
+	@Test
+	void copyWithTypeKeepsConfiguredJsonMapper() {
+		JsonMapper customMapper = JsonMapper.builder().build();
+		try (JacksonJsonSerializer<Object> ser = new JacksonJsonSerializer<>().jsonMapper(customMapper);
+				JacksonJsonDeserializer<Object> deser = new JacksonJsonDeserializer<>().jsonMapper(customMapper)) {
+
+			JacksonJsonSerializer<Parent> serCopy = ser.copyWithType(Parent.class);
+			JacksonJsonDeserializer<Parent> deserCopy = deser.copyWithType(Parent.class);
+
+			assertThat(serCopy.getJsonMapper()).isSameAs(customMapper);
+			assertThat(deserCopy.getJsonMapper()).isSameAs(customMapper);
+
+			serCopy.close();
+			deserCopy.close();
+		}
+	}
+
+	@Test
 	void typeMappingHonoredWhenClassLoadedByDifferentClassLoader() throws Exception {
 		DefaultJacksonJavaTypeMapper mapper = new DefaultJacksonJavaTypeMapper();
 		mapper.setIdClassMapping(Map.of("my-alias", Foo.class));
@@ -507,6 +661,14 @@ public class JsonSerializationTests {
 
 	public static JavaType stringTypeForTopic(String topic, byte[] data, Headers headers) {
 		return TypeFactory.createDefaultInstance().constructType(String.class);
+	}
+
+	public static JsonMapper customMapperForMethod() {
+		return CUSTOM_STATIC_MAPPER;
+	}
+
+	public static JsonMapper customMapperForMethodWithConfigs(Map<String, ?> configs, boolean isKey) {
+		return CUSTOM_STATIC_MAPPER_WITH_CONFIGS;
 	}
 
 	static class DummyEntityJsonDeserializer extends JacksonJsonDeserializer<DummyEntity> {
@@ -564,6 +726,24 @@ public class JsonSerializationTests {
 
 		Child(int number) {
 			super(number);
+		}
+
+	}
+
+	public static class CustomMapperSupplier implements Supplier<JsonMapper> {
+
+		@Override
+		public JsonMapper get() {
+			return JsonMapper.builder().build();
+		}
+
+	}
+
+	public static class CustomMapperBuilderCustomizer implements Consumer<JsonMapper.Builder> {
+
+		@Override
+		public void accept(JsonMapper.Builder builder) {
+			builder.enable(SerializationFeature.INDENT_OUTPUT);
 		}
 
 	}


### PR DESCRIPTION
### Summary

This pull request introduces configuration-driven and fluent customization for the `JsonMapper` backing `JacksonJsonSerializer`, `JacksonJsonDeserializer`, and `JacksonJsonSerde`.

Previously, customizing mapper configurations required creating explicit subclasses. In declarative and property-driven architectures (such as Spring Cloud Stream Kafka Binder or externalized client properties), subclassing adds unnecessary boilerplate and maintenance overhead.

This change enables declarative and programmatic configuration of the mapper while honoring the immutability design of Jackson 3:

- **Declarative Configuration**: Allows supplying or tailoring the mapper via standard Kafka configuration properties supporting mapper instances, `Supplier<JsonMapper>` types, `Consumer<JsonMapper.Builder>` customizers, or static factory method references.
- **Key & Value Scoping**: Supports topic-level or role-specific mappers via dedicated key and value configuration properties alongside global fallbacks.
- **Fluent API**: Exposes `jsonMapper(...)` configuration on serializer, deserializer, and serde builders.
- **Documentation & Verification**: Updates the reference guide and adds test coverage for all configuration pathways.

Fixes #4535