### PR TITLE
GH-4272: Bound recovery failures per record

### DIFF
--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/annotation-error-handling.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/kafka/annotation-error-handling.adoc
@@ -283,6 +283,8 @@ See the JavaDocs for more information.
 IMPORTANT: If the recoverer fails (throws an exception), the failed record will be included in the seeks.
 If the recoverer fails, the `BackOff` will be reset by default and redeliveries will again go through the back offs before recovery is attempted again.
 To skip retries after a recovery failure, set the error handler's `resetStateOnRecoveryFailure` to `false`.
+Starting with version 4.2, you can also bound the number of times recovery may fail for the same record by setting the error handler's `maxRecoveryFailures`; once the limit is reached, the record is logged at `ERROR` level and skipped as if it had been recovered, instead of being redelivered indefinitely.
+By default, there is no limit.
 
 You can provide the error handler with a `BiFunction<ConsumerRecord<?, ?>, Exception, BackOff>` to determine the `BackOff` to use, based on the failed record and/or the exception:
 
@@ -705,6 +707,8 @@ IMPORTANT: If the recoverer fails (throws an exception), the failed record will 
 Starting with version 2.5.5, if the recoverer fails, the `BackOff` will be reset by default and redeliveries will again go through the back offs before recovery is attempted again.
 With earlier versions, the `BackOff` was not reset and recovery was re-attempted on the next failure.
 To revert to the previous behavior, set the processor's `resetStateOnRecoveryFailure` property to `false`.
+Starting with version 4.2, you can also bound the number of times recovery may fail for the same record by setting the processor's `maxRecoveryFailures`; once the limit is reached, the record is logged at `ERROR` level and skipped as if it had been recovered, instead of being redelivered indefinitely.
+By default, there is no limit.
 
 Starting with version 2.6, you can now provide the processor with a `BiFunction<ConsumerRecord<?, ?>, Exception, BackOff>` to determine the `BackOff` to use, based on the failed record and/or the exception:
 
@@ -950,6 +954,8 @@ IMPORTANT: If the recoverer fails (throws an exception), the failed record will 
 Starting with version 2.5.5, if the recoverer fails, the `BackOff` will be reset by default and redeliveries will again go through the back offs before recovery is attempted again.
 With earlier versions, the `BackOff` was not reset and recovery was re-attempted on the next failure.
 To revert to the previous behavior, set the error handler's `resetStateOnRecoveryFailure` property to `false`.
+Starting with version 4.2, you can also bound the number of times recovery may fail for the same record by setting the error handler's `maxRecoveryFailures`; once the limit is reached, the record is logged at `ERROR` level and skipped as if it had been recovered, instead of being redelivered indefinitely.
+By default, there is no limit.
 
 Starting with version 2.6.3, set `resetStateOnExceptionChange` to `true` and the retry sequence will be restarted (including the selection of a new `BackOff`, if so configured) if the exception type changes between failures.
 By default, the exception type is not considered.

--- a/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
+++ b/spring-kafka-docs/src/main/antora/modules/ROOT/pages/whats-new.adoc
@@ -22,6 +22,15 @@ In a non-concurrent container with multiple partitions, the container calls this
 This fixes a bug where a healthy batch from one partition would reset the backoff retry counter for an unrelated failing partition, preventing broken records from ever reaching the dead-letter topic.
 Implementations of `CommonErrorHandler` that maintain per-partition state (such as custom subclasses of `FailedRecordProcessor`) may override this method to apply the same scoping.
 
+[[x42-error-handler-max-recovery-failures]]
+=== Bounded Recovery Failures in Error Handlers
+
+`DefaultErrorHandler` and `DefaultAfterRollbackProcessor` (via `FailedRecordProcessor`) now have a `setMaxRecoveryFailures(int)` property.
+When the recoverer keeps throwing for the same record (for example, the dead-letter topic is unavailable), the record was previously seeked to and redelivered indefinitely.
+With the limit set, once recovery has failed that many times for a record, it is logged at `ERROR` level and skipped as if it had been recovered.
+By default, there is no limit.
+See xref:kafka/annotation-error-handling.adoc#default-eh[Default Error Handler].
+
 [[x42-listener-observation-tags]]
 === Listener Observation Meter Tags
 

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordProcessor.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordProcessor.java
@@ -36,6 +36,7 @@ import org.springframework.util.backoff.FixedBackOff;
  * Common super class for classes that deal with failing to consume a consumer record.
  *
  * @author Gary Russell
+ * @author Bill Kim
  * @since 2.3.1
  *
  */
@@ -123,6 +124,20 @@ public abstract class FailedRecordProcessor extends ExceptionClassifier implemen
 	 */
 	public void setResetStateOnExceptionChange(boolean resetStateOnExceptionChange) {
 		this.failureTracker.setResetStateOnExceptionChange(resetStateOnExceptionChange);
+	}
+
+	/**
+	 * Set the maximum number of times recovery may fail for the same record before the
+	 * record is skipped as if it had been recovered: it is logged at ERROR level, it is
+	 * no longer included in the seeks, and its offset is committed according to the
+	 * container's ack mode. By default there is no limit; a record whose recovery keeps
+	 * failing is redelivered until the recoverer succeeds.
+	 * @param maxRecoveryFailures the maximum number of recovery failures; must be greater than 0.
+	 * @since 4.2
+	 * @see #setResetStateOnRecoveryFailure(boolean)
+	 */
+	public void setMaxRecoveryFailures(int maxRecoveryFailures) {
+		this.failureTracker.setMaxRecoveryFailures(maxRecoveryFailures);
 	}
 
 	/**

--- a/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordTracker.java
+++ b/spring-kafka/src/main/java/org/springframework/kafka/listener/FailedRecordTracker.java
@@ -44,6 +44,7 @@ import org.springframework.util.backoff.BackOffExecution;
  * Track record processing failure counts.
  *
  * @author Gary Russell
+ * @author Bill Kim
  * @since 2.2
  *
  */
@@ -51,7 +52,11 @@ class FailedRecordTracker implements RecoveryStrategy {
 
 	private final Map<Thread, Map<TopicPartition, FailedRecord>> failures = new ConcurrentHashMap<>();
 
+	private final Map<Thread, Map<TopicPartition, RecoveryFailures>> recoveryFailures = new ConcurrentHashMap<>();
+
 	private final ConsumerAwareRecordRecoverer recoverer;
+
+	private final LogAccessor logger;
 
 	private final boolean noRetries;
 
@@ -67,6 +72,8 @@ class FailedRecordTracker implements RecoveryStrategy {
 
 	private boolean resetStateOnExceptionChange = true;
 
+	private int maxRecoveryFailures = Integer.MAX_VALUE;
+
 	FailedRecordTracker(@Nullable BiConsumer<ConsumerRecord<?, ?>, Exception> recoverer, BackOff backOff,
 			LogAccessor logger) {
 
@@ -78,6 +85,7 @@ class FailedRecordTracker implements RecoveryStrategy {
 			@Nullable BackOffHandler backOffHandler, LogAccessor logger) {
 
 		Assert.notNull(backOff, "'backOff' cannot be null");
+		this.logger = logger;
 		if (recoverer == null) {
 			this.recoverer = (rec, consumer, thr) -> {
 				Map<TopicPartition, FailedRecord> map = this.failures.get(Thread.currentThread());
@@ -143,6 +151,17 @@ class FailedRecordTracker implements RecoveryStrategy {
 	}
 
 	/**
+	 * Set the maximum number of times recovery may fail for the same record before the
+	 * record is skipped as if it had been recovered. By default there is no limit.
+	 * @param maxRecoveryFailures the maximum number of recovery failures; must be greater than 0.
+	 * @since 4.2
+	 */
+	public void setMaxRecoveryFailures(int maxRecoveryFailures) {
+		Assert.isTrue(maxRecoveryFailures > 0, "'maxRecoveryFailures' must be greater than 0");
+		this.maxRecoveryFailures = maxRecoveryFailures;
+	}
+
+	/**
 	 * Set one or more {@link RetryListener} to receive notifications of retries and
 	 * recovery.
 	 * @param listeners the listeners.
@@ -172,13 +191,13 @@ class FailedRecordTracker implements RecoveryStrategy {
 			@Nullable MessageListenerContainer container,
 			@Nullable Consumer<?, ?> consumer) throws InterruptedException {
 
+		TopicPartition topicPartition = new TopicPartition(record.topic(), record.partition());
 		if (this.noRetries) {
-			attemptRecovery(record, exception, null, consumer);
+			attemptRecovery(record, exception, topicPartition, consumer);
 			return true;
 		}
 		Thread currentThread = Thread.currentThread();
 		Map<TopicPartition, FailedRecord> map = this.failures.computeIfAbsent(currentThread, t -> new HashMap<>());
-		TopicPartition topicPartition = new TopicPartition(record.topic(), record.partition());
 		FailedRecord failedRecord = getFailedRecordInstance(record, exception, map, topicPartition);
 		this.retryListeners.forEach(rl ->
 				rl.failedDelivery(record, exception, failedRecord.getDeliveryAttempts().get()));
@@ -224,16 +243,20 @@ class FailedRecordTracker implements RecoveryStrategy {
 		return backOffToUse != null ? backOffToUse : this.backOff;
 	}
 
-	private void attemptRecovery(ConsumerRecord<?, ?> record, @Nullable Exception exception, @Nullable TopicPartition tp,
+	private void attemptRecovery(ConsumerRecord<?, ?> record, @Nullable Exception exception, TopicPartition tp,
 			@Nullable Consumer<?, ?> consumer) {
 
 		try {
 			this.recoverer.accept(record, consumer, exception);
 			this.retryListeners.forEach(rl -> rl.recovered(record, exception));
+			clearRecoveryFailures(tp);
 		}
 		catch (RuntimeException e) {
 			this.retryListeners.forEach(rl -> rl.recoveryFailed(record, exception, e));
-			if (tp != null && this.resetStateOnRecoveryFailure) {
+			if (recoveryFailuresExhausted(record, tp, e)) {
+				return;
+			}
+			if (this.resetStateOnRecoveryFailure) {
 				Map<TopicPartition, FailedRecord> topicPartitionFailedRecordMap = this.failures.get(Thread.currentThread());
 				if (topicPartitionFailedRecordMap != null) {
 					topicPartitionFailedRecordMap.remove(tp);
@@ -243,8 +266,45 @@ class FailedRecordTracker implements RecoveryStrategy {
 		}
 	}
 
+	private boolean recoveryFailuresExhausted(ConsumerRecord<?, ?> record, TopicPartition tp, RuntimeException failure) {
+		if (this.maxRecoveryFailures == Integer.MAX_VALUE) {
+			return false;
+		}
+		Map<TopicPartition, RecoveryFailures> map = this.recoveryFailures.computeIfAbsent(Thread.currentThread(),
+				t -> new HashMap<>());
+		RecoveryFailures failures = map.get(tp);
+		if (failures == null || failures.getOffset() != record.offset()) {
+			failures = new RecoveryFailures(record.offset());
+			map.put(tp, failures);
+		}
+		int count = failures.increment();
+		if (count < this.maxRecoveryFailures) {
+			return false;
+		}
+		clearRecoveryFailures(tp);
+		this.logger.error(failure, () -> "Recovery failed " + count + " times for " + KafkaUtils.format(record)
+				+ "; skipping the record");
+		return true;
+	}
+
+	private void clearRecoveryFailures(TopicPartition tp) {
+		clearRecoveryFailures(List.of(tp));
+	}
+
+	private void clearRecoveryFailures(Collection<TopicPartition> partitions) {
+		Thread currentThread = Thread.currentThread();
+		Map<TopicPartition, RecoveryFailures> map = this.recoveryFailures.get(currentThread);
+		if (map != null) {
+			partitions.forEach(map::remove);
+			if (map.isEmpty()) {
+				this.recoveryFailures.remove(currentThread);
+			}
+		}
+	}
+
 	void clearThreadState() {
 		this.failures.remove(Thread.currentThread());
+		this.recoveryFailures.remove(Thread.currentThread());
 	}
 
 	void clearThreadStateFor(Collection<TopicPartition> partitions) {
@@ -252,6 +312,7 @@ class FailedRecordTracker implements RecoveryStrategy {
 		if (map != null) {
 			partitions.forEach(map::remove);
 		}
+		clearRecoveryFailures(partitions);
 	}
 
 	ConsumerAwareRecordRecoverer getRecoverer() {
@@ -314,6 +375,26 @@ class FailedRecordTracker implements RecoveryStrategy {
 
 		void setLastException(@Nullable Exception lastException) {
 			this.lastException = lastException;
+		}
+
+	}
+
+	static final class RecoveryFailures {
+
+		private final long offset;
+
+		private int count;
+
+		RecoveryFailures(long offset) {
+			this.offset = offset;
+		}
+
+		long getOffset() {
+			return this.offset;
+		}
+
+		int increment() {
+			return ++this.count;
 		}
 
 	}

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/DefaultErrorHandlerRecordTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/DefaultErrorHandlerRecordTests.java
@@ -39,6 +39,7 @@ import org.springframework.util.backoff.FixedBackOff;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -49,12 +50,14 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 /**
  * {@link DefaultErrorHandler} tests for record listeners.
  *
  * @author Gary Russell
  * @author Soby Chacko
+ * @author Bill Kim
  * @since 2.8
  *
  */
@@ -184,6 +187,62 @@ public class DefaultErrorHandlerRecordTests {
 				.extracting(Throwable::getMessage)
 				.isEqualTo("test recoverer failure");
 		assertThat(isRecovered.get()).isTrue();
+	}
+
+	@Test
+	void skipAfterMaxRecoveryFailures() {
+		AtomicInteger recoveryAttempts = new AtomicInteger();
+		DefaultErrorHandler handler = new DefaultErrorHandler((r, t) -> {
+			recoveryAttempts.incrementAndGet();
+			throw new RuntimeException("test recoverer failure");
+		}, new FixedBackOff(0L, 0L));
+		handler.setMaxRecoveryFailures(2);
+		AtomicInteger recoveryFailures = new AtomicInteger();
+		AtomicBoolean isRecovered = new AtomicBoolean();
+		handler.setRetryListeners(new RetryListener() {
+
+			@Override
+			public void failedDelivery(ConsumerRecord<?, ?> record, Exception ex, int deliveryAttempt) {
+			}
+
+			@Override
+			public void recovered(ConsumerRecord<?, ?> record, Exception ex) {
+				isRecovered.set(true);
+			}
+
+			@Override
+			public void recoveryFailed(ConsumerRecord<?, ?> record, Exception original, Exception failure) {
+				recoveryFailures.incrementAndGet();
+			}
+
+		});
+		ConsumerRecord<String, String> record1 = new ConsumerRecord<>("foo", 0, 0L, "foo", "bar");
+		ConsumerRecord<String, String> record2 = new ConsumerRecord<>("foo", 1, 1L, "foo", "bar");
+		List<ConsumerRecord<?, ?>> records = Arrays.asList(record1, record2);
+		IllegalStateException illegalState = new IllegalStateException();
+		Consumer<?, ?> consumer = mock(Consumer.class);
+		MessageListenerContainer container = mock(MessageListenerContainer.class);
+		assertThatExceptionOfType(RecordInRetryException.class).isThrownBy(() ->
+				handler.handleRemaining(illegalState, records, consumer, container));
+		handler.handleRemaining(illegalState, records, consumer, container);
+		InOrder inOrder = inOrder(consumer);
+		inOrder.verify(consumer).seek(new TopicPartition("foo", 0), 0L); // recovery failed once, not skipped yet
+		inOrder.verify(consumer, times(2)).seek(new TopicPartition("foo", 1), 1L); // record1 skipped the second time
+		inOrder.verifyNoMoreInteractions();
+		assertThat(recoveryAttempts.get()).isEqualTo(2);
+		assertThat(recoveryFailures.get()).isEqualTo(2);
+		assertThat(isRecovered.get()).isFalse();
+		handler.setSeekAfterError(false);
+		assertThat(handler.handleOne(illegalState, record1, consumer, container)).isFalse();
+		assertThat(handler.handleOne(illegalState, record1, consumer, container)).isTrue();
+		assertThat(recoveryAttempts.get()).isEqualTo(4);
+		verifyNoMoreInteractions(consumer);
+	}
+
+	@Test
+	void maxRecoveryFailuresMustBePositive() {
+		DefaultErrorHandler handler = new DefaultErrorHandler();
+		assertThatIllegalArgumentException().isThrownBy(() -> handler.setMaxRecoveryFailures(0));
 	}
 
 	@Test

--- a/spring-kafka/src/test/java/org/springframework/kafka/listener/FailedRecordTrackerTests.java
+++ b/spring-kafka/src/test/java/org/springframework/kafka/listener/FailedRecordTrackerTests.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.kafka.clients.consumer.Consumer;
@@ -35,11 +36,14 @@ import org.springframework.util.backoff.BackOffExecution;
 import org.springframework.util.backoff.FixedBackOff;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 /**
  * @author Gary Russell
+ * @author Bill Kim
  * @since 2.2.5
  *
  */
@@ -232,6 +236,122 @@ public class FailedRecordTrackerTests {
 				new ListenerExecutionFailedException("", iae)));
 		assertThat(tracker.recovered(record, ex, mock(MessageListenerContainer.class), consumer)).isTrue();
 		assertThat(captured.get()).isSameAs(iae);
+	}
+
+	@Test
+	void recoveryFailuresUnboundedByDefault() {
+		AtomicInteger recoveryAttempts = new AtomicInteger();
+		FailedRecordTracker tracker = new FailedRecordTracker((r, e) -> {
+			recoveryAttempts.incrementAndGet();
+			throw new IllegalStateException("recoverer");
+		}, new FixedBackOff(0L, 0L), mock(LogAccessor.class));
+		ConsumerRecord<?, ?> record = new ConsumerRecord<>("foo", 0, 0L, "bar", "baz");
+		for (int i = 0; i < 5; i++) {
+			assertThatIllegalStateException().isThrownBy(() -> tracker.skip(record, new RuntimeException()));
+		}
+		assertThat(recoveryAttempts.get()).isEqualTo(5);
+	}
+
+	@Test
+	void skipAfterMaxRecoveryFailuresWithNoRetries() {
+		AtomicInteger recoveryAttempts = new AtomicInteger();
+		FailedRecordTracker tracker = new FailedRecordTracker((r, e) -> {
+			recoveryAttempts.incrementAndGet();
+			throw new IllegalStateException("recoverer");
+		}, new FixedBackOff(0L, 0L), mock(LogAccessor.class));
+		tracker.setMaxRecoveryFailures(2);
+		List<Exception> recoveryFailures = new ArrayList<>();
+		AtomicBoolean recovered = new AtomicBoolean();
+		tracker.setRetryListeners(new RetryListener() {
+
+			@Override
+			public void failedDelivery(ConsumerRecord<?, ?> record, Exception ex, int deliveryAttempt) {
+			}
+
+			@Override
+			public void recovered(ConsumerRecord<?, ?> record, Exception ex) {
+				recovered.set(true);
+			}
+
+			@Override
+			public void recoveryFailed(ConsumerRecord<?, ?> record, Exception original, Exception failure) {
+				recoveryFailures.add(failure);
+			}
+
+		});
+		ConsumerRecord<?, ?> record = new ConsumerRecord<>("foo", 0, 0L, "bar", "baz");
+		assertThatIllegalStateException().isThrownBy(() -> tracker.skip(record, new RuntimeException()));
+		assertThat(tracker.skip(record, new RuntimeException())).isTrue();
+		assertThat(recoveryAttempts.get()).isEqualTo(2);
+		assertThat(recoveryFailures).hasSize(2);
+		assertThat(recovered.get()).isFalse();
+		// the count starts over once the record has been skipped
+		assertThatIllegalStateException().isThrownBy(() -> tracker.skip(record, new RuntimeException()));
+		assertThat(tracker.skip(record, new RuntimeException())).isTrue();
+	}
+
+	@Test
+	void skipAfterMaxRecoveryFailuresSurvivesBackOffReset() {
+		FailedRecordTracker tracker = new FailedRecordTracker((r, e) -> {
+			throw new IllegalStateException("recoverer");
+		}, new FixedBackOff(0L, 1L), mock(LogAccessor.class));
+		tracker.setMaxRecoveryFailures(2);
+		ConsumerRecord<?, ?> record = new ConsumerRecord<>("foo", 0, 0L, "bar", "baz");
+		assertThat(tracker.skip(record, new RuntimeException())).isFalse();
+		assertThatIllegalStateException().isThrownBy(() -> tracker.skip(record, new RuntimeException()));
+		// the back off was reset, so the record is retried once more before the second recovery attempt
+		assertThat(tracker.skip(record, new RuntimeException())).isFalse();
+		assertThat(tracker.skip(record, new RuntimeException())).isTrue();
+	}
+
+	@Test
+	void skipAfterMaxRecoveryFailuresWithoutBackOffReset() {
+		FailedRecordTracker tracker = new FailedRecordTracker((r, e) -> {
+			throw new IllegalStateException("recoverer");
+		}, new FixedBackOff(0L, 1L), mock(LogAccessor.class));
+		tracker.setMaxRecoveryFailures(2);
+		tracker.setResetStateOnRecoveryFailure(false);
+		ConsumerRecord<?, ?> record = new ConsumerRecord<>("foo", 0, 0L, "bar", "baz");
+		assertThat(tracker.skip(record, new RuntimeException())).isFalse();
+		assertThatIllegalStateException().isThrownBy(() -> tracker.skip(record, new RuntimeException()));
+		assertThat(tracker.skip(record, new RuntimeException())).isTrue();
+	}
+
+	@Test
+	void recoveryFailuresCountedPerRecord() {
+		AtomicBoolean recovererShouldFail = new AtomicBoolean(true);
+		FailedRecordTracker tracker = new FailedRecordTracker((r, e) -> {
+			if (recovererShouldFail.get()) {
+				throw new IllegalStateException("recoverer");
+			}
+		}, new FixedBackOff(0L, 0L), mock(LogAccessor.class));
+		tracker.setMaxRecoveryFailures(2);
+		ConsumerRecord<?, ?> record0 = new ConsumerRecord<>("foo", 0, 0L, "bar", "baz");
+		ConsumerRecord<?, ?> record1 = new ConsumerRecord<>("foo", 0, 1L, "bar", "baz");
+		ConsumerRecord<?, ?> otherPartition = new ConsumerRecord<>("foo", 1, 0L, "bar", "baz");
+		assertThatIllegalStateException().isThrownBy(() -> tracker.skip(record0, new RuntimeException()));
+		// a different offset on the same partition starts its own count
+		assertThatIllegalStateException().isThrownBy(() -> tracker.skip(record1, new RuntimeException()));
+		assertThat(tracker.skip(record1, new RuntimeException())).isTrue();
+		// so does a different partition
+		assertThatIllegalStateException().isThrownBy(() -> tracker.skip(otherPartition, new RuntimeException()));
+		// a successful recovery clears the count
+		recovererShouldFail.set(false);
+		assertThat(tracker.skip(otherPartition, new RuntimeException())).isTrue();
+		recovererShouldFail.set(true);
+		assertThatIllegalStateException().isThrownBy(() -> tracker.skip(otherPartition, new RuntimeException()));
+		// as does clearing the thread state
+		tracker.clearThreadStateFor(List.of(new TopicPartition("foo", 1)));
+		assertThatIllegalStateException().isThrownBy(() -> tracker.skip(otherPartition, new RuntimeException()));
+		tracker.clearThreadState();
+		assertThatIllegalStateException().isThrownBy(() -> tracker.skip(otherPartition, new RuntimeException()));
+		assertThat(tracker.skip(otherPartition, new RuntimeException())).isTrue();
+	}
+
+	@Test
+	void maxRecoveryFailuresMustBePositive() {
+		FailedRecordTracker tracker = new FailedRecordTracker(null, new FixedBackOff(0L, 0L), mock(LogAccessor.class));
+		assertThatIllegalArgumentException().isThrownBy(() -> tracker.setMaxRecoveryFailures(0));
 	}
 
 }


### PR DESCRIPTION
Fixes #4272

When a `ConsumerRecordRecoverer` keeps throwing for the same record, `DefaultErrorHandler` seeks back to it and the record is redelivered indefinitely; `resetStateOnRecoveryFailure` and `seekAfterError` change how it is redelivered, not whether. The consumer never advances past the offset.

This adds `FailedRecordProcessor.setMaxRecoveryFailures(int)` (so both `DefaultErrorHandler` and `DefaultAfterRollbackProcessor` get it). Once recovery has failed that many times for a record, the record is logged at ERROR level with the last recovery exception and treated as recovered: it is no longer included in the seeks and its offset is committed according to the ack mode. `RetryListener.recoveryFailed` is still called for every failure. Default is unlimited, i.e. the current behavior.

The count lives next to the retry state in `FailedRecordTracker` rather than inside `FailedRecord`, since that state is discarded on a recovery failure when `resetStateOnRecoveryFailure` is `true` (the default) and the no-retries path has no retry state at all. It is cleared on a successful recovery, when a different offset fails on the partition, and by `clearThreadState` / `clearThreadStateFor`.

Tests cover the default (unbounded), the no-retries path, the count surviving a back-off reset, `resetStateOnRecoveryFailure=false`, per-record/per-partition scoping, the handler-level seek behaviour, and the argument check. Docs and what's-new updated.
